### PR TITLE
Remove any other editor modifications

### DIFF
--- a/includes/class-newspack-newsletters.php
+++ b/includes/class-newspack-newsletters.php
@@ -83,6 +83,7 @@ final class Newspack_Newsletters {
 			}
 		}
 
+		remove_editor_styles();
 		remove_theme_support( 'editor-color-palette' );
 	}
 

--- a/includes/class-newspack-newsletters.php
+++ b/includes/class-newspack-newsletters.php
@@ -42,7 +42,7 @@ final class Newspack_Newsletters {
 	 * Constructor.
 	 */
 	public function __construct() {
-		add_action( 'admin_init', [ __CLASS__, 'remove_other_editor_modifications' ] );
+		add_action( 'the_post', [ __CLASS__, 'remove_other_editor_modifications' ] );
 		add_action( 'init', [ __CLASS__, 'register_cpt' ] );
 		add_action( 'init', [ __CLASS__, 'register_meta' ] );
 		add_action( 'enqueue_block_editor_assets', [ __CLASS__, 'enqueue_block_editor_assets' ] );
@@ -59,17 +59,7 @@ final class Newspack_Newsletters {
 	 * Remove editor color palette theme supports - the MJML parser uses a static list of default editor colors.
 	 */
 	public static function remove_other_editor_modifications() {
-		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
-		$post = isset( $_GET['post'] ) ? sanitize_text_field( $_GET['post'] ) : false;
-		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
-		$post_type = isset( $_GET['post_type'] ) ? sanitize_text_field( $_GET['post_type'] ) : false;
-		if ( ! $post && ! $post_type ) {
-			return;
-		}
-		if ( $post ) {
-			$post_type = get_post_type( $post );
-		}
-		if ( $post_type && self::NEWSPACK_NEWSLETTERS_CPT != $post_type ) {
+		if ( self::NEWSPACK_NEWSLETTERS_CPT != get_post_type() ) {
 			return;
 		}
 

--- a/includes/class-newspack-newsletters.php
+++ b/includes/class-newspack-newsletters.php
@@ -76,8 +76,8 @@ final class Newspack_Newsletters {
 		$enqueue_block_editor_assets_filters = $GLOBALS['wp_filter']['enqueue_block_editor_assets']->callbacks;
 		foreach ( $enqueue_block_editor_assets_filters as $index => $filter ) {
 			$action_handlers = array_keys( $filter );
-			if ( ! in_array( __CLASS__ . '::enqueue_block_editor_assets', $action_handlers ) ) {
-				foreach ( $action_handlers as $handler ) {
+			foreach ( $action_handlers as $handler ) {
+				if ( __CLASS__ . '::enqueue_block_editor_assets' != $handler ) {
 					remove_action( 'enqueue_block_editor_assets', $handler, $index );
 				}
 			}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

This way theme styles are not applied to the Newsletter editor.

Closes #7 
Closes #69 

### How to test the changes in this Pull Request:

1. Create a new post, observe that it has some of theme's styling and potentially* a custom colour palette
2. Create a new newsletter, observe that it has just the default Gutenberg editor styles and the default colour palette

* `twentytwenty` theme has one for example

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
