### PR TITLE
Set publish button text to 'Send Campaign'

### DIFF
--- a/src/editor/editor/index.js
+++ b/src/editor/editor/index.js
@@ -5,6 +5,7 @@ import { compose } from '@wordpress/compose';
 import apiFetch from '@wordpress/api-fetch';
 import { withDispatch, withSelect } from '@wordpress/data';
 import { useEffect } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -15,7 +16,16 @@ import './style.scss';
 export default compose( [
 	withDispatch( dispatch => {
 		const { lockPostSaving, unlockPostSaving, editPost } = dispatch( 'core/editor' );
-		return { lockPostSaving, unlockPostSaving, editPost };
+		return {
+			lockPostSaving,
+			unlockPostSaving,
+			editPost,
+			updateDefaultPublishButtonText: () => {
+				dispatch( 'core/block-editor' ).updateSettings( {
+					publishActionText: __( 'Send Campaign', 'newspack-newsletters' ),
+				} );
+			},
+		};
 	} ),
 	withSelect( select => {
 		const { getCurrentPostId, getEditedPostAttribute } = select( 'core/editor' );
@@ -29,6 +39,7 @@ export default compose( [
 	} ),
 ] )( props => {
 	useEffect(() => {
+		props.updateDefaultPublishButtonText();
 		// Fetch initially if the sidebar is be hidden.
 		if ( props.activeSidebarName !== 'edit-post/document' ) {
 			apiFetch( { path: `/newspack-newsletters/v1/mailchimp/${ props.postId }` } ).then( result => {


### PR DESCRIPTION
_NOTE: This depends on https://github.com/WordPress/gutenberg/pull/21573. If it get's merged, this PR will be ready._

---

### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Change the "Publish" text to "Send Campaign".

### How to test the changes in this Pull Request:

1. Open a newsletter or create new
2. Verify that "Send Campaign" is rendered instead of "Publish" following locations:
  - primary button in editor's top bar
  - "Status & visibility" panel of the sidebar
  - primary button in pre-publish checks sidebar
  - publishing date setting panel in  pre-publish checks sidebar

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
