### PR TITLE
feat: move MJML creds to plugin settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,21 +1,19 @@
 # newspack-newsletters
 Author email newsletters in WordPress
 
+## Setup
+
+Copy your Mailchimp API key, which can be found in Mailchimp in `Account->Extras->API Keys`.
+Request [MJML API access](https://mjml.io/api).
+
+Navigate to `Settings->Newspack Newsletters`. Input Mailchimp API key and MJML API key and secret.
+
 ## Use
 
-Copy your Mailchimp API key, which can be found in Mailchimp in `Account->Extras->API Keys`. Navigate to `Settings->Newspack Newsletters`. Input Mailchimp API key. Click Newsletters in the left menu. Create a new one.
+Click Newsletters in the left menu. Create a new one.
 
 ## Development
 
 Run `composer update && npm install`.
 
 Run `npm run build`.
-
-#### Environment variables
-
-This feature requires environment variables to be set (e.g. in `wp-config.php`):
-
-```php
-define( 'NEWSPACK_MJML_API_KEY', 'abc1' );
-define( 'NEWSPACK_MJML_API_SECRET', 'abc1' );
-```

--- a/includes/class-newspack-newsletters-renderer.php
+++ b/includes/class-newspack-newsletters-renderer.php
@@ -472,8 +472,8 @@ final class Newspack_Newsletters_Renderer {
 	 * @return string API key and API secret as a key:secret string.
 	 */
 	public static function mjml_api_credentials() {
-		$key    = ( defined( 'NEWSPACK_MJML_API_KEY' ) && NEWSPACK_MJML_API_KEY ) ? NEWSPACK_MJML_API_KEY : false;
-		$secret = ( defined( 'NEWSPACK_MJML_API_SECRET' ) && NEWSPACK_MJML_API_SECRET ) ? NEWSPACK_MJML_API_SECRET : false;
+		$key    = get_option( 'newspack_newsletters_mjml_api_key', false );
+		$secret = get_option( 'newspack_newsletters_mjml_api_secret', false );
 		if ( isset( $key, $secret ) ) {
 			return "$key:$secret";
 		}

--- a/includes/class-newspack-newsletters-settings.php
+++ b/includes/class-newspack-newsletters-settings.php
@@ -20,6 +20,28 @@ class Newspack_Newsletters_Settings {
 	}
 
 	/**
+	 * Retreives list of settings.
+	 *
+	 * @return array Settings list.
+	 */
+	public static function get_settings_list() {
+		return array(
+			array(
+				'description' => __( 'Mailchimp API Key', 'newspack' ),
+				'key'         => 'newspack_newsletters_mailchimp_api_key',
+			),
+			array(
+				'description' => __( 'MJML API Key', 'newspack' ),
+				'key'         => 'newspack_newsletters_mjml_api_key',
+			),
+			array(
+				'description' => __( 'MJML API Secret', 'newspack' ),
+				'key'         => 'newspack_newsletters_mjml_api_secret',
+			),
+		);
+	}
+
+	/**
 	 * Add options page
 	 */
 	public static function add_plugin_page() {
@@ -36,7 +58,6 @@ class Newspack_Newsletters_Settings {
 	 * Options page callback
 	 */
 	public static function create_admin_page() {
-		$newspack_newsletters_mailchimp_api_key = get_option( 'newspack_newsletters_mailchimp_api_key' );
 		?>
 		<div class="wrap">
 			<h1>Newspack Newsletters Settings</h1>
@@ -55,33 +76,40 @@ class Newspack_Newsletters_Settings {
 	 * Register and add settings
 	 */
 	public static function page_init() {
-		register_setting(
-			'newspack_newsletters_options_group',
-			'newspack_newsletters_mailchimp_api_key'
-		);
 		add_settings_section(
 			'newspack_newsletters_options_group',
 			'Newspack Newsletters Custom Settings',
 			null,
 			'newspack-newsletters-settings-admin'
 		);
-		add_settings_field(
-			'newspack_newsletters_mailchimp_api_key',
-			__( 'Mailchimp API Key', 'newspack' ),
-			[ __CLASS__, 'newspack_newsletters_mailchimp_api_key_callback' ],
-			'newspack-newsletters-settings-admin',
-			'newspack_newsletters_options_group'
-		);
+		foreach ( self::get_settings_list() as $setting ) {
+			register_setting(
+				'newspack_newsletters_options_group',
+				$setting['key']
+			);
+			add_settings_field(
+				$setting['key'],
+				$setting['description'],
+				[ __CLASS__, 'newspack_newsletters_settings_callback' ],
+				'newspack-newsletters-settings-admin',
+				'newspack_newsletters_options_group',
+				$setting['key']
+			);
+		};
 	}
 
 	/**
-	 * Render Mailchimp API  field.
+	 * Render settings fields.
+	 *
+	 * @param string $key Setting key.
 	 */
-	public static function newspack_newsletters_mailchimp_api_key_callback() {
-		$newspack_newsletters_mailchimp_api_key = get_option( 'newspack_newsletters_mailchimp_api_key', false );
+	public static function newspack_newsletters_settings_callback( $key ) {
+		$value = get_option( $key, false );
 		printf(
-			'<input type="text" id="newspack_newsletters_mailchimp_api_key" name="newspack_newsletters_mailchimp_api_key" value="%s" />',
-			esc_attr( $newspack_newsletters_mailchimp_api_key )
+			'<input type="text" id="%s" name="%s" value="%s" class="widefat" />',
+			esc_attr( $key ),
+			esc_attr( $key ),
+			esc_attr( $value )
 		);
 	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Moves MJML API credentials input location from environment to plugin settings.

Closes #16.

### How to test the changes in this Pull Request:

1. Set up plugin as outlined in the README
2. Remove MJML credentials from environment (wp-config.php, probably)
3. Create a newsletter with some content, preview in Mailchimp. Should work as expected.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
