### PR TITLE
fix: send content to mailchimp immediately before sending campaign

### DIFF
--- a/includes/class-newspack-newsletters.php
+++ b/includes/class-newspack-newsletters.php
@@ -524,6 +524,12 @@ final class Newspack_Newsletters {
 			);
 		}
 
+		$sync_result = self::sync_with_mailchimp( $post, true );
+
+		if ( is_wp_error( $sync_result ) ) {
+			return $sync_result;
+		}
+
 		$mc_campaign_id = get_post_meta( $id, 'mc_campaign_id', true );
 		if ( ! $mc_campaign_id ) {
 			return new WP_Error(
@@ -533,24 +539,6 @@ final class Newspack_Newsletters {
 		}
 
 		$mc = new Mailchimp( self::mailchimp_api_key() );
-
-		$payload = [
-			'type'         => 'regular',
-			'content_type' => 'template',
-			'settings'     => [
-				'subject_line' => $post->post_title,
-				'title'        => $post->post_title,
-			],
-		];
-
-		$mc->patch( "campaigns/$mc_campaign_id", $payload );
-
-		$renderer        = new Newspack_Newsletters_Renderer();
-		$content_payload = [
-			'html' => $renderer->render_html_email( $post ),
-		];
-
-		$mc->put( "campaigns/$mc_campaign_id/content", $content_payload );
 
 		$payload = [
 			'send_type' => 'html',

--- a/includes/class-newspack-newsletters.php
+++ b/includes/class-newspack-newsletters.php
@@ -383,52 +383,6 @@ final class Newspack_Newsletters {
 	}
 
 	/**
-	 * Send the Mailchimp campaign.
-	 *
-	 * @param WP_REST_Request $request API request object.
-	 */
-	public static function api_send_mailchimp_campaign( $request ) {
-		$id           = $request['id'];
-		$sender_name  = $request['sender_name'];
-		$sender_email = $request['sender_email'];
-		if ( self::NEWSPACK_NEWSLETTERS_CPT !== get_post_type( $id ) ) {
-			return new WP_Error(
-				'newspack_newsletters_incorrect_post_type',
-				__( 'Post is not a Newsletter.', 'newspack-newsletters' )
-			);
-		}
-
-
-		$mc_campaign_id = get_post_meta( $id, 'mc_campaign_id', true );
-		if ( ! $mc_campaign_id ) {
-			return new WP_Error(
-				'newspack_newsletters_no_campaign_id',
-				__( 'Mailchimp campaign ID not found.', 'newspack-newsletters' )
-			);
-		}
-
-		$mc = new Mailchimp( self::mailchimp_api_key() );
-
-		$payload = [
-			'settings' => [
-				'from_name' => $sender_name,
-				'reply_to'  => $sender_email,
-			],
-		];
-		$mc->patch( "campaigns/$mc_campaign_id", $payload );
-
-		$payload = [
-			'send_type' => 'html',
-		];
-		$result  = $mc->post( "campaigns/$mc_campaign_id/actions/send", $payload );
-
-		$data           = self::retrieve_data( $id );
-		$data['result'] = $result;
-
-		return \rest_ensure_response( $data );
-	}
-
-	/**
 	 * Get Mailchimp data.
 	 *
 	 * @param string $id post ID.

--- a/includes/class-newspack-newsletters.php
+++ b/includes/class-newspack-newsletters.php
@@ -545,7 +545,6 @@ final class Newspack_Newsletters {
 			);
 		}
 
-
 		$mc_campaign_id = get_post_meta( $id, 'mc_campaign_id', true );
 		if ( ! $mc_campaign_id ) {
 			return new WP_Error(
@@ -555,6 +554,24 @@ final class Newspack_Newsletters {
 		}
 
 		$mc = new Mailchimp( self::mailchimp_api_key() );
+
+		$payload = [
+			'type'         => 'regular',
+			'content_type' => 'template',
+			'settings'     => [
+				'subject_line' => $post->post_title,
+				'title'        => $post->post_title,
+			],
+		];
+
+		$mc->patch( "campaigns/$mc_campaign_id", $payload );
+
+		$renderer        = new Newspack_Newsletters_Renderer();
+		$content_payload = [
+			'html' => $renderer->render_html_email( $post ),
+		];
+
+		$mc->put( "campaigns/$mc_campaign_id/content", $content_payload );
 
 		$payload = [
 			'send_type' => 'html',


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Synchronizes newsletter post content with Mailchimp immediately before publishing. This resolves an issue where changes made between the last save and the publish do not get conveyed to Mailchimp and the campaign that is sent is out of date.

Closes https://github.com/Automattic/newspack-newsletters/issues/33

### How to test the changes in this Pull Request:

1. On `master`, create a new Newsletter, then Save.
2. Make some changes, then without saving again, click Publish. 
3. Observe that the campaign that is sent does not include the changes.
4. Switch to this branch, repeast.
5. Observe the last minute changes are reflected in the campaign that is sent.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
