### PR TITLE
feat: placeholder text for no template or blank template

### DIFF
--- a/src/components/template-modal/index.js
+++ b/src/components/template-modal/index.js
@@ -68,7 +68,15 @@ class TemplateModal extends Component {
 					</div>
 
 					<div className="newspack-newsletters-modal__preview">
-						{ blockPreview && <BlockPreview blocks={ blockPreview } viewportWidth={ 810 } /> }
+						{ blockPreview && blockPreview.length > 0 && (
+							<BlockPreview blocks={ blockPreview } viewportWidth={ 810 } />
+						) }
+						{ blockPreview && 0 === blockPreview.length && (
+							<p>{ __( 'Blank layout.', 'newspack-newsletters' ) }</p>
+						) }
+						{ ! blockPreview && (
+							<p>{ __( 'Select a layout to preview.', 'newspack-newsletters' ) }</p>
+						) }
 					</div>
 				</div>
 

--- a/src/components/template-modal/index.js
+++ b/src/components/template-modal/index.js
@@ -68,13 +68,9 @@ class TemplateModal extends Component {
 					</div>
 
 					<div className="newspack-newsletters-modal__preview">
-						{ blockPreview && blockPreview.length > 0 && (
+						{ blockPreview && blockPreview.length > 0 ? (
 							<BlockPreview blocks={ blockPreview } viewportWidth={ 810 } />
-						) }
-						{ blockPreview && 0 === blockPreview.length && (
-							<p>{ __( 'Blank layout.', 'newspack-newsletters' ) }</p>
-						) }
-						{ ! blockPreview && (
+						) : (
 							<p>{ __( 'Select a layout to preview.', 'newspack-newsletters' ) }</p>
 						) }
 					</div>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Adds placeholder text to the template picker's preview pane. If the blank template is selected: "Blank template." If no template is selected: "Select a layout to preview." At present there is no way to have no template selected, but I left this state in just in case the logic changes.

Closes https://github.com/Automattic/newspack-newsletters/issues/35.

![Screen Shot 2020-04-14 at 2 12 24 PM](https://user-images.githubusercontent.com/1477002/79259269-6da66800-7e5a-11ea-946e-99bcd43aca67.png)

### How to test the changes in this Pull Request:

1. Create a new Newsletter.
2. Verify "Blank template." text in the preview pane.
3. Select Template 1, verify the text disappears and is replaced by a preview of the template.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
