### PR TITLE
fix: increase mjml request timeout, handle errors

### DIFF
--- a/includes/class-newspack-newsletters-renderer.php
+++ b/includes/class-newspack-newsletters-renderer.php
@@ -508,11 +508,10 @@ final class Newspack_Newsletters_Renderer {
 					'headers' => array(
 						'Authorization' => 'Basic ' . base64_encode( $mjml_creds ),
 					),
+					'timeout' => 45, // phpcs:ignore WordPressVIPMinimum.Performance.RemoteRequestTimeout.timeout_timeout
 				)
 			);
-
-			$email_html = json_decode( $request['body'] )->html;
-			return $email_html;
+			return is_wp_error( $request ) ? $request : json_decode( $request['body'] )->html;
 		}
 	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

At the default timeout of 5s MJML API requests seem to be timing out frequently when converting complex content. This PR increases the timeout to 45s and fixes an issue that caused PHP to fatal when there was a timeout.

Closes https://github.com/Automattic/newspack-newsletters/issues/37

### How to test the changes in this Pull Request:

1. On `master` insert Template 1, and save the post. If you're "lucky" this will cause a timeout which will cause this PHP fatal in the log:

```
PHP Fatal error:  Uncaught Error: Cannot use object of type WP_Error as array in /srv/www/newspack-repos/newspack-newsletters/includes/class-newspack-newsletters-renderer.php:514
```
2. Switch to this branch and try saving numerous times. There should be no fatals and the content should be converted successfully.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
