### PR TITLE
Subject In Sidebar

### DIFF
--- a/includes/class-newspack-newsletters.php
+++ b/includes/class-newspack-newsletters.php
@@ -47,6 +47,7 @@ final class Newspack_Newsletters {
 		add_action( 'enqueue_block_editor_assets', [ __CLASS__, 'enqueue_block_editor_assets' ] );
 		add_action( 'enqueue_block_editor_assets', [ __CLASS__, 'disable_gradients' ] );
 		add_action( 'rest_api_init', [ __CLASS__, 'rest_api_init' ] );
+		add_action( 'default_title', [ __CLASS__, 'default_title' ], 10, 2 );
 		add_action( 'save_post_' . self::NEWSPACK_NEWSLETTERS_CPT, [ __CLASS__, 'sync_with_mailchimp' ], 10, 3 );
 		add_action( 'publish_' . self::NEWSPACK_NEWSLETTERS_CPT, [ __CLASS__, 'send_campaign' ], 10, 2 );
 		add_filter( 'allowed_block_types', [ __CLASS__, 'newsletters_allowed_block_types' ], 10, 2 );
@@ -603,6 +604,20 @@ final class Newspack_Newsletters {
 			array_values( $extra )
 		);
 		return str_replace( $search, $replace, $content );
+	}
+
+	/**
+	 * Set initial title of newsletter.
+	 *
+	 * @param string  $post_title Post title.
+	 * @param WP_Post $post Post.
+	 * @return string Title.
+	 */
+	public static function default_title( $post_title, $post ) {
+		if ( self::NEWSPACK_NEWSLETTERS_CPT === get_post_type( $post ) ) {
+			$post_title = gmdate( get_option( 'date_format' ) );
+		}
+		return $post_title;
 	}
 }
 Newspack_Newsletters::instance();

--- a/src/editor/editor/style.scss
+++ b/src/editor/editor/style.scss
@@ -2,3 +2,8 @@
 .editor-post-preview__dropdown {
 	display: none;
 }
+
+// TODO hide title after it's not required in MC initial call
+.editor-post-title {
+	display: none;
+}

--- a/src/editor/editor/style.scss
+++ b/src/editor/editor/style.scss
@@ -3,7 +3,6 @@
 	display: none;
 }
 
-// TODO hide title after it's not required in MC initial call
 .editor-post-title {
 	display: none;
 }

--- a/src/editor/sidebar/index.js
+++ b/src/editor/sidebar/index.js
@@ -109,6 +109,7 @@ class Sidebar extends Component {
 	 * Render
 	 */
 	render() {
+		const { editPost, title } = this.props;
 		const {
 			campaign,
 			hasResults,
@@ -171,7 +172,6 @@ class Sidebar extends Component {
 						</Button>
 					</Modal>
 				) }
-
 				<SelectControl
 					label={ __( 'Mailchimp Lists', 'newspack-newsletters' ) }
 					value={ list_id }
@@ -187,6 +187,12 @@ class Sidebar extends Component {
 					] }
 					onChange={ value => this.setList( value ) }
 					disabled={ inFlight }
+				/>
+				<TextControl
+					label={ __( 'Subject', 'newspack-newsletters' ) }
+					value={ title }
+					disabled={ inFlight }
+					onChange={ value => editPost( { title: value } ) }
 				/>
 				<TextControl
 					label={ __( 'Sender name', 'newspack-newsletters' ) }
@@ -223,8 +229,15 @@ class Sidebar extends Component {
 
 export default compose( [
 	withSelect( select => {
-		const { getCurrentPostId, isPublishingPost, isSavingPost } = select( 'core/editor' );
-		return { postId: getCurrentPostId(), isPublishingPost, isSavingPost };
+		const { getEditedPostAttribute, getCurrentPostId, isPublishingPost, isSavingPost } = select(
+			'core/editor'
+		);
+		return {
+			title: getEditedPostAttribute( 'title' ),
+			postId: getCurrentPostId(),
+			isPublishingPost,
+			isSavingPost,
+		};
 	} ),
 	withDispatch( dispatch => {
 		const { editPost } = dispatch( 'core/editor' );

--- a/src/editor/sidebar/style.scss
+++ b/src/editor/sidebar/style.scss
@@ -1,8 +1,3 @@
-// TODO hide title after it's not required in MC initial call
-.editor-post-title {
-	// display: none;
-}
-
 .wp-block {
 	max-width: 568px;
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR resolves the title/subject confusion in the following way:

- Post title is hidden, via CSS
- Subject field added to sidebar, which is bound to post title.
- New newsletter titles are the current date.

Closes https://github.com/Automattic/newspack-newsletters/issues/19

### How to test the changes in this Pull Request:

1. Create a new newsletter.
2. Verify the title is hidden.
3. Verify there is a subject field in the sidebar, and it is set to the current date.
4. Change the subject field, save the post, verify the change persists.
5. Send a test email, or actual campaign, verify the subject of the email matches the subject field.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
