### PR TITLE
feat: update pre-check with notice and reorganize sidebar

### DIFF
--- a/src/editor/blocks-validation/blocks-filters.js
+++ b/src/editor/blocks-validation/blocks-filters.js
@@ -53,11 +53,12 @@ const withUnsupportedFeaturesNotices = createHigherOrderComponent( BlockListBloc
 						'These features will not be displayed correctly in an email, please remove them:',
 						'newspack-newsletters'
 					) }
-					<ul>
-						{ warnings.map( ( warning, i ) => (
-							<li key={ i }>{ warning }</li>
-						) ) }
-					</ul>
+					{ warnings.map( ( warning, i ) => (
+						<strong key={ i }>
+							<br />
+							{ warning }
+						</strong>
+					) ) }
 				</div>
 				<BlockListBlock { ...props } />
 			</div>

--- a/src/editor/pre-publish-slot/index.js
+++ b/src/editor/pre-publish-slot/index.js
@@ -1,6 +1,7 @@
 /**
  * WordPress dependencies
  */
+import { Notice } from '@wordpress/components';
 import { withSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 
@@ -13,12 +14,20 @@ export default withSelect( select => {
 } )( ( { validationErrors } ) => {
 	if ( validationErrors.length ) {
 		return (
-			<ul>
+			<ul className="newspack-newsletters__pre-publish-errors">
 				{ validationErrors.map( ( message, index ) => (
-					<li key={ index }>{ message }</li>
+					<li key={ index }>
+						<Notice status="error" isDismissible={ false }>
+							{ message }
+						</Notice>
+					</li>
 				) ) }
 			</ul>
 		);
 	}
-	return __( 'Newsletter is ready to send', 'newspack-newsletters' );
+	return (
+		<Notice isDismissible={ false }>
+			{ __( 'Newsletter is ready to be sent.', 'newspack-newsletters' ) }
+		</Notice>
+	);
 } );

--- a/src/editor/sidebar/index.js
+++ b/src/editor/sidebar/index.js
@@ -122,24 +122,26 @@ class Sidebar extends Component {
 			senderDirty,
 		} = this.state;
 		if ( ! hasResults ) {
-			return [
-				__( 'Retrieving Mailchimp data', 'newspack-newsletters' ),
-				<Spinner key="spinner" />,
-			];
+			return (
+				<div className="newspack-newsletters__loading-data">
+					{ __( 'Retrieving Mailchimp data...', 'newspack-newsletters' ) }
+					<Spinner key="spinner" />
+				</div>
+			);
 		}
 		const { recipients, status, long_archive_url } = campaign || {};
 		const { list_id } = recipients || {};
 		if ( ! status ) {
 			return (
 				<Notice status="info" isDismissible={ false }>
-					<p>{ __( 'Publish to sync to Mailchimp', 'newspack-newsletters' ) }</p>
+					{ __( 'Publish to sync to Mailchimp.', 'newspack-newsletters' ) }
 				</Notice>
 			);
 		}
 		if ( 'sent' === status || 'sending' === status ) {
 			return (
-				<Notice status="info" isDismissible={ false }>
-					<p>{ __( 'Campaign has been sent.', 'newspack-newsletters' ) }</p>
+				<Notice status="success" isDismissible={ false }>
+					{ __( 'Campaign has been sent.', 'newspack-newsletters' ) }
 				</Notice>
 			);
 		}
@@ -173,12 +175,12 @@ class Sidebar extends Component {
 					</Modal>
 				) }
 				<SelectControl
-					label={ __( 'Mailchimp Lists', 'newspack-newsletters' ) }
+					label={ __( 'Mailchimp list', 'newspack-newsletters' ) }
 					value={ list_id }
 					options={ [
 						{
 							value: null,
-							label: __( '-- Select A List --', 'newspack-newsletters' ),
+							label: __( '-- Select a list --', 'newspack-newsletters' ),
 						},
 						...lists.map( ( { id, name } ) => ( {
 							value: id,
@@ -208,19 +210,52 @@ class Sidebar extends Component {
 				/>
 				{ senderDirty && (
 					<Button
-						isPrimary
+						isLink
 						onClick={ () => this.updateSender( senderName, senderEmail ) }
 						disabled={ inFlight }
 					>
 						{ __( 'Update Sender', 'newspack-newsletters' ) }
 					</Button>
 				) }
+				<hr />
+				<Button
+					isPrimary
+					onClick={ () => this.setState( { showTestModal: true } ) }
+					disabled={ inFlight }
+				>
+					{ __( 'Send Test', 'newspack-newsletters' ) }
+				</Button>
+				{ showTestModal && (
+					<Modal
+						title={ __( 'Send Test Email', 'newspack-newsletters' ) }
+						onRequestClose={ () => this.setState( { showTestModal: false } ) }
+						className="newspack-newsletters__send-test"
+					>
+						<TextControl
+							label={ __( 'Send to this email', 'newspack-newsletters' ) }
+							value={ testEmail }
+							onChange={ value => this.setState( { testEmail: value } ) }
+						/>
+						<Button
+							isPrimary
+							onClick={ () =>
+								this.setState( { showTestModal: false }, () => this.sendMailchimpTest() )
+							}
+						>
+							{ __( 'Send Test', 'newspack-newsletters' ) }
+						</Button>
+						<Button isTertiary onClick={ () => this.setState( { showTestModal: false } ) }>
+							{ __( 'Cancel', 'newspack-newsletters' ) }
+						</Button>
+					</Modal>
+				) }
 				{ long_archive_url && (
-					<div>
+					<Fragment>
+						<hr />
 						<ExternalLink href={ long_archive_url }>
 							{ __( 'View on Mailchimp', 'newspack-newsletters' ) }
 						</ExternalLink>
-					</div>
+					</Fragment>
 				) }
 			</Fragment>
 		);

--- a/src/editor/sidebar/index.js
+++ b/src/editor/sidebar/index.js
@@ -147,33 +147,6 @@ class Sidebar extends Component {
 		}
 		return (
 			<Fragment>
-				<Button
-					isPrimary
-					onClick={ () => this.setState( { showTestModal: true } ) }
-					disabled={ inFlight }
-				>
-					{ __( 'Send Test', 'newspack-newsletters' ) }
-				</Button>
-				{ showTestModal && (
-					<Modal
-						title={ __( 'Send Test Email', 'newspack-newsletters' ) }
-						onRequestClose={ () => this.setState( { showTestModal: false } ) }
-					>
-						<TextControl
-							label={ __( 'Send to this email', 'newspack-newsletters' ) }
-							value={ testEmail }
-							onChange={ value => this.setState( { testEmail: value } ) }
-						/>
-						<Button
-							isPrimary
-							onClick={ () =>
-								this.setState( { showTestModal: false }, () => this.sendMailchimpTest() )
-							}
-						>
-							{ __( 'Send', 'newspack-newsletters' ) }
-						</Button>
-					</Modal>
-				) }
 				<SelectControl
 					label={ __( 'Mailchimp list', 'newspack-newsletters' ) }
 					value={ list_id }

--- a/src/editor/sidebar/index.js
+++ b/src/editor/sidebar/index.js
@@ -147,8 +147,35 @@ class Sidebar extends Component {
 		}
 		return (
 			<Fragment>
+				<strong>{ __( 'From', 'newspack-newsletters' ) }</strong>
+				<TextControl
+					label={ __( 'Name', 'newspack-newsletters' ) }
+					className="newspack-newsletters__name-textcontrol"
+					value={ senderName }
+					disabled={ inFlight }
+					onChange={ value => this.setState( { senderName: value, senderDirty: true } ) }
+				/>
+				<TextControl
+					label={ __( 'Email', 'newspack-newsletters' ) }
+					className="newspack-newsletters__email-textcontrol"
+					value={ senderEmail }
+					type="email"
+					disabled={ inFlight }
+					onChange={ value => this.setState( { senderEmail: value, senderDirty: true } ) }
+				/>
+				{ senderDirty && (
+					<Button
+						isLink
+						onClick={ () => this.updateSender( senderName, senderEmail ) }
+						disabled={ inFlight }
+					>
+						{ __( 'Update Sender', 'newspack-newsletters' ) }
+					</Button>
+				) }
+				<hr />
 				<SelectControl
-					label={ __( 'Mailchimp list', 'newspack-newsletters' ) }
+					label={ __( 'To', 'newspack-newsletters' ) }
+					className="newspack-newsletters__to-selectcontrol"
 					value={ list_id }
 					options={ [
 						{
@@ -163,33 +190,14 @@ class Sidebar extends Component {
 					onChange={ value => this.setList( value ) }
 					disabled={ inFlight }
 				/>
+				<hr />
 				<TextControl
 					label={ __( 'Subject', 'newspack-newsletters' ) }
+					className="newspack-newsletters__subject-textcontrol"
 					value={ title }
 					disabled={ inFlight }
 					onChange={ value => editPost( { title: value } ) }
 				/>
-				<TextControl
-					label={ __( 'Sender name', 'newspack-newsletters' ) }
-					value={ senderName }
-					disabled={ inFlight }
-					onChange={ value => this.setState( { senderName: value, senderDirty: true } ) }
-				/>
-				<TextControl
-					label={ __( 'Sender email', 'newspack-newsletters' ) }
-					value={ senderEmail }
-					disabled={ inFlight }
-					onChange={ value => this.setState( { senderEmail: value, senderDirty: true } ) }
-				/>
-				{ senderDirty && (
-					<Button
-						isLink
-						onClick={ () => this.updateSender( senderName, senderEmail ) }
-						disabled={ inFlight }
-					>
-						{ __( 'Update Sender', 'newspack-newsletters' ) }
-					</Button>
-				) }
 				<hr />
 				<Button
 					isPrimary
@@ -207,6 +215,7 @@ class Sidebar extends Component {
 						<TextControl
 							label={ __( 'Send to this email', 'newspack-newsletters' ) }
 							value={ testEmail }
+							type="email"
 							onChange={ value => this.setState( { testEmail: value } ) }
 						/>
 						<Button

--- a/src/editor/sidebar/style.scss
+++ b/src/editor/sidebar/style.scss
@@ -28,4 +28,25 @@
 			}
 		}
 	}
+
+	&__loading-data {
+		align-items: center;
+		display: flex;
+
+		.components-spinner {
+			margin-top: 0;
+		}
+	}
+
+	&__send-test {
+		.components-button + .components-button {
+			margin-left: 12px;
+		}
+	}
+}
+
+.editor-post-publish-panel__prepublish {
+	.components-notice {
+		margin: 0;
+	}
 }

--- a/src/editor/sidebar/style.scss
+++ b/src/editor/sidebar/style.scss
@@ -38,6 +38,17 @@
 		}
 	}
 
+	&__name-textcontrol {
+		margin-top: 8px;
+	}
+
+	&__subject-textcontrol,
+	&__to-selectcontrol {
+		.components-base-control__label {
+			font-weight: 600;
+		}
+	}
+
 	&__send-test {
 		.components-button + .components-button {
 			margin-left: 12px;

--- a/src/editor/sidebar/style.scss
+++ b/src/editor/sidebar/style.scss
@@ -54,6 +54,14 @@
 			margin-left: 12px;
 		}
 	}
+
+	&__pre-publish-errors {
+		margin: 0;
+
+		> li:last-child {
+			margin-bottom: 0;
+		}
+	}
 }
 
 .editor-post-publish-panel__prepublish {

--- a/src/editor/utils.js
+++ b/src/editor/utils.js
@@ -1,6 +1,7 @@
 /**
  * WordPress dependencies
  */
+import { Notice } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 
 const validateCampaign = campaign => {
@@ -10,18 +11,32 @@ const validateCampaign = campaign => {
 
 	const messages = [];
 	if ( 'sent' === status || 'sending' === status ) {
-		messages.push( __( 'Newsletter has already been sent', 'newspack-newsletters' ) );
+		messages.push(
+			<Notice status="error" isDismissible={ false }>
+				{ __( 'Newsletter has already been sent.', 'newspack-newsletters' ) }
+			</Notice>
+		);
 	}
 	if ( ! listId ) {
 		messages.push(
-			__( 'A Mailchimp list must be selected before publishing.', 'newspack-newsletters' )
+			<Notice status="error" isDismissible={ false }>
+				{ __( 'A Mailchimp list must be selected before publishing.', 'newspack-newsletters' ) }
+			</Notice>
 		);
 	}
 	if ( ! senderName || senderName.length < 1 ) {
-		messages.push( __( 'Sender name must be set.', 'newspack-newsletters' ) );
+		messages.push(
+			<Notice status="error" isDismissible={ false }>
+				{ __( 'Sender name must be set.', 'newspack-newsletters' ) }
+			</Notice>
+		);
 	}
 	if ( ! senderEmail || senderEmail.length < 1 ) {
-		messages.push( __( 'Sender email must be set.', 'newspack-newsletters' ) );
+		messages.push(
+			<Notice status="error" isDismissible={ false }>
+				{ __( 'Sender email must be set.', 'newspack-newsletters' ) }
+			</Notice>
+		);
 	}
 
 	return messages;

--- a/src/editor/utils.js
+++ b/src/editor/utils.js
@@ -1,7 +1,6 @@
 /**
  * WordPress dependencies
  */
-import { Notice } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 
 const validateCampaign = campaign => {
@@ -11,32 +10,18 @@ const validateCampaign = campaign => {
 
 	const messages = [];
 	if ( 'sent' === status || 'sending' === status ) {
-		messages.push(
-			<Notice status="error" isDismissible={ false }>
-				{ __( 'Newsletter has already been sent.', 'newspack-newsletters' ) }
-			</Notice>
-		);
+		messages.push( __( 'Newsletter has already been sent.', 'newspack-newsletters' ) );
 	}
 	if ( ! listId ) {
 		messages.push(
-			<Notice status="error" isDismissible={ false }>
-				{ __( 'A Mailchimp list must be selected before publishing.', 'newspack-newsletters' ) }
-			</Notice>
+			__( 'A Mailchimp list must be selected before publishing.', 'newspack-newsletters' )
 		);
 	}
 	if ( ! senderName || senderName.length < 1 ) {
-		messages.push(
-			<Notice status="error" isDismissible={ false }>
-				{ __( 'Sender name must be set.', 'newspack-newsletters' ) }
-			</Notice>
-		);
+		messages.push( __( 'Sender name must be set.', 'newspack-newsletters' ) );
 	}
 	if ( ! senderEmail || senderEmail.length < 1 ) {
-		messages.push(
-			<Notice status="error" isDismissible={ false }>
-				{ __( 'Sender email must be set.', 'newspack-newsletters' ) }
-			</Notice>
-		);
+		messages.push( __( 'Sender email must be set.', 'newspack-newsletters' ) );
 	}
 
 	return messages;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR wraps the pre-check error messages into a `Notice` component.

I've also reorganised the sidebar settings.

### How to test the changes in this Pull Request:

1. Switch to this branch
2. Try to publish without selecting a list and/or a sender name/email (you should see the error(s))

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
