### PR TITLE
fix: include vendor in release package

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,6 +46,9 @@ jobs:
     steps:
       - checkout_with_workspace
       - run:
+          name: Install PHP dependencies
+          command: composer install --no-dev --no-scripts
+      - run:
           name: Release new version
           command: npm run release
 

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 /node_modules/
 /dist/
 .DS_Store
+release

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "lint:js:staged": "eslint --ext .js,.jsx",
     "lint:scss:staged": "stylelint --syntax scss",
     "lint:php:staged": "./vendor/bin/phpcs",
-    "release:archive": "mkdir -p release && zip -r release/newspack-newsletters.zip . -x node_modules/\\* .git/\\* .github/\\* .gitignore .DS_Store vendor/\\*",
+    "release:archive": "mkdir -p release && zip -r release/newspack-newsletters.zip . -x node_modules/\\* .git/\\* .github/\\* .gitignore .DS_Store/\\*",
     "release": "npm run build && npm run semantic-release"
   },
   "lint-staged": {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Production code uses composer packages, so they should be included in the release zip.

### How to test the changes in this Pull Request:

1. Remove `vendor` folder
2. Run `composer install --no-dev --no-scripts`
3. Run `npm run release:archive`
1. Observe that a `release/newspack-newsletters.zip` files has been created
1. Add the plugin manually on a WP site
1. All should work as expected

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
