### PR TITLE
Fix modal content background and preview items since Gutenberg 7.9

### DIFF
--- a/src/components/template-modal/style.scss
+++ b/src/components/template-modal/style.scss
@@ -44,7 +44,10 @@
 	}
 
 	&__content {
-		height: calc( 100% - 24px - 60px );
+		background: $light-gray-200;
+		height: calc( 100% - 36px );
+		margin: -24px;
+		padding: 24px;
 
 		@media only screen and ( min-width: 600px ) {
 			display: grid;
@@ -96,12 +99,17 @@
 				padding: 0 0 100%;
 				position: relative;
 				width: 100%;
+
+				.block-editor-block-preview__container {
+					position: absolute;
+				}
 			}
 		}
 	}
 
 	&__preview {
 		align-items: center;
+		background: white;
 		border: 1px solid $light-gray-500;
 		border-radius: 2px;
 		display: none;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR fixes a few visual inconsistencies since Gutenberg 7.9
It adds a light background to the content of the modal and fixes the height of the layout thumbnails.

### How to test the changes in this Pull Request:

1. Make sure you have the latest version of Gutenberg
2. Add a new Newsletter and admire the bugs! 😱 
3. Switch to this branch
4. Try to add a new Newsletter... it should look better now 😅 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
