### PR TITLE
Change logo size to medium

### DIFF
--- a/includes/class-newspack-newsletters.php
+++ b/includes/class-newspack-newsletters.php
@@ -556,7 +556,7 @@ final class Newspack_Newsletters {
 	public static function template_token_replacement( $content, $extra = [] ) {
 		$sitename       = get_bloginfo( 'name' );
 		$custom_logo_id = get_theme_mod( 'custom_logo' );
-		$logo           = $custom_logo_id ? wp_get_attachment_image_src( $custom_logo_id, 'thumbnail' )[0] : null;
+		$logo           = $custom_logo_id ? wp_get_attachment_image_src( $custom_logo_id, 'medium' )[0] : null;
 
 		$sitename_block = sprintf(
 			'<!-- wp:heading {"align":"center","level":1} --><h1 class="has-text-align-center">%s</h1><!-- /wp:heading -->',
@@ -564,7 +564,7 @@ final class Newspack_Newsletters {
 		);
 
 		$logo_block = $logo ? sprintf(
-			'<!-- wp:image {"align":"center","id":%s,"sizeSlug":"thumbnail"} --><figure class="wp-block-image aligncenter size-thumbnail"><img src="%s" alt="%s" class="wp-image-%s" /></figure><!-- /wp:image -->',
+			'<!-- wp:image {"align":"center","id":%s,"sizeSlug":"medium"} --><figure class="wp-block-image aligncenter size-medium"><img src="%s" alt="%s" class="wp-image-%s" /></figure><!-- /wp:image -->',
 			$custom_logo_id,
 			$logo,
 			$sitename,


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Thumbnail size will automatically crop a logo to a square which is not ideal when most logos aren't 1:1.

Instead this PR uses the Medium size. If it's too large for a user, they can use the Image Dimensions settings.

__Before:__

<img width="1552" alt="1 before" src="https://user-images.githubusercontent.com/177929/79442615-b1bb7900-7fd0-11ea-945b-a12ddfe79c3f.png">

__After:__

<img width="1552" alt="2 after" src="https://user-images.githubusercontent.com/177929/79442626-b7b15a00-7fd0-11ea-9a94-6b8b4a914a36.png">

### How to test the changes in this Pull Request:

1. Update your site logo to something else other than a square or circle (you can test with this [cool Newspack logo](https://user-images.githubusercontent.com/177929/79442538-951f4100-7fd0-11ea-839f-47839077f72e.png))
2. Add a new Newsletter. Notice your logo is now cropped.
3. Switch to this branch.
4. Add another new Newsletter. This time your logo should be displayed properly.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
