### PR TITLE
Prevent modal closing after autosave

### DIFF
--- a/src/editor/index.js
+++ b/src/editor/index.js
@@ -48,7 +48,7 @@ const NewsletterEdit = ( {
 	getBlocks,
 	insertBlocks,
 	replaceBlocks,
-	isEditedPostNew,
+	isEditedPostEmpty,
 	savePost,
 } ) => {
 	const templates =
@@ -70,7 +70,7 @@ const NewsletterEdit = ( {
 	};
 
 	const isDisplayingTemplateModal =
-		isEditedPostNew && templates && templates.length && insertedTemplate === null;
+		isEditedPostEmpty && templates && templates.length && insertedTemplate === null;
 
 	return isDisplayingTemplateModal ? (
 		<TemplateModal
@@ -94,10 +94,10 @@ const NewsletterEdit = ( {
 
 const NewsletterEditWithSelect = compose( [
 	withSelect( select => {
-		const { isEditedPostNew } = select( 'core/editor' );
+		const { isEditedPostEmpty } = select( 'core/editor' );
 		const { getBlocks } = select( 'core/block-editor' );
 		return {
-			isEditedPostNew: isEditedPostNew(),
+			isEditedPostEmpty: isEditedPostEmpty(),
 			getBlocks,
 		};
 	} ),


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes #45 

### How to test the changes in this Pull Request:

1. Create new newsletter 
2. Wait for a minute
3. Observe that the URL has changed (post has been saved), but the modal is still visible
1. Reload the page, the modal should still be visible as there is no content
1. Add some content, save draft, reload page – observe that the modal is not there anymore

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
