### PR TITLE
Delete Mailchimp Campaign After Post Is Trashed

### DIFF
--- a/includes/class-newspack-newsletters.php
+++ b/includes/class-newspack-newsletters.php
@@ -48,7 +48,7 @@ final class Newspack_Newsletters {
 		add_action( 'enqueue_block_editor_assets', [ __CLASS__, 'disable_gradients' ] );
 		add_action( 'rest_api_init', [ __CLASS__, 'rest_api_init' ] );
 		add_action( 'default_title', [ __CLASS__, 'default_title' ], 10, 2 );
-		add_action( 'save_post_' . self::NEWSPACK_NEWSLETTERS_CPT, [ __CLASS__, 'save_post' ], 10, 3 );
+		add_action( 'save_post_' . self::NEWSPACK_NEWSLETTERS_CPT, [ __CLASS__, 'save_post' ], 10, 2 );
 		add_action( 'publish_' . self::NEWSPACK_NEWSLETTERS_CPT, [ __CLASS__, 'send_campaign' ], 10, 2 );
 		add_action( 'wp_trash_post', [ __CLASS__, 'trash_post' ], 10, 1 );
 		add_filter( 'allowed_block_types', [ __CLASS__, 'newsletters_allowed_block_types' ], 10, 2 );
@@ -429,14 +429,13 @@ final class Newspack_Newsletters {
 	 *
 	 * @param string  $id post ID.
 	 * @param WP_Post $post the post.
-	 * @param boolean $update whether it's an update.
 	 */
-	public static function save_post( $id, $post, $update ) {
+	public static function save_post( $id, $post ) {
 		$status = get_post_status( $id );
 		if ( 'trash' === $status ) {
 			return;
 		}
-		self::sync_with_mailchimp( $post, $update );
+		self::sync_with_mailchimp( $post );
 	}
 
 	/**
@@ -469,9 +468,8 @@ final class Newspack_Newsletters {
 	 * Synchronize CPT with Mailchimp campaign.
 	 *
 	 * @param WP_Post $post the post.
-	 * @param boolean $update whether it's an update.
 	 */
-	public static function sync_with_mailchimp( $post, $update = false ) {
+	public static function sync_with_mailchimp( $post ) {
 		$api_key = self::mailchimp_api_key();
 		if ( ! $api_key ) {
 			return new WP_Error(
@@ -491,7 +489,6 @@ final class Newspack_Newsletters {
 		];
 
 		$mc_campaign_id = null;
-		$campaign       = null;
 
 		$mc_campaign_id = get_post_meta( $post->ID, 'mc_campaign_id', true );
 		if ( $mc_campaign_id ) {
@@ -549,7 +546,7 @@ final class Newspack_Newsletters {
 			);
 		}
 
-		$sync_result = self::sync_with_mailchimp( $post, true );
+		$sync_result = self::sync_with_mailchimp( $post );
 
 		if ( is_wp_error( $sync_result ) ) {
 			return $sync_result;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

When a newsletter is trashed, the corresponding Mailchimp campaign will be deleted. The campaign deletion occurs when the newsletter is trashed, _not_ when permanently deleted. Campaigns that have already been sent will not be deleted in Mailchimp, only drafts. If a trashed newsletter is restored, a new Mailchimp campaign will be created with the post content.

@adekbadek note I had to unravel the `$update` logic we discussed so that a new campaign is always created if the post doesn't have a campaign id stored. Let me know if you think this is problematic.

Closes https://github.com/Automattic/newspack-newsletters/issues/29

### How to test the changes in this Pull Request:

1. Create a newsletter, populate with a template, save. Observe the corresponding campaign is created in Mailchimp.
2. Trash the newsletter in WordPress. Observe the corresponding campaign is deleted in Mailchimp.
3. Restore the newsletter. Observe a new campaign is created in Mailchimp.
4. Send the newsletter.
5. Trash the newsletter. Observe the campaign in Mailchimp is NOT deleted, since it has been sent.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
