### PR TITLE
Support Multiple Test Emails

### DIFF
--- a/includes/class-newspack-newsletters.php
+++ b/includes/class-newspack-newsletters.php
@@ -178,7 +178,7 @@ final class Newspack_Newsletters {
 						'sanitize_callback' => 'absint',
 					],
 					'test_email' => [
-						'sanitize_callback' => 'sanitize_email',
+						'sanitize_callback' => 'sanitize_text_field',
 					],
 				],
 			]
@@ -357,8 +357,6 @@ final class Newspack_Newsletters {
 				__( 'Post is not a Newsletter.', 'newspack-newsletters' )
 			);
 		}
-
-
 		$mc_campaign_id = get_post_meta( $id, 'mc_campaign_id', true );
 		if ( ! $mc_campaign_id ) {
 			return new WP_Error(
@@ -367,11 +365,14 @@ final class Newspack_Newsletters {
 			);
 		}
 
-		$mc      = new Mailchimp( self::mailchimp_api_key() );
+		$mc = new Mailchimp( self::mailchimp_api_key() );
+
+		$test_emails = explode( ',', $test_email );
+		foreach ( $test_emails as &$email ) {
+			$email = sanitize_email( trim( $email ) );
+		}
 		$payload = [
-			'test_emails' => [
-				$test_email,
-			],
+			'test_emails' => $test_emails,
 			'send_type'   => 'html',
 		];
 		$result  = $mc->post( "campaigns/$mc_campaign_id/actions/test", $payload );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Adds support for multiple test emails.

Closes https://github.com/Automattic/newspack-newsletters/issues/57

### How to test the changes in this Pull Request:

1. Create a new Newsletter, and populate with a template.
2. In Sidebar click `Send Test`.
3. Observe the help text below the text input.
4. Input multiple email addresses, separated by commas.
5. Verify all emails receive the test email.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
