### PR TITLE
API Key Modal

### DIFF
--- a/package.json
+++ b/package.json
@@ -105,6 +105,7 @@
     "@wordpress/keycodes": "^2.10.0",
     "@wordpress/plugins": "^2.13.0",
     "@wordpress/url": "^2.13.0",
+    "classnames": "^2.2.6",
     "lodash": "^4.17.15",
     "newspack-components": "^1.1.0",
     "webpack": "^4.42.1"

--- a/src/components/template-modal/index.js
+++ b/src/components/template-modal/index.js
@@ -25,8 +25,8 @@ export default ( { hasKeys, onInsertTemplate, onSetupStatus, templates } ) => {
 			shouldCloseOnEsc={ false }
 			title={
 				hasKeys
-					? __( 'Select a layout', 'newspack-newsletters' )
-					: __( 'Set up', 'newspack-newsletters' )
+					? __( 'Select a layout for your newsletter', 'newspack-newsletters' )
+					: __( 'Configure the newsletters', 'newspack-newsletters' )
 			}
 		>
 			{ hasKeys ? (

--- a/src/components/template-modal/index.js
+++ b/src/components/template-modal/index.js
@@ -5,88 +5,35 @@
 /**
  * WordPress dependencies
  */
-import { parse } from '@wordpress/blocks';
-import { __, sprintf } from '@wordpress/i18n';
-import { Component } from '@wordpress/element';
-import { Button, Modal } from '@wordpress/components';
-import { ENTER, SPACE } from '@wordpress/keycodes';
-import { BlockPreview } from '@wordpress/block-editor';
+import { Modal } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
  */
+import TemplatePicker from './screens/template-picker';
+import APIKeys from './screens/api-keys';
 import './style.scss';
 
-class TemplateModal extends Component {
-	generateBlockPreview = () => {
-		const { selectedTemplate, templates } = this.props;
-		return templates && templates[ selectedTemplate ]
-			? parse( templates[ selectedTemplate ].content )
-			: null;
-	};
-	render = () => {
-		const { onInsertTemplate, onSelectTemplate, selectedTemplate, templates } = this.props;
-		const blockPreview = this.generateBlockPreview();
-		return (
-			<Modal
-				className="newspack-newsletters-modal__frame"
-				isDismissible={ false }
-				overlayClassName="newspack-newsletters-modal__screen-overlay"
-				shouldCloseOnClickOutside={ false }
-				shouldCloseOnEsc={ false }
-				title={ __( 'Select a layout', 'newspack-newsletters' ) }
-			>
-				<div className="newspack-newsletters-modal__content">
-					<div className="newspack-newsletters-modal__patterns">
-						<div className="block-editor-patterns">
-							{ ( templates || [] ).map( ( { title, content }, index ) => (
-								<div
-									key={ index }
-									className={
-										selectedTemplate === index
-											? 'selected block-editor-patterns__item'
-											: 'block-editor-patterns__item'
-									}
-									onClick={ () => onSelectTemplate( index ) }
-									onKeyDown={ event => {
-										if ( ENTER === event.keyCode || SPACE === event.keyCode ) {
-											event.preventDefault();
-											onSelectTemplate( index );
-										}
-									} }
-									role="button"
-									tabIndex="0"
-									aria-label={ title }
-								>
-									<div className="block-editor-patterns__item-preview">
-										<BlockPreview blocks={ parse( content ) } viewportWidth={ 810 } />
-									</div>
-									<div className="block-editor-patterns__item-title">{ title }</div>
-								</div>
-							) ) }
-						</div>
-					</div>
-
-					<div className="newspack-newsletters-modal__preview">
-						{ blockPreview && blockPreview.length > 0 ? (
-							<BlockPreview blocks={ blockPreview } viewportWidth={ 810 } />
-						) : (
-							<p>{ __( 'Select a layout to preview.', 'newspack-newsletters' ) }</p>
-						) }
-					</div>
-				</div>
-
-				{ selectedTemplate !== null && (
-					<Button isPrimary onClick={ () => onInsertTemplate( selectedTemplate ) }>
-						{ sprintf(
-							__( 'Use %s layout', 'newspack-newsletter' ),
-							templates[ selectedTemplate ].title
-						) }
-					</Button>
-				) }
-			</Modal>
-		);
-	};
-}
-
-export default TemplateModal;
+export default ( { hasKeys, onInsertTemplate, onSetupStatus, templates } ) => {
+	return (
+		<Modal
+			className="newspack-newsletters-modal__frame"
+			isDismissible={ false }
+			overlayClassName="newspack-newsletters-modal__screen-overlay"
+			shouldCloseOnClickOutside={ false }
+			shouldCloseOnEsc={ false }
+			title={
+				hasKeys
+					? __( 'Select a layout', 'newspack-newsletters' )
+					: __( 'Set up', 'newspack-newsletters' )
+			}
+		>
+			{ hasKeys ? (
+				<TemplatePicker templates={ templates } onInsertTemplate={ onInsertTemplate } />
+			) : (
+				<APIKeys onSetupStatus={ onSetupStatus } />
+			) }
+		</Modal>
+	);
+};

--- a/src/components/template-modal/screens/api-keys/index.js
+++ b/src/components/template-modal/screens/api-keys/index.js
@@ -1,0 +1,117 @@
+/**
+ * WordPress dependencies
+ */
+import apiFetch from '@wordpress/api-fetch';
+import { Button, ExternalLink, Spinner, TextControl } from '@wordpress/components';
+import { Fragment, useEffect, useState } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import { ENTER } from '@wordpress/keycodes';
+
+export default ( { onSetupStatus } ) => {
+	const [ keys, setKeys ] = useState( {} );
+	const [ inFlight, setInFlight ] = useState( false );
+	const [ errors, setErrors ] = useState( {} );
+	const commitSettings = () => {
+		setInFlight( true );
+		setErrors( {} );
+		apiFetch( {
+			path: '/newspack-newsletters/v1/keys',
+			method: 'POST',
+			data: keys,
+		} )
+			.then( results => {
+				setInFlight( false );
+				setKeys( results );
+				onSetupStatus( results.status );
+			} )
+			.catch( handleErrors );
+	};
+	const handleErrors = error => {
+		const allErrors = { [ error.code ]: error.message };
+		( error.additional_errors || [] ).forEach(
+			additionalError => ( allErrors[ additionalError.code ] = additionalError.message )
+		);
+		setErrors( allErrors );
+		setInFlight( false );
+	};
+	useEffect(() => {
+		setInFlight( true );
+		apiFetch( { path: `/newspack-newsletters/v1/keys` } )
+			.then( results => {
+				setInFlight( false );
+				setKeys( results );
+				onSetupStatus( results.status );
+			} )
+			.catch( handleErrors );
+	}, []);
+
+	const {
+		mailchimp_api_key: mailchimpAPIKey = '',
+		mjml_api_key: mjmlApplicationId = '',
+		mjml_api_secret: mjmlAPISecret = '',
+	} = keys;
+	return (
+		<Fragment>
+			<div className="newspack-newsletters-modal__content">
+				<div>
+					<h4>{ __( 'Enter your Mailchimp API key', 'newspack-newsletters' ) }</h4>
+					{ errors.newspack_newsletters_invalid_keys_mailchimp && (
+						<p className="error">{ errors.newspack_newsletters_invalid_keys_mailchimp }</p>
+					) }
+					<TextControl
+						label={ __( 'Mailchimp API Key', 'newspack-newsletters' ) }
+						value={ mailchimpAPIKey }
+						onChange={ value => setKeys( { ...keys, mailchimp_api_key: value } ) }
+						disabled={ inFlight }
+						onKeyDown={ event => {
+							if ( ENTER === event.keyCode ) {
+								event.preventDefault();
+								commitSettings();
+							}
+						} }
+					/>
+					{ inFlight && <Spinner /> }
+					<ExternalLink href="https://mailchimp.com/help/about-api-keys/">
+						{ __( 'About Mailchimp API keys', 'newspack-newsletters' ) }
+					</ExternalLink>
+					<h4>{ __( 'Enter your MJML API keys', 'newspack-newsletters' ) }</h4>
+					{ errors.newspack_newsletters_invalid_keys_mjml && (
+						<p className="error">{ errors.newspack_newsletters_invalid_keys_mjml }</p>
+					) }
+					<TextControl
+						label={ __( 'MJML Application ID', 'newspack-newsletters' ) }
+						value={ mjmlApplicationId }
+						onChange={ value => setKeys( { ...keys, mjml_api_key: value } ) }
+						disabled={ inFlight }
+						onKeyDown={ event => {
+							if ( ENTER === event.keyCode ) {
+								event.preventDefault();
+								commitSettings();
+							}
+						} }
+					/>
+					{ inFlight && <Spinner /> }
+					<TextControl
+						label={ __( 'MJML Secret Key', 'newspack-newsletters' ) }
+						value={ mjmlAPISecret }
+						onChange={ value => setKeys( { ...keys, mjml_api_secret: value } ) }
+						disabled={ inFlight }
+						onKeyDown={ event => {
+							if ( ENTER === event.keyCode ) {
+								event.preventDefault();
+								commitSettings();
+							}
+						} }
+					/>
+					{ inFlight && <Spinner /> }
+					<ExternalLink href="https://mjml.io/api">
+						{ __( 'Request MJML API keys', 'newspack-newsletters' ) }
+					</ExternalLink>
+				</div>
+			</div>
+			<Button isPrimary onClick={ commitSettings }>
+				{ __( 'Save Settings', 'newspack-newsletter' ) }
+			</Button>
+		</Fragment>
+	);
+};

--- a/src/components/template-modal/screens/api-keys/index.js
+++ b/src/components/template-modal/screens/api-keys/index.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import apiFetch from '@wordpress/api-fetch';
-import { Button, ExternalLink, Spinner, TextControl } from '@wordpress/components';
+import { Button, ExternalLink, TextControl } from '@wordpress/components';
 import { Fragment, useEffect, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { ENTER } from '@wordpress/keycodes';
@@ -50,6 +50,8 @@ export default ( { onSetupStatus } ) => {
 		mjml_api_key: mjmlApplicationId = '',
 		mjml_api_secret: mjmlAPISecret = '',
 	} = keys;
+	const canSubmit =
+		mailchimpAPIKey.length > 0 && mjmlApplicationId.length > 0 && mjmlAPISecret.length > 0;
 	return (
 		<Fragment>
 			<div className="newspack-newsletters-modal__content newspack-newsletters-modal__settings">
@@ -61,7 +63,7 @@ export default ( { onSetupStatus } ) => {
 						onChange={ value => setKeys( { ...keys, mailchimp_api_key: value } ) }
 						disabled={ inFlight }
 						onKeyDown={ event => {
-							if ( ENTER === event.keyCode ) {
+							if ( canSubmit && ENTER === event.keyCode ) {
 								event.preventDefault();
 								commitSettings();
 							}
@@ -71,7 +73,6 @@ export default ( { onSetupStatus } ) => {
 					{ errors.newspack_newsletters_invalid_keys_mailchimp && (
 						<p className="error">{ errors.newspack_newsletters_invalid_keys_mailchimp }</p>
 					) }
-					{ inFlight && <Spinner /> }
 					<p>
 						<ExternalLink href="https://us1.admin.mailchimp.com/account/api/">
 							{ __( 'Generate Mailchimp API key', 'newspack-newsletters' ) }
@@ -89,7 +90,7 @@ export default ( { onSetupStatus } ) => {
 						onChange={ value => setKeys( { ...keys, mjml_api_key: value } ) }
 						disabled={ inFlight }
 						onKeyDown={ event => {
-							if ( ENTER === event.keyCode ) {
+							if ( canSubmit && ENTER === event.keyCode ) {
 								event.preventDefault();
 								commitSettings();
 							}
@@ -102,7 +103,7 @@ export default ( { onSetupStatus } ) => {
 						onChange={ value => setKeys( { ...keys, mjml_api_secret: value } ) }
 						disabled={ inFlight }
 						onKeyDown={ event => {
-							if ( ENTER === event.keyCode ) {
+							if ( canSubmit && ENTER === event.keyCode ) {
 								event.preventDefault();
 								commitSettings();
 							}
@@ -112,7 +113,6 @@ export default ( { onSetupStatus } ) => {
 					{ errors.newspack_newsletters_invalid_keys_mjml && (
 						<p className="error">{ errors.newspack_newsletters_invalid_keys_mjml }</p>
 					) }
-					{ inFlight && <Spinner /> }
 					<p>
 						<ExternalLink href="https://mjml.io/api">
 							{ __( 'Request MJML API keys', 'newspack-newsletters' ) }
@@ -120,7 +120,7 @@ export default ( { onSetupStatus } ) => {
 					</p>
 				</div>
 			</div>
-			<Button isPrimary onClick={ commitSettings }>
+			<Button isPrimary onClick={ commitSettings } disabled={ inFlight || ! canSubmit }>
 				{ __( 'Save settings', 'newspack-newsletter' ) }
 			</Button>
 		</Fragment>

--- a/src/components/template-modal/screens/api-keys/index.js
+++ b/src/components/template-modal/screens/api-keys/index.js
@@ -10,7 +10,7 @@ import { ENTER } from '@wordpress/keycodes';
 /**
  * External dependencies
  */
-import classNames from 'classnames';
+import classnames from 'classnames';
 
 export default ( { onSetupStatus } ) => {
 	const [ keys, setKeys ] = useState( {} );
@@ -57,7 +57,7 @@ export default ( { onSetupStatus } ) => {
 	} = keys;
 	const canSubmit =
 		mailchimpAPIKey.length > 0 && mjmlApplicationId.length > 0 && mjmlAPISecret.length > 0;
-	const classes = classNames(
+	const classes = classnames(
 		'newspack-newsletters-modal__content',
 		'newspack-newsletters-modal__settings',
 		inFlight && 'newspack-newsletters-modal__in-flight'

--- a/src/components/template-modal/screens/api-keys/index.js
+++ b/src/components/template-modal/screens/api-keys/index.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import apiFetch from '@wordpress/api-fetch';
-import { Button, ExternalLink, TextControl } from '@wordpress/components';
+import { Button, ExternalLink, Spinner, TextControl } from '@wordpress/components';
 import { Fragment, useEffect, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { ENTER } from '@wordpress/keycodes';
@@ -66,6 +66,7 @@ export default ( { onSetupStatus } ) => {
 		<Fragment>
 			<div className={ classes }>
 				<div className="newspack-newsletters-modal__settings-wrapper">
+					{ inFlight && <Spinner /> }
 					<h4>{ __( 'Enter your Mailchimp API key', 'newspack-newsletters' ) }</h4>
 					<TextControl
 						label={ __( 'Mailchimp API key', 'newspack-newsletters' ) }

--- a/src/components/template-modal/screens/api-keys/index.js
+++ b/src/components/template-modal/screens/api-keys/index.js
@@ -7,6 +7,11 @@ import { Fragment, useEffect, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { ENTER } from '@wordpress/keycodes';
 
+/**
+ * External dependencies
+ */
+import classNames from 'classnames';
+
 export default ( { onSetupStatus } ) => {
 	const [ keys, setKeys ] = useState( {} );
 	const [ inFlight, setInFlight ] = useState( false );
@@ -52,9 +57,14 @@ export default ( { onSetupStatus } ) => {
 	} = keys;
 	const canSubmit =
 		mailchimpAPIKey.length > 0 && mjmlApplicationId.length > 0 && mjmlAPISecret.length > 0;
+	const classes = classNames(
+		'newspack-newsletters-modal__content',
+		'newspack-newsletters-modal__settings',
+		inFlight && 'newspack-newsletters-modal__in-flight'
+	);
 	return (
 		<Fragment>
-			<div className="newspack-newsletters-modal__content newspack-newsletters-modal__settings">
+			<div className={ classes }>
 				<div className="newspack-newsletters-modal__settings-wrapper">
 					<h4>{ __( 'Enter your Mailchimp API key', 'newspack-newsletters' ) }</h4>
 					<TextControl

--- a/src/components/template-modal/screens/api-keys/index.js
+++ b/src/components/template-modal/screens/api-keys/index.js
@@ -52,14 +52,11 @@ export default ( { onSetupStatus } ) => {
 	} = keys;
 	return (
 		<Fragment>
-			<div className="newspack-newsletters-modal__content">
-				<div>
+			<div className="newspack-newsletters-modal__content newspack-newsletters-modal__settings">
+				<div className="newspack-newsletters-modal__settings-wrapper">
 					<h4>{ __( 'Enter your Mailchimp API key', 'newspack-newsletters' ) }</h4>
-					{ errors.newspack_newsletters_invalid_keys_mailchimp && (
-						<p className="error">{ errors.newspack_newsletters_invalid_keys_mailchimp }</p>
-					) }
 					<TextControl
-						label={ __( 'Mailchimp API Key', 'newspack-newsletters' ) }
+						label={ __( 'Mailchimp API key', 'newspack-newsletters' ) }
 						value={ mailchimpAPIKey }
 						onChange={ value => setKeys( { ...keys, mailchimp_api_key: value } ) }
 						disabled={ inFlight }
@@ -69,17 +66,25 @@ export default ( { onSetupStatus } ) => {
 								commitSettings();
 							}
 						} }
+						className={ errors.newspack_newsletters_invalid_keys_mailchimp && 'has-error' }
 					/>
-					{ inFlight && <Spinner /> }
-					<ExternalLink href="https://mailchimp.com/help/about-api-keys/">
-						{ __( 'About Mailchimp API keys', 'newspack-newsletters' ) }
-					</ExternalLink>
-					<h4>{ __( 'Enter your MJML API keys', 'newspack-newsletters' ) }</h4>
-					{ errors.newspack_newsletters_invalid_keys_mjml && (
-						<p className="error">{ errors.newspack_newsletters_invalid_keys_mjml }</p>
+					{ errors.newspack_newsletters_invalid_keys_mailchimp && (
+						<p className="error">{ errors.newspack_newsletters_invalid_keys_mailchimp }</p>
 					) }
+					{ inFlight && <Spinner /> }
+					<p>
+						<ExternalLink href="https://us1.admin.mailchimp.com/account/api/">
+							{ __( 'Generate Mailchimp API key', 'newspack-newsletters' ) }
+						</ExternalLink>
+						<span className="separator"> | </span>
+						<ExternalLink href="https://mailchimp.com/help/about-api-keys/">
+							{ __( 'About Mailchimp API keys', 'newspack-newsletters' ) }
+						</ExternalLink>
+					</p>
+					<hr />
+					<h4>{ __( 'Enter your MJML API keys', 'newspack-newsletters' ) }</h4>
 					<TextControl
-						label={ __( 'MJML Application ID', 'newspack-newsletters' ) }
+						label={ __( 'MJML application ID', 'newspack-newsletters' ) }
 						value={ mjmlApplicationId }
 						onChange={ value => setKeys( { ...keys, mjml_api_key: value } ) }
 						disabled={ inFlight }
@@ -89,10 +94,10 @@ export default ( { onSetupStatus } ) => {
 								commitSettings();
 							}
 						} }
+						className={ errors.newspack_newsletters_invalid_keys_mjml && 'has-error' }
 					/>
-					{ inFlight && <Spinner /> }
 					<TextControl
-						label={ __( 'MJML Secret Key', 'newspack-newsletters' ) }
+						label={ __( 'MJML secret key', 'newspack-newsletters' ) }
 						value={ mjmlAPISecret }
 						onChange={ value => setKeys( { ...keys, mjml_api_secret: value } ) }
 						disabled={ inFlight }
@@ -102,15 +107,21 @@ export default ( { onSetupStatus } ) => {
 								commitSettings();
 							}
 						} }
+						className={ errors.newspack_newsletters_invalid_keys_mjml && 'has-error' }
 					/>
+					{ errors.newspack_newsletters_invalid_keys_mjml && (
+						<p className="error">{ errors.newspack_newsletters_invalid_keys_mjml }</p>
+					) }
 					{ inFlight && <Spinner /> }
-					<ExternalLink href="https://mjml.io/api">
-						{ __( 'Request MJML API keys', 'newspack-newsletters' ) }
-					</ExternalLink>
+					<p>
+						<ExternalLink href="https://mjml.io/api">
+							{ __( 'Request MJML API keys', 'newspack-newsletters' ) }
+						</ExternalLink>
+					</p>
 				</div>
 			</div>
 			<Button isPrimary onClick={ commitSettings }>
-				{ __( 'Save Settings', 'newspack-newsletter' ) }
+				{ __( 'Save settings', 'newspack-newsletter' ) }
 			</Button>
 		</Fragment>
 	);

--- a/src/components/template-modal/screens/template-picker/index.js
+++ b/src/components/template-modal/screens/template-picker/index.js
@@ -4,7 +4,7 @@
 import { parse } from '@wordpress/blocks';
 import { Fragment, useState } from '@wordpress/element';
 import { Button } from '@wordpress/components';
-import { __, sprintf } from '@wordpress/i18n';
+import { __ } from '@wordpress/i18n';
 import { BlockPreview } from '@wordpress/block-editor';
 import { ENTER, SPACE } from '@wordpress/keycodes';
 
@@ -60,10 +60,9 @@ export default ( { onInsertTemplate, templates } ) => {
 			</div>
 			{ selectedTemplate !== null && (
 				<Button isPrimary onClick={ () => onInsertTemplate( selectedTemplate ) }>
-					{ sprintf(
-						__( 'Use %s layout', 'newspack-newsletter' ),
-						templates[ selectedTemplate ].title
-					) }
+					{ blockPreview && blockPreview.length > 0
+						? __( 'Use this layout', 'newspack-newsletters' )
+						: __( 'Use blank layout', 'newspack-newsletters' ) }
 				</Button>
 			) }
 		</Fragment>

--- a/src/components/template-modal/screens/template-picker/index.js
+++ b/src/components/template-modal/screens/template-picker/index.js
@@ -1,0 +1,71 @@
+/**
+ * WordPress dependencies
+ */
+import { parse } from '@wordpress/blocks';
+import { Fragment, useState } from '@wordpress/element';
+import { Button } from '@wordpress/components';
+import { __, sprintf } from '@wordpress/i18n';
+import { BlockPreview } from '@wordpress/block-editor';
+import { ENTER, SPACE } from '@wordpress/keycodes';
+
+export default ( { onInsertTemplate, templates } ) => {
+	const [ selectedTemplate, setSelectedTemplate ] = useState( 0 );
+	const generateBlockPreview = () => {
+		return templates && templates[ selectedTemplate ]
+			? parse( templates[ selectedTemplate ].content )
+			: null;
+	};
+	const blockPreview = generateBlockPreview();
+
+	return (
+		<Fragment>
+			<div className="newspack-newsletters-modal__content">
+				<div className="newspack-newsletters-modal__patterns">
+					<div className="block-editor-patterns">
+						{ ( templates || [] ).map( ( { title, content }, index ) => (
+							<div
+								key={ index }
+								className={
+									selectedTemplate === index
+										? 'selected block-editor-patterns__item'
+										: 'block-editor-patterns__item'
+								}
+								onClick={ () => setSelectedTemplate( index ) }
+								onKeyDown={ event => {
+									if ( ENTER === event.keyCode || SPACE === event.keyCode ) {
+										event.preventDefault();
+										setSelectedTemplate( index );
+									}
+								} }
+								role="button"
+								tabIndex="0"
+								aria-label={ title }
+							>
+								<div className="block-editor-patterns__item-preview">
+									<BlockPreview blocks={ parse( content ) } viewportWidth={ 810 } />
+								</div>
+								<div className="block-editor-patterns__item-title">{ title }</div>
+							</div>
+						) ) }
+					</div>
+				</div>
+
+				<div className="newspack-newsletters-modal__preview">
+					{ blockPreview && blockPreview.length > 0 ? (
+						<BlockPreview blocks={ blockPreview } viewportWidth={ 810 } />
+					) : (
+						<p>{ __( 'Select a layout to preview.', 'newspack-newsletters' ) }</p>
+					) }
+				</div>
+			</div>
+			{ selectedTemplate !== null && (
+				<Button isPrimary onClick={ () => onInsertTemplate( selectedTemplate ) }>
+					{ sprintf(
+						__( 'Use %s layout', 'newspack-newsletter' ),
+						templates[ selectedTemplate ].title
+					) }
+				</Button>
+			) }
+		</Fragment>
+	);
+};

--- a/src/components/template-modal/style.scss
+++ b/src/components/template-modal/style.scss
@@ -4,23 +4,27 @@
 	&__screen-overlay {
 		animation: none;
 		background: white;
-		margin-top: 46px;
+		top: 46px;
 
 		@media only screen and ( min-width: 783px ) {
-			margin-left: 36px;
-			margin-top: 32px;
+			left: 36px;
+			top: 32px;
 
 			// Fullscreen mode
 			.is-fullscreen-mode & {
-				margin-left: 0;
-				margin-top: 0;
+				left: 60px;
+				top: 0;
+
+				.components-modal__header {
+					height: 61px;
+				}
 			}
 		}
 
 		@media only screen and ( min-width: 961px ) {
 			// Not folded sidebar
 			body:not( .folded ):not( .is-fullscreen-mode ) & {
-				margin-left: 160px;
+				left: 160px;
 			}
 		}
 	}
@@ -54,6 +58,19 @@
 			gap: 0 24px;
 			grid-template-columns: 1fr 2fr;
 			grid-template-rows: 1fr;
+		}
+
+		@media only screen and ( min-width: 783px ) {
+			// Fullscreen mode
+			.is-fullscreen-mode & {
+				bottom: 0;
+				height: auto;
+				left: 0;
+				margin: 0;
+				position: fixed;
+				right: 0;
+				top: 61px;
+			}
 		}
 
 		+ .is-primary {

--- a/src/components/template-modal/style.scss
+++ b/src/components/template-modal/style.scss
@@ -62,8 +62,36 @@
 			top: 12px;
 			z-index: 11;
 		}
+	}
+
+	&__settings {
+		@media only screen and ( min-width: 600px ) {
+			display: block;
+
+			&-wrapper {
+				max-width: 600px;
+				width: 66.66%;
+			}
+		}
+
+		h4:first-of-type {
+			margin-top: 0;
+		}
+
+		.components-spinner {
+			margin: 0;
+		}
+
 		.error {
-			color: red;
+			color: $alert-red;
+		}
+
+		.components-base-control {
+			&.has-error {
+				input[type='text'] {
+					border-color: $alert-red;
+				}
+			}
 		}
 	}
 

--- a/src/components/template-modal/style.scss
+++ b/src/components/template-modal/style.scss
@@ -65,12 +65,22 @@
 	}
 
 	&__settings {
-		@media only screen and ( min-width: 600px ) {
-			display: block;
+		align-items: flex-start;
+		display: flex;
+		justify-content: center;
 
-			&-wrapper {
+		@media only screen and ( min-width: 600px ) {
+			display: flex;
+		}
+
+		&-wrapper {
+			flex: 0 0 100%;
+			position: relative;
+
+			@media only screen and ( min-width: 600px ) {
+				margin-left: auto;
+				margin-right: auto;
 				max-width: 600px;
-				width: 66.66%;
 			}
 		}
 
@@ -79,7 +89,11 @@
 		}
 
 		.components-spinner {
-			margin: 0;
+			left: 50%;
+			margin: -9px 0 0 -9px;
+			margin-left: -9px;
+			position: absolute;
+			top: 50%;
 		}
 
 		.error {
@@ -92,6 +106,14 @@
 					border-color: $alert-red;
 				}
 			}
+		}
+	}
+
+	&__in-flight {
+		pointer-events: none;
+
+		> div > *:not( .components-spinner ) {
+			opacity: 0.3;
 		}
 	}
 

--- a/src/components/template-modal/style.scss
+++ b/src/components/template-modal/style.scss
@@ -62,6 +62,9 @@
 			top: 12px;
 			z-index: 11;
 		}
+		.error {
+			color: red;
+		}
 	}
 
 	&__patterns {

--- a/src/editor/index.js
+++ b/src/editor/index.js
@@ -59,8 +59,10 @@ const NewsletterEdit = ( {
 	const templates =
 		window && window.newspack_newsletters_data && window.newspack_newsletters_data.templates;
 
-	const [ selectedTemplate, setSelectedTemplate ] = useState( 0 );
 	const [ insertedTemplate, setInserted ] = useState( null );
+	const [ hasKeys, setHasKeys ] = useState(
+		window && window.newspack_newsletters_data && window.newspack_newsletters_data.has_keys
+	);
 
 	const handleTemplateInsertion = templateIndex => {
 		const template = templates[ templateIndex ];
@@ -73,16 +75,16 @@ const NewsletterEdit = ( {
 		setInserted( templateIndex );
 		setTimeout( savePost, 1 );
 	};
-
 	const isDisplayingTemplateModal =
-		isEditedPostEmpty && templates && templates.length && insertedTemplate === null;
+		! hasKeys ||
+		( isEditedPostEmpty && templates && templates.length && insertedTemplate === null );
 
 	return isDisplayingTemplateModal ? (
 		<TemplateModal
 			templates={ templates }
 			onInsertTemplate={ handleTemplateInsertion }
-			onSelectTemplate={ setSelectedTemplate }
-			selectedTemplate={ selectedTemplate }
+			hasKeys={ hasKeys }
+			onSetupStatus={ status => setHasKeys( status ) }
 		/>
 	) : (
 		<Fragment>

--- a/src/editor/sidebar/index.js
+++ b/src/editor/sidebar/index.js
@@ -6,7 +6,15 @@ import apiFetch from '@wordpress/api-fetch';
 import { compose } from '@wordpress/compose';
 import { withSelect, withDispatch } from '@wordpress/data';
 import { Component, Fragment } from '@wordpress/element';
-import { Button, Modal, Notice, SelectControl, Spinner, TextControl } from '@wordpress/components';
+import {
+	Button,
+	ExternalLink,
+	Modal,
+	Notice,
+	SelectControl,
+	Spinner,
+	TextControl,
+} from '@wordpress/components';
 
 /**
  * External dependencies


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Adds a first screen to the Template Picker modal where users input the API keys needed to use the plugin (Mailchimp and MJML). 

- Refactor of the template picker to support multiple screens. Also refactored using React Hooks.
- New endpoints to get and set the API keys: `newspack-newsletters/v1/keys` GET|POST
- When keys are set they are also verified by pinging the services. 

Notes for @thomasguillot: 
- To avoid confusion I've left this completely un-styled. 
- I used `Spinner` components to show the In-Flight state, but these are ugly and poorly placed. I suspect you'll have a different idea about this state anyway, so I put them in just to demonstrate how to detect the state.
- I included error messages for Mailchimp and MJML if the keys are empty or invalid. I assume you'll also want to handle these differently.

Closes https://github.com/Automattic/newspack-newsletters/issues/52
Closes https://github.com/Automattic/newspack-newsletters/issues/82

### Screenshots
<details>
<img width="1335" alt="Screen Shot 2020-04-19 at 9 06 45 AM" src="https://user-images.githubusercontent.com/1477002/79690543-fccfc900-8228-11ea-8088-dff22aeb2e71.png">
<img width="1335" alt="Screen Shot 2020-04-19 at 9 07 22 AM" src="https://user-images.githubusercontent.com/1477002/79690560-13762000-8229-11ea-8ecf-e83540af1dc5.png">
</details>

### How to test the changes in this Pull Request:

1. Go to Settings->Newspack Newsletters and clear out all three keys. 
2. Create a new Newsletter, observe the API Keys modal screen.
3. Try submitting with various combinations of blank fields, valid keys, and invalid keys. Verify the relevancy of the error messages displayed in each case.
4. Try submitting valid keys in all three fields. Verify the modal switches to the Template Picker. In Settings->Newspack Newsletters verify the keys have been set correctly.
5. Try submitting fields by clicking the blue button as well as pressing ENTER while in a text input.
6. After keys have been set, create a new Newsletter and observe the Template Picker is displayed, not the API Key screen.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
