### PR TITLE
fix: move settings menu item to newspack newsletters menu

### DIFF
--- a/includes/class-newspack-newsletters-settings.php
+++ b/includes/class-newspack-newsletters-settings.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Newspack Newsletters Settubgs Page
+ * Newspack Newsletters Settings Page
  *
  * @package Newspack
  */
@@ -45,10 +45,10 @@ class Newspack_Newsletters_Settings {
 	 * Add options page
 	 */
 	public static function add_plugin_page() {
-		add_submenu_page( 
+		add_submenu_page(
 			'edit.php?post_type=' . Newspack_Newsletters::NEWSPACK_NEWSLETTERS_CPT,
-			__( 'Newspack Newsletters Settings', 'newspack-newsletters' ), 
-			__( 'Settings', 'newspack-newsletters' ), 
+			__( 'Newsletters Settings', 'newspack-newsletters' ),
+			__( 'Settings', 'newspack-newsletters' ),
 			'manage_options',
 			'newspack-newsletters-settings-admin',
 			[ __CLASS__, 'create_admin_page' ]
@@ -61,7 +61,7 @@ class Newspack_Newsletters_Settings {
 	public static function create_admin_page() {
 		?>
 		<div class="wrap">
-			<h1><?php esc_html_e( 'Newspack Newsletters Settings', 'newspack-newsletters' ); ?></h1>
+			<h1><?php esc_html_e( 'Newsletters Settings', 'newspack-newsletters' ); ?></h1>
 			<form method="post" action="options.php">
 			<?php
 				settings_fields( 'newspack_newsletters_options_group' );

--- a/includes/class-newspack-newsletters-settings.php
+++ b/includes/class-newspack-newsletters-settings.php
@@ -45,9 +45,10 @@ class Newspack_Newsletters_Settings {
 	 * Add options page
 	 */
 	public static function add_plugin_page() {
-		add_options_page(
-			__( 'Newspack Newsletters Settings', 'newspack-newsletters' ),
-			__( 'Newspack Newsletters', 'newspack-newsletters' ),
+		add_submenu_page( 
+			'edit.php?post_type=' . Newspack_Newsletters::NEWSPACK_NEWSLETTERS_CPT,
+			__( 'Newspack Newsletters Settings', 'newspack-newsletters' ), 
+			__( 'Settings', 'newspack-newsletters' ), 
 			'manage_options',
 			'newspack-newsletters-settings-admin',
 			[ __CLASS__, 'create_admin_page' ]


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Moves Settings submenu to Newsletters, rename to "Settings."

Closes https://github.com/Automattic/newspack-newsletters/issues/68

<img width="1335" alt="Screen Shot 2020-04-19 at 11 27 24 AM" src="https://user-images.githubusercontent.com/1477002/79692025-ca29ce80-8230-11ea-99ed-cdf315edfdd7.png">

### How to test the changes in this Pull Request:

1. Verify "Settings" submenu under Newsletters.
2. Verify page continues to function as before.
3. Verify "Newspack Newsletter Settings" removed from top-level Settings menu.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
