### PR TITLE
feat: list management link

### DIFF
--- a/src/editor/sidebar/index.js
+++ b/src/editor/sidebar/index.js
@@ -209,7 +209,7 @@ class Sidebar extends Component {
 				</Notice>
 			);
 		}
-		const { web_id: listWebId } = lists.find( ( { id } ) => list_id === id );
+		const { web_id: listWebId } = list_id && lists.find( ( { id } ) => list_id === id );
 		return (
 			<Fragment>
 				<TextControl

--- a/src/editor/sidebar/index.js
+++ b/src/editor/sidebar/index.js
@@ -209,6 +209,7 @@ class Sidebar extends Component {
 				</Notice>
 			);
 		}
+		const { web_id: listWebId } = lists.find( ( { id } ) => list_id === id );
 		return (
 			<Fragment>
 				<TextControl
@@ -236,6 +237,11 @@ class Sidebar extends Component {
 					onChange={ value => this.setList( value ) }
 					disabled={ inFlight }
 				/>
+				{ listWebId && (
+					<ExternalLink href={ `https://us7.admin.mailchimp.com/lists/members/?id=${ listWebId }` }>
+						{ __( 'Manage list', 'newspack-newsletters' ) }
+					</ExternalLink>
+				) }
 				{ this.interestCategories() }
 				<hr />
 				<strong>{ __( 'From', 'newspack-newsletters' ) }</strong>

--- a/src/editor/sidebar/index.js
+++ b/src/editor/sidebar/index.js
@@ -219,7 +219,6 @@ class Sidebar extends Component {
 					disabled={ inFlight }
 					onChange={ value => editPost( { title: value } ) }
 				/>
-				<hr />
 				<SelectControl
 					label={ __( 'To', 'newspack-newsletters' ) }
 					className="newspack-newsletters__to-selectcontrol"
@@ -238,12 +237,15 @@ class Sidebar extends Component {
 					disabled={ inFlight }
 				/>
 				{ listWebId && (
-					<ExternalLink href={ `https://us7.admin.mailchimp.com/lists/members/?id=${ listWebId }` }>
-						{ __( 'Manage list', 'newspack-newsletters' ) }
-					</ExternalLink>
+					<p>
+						<ExternalLink
+							href={ `https://us7.admin.mailchimp.com/lists/members/?id=${ listWebId }` }
+						>
+							{ __( 'Manage list', 'newspack-newsletters' ) }
+						</ExternalLink>
+					</p>
 				) }
 				{ this.interestCategories() }
-				<hr />
 				<strong>{ __( 'From', 'newspack-newsletters' ) }</strong>
 				<TextControl
 					label={ __( 'Name', 'newspack-newsletters' ) }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Adds a List Management link beneath list `SelectControl` that links to Mailchimp Admin page for the list.

@thomasguillot there's no space between the link and the Groups UI beneath, but I left untouched.

Question: This assumes the base URL for Mailchimp admin URLs is `https://us7.admin.mailchimp.com`. This may not always be true. I've opened https://github.com/Automattic/newspack-newsletters/issues/76 to keep track of this question.

<img width="280" alt="Screen Shot 2020-04-19 at 11 56 41 AM" src="https://user-images.githubusercontent.com/1477002/79692773-f9423f00-8234-11ea-9953-adefc0ea8cfa.png">

Closes https://github.com/Automattic/newspack-newsletters/issues/65

### How to test the changes in this Pull Request:

Select a list, verify the `ExternalLink` appears beneath it. Verify the link leads to Mailchimp's list administration page.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
