### PR TITLE
Post-Activation Banner

### DIFF
--- a/src/admin/index.js
+++ b/src/admin/index.js
@@ -1,0 +1,11 @@
+const jQuery = window && window.jQuery;
+
+jQuery( document ).ready( () => {
+	jQuery( document ).on( 'click', '.newspack-newsletters-notification-nag .notice-dismiss', () => {
+		const data = {
+			action: 'newspack_newsletters_activation_nag_dismissal',
+		};
+		const { ajaxurl } = window && window.newspack_newsletters_activation_nag_dismissal_params;
+		jQuery.post( ajaxurl, data, () => null );
+	} );
+} );

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -6,7 +6,6 @@
 /**
  * External dependencies
  */
-const fs = require( 'fs' );
 const getBaseWebpackConfig = require( '@automattic/calypso-build/webpack.config.js' );
 const path = require( 'path' );
 
@@ -19,12 +18,14 @@ const path = require( 'path' );
  * Internal variables
  */
 const editor = path.join( __dirname, 'src', 'editor' );
+const admin = path.join( __dirname, 'src', 'admin' );
 
 const webpackConfig = getBaseWebpackConfig(
 	{ WP: true },
 	{
 		entry: {
-			editor: editor,
+			editor,
+			admin,
 		},
 		'output-path': path.join( __dirname, 'dist' ),
 	}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Adds an info notification after installation instructing users to go to Settings to input API keys. The notification will appear on all admin pages except for those associated with Newsletters. If all three API keys are set the notification will not be shown. The notification can be dismissed, after which it will never be shown again. 

Closes https://github.com/Automattic/newspack-newsletters/issues/73

<img width="1180" alt="Screen Shot 2020-04-19 at 5 17 52 PM" src="https://user-images.githubusercontent.com/1477002/79700298-b4cd9800-8262-11ea-8f6d-0cccf3c9170a.png">

### How to test the changes in this Pull Request:

1.  On settings page, clear all API keys, then navigate to the Dashboard home. Verify the notification is shown.
2. Verify the link to Settings is correct.
3. Navigate to Settings and fill in all three API key fields. Verify the notification is no longer shown.
4. Clear API keys so the notification comes back. Click the X to dismiss it. Verify that it no longer appears on any pages.

If necessary, the dismissal can be reset by running this query:

```
DELETE FROM wp_options WHERE option_name = 'newspack_newsletters_activation_nag_viewed';
```

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
