### PR TITLE
Fix layout preview viewport width

### DIFF
--- a/src/components/template-modal/index.js
+++ b/src/components/template-modal/index.js
@@ -59,7 +59,7 @@ class TemplateModal extends Component {
 									aria-label={ title }
 								>
 									<div className="block-editor-patterns__item-preview">
-										<BlockPreview blocks={ parse( content ) } viewportWidth={ 810 } />
+										<BlockPreview blocks={ parse( content ) } viewportWidth={ 568 } />
 									</div>
 									<div className="block-editor-patterns__item-title">{ title }</div>
 								</div>
@@ -69,7 +69,7 @@ class TemplateModal extends Component {
 
 					<div className="newspack-newsletters-modal__preview">
 						{ blockPreview && blockPreview.length > 0 ? (
-							<BlockPreview blocks={ blockPreview } viewportWidth={ 810 } />
+							<BlockPreview blocks={ blockPreview } viewportWidth={ 568 } />
 						) : (
 							<p>{ __( 'Select a layout to preview.', 'newspack-newsletters' ) }</p>
 						) }

--- a/src/components/template-modal/style.scss
+++ b/src/components/template-modal/style.scss
@@ -125,7 +125,7 @@
 			&__container {
 				align-self: flex-start;
 				margin: 0 auto;
-				max-width: 810px;
+				max-width: 568px;
 			}
 		}
 	}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Since the editor width has changed the previews look slightly off

__Before:__

<img width="1552" alt="1 before" src="https://user-images.githubusercontent.com/177929/79773145-f4f74e00-8328-11ea-98c1-d3a24f6da39f.png">

__After:__

<img width="1552" alt="2 after" src="https://user-images.githubusercontent.com/177929/79773128-f163c700-8328-11ea-8b50-da7ce7a1bdf8.png">

### How to test the changes in this Pull Request:

1. Add a new newsletter. Layouts look broken 
2. Switch to this branch
3. Refresh

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
