### PR TITLE
fix: support for reusable blocks in newsletters

### DIFF
--- a/includes/class-newspack-newsletters.php
+++ b/includes/class-newspack-newsletters.php
@@ -136,6 +136,7 @@ final class Newspack_Newsletters {
 			return $allowed_block_types;
 		}
 		return array(
+			'core/block',
 			'core/group',
 			'core/paragraph',
 			'core/heading',


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Adds support for reusable blocks in Newsletters. 

Closes https://github.com/Automattic/newspack-newsletters/issues/81

### How to test the changes in this Pull Request:

1. On `master`, create a Newsletter and insert a tempalte.
2. Select any block, then click the triple dot icon in the toolbar. Verify "Add To Reusable Blocks" is not present. 
3. Switch to this branch, verify "Add To Reusable Blocks" is now present and works correctly.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
