### PR TITLE
fix: bring back groups ui

### DIFF
--- a/src/editor/sidebar/index.js
+++ b/src/editor/sidebar/index.js
@@ -92,7 +92,8 @@ class Sidebar extends Component {
 	};
 
 	interestCategories = () => {
-		const { campaign, inFlight, interestCategories } = this.state;
+		const { campaign, interestCategories } = this.props;
+		const { inFlight } = this.state;
 		if (
 			! interestCategories ||
 			! interestCategories.categories ||
@@ -278,6 +279,7 @@ export default compose( [
 		return {
 			title: getEditedPostAttribute( 'title' ),
 			campaign: meta.campaign,
+			interestCategories: meta.interestCategories,
 			lists: meta.lists ? meta.lists.lists : [],
 			postId: getCurrentPostId(),
 		};

--- a/src/editor/utils.js
+++ b/src/editor/utils.js
@@ -27,12 +27,17 @@ const validateCampaign = campaign => {
 	return messages;
 };
 
-export const getEditPostPayload = ( { campaign, lists } ) => ( {
+export const getEditPostPayload = ( {
+	campaign,
+	interest_categories: interestCategories,
+	lists,
+} ) => ( {
 	meta: {
 		// These meta fields do not have to be registered on the back end,
 		// as they are not used there.
 		campaignValidationErrors: validateCampaign( campaign ),
 		campaign,
+		interestCategories,
 		lists,
 	},
 } );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Restores the Groups UI and functionality. 

Closes https://github.com/Automattic/newspack-newsletters/issues/89

### How to test the changes in this Pull Request:

Create a new Newsletter, select a list with Groups defined, observe the groups UI and functionality is back.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
