### PR TITLE
Simplify title of newsletter settings panel

### DIFF
--- a/src/editor/index.js
+++ b/src/editor/index.js
@@ -91,7 +91,7 @@ const NewsletterEdit = ( {
 			<NestedColumnsDetection />
 			<PluginDocumentSettingPanel
 				name="newsletters-settings-panel"
-				title={ __( ' Newsletter Settings', 'newspack-newsletters' ) }
+				title={ __( 'Newsletter', 'newspack-newsletters' ) }
 			>
 				<Sidebar />
 			</PluginDocumentSettingPanel>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Changed title from "Newsletter Settings" to simply "Newsletter".

### How to test the changes in this Pull Request:

1. Check the title of the sidebar panel

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
