### PR TITLE
Fix initial setup errors

### DIFF
--- a/includes/class-newspack-newsletters.php
+++ b/includes/class-newspack-newsletters.php
@@ -321,11 +321,11 @@ final class Newspack_Newsletters {
 		$mailchimp_api_key = self::mailchimp_api_key();
 		$mjml_api_key      = get_option( 'newspack_newsletters_mjml_api_key', false );
 		$mjml_api_secret   = get_option( 'newspack_newsletters_mjml_api_secret', false );
-		
+
 		$keys = [
-			'mailchimp_api_key' => $mailchimp_api_key,
-			'mjml_api_key'      => $mjml_api_key,
-			'mjml_api_secret'   => $mjml_api_secret,
+			'mailchimp_api_key' => $mailchimp_api_key ? $mailchimp_api_key : '',
+			'mjml_api_key'      => $mjml_api_key ? $mjml_api_key : '',
+			'mjml_api_secret'   => $mjml_api_secret ? $mjml_api_secret : '',
 			'status'            => ! empty( $mailchimp_api_key ) && ! empty( $mjml_api_key ) && ! empty( $mjml_api_secret ),
 		];
 		return \rest_ensure_response( $keys );
@@ -342,11 +342,9 @@ final class Newspack_Newsletters {
 		$mjml_api_secret   = $request['mjml_api_secret'];
 		$wp_error          = new WP_Error();
 
-		$errors = [];
-
 		if ( empty( $mailchimp_api_key ) ) {
-			$wp_error->add( 
-				'newspack_newsletters_invalid_keys_mailchimp', 
+			$wp_error->add(
+				'newspack_newsletters_invalid_keys_mailchimp',
 				__( 'Please input a Mailchimp API key.', 'newspack-newsletters' )
 			);
 		} else {
@@ -359,16 +357,16 @@ final class Newspack_Newsletters {
 			if ( $ping ) {
 				update_option( 'newspack_newsletters_mailchimp_api_key', $mailchimp_api_key );
 			} else {
-				$wp_error->add( 
-					'newspack_newsletters_invalid_keys_mailchimp', 
+				$wp_error->add(
+					'newspack_newsletters_invalid_keys_mailchimp',
 					__( 'Please input a valid Mailchimp API key.', 'newspack-newsletters' )
 				);
 			}
 		}
 
 		if ( empty( $mjml_api_key ) || empty( $mjml_api_secret ) ) {
-			$wp_error->add( 
-				'newspack_newsletters_invalid_keys_mjml', 
+			$wp_error->add(
+				'newspack_newsletters_invalid_keys_mjml',
 				__( 'Please input MJML application ID and secret key.', 'newspack-newsletters' )
 			);
 		} else {
@@ -392,8 +390,8 @@ final class Newspack_Newsletters {
 				update_option( 'newspack_newsletters_mjml_api_key', $mjml_api_key );
 				update_option( 'newspack_newsletters_mjml_api_secret', $mjml_api_secret );
 			} else {
-				$wp_error->add( 
-					'newspack_newsletters_invalid_keys_mjml', 
+				$wp_error->add(
+					'newspack_newsletters_invalid_keys_mjml',
 					__( 'Please input valid MJML application ID and secret key.', 'newspack-newsletters' )
 				);
 			}
@@ -753,8 +751,6 @@ final class Newspack_Newsletters {
 				'title'        => $post->post_title,
 			],
 		];
-
-		$mc_campaign_id = null;
 
 		$mc_campaign_id = get_post_meta( $post->ID, 'mc_campaign_id', true );
 		if ( $mc_campaign_id ) {

--- a/src/components/template-modal/screens/api-keys/index.js
+++ b/src/components/template-modal/screens/api-keys/index.js
@@ -6,11 +6,14 @@ import { Button, ExternalLink, Spinner, TextControl } from '@wordpress/component
 import { Fragment, useEffect, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { ENTER } from '@wordpress/keycodes';
+import { dispatch } from '@wordpress/data';
 
 /**
  * External dependencies
  */
 import classnames from 'classnames';
+
+const { lockPostAutosaving, unlockPostAutosaving, savePost } = dispatch( 'core/editor' );
 
 export default ( { onSetupStatus } ) => {
 	const [ keys, setKeys ] = useState( {} );
@@ -25,9 +28,12 @@ export default ( { onSetupStatus } ) => {
 			data: keys,
 		} )
 			.then( results => {
-				setInFlight( false );
-				setKeys( results );
-				onSetupStatus( results.status );
+				unlockPostAutosaving( 'newsletters-modal-is-open-lock' );
+				savePost().then( () => {
+					setInFlight( false );
+					setKeys( results );
+					onSetupStatus( results.status );
+				} );
 			} )
 			.catch( handleErrors );
 	};
@@ -40,6 +46,7 @@ export default ( { onSetupStatus } ) => {
 		setInFlight( false );
 	};
 	useEffect(() => {
+		lockPostAutosaving( 'newsletters-modal-is-open-lock' );
 		setInFlight( true );
 		apiFetch( { path: `/newspack-newsletters/v1/keys` } )
 			.then( results => {

--- a/src/editor/editor/index.js
+++ b/src/editor/editor/index.js
@@ -15,12 +15,17 @@ import './style.scss';
 
 const Editor = compose( [
 	withSelect( select => {
-		const { getCurrentPostId, getEditedPostAttribute, isPublishingPost, isSavingPost } = select(
-			'core/editor'
-		);
+		const {
+			getCurrentPostId,
+			getEditedPostAttribute,
+			isPublishingPost,
+			isSavingPost,
+			isCleanNewPost,
+		} = select( 'core/editor' );
 		const { getActiveGeneralSidebarName } = select( 'core/edit-post' );
 		const meta = getEditedPostAttribute( 'meta' );
 		return {
+			isCleanNewPost: isCleanNewPost(),
 			postId: getCurrentPostId(),
 			isReady: meta.campaignValidationErrors ? meta.campaignValidationErrors.length === 0 : false,
 			activeSidebarName: getActiveGeneralSidebarName(),
@@ -34,9 +39,11 @@ const Editor = compose( [
 ] )( props => {
 	// Fetch campaign data.
 	useEffect(() => {
-		apiFetch( { path: `/newspack-newsletters/v1/mailchimp/${ props.postId }` } ).then( result => {
-			props.editPost( getEditPostPayload( result ) );
-		} );
+		if ( ! props.isCleanNewPost && ! props.isPublishingOrSavingPost ) {
+			apiFetch( { path: `/newspack-newsletters/v1/mailchimp/${ props.postId }` } ).then( result => {
+				props.editPost( getEditPostPayload( result ) );
+			} );
+		}
 	}, [ props.isPublishingOrSavingPost ]);
 
 	// Lock or unlock post publishing.


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

There are two issues in the initial setup flow: `"false"` values in credentials inputs (#97) and empty campaign being returned. This fixed both.

Closes #97

### How to test the changes in this Pull Request:

1. Ensure branch is `master`
2. Remove credentials (`wp db query "DELETE FROM wp_options WHERE option_name LIKE 'newspack_newsletters%'"`)
3. Add new newsletter post, observe:
    - an error in network tab and JS console – a call to Mailchimp API was made without the API key
    - values for credentials are all `"false"` (#97)
1. Fill in the credentials, choose layout, and save draft. Observe that now the spinner in the sidebar, next to "Retrieving Mailchimp data…", is spinning indefinitely. Observe in the network tab that an empty campaign data was returned. 
1. Switch to this branch, clear the credentials again. 
1. Add a new newsletter post, observe no errors in neither network tab or JS console
1. Fill in the credentials, select layout, all should work as expected

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
