### PR TITLE
fix: remove data center prefix from mailchimp url

### DIFF
--- a/src/editor/sidebar/index.js
+++ b/src/editor/sidebar/index.js
@@ -201,9 +201,7 @@ class Sidebar extends Component {
 				/>
 				{ listWebId && (
 					<p>
-						<ExternalLink
-							href={ `https://us7.admin.mailchimp.com/lists/members/?id=${ listWebId }` }
-						>
+						<ExternalLink href={ `https://admin.mailchimp.com/lists/members/?id=${ listWebId }` }>
 							{ __( 'Manage list', 'newspack-newsletters' ) }
 						</ExternalLink>
 					</p>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

The data center prefix on Mailchimp dashboard URLs will differ from account to account, but if it is omitted from a dashboard URL Mailchimp will redirect to the correct one (h/t @BradHudson for the solution). In this PR the `Manage List` link URLs are corrected accordingly.

Closes https://github.com/Automattic/newspack-newsletters/issues/76

### How to test the changes in this Pull Request:

1. Create a Newsletter, select a list.
2. Verify the `Manage List` link goes to the list's management page in the Mailchimp dashboard.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
