### PR TITLE
Test Email Notifications

### DIFF
--- a/src/components/with-api-handler/index.js
+++ b/src/components/with-api-handler/index.js
@@ -42,5 +42,5 @@ export default () =>
 				/>
 			);
 		},
-		'newspack-newsletters-with-api-response'
+		'newspack-newsletters-with-api-handler'
 	);

--- a/src/components/with-api-handler/index.js
+++ b/src/components/with-api-handler/index.js
@@ -42,5 +42,5 @@ export default () =>
 				/>
 			);
 		},
-		'newspack-newsletters-with-api-handler'
+		'with-api-handler'
 	);

--- a/src/components/with-newsletter-api/index.js
+++ b/src/components/with-newsletter-api/index.js
@@ -1,0 +1,44 @@
+/**
+ * WordPress dependencies
+ */
+import apiFetch from '@wordpress/api-fetch';
+import { dispatch, select } from '@wordpress/data';
+import { createHigherOrderComponent } from '@wordpress/compose';
+import { useState } from '@wordpress/element';
+
+export default () =>
+	createHigherOrderComponent(
+		OriginalComponent => props => {
+			const [ inFlight, setInFlight ] = useState( false );
+			const { createSuccessNotice, createErrorNotice, removeNotice } = dispatch( 'core/notices' );
+			const { getNotices } = select( 'core/notices' );
+			const apiFetchWithErrorHandling = apiRequest => {
+				setInFlight( true );
+				return new Promise( ( resolve, reject ) => {
+					apiFetch( apiRequest )
+						.then( response => {
+							const { message } = response;
+							if ( message ) {
+								createSuccessNotice( message );
+							}
+							setInFlight( false );
+							resolve( response );
+						} )
+						.catch( error => {
+							getNotices().forEach( notice => removeNotice( notice.id ) );
+							createErrorNotice( error );
+							setInFlight( false );
+							reject( error );
+						} );
+				} );
+			};
+			return (
+				<OriginalComponent
+					{ ...props }
+					apiFetchWithErrorHandling={ apiFetchWithErrorHandling }
+					inFlight={ inFlight }
+				/>
+			);
+		},
+		'newspack-newsletters-with-api-response'
+	);

--- a/src/components/with-newsletter-api/index.js
+++ b/src/components/with-newsletter-api/index.js
@@ -19,14 +19,16 @@ export default () =>
 						.then( response => {
 							const { message } = response;
 							if ( message ) {
+								getNotices().forEach( notice => removeNotice( notice.id ) );
 								createSuccessNotice( message );
 							}
 							setInFlight( false );
 							resolve( response );
 						} )
 						.catch( error => {
+							const { message } = error;
 							getNotices().forEach( notice => removeNotice( notice.id ) );
-							createErrorNotice( error );
+							createErrorNotice( message );
 							setInFlight( false );
 							reject( error );
 						} );

--- a/src/editor/editor/index.js
+++ b/src/editor/editor/index.js
@@ -2,7 +2,6 @@
  * WordPress dependencies
  */
 import { compose } from '@wordpress/compose';
-import apiFetch from '@wordpress/api-fetch';
 import { withDispatch, withSelect } from '@wordpress/data';
 import { useEffect } from '@wordpress/element';
 import { registerPlugin } from '@wordpress/plugins';
@@ -11,9 +10,11 @@ import { registerPlugin } from '@wordpress/plugins';
  * Internal dependencies
  */
 import { getEditPostPayload } from '../utils';
+import withNewsletterApi from '../../components/with-newsletter-api';
 import './style.scss';
 
 const Editor = compose( [
+	withNewsletterApi(),
 	withSelect( select => {
 		const {
 			getCurrentPostId,
@@ -40,9 +41,13 @@ const Editor = compose( [
 	// Fetch campaign data.
 	useEffect(() => {
 		if ( ! props.isCleanNewPost && ! props.isPublishingOrSavingPost ) {
-			apiFetch( { path: `/newspack-newsletters/v1/mailchimp/${ props.postId }` } ).then( result => {
-				props.editPost( getEditPostPayload( result ) );
-			} );
+			props
+				.apiFetchWithErrorHandling( {
+					path: `/newspack-newsletters/v1/mailchimp/${ props.postId }`,
+				} )
+				.then( result => {
+					props.editPost( getEditPostPayload( result ) );
+				} );
 		}
 	}, [ props.isPublishingOrSavingPost ]);
 

--- a/src/editor/editor/index.js
+++ b/src/editor/editor/index.js
@@ -10,11 +10,11 @@ import { registerPlugin } from '@wordpress/plugins';
  * Internal dependencies
  */
 import { getEditPostPayload } from '../utils';
-import withNewsletterApi from '../../components/with-newsletter-api';
+import withApiHandler from '../../components/with-api-handler';
 import './style.scss';
 
 const Editor = compose( [
-	withNewsletterApi(),
+	withApiHandler(),
 	withSelect( select => {
 		const {
 			getCurrentPostId,

--- a/src/editor/sidebar/index.js
+++ b/src/editor/sidebar/index.js
@@ -23,7 +23,7 @@ import { get } from 'lodash';
  * Internal dependencies
  */
 import { getEditPostPayload } from '../utils';
-import withNewsletterApi from '../../components/with-newsletter-api';
+import withApiHandler from '../../components/with-api-handler';
 import './style.scss';
 
 class Sidebar extends Component {
@@ -216,7 +216,7 @@ class Sidebar extends Component {
 }
 
 export default compose( [
-	withNewsletterApi(),
+	withApiHandler(),
 	withSelect( select => {
 		const { getEditedPostAttribute, getCurrentPostId } = select( 'core/editor' );
 		const meta = getEditedPostAttribute( 'meta' );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Adds a Higher Order Component to handle error/success notifications for all API traffic, as well as managing "in flight" state (taken pretty directly from https://github.com/Automattic/newspack-newsletters/pulls, h/t @adekbadek ). Implements error and success messaging for the test email feature. 

After this PR lands, we'll open separate PRs for error/success notification in other specific features.

Closes https://github.com/Automattic/newspack-newsletters/issues/27.

### How to test the changes in this Pull Request:

1. Create a Newsletter, send a test email to `a@example.com`. Observe  detailed error message.
2. Send a test email to a real address. Observe success message. Verify the email has actually been sent. 
3. Refresh editor. In another window, navigate to Newsletters->Settings, clear out the Mailchimp API key and Save. Send a test email to a real address, observe appropriate error message.
4. Repeat step 3, but this time only remove one character from the end of the key. In this case Mailchimp fails silently — observe an appropriate generic error. 
5. Observe there is never more than one notification visible at a time.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
