### PR TITLE
feat: separate panel for test email ui

### DIFF
--- a/src/editor/index.js
+++ b/src/editor/index.js
@@ -16,6 +16,7 @@ import { registerPlugin } from '@wordpress/plugins';
  */
 import TemplateModal from '../components/template-modal';
 import Sidebar from './sidebar/';
+import Testing from './testing/';
 import registerEditorPlugin from './editor/';
 import registerPrePublishSlot from './pre-publish-slot';
 import registerPostStatusSlot from './post-status-slot';
@@ -94,6 +95,12 @@ const NewsletterEdit = ( {
 				title={ __( 'Newsletter', 'newspack-newsletters' ) }
 			>
 				<Sidebar />
+			</PluginDocumentSettingPanel>
+			<PluginDocumentSettingPanel
+				name="newsletters-testing-panel"
+				title={ __( 'Testing', 'newspack-newsletters' ) }
+			>
+				<Testing />
 			</PluginDocumentSettingPanel>
 		</Fragment>
 	);

--- a/src/editor/sidebar/index.js
+++ b/src/editor/sidebar/index.js
@@ -9,7 +9,6 @@ import { Component, Fragment } from '@wordpress/element';
 import {
 	Button,
 	ExternalLink,
-	Modal,
 	Notice,
 	SelectControl,
 	Spinner,
@@ -30,24 +29,9 @@ import './style.scss';
 class Sidebar extends Component {
 	state = {
 		inFlight: false,
-		showTestModal: false,
-		testEmail: '',
 		senderEmail: '',
 		senderName: '',
 		senderDirty: false,
-	};
-	sendMailchimpTest = () => {
-		const { testEmail } = this.state;
-		this.setState( { inFlight: true } );
-		const { postId } = this.props;
-		const params = {
-			path: `/newspack-newsletters/v1/mailchimp/${ postId }/test`,
-			data: {
-				test_email: testEmail,
-			},
-			method: 'POST',
-		};
-		apiFetch( params ).then( this.setStateFromAPIResponse );
 	};
 	setList = listId => {
 		this.setState( { inFlight: true } );
@@ -147,7 +131,7 @@ class Sidebar extends Component {
 	 */
 	render() {
 		const { campaign, lists, editPost, title } = this.props;
-		const { inFlight, showTestModal, testEmail, senderName, senderEmail, senderDirty } = this.state;
+		const { inFlight, senderName, senderEmail, senderDirty } = this.state;
 		if ( ! campaign ) {
 			return (
 				<div className="newspack-newsletters__loading-data">
@@ -233,39 +217,6 @@ class Sidebar extends Component {
 					>
 						{ __( 'Update Sender', 'newspack-newsletters' ) }
 					</Button>
-				) }
-				<hr />
-				<Button
-					isSecondary
-					onClick={ () => this.setState( { showTestModal: true } ) }
-					disabled={ inFlight }
-				>
-					{ __( 'Send a Test Email', 'newspack-newsletters' ) }
-				</Button>
-				{ showTestModal && (
-					<Modal
-						title={ __( 'Send a Test Email', 'newspack-newsletters' ) }
-						onRequestClose={ () => this.setState( { showTestModal: false } ) }
-						className="newspack-newsletters__send-test"
-					>
-						<TextControl
-							label={ __( 'Send a test to', 'newspack-newsletters' ) }
-							value={ testEmail }
-							type="email"
-							onChange={ value => this.setState( { testEmail: value } ) }
-						/>
-						<Button
-							isPrimary
-							onClick={ () =>
-								this.setState( { showTestModal: false }, () => this.sendMailchimpTest() )
-							}
-						>
-							{ __( 'Send Test', 'newspack-newsletters' ) }
-						</Button>
-						<Button isSecondary onClick={ () => this.setState( { showTestModal: false } ) }>
-							{ __( 'Cancel', 'newspack-newsletters' ) }
-						</Button>
-					</Modal>
 				) }
 			</Fragment>
 		);

--- a/src/editor/testing/index.js
+++ b/src/editor/testing/index.js
@@ -1,0 +1,41 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import apiFetch from '@wordpress/api-fetch';
+import { withSelect } from '@wordpress/data';
+import { Fragment, useState } from '@wordpress/element';
+import { Button, TextControl } from '@wordpress/components';
+
+export default withSelect( select => {
+	const { getCurrentPostId } = select( 'core/editor' );
+	return { postId: getCurrentPostId() };
+} )( ( { postId } ) => {
+	const [ inFlight, setInFlight ] = useState( false );
+	const [ testEmail, setTestEmail ] = useState( '' );
+	const sendMailchimpTest = () => {
+		setInFlight( true );
+		const params = {
+			path: `/newspack-newsletters/v1/mailchimp/${ postId }/test`,
+			data: {
+				test_email: testEmail,
+			},
+			method: 'POST',
+		};
+		apiFetch( params ).then( () => setInFlight( false ) );
+	};
+	return (
+		<Fragment>
+			<TextControl
+				label={ __( 'Send a test to', 'newspack-newsletters' ) }
+				value={ testEmail }
+				type="email"
+				onChange={ setTestEmail }
+				help={ __( 'Use commas to separate multiple emails.', 'newspack-newsletters' ) }
+			/>
+			<Button isPrimary onClick={ sendMailchimpTest } disabled={ testEmail.length < 1 || inFlight }>
+				{ __( 'Send a Test Email', 'newspack-newsletters' ) }
+			</Button>
+		</Fragment>
+	);
+} );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Adds a `Testing` panel in the sidebar with test email `TextControl` and `Button` to send test. After https://github.com/Automattic/newspack-newsletters/pulls lands we'll be able to notify on success and failure when sending test emails.

Closes https://github.com/Automattic/newspack-newsletters/issues/94

![Screen Shot 2020-04-21 at 10 00 01 PM](https://user-images.githubusercontent.com/1477002/79932435-7c24ee80-841b-11ea-9473-55ac50ea7b23.png)

### How to test the changes in this Pull Request:

1. Create a Newsletter.
2. Observe Testing panel in the sidebar.
3. Send a test to a real email, verify the email is sent.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
