### PR TITLE
feat: sidebar ui to change template

### DIFF
--- a/includes/class-newspack-newsletters.php
+++ b/includes/class-newspack-newsletters.php
@@ -49,7 +49,7 @@ final class Newspack_Newsletters {
 		add_action( 'enqueue_block_editor_assets', [ __CLASS__, 'disable_gradients' ] );
 		add_action( 'rest_api_init', [ __CLASS__, 'rest_api_init' ] );
 		add_action( 'default_title', [ __CLASS__, 'default_title' ], 10, 2 );
-		add_action( 'save_post_' . self::NEWSPACK_NEWSLETTERS_CPT, [ __CLASS__, 'save_post' ], 10, 2 );
+		add_action( 'save_post_' . self::NEWSPACK_NEWSLETTERS_CPT, [ __CLASS__, 'save_post' ], 10, 3 );
 		add_action( 'publish_' . self::NEWSPACK_NEWSLETTERS_CPT, [ __CLASS__, 'send_campaign' ], 10, 2 );
 		add_action( 'wp_trash_post', [ __CLASS__, 'trash_post' ], 10, 1 );
 		add_filter( 'allowed_block_types', [ __CLASS__, 'newsletters_allowed_block_types' ], 10, 2 );
@@ -66,6 +66,45 @@ final class Newspack_Newsletters {
 		}
 		include_once dirname( __FILE__ ) . '/class-newspack-newsletters-settings.php';
 		include_once dirname( __FILE__ ) . '/class-newspack-newsletters-renderer.php';
+	}
+
+	/**
+	 * Register custom fields.
+	 */
+	public static function register_meta() {
+		\register_meta(
+			'post',
+			'mc_campaign_id',
+			[
+				'object_subtype' => self::NEWSPACK_NEWSLETTERS_CPT,
+				'show_in_rest'   => true,
+				'type'           => 'string',
+				'single'         => true,
+				'auth_callback'  => '__return_true',
+			]
+		);
+		\register_meta(
+			'post',
+			'mc_list_id',
+			[
+				'object_subtype' => self::NEWSPACK_NEWSLETTERS_CPT,
+				'show_in_rest'   => true,
+				'type'           => 'string',
+				'single'         => true,
+				'auth_callback'  => '__return_true',
+			]
+		);
+		\register_meta(
+			'post',
+			'template_id',
+			[
+				'object_subtype' => self::NEWSPACK_NEWSLETTERS_CPT,
+				'show_in_rest'   => true,
+				'type'           => 'integer',
+				'single'         => true,
+				'auth_callback'  => '__return_true',
+			]
+		);
 	}
 
 	/**
@@ -561,34 +600,6 @@ final class Newspack_Newsletters {
 	}
 
 	/**
-	 * Register custom fields.
-	 */
-	public static function register_meta() {
-		\register_meta(
-			'post',
-			'mc_campaign_id',
-			[
-				'object_subtype' => self::NEWSPACK_NEWSLETTERS_CPT,
-				'show_in_rest'   => true,
-				'type'           => 'string',
-				'single'         => true,
-				'auth_callback'  => '__return_true',
-			]
-		);
-		\register_meta(
-			'post',
-			'mc_list_id',
-			[
-				'object_subtype' => self::NEWSPACK_NEWSLETTERS_CPT,
-				'show_in_rest'   => true,
-				'type'           => 'string',
-				'single'         => true,
-				'auth_callback'  => '__return_true',
-			]
-		);
-	}
-
-	/**
 	 * Get Mailchimp data.
 	 *
 	 * @param WP_REST_Request $request API request object.
@@ -694,8 +705,12 @@ final class Newspack_Newsletters {
 	 *
 	 * @param string  $id post ID.
 	 * @param WP_Post $post the post.
+	 * @param boolean $update Is this the initial save of the post.
 	 */
-	public static function save_post( $id, $post ) {
+	public static function save_post( $id, $post, $update ) {
+		if ( ! $update ) {
+			update_post_meta( $id, 'template_id', -1 );
+		}
 		$status = get_post_status( $id );
 		if ( 'trash' === $status ) {
 			return;

--- a/includes/class-newspack-newsletters.php
+++ b/includes/class-newspack-newsletters.php
@@ -705,7 +705,7 @@ final class Newspack_Newsletters {
 	 *
 	 * @param string  $id post ID.
 	 * @param WP_Post $post the post.
-	 * @param boolean $update Is this the initial save of the post.
+	 * @param boolean $update Is this an update of the post.
 	 */
 	public static function save_post( $id, $post, $update ) {
 		if ( ! $update ) {

--- a/src/editor/index.js
+++ b/src/editor/index.js
@@ -103,7 +103,7 @@ const NewsletterEdit = ( {
 			</PluginDocumentSettingPanel>
 			<PluginDocumentSettingPanel
 				name="newsletters-layout-panel"
-				title={ __( 'Newsletter Layout', 'newspack-newsletters' ) }
+				title={ __( 'Layout', 'newspack-newsletters' ) }
 			>
 				<Layout templates={ templates } />
 			</PluginDocumentSettingPanel>

--- a/src/editor/index.js
+++ b/src/editor/index.js
@@ -96,16 +96,16 @@ const NewsletterEdit = ( {
 				<Sidebar />
 			</PluginDocumentSettingPanel>
 			<PluginDocumentSettingPanel
-				name="newsletters-testing-panel"
-				title={ __( 'Testing', 'newspack-newsletters' ) }
-			>
-				<Testing />
-			</PluginDocumentSettingPanel>
-			<PluginDocumentSettingPanel
 				name="newsletters-layout-panel"
 				title={ __( 'Layout', 'newspack-newsletters' ) }
 			>
 				<Layout templates={ templates } />
+			</PluginDocumentSettingPanel>
+			<PluginDocumentSettingPanel
+				name="newsletters-testing-panel"
+				title={ __( 'Testing', 'newspack-newsletters' ) }
+			>
+				<Testing />
 			</PluginDocumentSettingPanel>
 		</Fragment>
 	);

--- a/src/editor/index.js
+++ b/src/editor/index.js
@@ -15,6 +15,7 @@ import { registerPlugin } from '@wordpress/plugins';
  * Internal dependencies
  */
 import TemplateModal from '../components/template-modal';
+import Layout from './layout/';
 import Sidebar from './sidebar/';
 import Testing from './testing/';
 import registerEditorPlugin from './editor/';
@@ -54,13 +55,13 @@ const NewsletterEdit = ( {
 	getBlocks,
 	insertBlocks,
 	replaceBlocks,
-	isEditedPostEmpty,
 	savePost,
+	setTemplateIDMeta,
+	templateId,
 } ) => {
 	const templates =
 		window && window.newspack_newsletters_data && window.newspack_newsletters_data.templates;
 
-	const [ insertedTemplate, setInserted ] = useState( null );
 	const [ hasKeys, setHasKeys ] = useState(
 		window && window.newspack_newsletters_data && window.newspack_newsletters_data.has_keys
 	);
@@ -73,12 +74,10 @@ const NewsletterEdit = ( {
 		} else {
 			insertBlocks( parse( template.content ) );
 		}
-		setInserted( templateIndex );
+		setTemplateIDMeta( templateIndex );
 		setTimeout( savePost, 1 );
 	};
-	const isDisplayingTemplateModal =
-		! hasKeys ||
-		( isEditedPostEmpty && templates && templates.length && insertedTemplate === null );
+	const isDisplayingTemplateModal = ! hasKeys || -1 === templateId;
 
 	return isDisplayingTemplateModal ? (
 		<TemplateModal
@@ -102,23 +101,37 @@ const NewsletterEdit = ( {
 			>
 				<Testing />
 			</PluginDocumentSettingPanel>
+			<PluginDocumentSettingPanel
+				name="newsletters-layout-panel"
+				title={ __( 'Newsletter Layout', 'newspack-newsletters' ) }
+			>
+				<Layout templates={ templates } />
+			</PluginDocumentSettingPanel>
 		</Fragment>
 	);
 };
 
 const NewsletterEditWithSelect = compose( [
 	withSelect( select => {
-		const { isEditedPostEmpty } = select( 'core/editor' );
+		const { getEditedPostAttribute } = select( 'core/editor' );
+		const meta = getEditedPostAttribute( 'meta' );
+		const { template_id: templateId } = meta;
 		const { getBlocks } = select( 'core/block-editor' );
 		return {
-			isEditedPostEmpty: isEditedPostEmpty(),
 			getBlocks,
+			templateId,
 		};
 	} ),
 	withDispatch( dispatch => {
 		const { savePost } = dispatch( 'core/editor' );
 		const { insertBlocks, replaceBlocks } = dispatch( 'core/block-editor' );
-		return { savePost, insertBlocks, replaceBlocks };
+		return {
+			savePost,
+			insertBlocks,
+			replaceBlocks,
+			setTemplateIDMeta: templateId =>
+				dispatch( 'core/editor' ).editPost( { meta: { template_id: templateId } } ),
+		};
 	} ),
 ] )( NewsletterEdit );
 

--- a/src/editor/layout/index.js
+++ b/src/editor/layout/index.js
@@ -34,19 +34,20 @@ export default compose( [
 	const blockPreview = content ? parse( content ) : null;
 	return (
 		<Fragment>
-			<div className="layout-panel-preview">
-				{ blockPreview && blockPreview.length > 0 ? (
-					<BlockPreview blocks={ blockPreview } viewportWidth={ 568 } />
-				) : (
-					<p>{ __( 'Select a layout to preview.', 'newspack-newsletters' ) }</p>
-				) }
+			<div className="block-editor-patterns newspack-newsletters__layout-panel-preview">
+				<div className="block-editor-patterns__item">
+					<div className="block-editor-patterns__item-preview">
+						<BlockPreview blocks={ blockPreview } viewportWidth={ 568 } />
+					</div>
+					<div className="block-editor-patterns__item-title">{ title }</div>
+				</div>
 			</div>
-			<h2>{ title }</h2>
 			<Button isPrimary onClick={ () => setWarningModalVisible( true ) }>
 				{ __( 'Change Layout', 'newspack-newsletters' ) }
 			</Button>
 			{ warningModalVisible && (
 				<Modal
+					className="newspack-newsletters__layout-panel-modal"
 					title={ __( 'Overwrite newsletter content?', 'newspack-newsletters' ) }
 					onRequestClose={ () => setWarningModalVisible( false ) }
 				>

--- a/src/editor/layout/index.js
+++ b/src/editor/layout/index.js
@@ -1,0 +1,75 @@
+/**
+ * WordPress dependencies
+ */
+import { compose } from '@wordpress/compose';
+import { parse } from '@wordpress/blocks';
+import { __ } from '@wordpress/i18n';
+import { BlockPreview } from '@wordpress/block-editor';
+import { withDispatch, withSelect } from '@wordpress/data';
+import { Fragment, useState } from '@wordpress/element';
+import { Button, Modal } from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
+import './style.scss';
+
+export default compose( [
+	withDispatch( dispatch => {
+		return {
+			setTemplateIDMeta: templateId =>
+				dispatch( 'core/editor' ).editPost( { meta: { template_id: templateId } } ),
+		};
+	} ),
+	withSelect( select => {
+		const { getEditedPostAttribute } = select( 'core/editor' );
+		const meta = getEditedPostAttribute( 'meta' );
+		const { template_id: templateId } = meta;
+		return { templateId };
+	} ),
+] )( ( { setTemplateIDMeta, templateId, templates } ) => {
+	const [ warningModalVisible, setWarningModalVisible ] = useState( false );
+	const currentTemplate = templates && templates[ templateId ] ? templates[ templateId ] : {};
+	const { content, title } = currentTemplate;
+	const blockPreview = content ? parse( content ) : null;
+	return (
+		<Fragment>
+			<div className="layout-panel-preview">
+				{ blockPreview && blockPreview.length > 0 ? (
+					<BlockPreview blocks={ blockPreview } viewportWidth={ 568 } />
+				) : (
+					<p>{ __( 'Select a layout to preview.', 'newspack-newsletters' ) }</p>
+				) }
+			</div>
+			<h2>{ title }</h2>
+			<Button isPrimary onClick={ () => setWarningModalVisible( true ) }>
+				{ __( 'Change Layout', 'newspack-newsletters' ) }
+			</Button>
+			{ warningModalVisible && (
+				<Modal
+					title={ __( 'Overwrite newsletter content?', 'newspack-newsletters' ) }
+					onRequestClose={ () => setWarningModalVisible( false ) }
+				>
+					<p>
+						{ __(
+							"Changing the newsletter's layout will remove any customizations or edits you have already made.",
+							'newspack-newsletters'
+						) }
+					</p>
+					<Button
+						isPrimary
+						onClick={ () => {
+							setTemplateIDMeta( -1 );
+							setWarningModalVisible( false );
+						} }
+					>
+						{ __( 'Change Layout', 'newspack-newsletters' ) }
+					</Button>
+					<Button isSecondary onClick={ () => setWarningModalVisible( false ) }>
+						{ __( 'Cancel', 'newspack-newsletters' ) }
+					</Button>
+				</Modal>
+			) }
+		</Fragment>
+	);
+} );

--- a/src/editor/layout/style.scss
+++ b/src/editor/layout/style.scss
@@ -1,7 +1,28 @@
-.layout-panel-preview {
-	border: 1px solid black;
-	padding: 1em;
-	overflow: hidden;
-	height: 300px;
-	margin-bottom: 1em;
+.newspack-newsletters__layout-panel {
+	&-preview {
+		background: transparent;
+		padding: 0;
+		pointer-events: none;
+
+		.block-editor-patterns {
+			&__item-preview {
+				overflow: hidden;
+				padding: 0 0 100%;
+				position: relative;
+				width: 100%;
+
+				.block-editor-block-preview__container {
+					position: absolute;
+				}
+			}
+		}
+	}
+
+	&-modal {
+		max-width: 360px;
+
+		.components-button + .components-button {
+			margin-left: 12px;
+		}
+	}
 }

--- a/src/editor/layout/style.scss
+++ b/src/editor/layout/style.scss
@@ -1,0 +1,7 @@
+.layout-panel-preview {
+	border: 1px solid black;
+	padding: 1em;
+	overflow: hidden;
+	height: 300px;
+	margin-bottom: 1em;
+}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Sidebar panel which displays the current layout and offers an option to pick a new one. 

@thomasguillot: I left it almost entirely unstyled. Note this will probably only work with newly created Newsletters, since the template selection is persisted as custom post meta.

Closes https://github.com/Automattic/newspack-newsletters/issues/72

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
