### PR TITLE
Save post before previewing or sending test email

### DIFF
--- a/src/editor/post-status-slot/index.js
+++ b/src/editor/post-status-slot/index.js
@@ -7,30 +7,48 @@ import { WebPreview } from 'newspack-components';
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { withSelect } from '@wordpress/data';
+import { withSelect, withDispatch } from '@wordpress/data';
+import { compose } from '@wordpress/compose';
 import { PluginPostStatusInfo } from '@wordpress/edit-post';
 import { registerPlugin } from '@wordpress/plugins';
 import { Button } from '@wordpress/components';
+import { useState } from '@wordpress/element';
 
-const StatusInfoPreviewButton = ( { url } ) =>
-	url ? (
+const StatusInfoPreviewButton = ( { url, savePost } ) => {
+	const [ inFlight, setInFlight ] = useState( false );
+	const handleClick = showPreview => async () => {
+		setInFlight( true );
+		await savePost();
+		showPreview();
+		setInFlight( false );
+	};
+	return (
 		<PluginPostStatusInfo>
 			<WebPreview
 				url={ url }
 				renderButton={ ( { showPreview } ) => (
-					<Button isPrimary onClick={ showPreview }>
+					<Button isPrimary disabled={ inFlight || ! url } onClick={ handleClick( showPreview ) }>
 						{ __( 'Preview', 'newspack-newsletters' ) }
 					</Button>
 				) }
 			/>
 		</PluginPostStatusInfo>
-	) : null;
+	);
+};
 
-const StatusInfoPreviewButtonWithSelect = withSelect( select => {
-	const { getEditedPostAttribute } = select( 'core/editor' );
-	const meta = getEditedPostAttribute( 'meta' );
-	return { url: meta.campaign && meta.campaign.long_archive_url };
-} )( StatusInfoPreviewButton );
+const StatusInfoPreviewButtonWithSelect = compose( [
+	withSelect( select => {
+		const { getEditedPostAttribute } = select( 'core/editor' );
+		const meta = getEditedPostAttribute( 'meta' );
+		return { url: meta.campaign && meta.campaign.long_archive_url };
+	} ),
+	withDispatch( dispatch => {
+		const { savePost } = dispatch( 'core/editor' );
+		return {
+			savePost,
+		};
+	} ),
+] )( StatusInfoPreviewButton );
 
 export default () => {
 	registerPlugin( 'newspack-newsletters-post-status-info', {

--- a/src/editor/testing/index.js
+++ b/src/editor/testing/index.js
@@ -3,18 +3,28 @@
  */
 import { __ } from '@wordpress/i18n';
 import apiFetch from '@wordpress/api-fetch';
-import { withSelect } from '@wordpress/data';
+import { withSelect, withDispatch } from '@wordpress/data';
+import { compose } from '@wordpress/compose';
 import { Fragment, useState } from '@wordpress/element';
 import { Button, TextControl } from '@wordpress/components';
 
-export default withSelect( select => {
-	const { getCurrentPostId } = select( 'core/editor' );
-	return { postId: getCurrentPostId() };
-} )( ( { postId } ) => {
+export default compose( [
+	withSelect( select => {
+		const { getCurrentPostId } = select( 'core/editor' );
+		return { postId: getCurrentPostId() };
+	} ),
+	withDispatch( dispatch => {
+		const { savePost } = dispatch( 'core/editor' );
+		return {
+			savePost,
+		};
+	} ),
+] )( ( { postId, savePost } ) => {
 	const [ inFlight, setInFlight ] = useState( false );
 	const [ testEmail, setTestEmail ] = useState( '' );
-	const sendMailchimpTest = () => {
+	const sendMailchimpTest = async () => {
 		setInFlight( true );
+		await savePost();
 		const params = {
 			path: `/newspack-newsletters/v1/mailchimp/${ postId }/test`,
 			data: {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Also, the preview button will be disabled instead of hidden to prevent UI jumping.

Closes #25

### How to test the changes in this Pull Request:

1. Open a newsletter post or create one
2. Make some changes, but don't save
3. Hit "Preview" – observe that the post is first saved, then the preview is shown. The preview should contain the up-to-date version.
1. Send a test email – observe that the post is first saved. The email should contain the up-to-date version.


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
