### PR TITLE
Sidebar: store sender data in post meta

### DIFF
--- a/src/editor/sidebar/index.js
+++ b/src/editor/sidebar/index.js
@@ -28,10 +28,19 @@ import './style.scss';
 
 class Sidebar extends Component {
 	state = {
-		senderEmail: '',
-		senderName: '',
 		senderDirty: false,
 	};
+	componentDidUpdate( prevProps ) {
+		if ( ! prevProps.campaign && this.props.campaign ) {
+			this.props.editPost( {
+				meta: {
+					senderName: this.props.campaign.settings.from_name,
+					senderEmail: this.props.campaign.settings.reply_to,
+				},
+			} );
+		}
+	}
+
 	setList = listId => {
 		const { apiFetchWithErrorHandling, postId } = this.props;
 		const params = {
@@ -63,11 +72,7 @@ class Sidebar extends Component {
 	setStateFromAPIResponse = result => {
 		this.props.editPost( getEditPostPayload( result ) );
 
-		this.setState( {
-			senderName: result.campaign.settings.from_name,
-			senderEmail: result.campaign.settings.reply_to,
-			senderDirty: false,
-		} );
+		this.setState( { senderDirty: false } );
 	};
 
 	interestCategories = () => {
@@ -124,8 +129,8 @@ class Sidebar extends Component {
 	 * Render
 	 */
 	render() {
-		const { campaign, inFlight, lists, editPost, title } = this.props;
-		const { senderName, senderEmail, senderDirty } = this.state;
+		const { inFlight, campaign, lists, editPost, title, senderName, senderEmail } = this.props;
+		const { senderDirty } = this.state;
 		if ( ! campaign ) {
 			return (
 				<div className="newspack-newsletters__loading-data">
@@ -191,7 +196,10 @@ class Sidebar extends Component {
 					className="newspack-newsletters__name-textcontrol"
 					value={ senderName }
 					disabled={ inFlight }
-					onChange={ value => this.setState( { senderName: value, senderDirty: true } ) }
+					onChange={ value => {
+						editPost( { meta: { senderName: value } } );
+						this.setState( { senderDirty: true } );
+					} }
 				/>
 				<TextControl
 					label={ __( 'Email', 'newspack-newsletters' ) }
@@ -199,7 +207,10 @@ class Sidebar extends Component {
 					value={ senderEmail }
 					type="email"
 					disabled={ inFlight }
-					onChange={ value => this.setState( { senderEmail: value, senderDirty: true } ) }
+					onChange={ value => {
+						editPost( { meta: { senderEmail: value } } );
+						this.setState( { senderDirty: true } );
+					} }
 				/>
 				{ senderDirty && (
 					<Button
@@ -226,6 +237,8 @@ export default compose( [
 			interestCategories: meta.interestCategories,
 			lists: meta.lists ? meta.lists.lists : [],
 			postId: getCurrentPostId(),
+			senderEmail: meta.senderEmail,
+			senderName: meta.senderName,
 		};
 	} ),
 	withDispatch( dispatch => {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes some issues arising from sender data being in the `Sidebar`'s state and campaign data.

### How to test the changes in this Pull Request:

1. Ensure branch is `master`
2. Open a newsletter and set sender name and email
3. Close and open the "Newsletter" panel
1. Observe that sender name and email disappeared
1. Switch to this branch
1. Repeat pt. 3
1. Observe that sender data is there as expected

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
