### PR TITLE
feat: error notifications for from name/email changes

### DIFF
--- a/includes/class-newspack-newsletters.php
+++ b/includes/class-newspack-newsletters.php
@@ -464,25 +464,33 @@ final class Newspack_Newsletters {
 				__( 'Mailchimp campaign ID not found.', 'newspack-newsletters' )
 			);
 		}
+		try {
+			$mc = new Mailchimp( self::mailchimp_api_key() );
 
-		$mc = new Mailchimp( self::mailchimp_api_key() );
+			$settings = [];
+			if ( $from_name ) {
+				$settings['from_name'] = $from_name;
+			}
+			if ( $reply_to ) {
+				$settings['reply_to'] = $reply_to;
+			}
+			$payload = [
+				'settings' => $settings,
+			];
+			$result  = self::validate_mailchimp_operation(
+				$mc->patch( "campaigns/$mc_campaign_id", $payload )
+			);
 
-		$settings = [];
-		if ( $from_name ) {
-			$settings['from_name'] = $from_name;
+			$data           = self::retrieve_data( $id );
+			$data['result'] = $result;
+
+			return \rest_ensure_response( $data );
+		} catch ( Exception $e ) {
+			return new WP_Error(
+				'newspack_newsletters_mailchimp_error',
+				$e->getMessage()
+			);
 		}
-		if ( $reply_to ) {
-			$settings['reply_to'] = $reply_to;
-		}
-		$payload = [
-			'settings' => $settings,
-		];
-		$result  = $mc->patch( "campaigns/$mc_campaign_id", $payload );
-
-		$data           = self::retrieve_data( $id );
-		$data['result'] = $result;
-
-		return \rest_ensure_response( $data );
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Adds try/catches to the API endpoint callbacks for setting the sender name and reply-to email.

Partially addresses https://github.com/Automattic/newspack-newsletters/issues/24

### How to test the changes in this Pull Request:

1. Create a Newsletter.
2. In another browser window, navigate to Newsletters->Settings and clear out the Mailchimp API key.
3. In the first window, input the sender name and email, then click to update. Observe the error notification.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
