### PR TITLE
fix: crash when editing 'from' fields

### DIFF
--- a/src/editor/sidebar/index.js
+++ b/src/editor/sidebar/index.js
@@ -209,10 +209,7 @@ class Sidebar extends Component {
 					<Button
 						isLink
 						onClick={ () => this.updateSender( senderName, senderEmail ) }
-						disabled={
-							inFlight ||
-							( senderEmail && senderEmail.length ? ! hasValidEmail( senderEmail ) : false )
-						}
+						disabled={ inFlight || ( senderEmail.length ? ! hasValidEmail( senderEmail ) : false ) }
 					>
 						{ __( 'Update Sender', 'newspack-newsletters' ) }
 					</Button>
@@ -233,8 +230,8 @@ export default compose( [
 			interestCategories: meta.interestCategories,
 			lists: meta.lists ? meta.lists.lists : [],
 			postId: getCurrentPostId(),
-			senderEmail: meta.senderEmail,
-			senderName: meta.senderName,
+			senderEmail: meta.senderEmail || '',
+			senderName: meta.senderName || '',
 		};
 	} ),
 	withDispatch( dispatch => {

--- a/src/editor/sidebar/index.js
+++ b/src/editor/sidebar/index.js
@@ -209,7 +209,10 @@ class Sidebar extends Component {
 					<Button
 						isLink
 						onClick={ () => this.updateSender( senderName, senderEmail ) }
-						disabled={ inFlight || ( senderEmail.length ? ! hasValidEmail( senderEmail ) : false ) }
+						disabled={
+							inFlight ||
+							( senderEmail && senderEmail.length ? ! hasValidEmail( senderEmail ) : false )
+						}
 					>
 						{ __( 'Update Sender', 'newspack-newsletters' ) }
 					</Button>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Fixes a bug that causes the editor to crash when sender name or email are edited.

Closes https://github.com/Automattic/newspack-newsletters/issues/117

### How to test the changes in this Pull Request:

1. On `master`, create a new Newsletter, insert a template, and begin editing the sender name field in the `Newsletter` sidebar.
2. Observe the editor crash.
3. Switch to this branch and repeat. Observe no crash.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
