### PR TITLE
feat: error notifications when retrieving mailchimp data

### DIFF
--- a/includes/class-newspack-newsletters.php
+++ b/includes/class-newspack-newsletters.php
@@ -707,24 +707,31 @@ final class Newspack_Newsletters {
 			);
 		}
 
-		$mc_campaign_id      = get_post_meta( $id, 'mc_campaign_id', true );
-		$mc                  = new Mailchimp( self::mailchimp_api_key() );
-		$campaign            = $mc_campaign_id ? $mc->get( "campaigns/$mc_campaign_id" ) : null;
-		$list_id             = $campaign && isset( $campaign['recipients']['list_id'] ) ? $campaign['recipients']['list_id'] : null;
-		$interest_categories = $list_id ? $mc->get( "lists/$list_id/interest-categories" ) : null;
-		if ( $interest_categories && count( $interest_categories['categories'] ) ) {
-			foreach ( $interest_categories['categories'] as &$category ) {
-				$category_id           = $category['id'];
-				$category['interests'] = $mc->get( "lists/$list_id/interest-categories/$category_id/interests" );
+		try {
+			$mc_campaign_id      = get_post_meta( $id, 'mc_campaign_id', true );
+			$mc                  = new Mailchimp( self::mailchimp_api_key() );
+			$campaign            = $mc_campaign_id ? self::validate_mailchimp_operation( $mc->get( "campaigns/$mc_campaign_id" ) ) : null;
+			$list_id             = $campaign && isset( $campaign['recipients']['list_id'] ) ? $campaign['recipients']['list_id'] : null;
+			$interest_categories = $list_id ? self::validate_mailchimp_operation( $mc->get( "lists/$list_id/interest-categories" ) ) : null;
+			if ( $interest_categories && count( $interest_categories['categories'] ) ) {
+				foreach ( $interest_categories['categories'] as &$category ) {
+					$category_id           = $category['id'];
+					$category['interests'] = self::validate_mailchimp_operation( $mc->get( "lists/$list_id/interest-categories/$category_id/interests" ) );
+				}
 			}
-		}
 
-		return [
-			'lists'               => $mc->get( 'lists' ),
-			'campaign'            => $campaign,
-			'campaign_id'         => $mc_campaign_id,
-			'interest_categories' => $interest_categories,
-		];
+			return [
+				'lists'               => self::validate_mailchimp_operation( $mc->get( 'lists' ) ),
+				'campaign'            => $campaign,
+				'campaign_id'         => $mc_campaign_id,
+				'interest_categories' => $interest_categories,
+			];
+		} catch ( Exception $e ) {
+			return new WP_Error(
+				'newspack_newsletters_mailchimp_error',
+				$e->getMessage()
+			);
+		}
 	}
 
 	/**

--- a/includes/class-newspack-newsletters.php
+++ b/includes/class-newspack-newsletters.php
@@ -708,7 +708,13 @@ final class Newspack_Newsletters {
 		}
 
 		try {
-			$mc_campaign_id      = get_post_meta( $id, 'mc_campaign_id', true );
+			$mc_campaign_id = get_post_meta( $id, 'mc_campaign_id', true );
+			if ( ! $mc_campaign_id ) {
+				return new WP_Error(
+					'newspack_newsletters_mailchimp_error',
+					__( 'No Mailchimp campaign ID found for this Newsletter', 'newspack-newsletter' )
+				);
+			}
 			$mc                  = new Mailchimp( self::mailchimp_api_key() );
 			$campaign            = $mc_campaign_id ? self::validate_mailchimp_operation( $mc->get( "campaigns/$mc_campaign_id" ) ) : null;
 			$list_id             = $campaign && isset( $campaign['recipients']['list_id'] ) ? $campaign['recipients']['list_id'] : null;

--- a/includes/class-newspack-newsletters.php
+++ b/includes/class-newspack-newsletters.php
@@ -716,7 +716,7 @@ final class Newspack_Newsletters {
 				);
 			}
 			$mc                  = new Mailchimp( self::mailchimp_api_key() );
-			$campaign            = $mc_campaign_id ? self::validate_mailchimp_operation( $mc->get( "campaigns/$mc_campaign_id" ) ) : null;
+			$campaign            = self::validate_mailchimp_operation( $mc->get( "campaigns/$mc_campaign_id" ) );
 			$list_id             = $campaign && isset( $campaign['recipients']['list_id'] ) ? $campaign['recipients']['list_id'] : null;
 			$interest_categories = $list_id ? self::validate_mailchimp_operation( $mc->get( "lists/$list_id/interest-categories" ) ) : null;
 			if ( $interest_categories && count( $interest_categories['categories'] ) ) {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Adds error catching and notification when retrieving Mailchimp data.

Partially addresses https://github.com/Automattic/newspack-newsletters/issues/24

### How to test the changes in this Pull Request:

1. Create a Newsletter, insert a template, verify the Newsletter sidebar loads correctly with no errors. 
2. In another window navigate to Newsletters->Settings, delete Mailchimp key and Save.
3. Refresh the editor window, observe error.
4. After restoring Mailchimp API key, enable custom fields for the post (3 dots, options, Custom fields), then add a random character to the `mc_campaign_id` field. 
5. Refresh the editor window, observe error.
6. After restoring the campaign ID, log in to Mailchimp and delete the campaign linked to the post.
7. Refresh the editor window, observe error. 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
