### PR TITLE
feat: error handling in save and publish operations

### DIFF
--- a/includes/class-newspack-newsletters-renderer.php
+++ b/includes/class-newspack-newsletters-renderer.php
@@ -533,6 +533,7 @@ final class Newspack_Newsletters_Renderer {
 	 *
 	 * @param WP_Post $post The post.
 	 * @return string email-compliant HTML.
+	 * @throws Exception Error message.
 	 */
 	public static function render_html_email( $post ) {
 		$mjml_creds = self::mjml_api_credentials();
@@ -552,6 +553,9 @@ final class Newspack_Newsletters_Renderer {
 					'timeout' => 45, // phpcs:ignore WordPressVIPMinimum.Performance.RemoteRequestTimeout.timeout_timeout
 				)
 			);
+			if ( 401 === intval( $request['response']['code'] ) ) {
+				throw new Exception( __( 'MJML error.', 'newspack_newsletters' ) );
+			}
 			return is_wp_error( $request ) ? $request : json_decode( $request['body'] )->html;
 		}
 	}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Adds error notifications in save and publish operations. These are trickier to catch since they are handled by standard Gutenberg XHR requests as opposed to custom endpoint defined by the plugin. To work around this, errors caught in save/publish are stored in a transient for 45 second, and are then displayed the next time the Mailchimp data retrieval endpoint is hit. This is tricky to test since many things you could do to break the flow will _also_ break the retrieval endpoint, so it's not clear where the error is coming from. The best way to test is to break the MML operation because this only occurs during save. 

### How to test the changes in this Pull Request:

1. Create a Newsletter, select a template.
2. In Newsletters->Settings, add a character to one of the MJML fields.
3. In the editor, save or publish the post. Observe the `MJML Error.` error notification.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
