### PR TITLE
fix: regression of test email error/success notifications

### DIFF
--- a/src/components/with-api-handler/index.js
+++ b/src/components/with-api-handler/index.js
@@ -12,6 +12,9 @@ export default () =>
 			const [ inFlight, setInFlight ] = useState( false );
 			const { createSuccessNotice, createErrorNotice, removeNotice } = dispatch( 'core/notices' );
 			const { getNotices } = select( 'core/notices' );
+			const setInFlightForAsync = () => {
+				setInFlight( true );
+			};
 			const apiFetchWithErrorHandling = apiRequest => {
 				setInFlight( true );
 				return new Promise( ( resolve, reject ) => {
@@ -38,6 +41,7 @@ export default () =>
 				<OriginalComponent
 					{ ...props }
 					apiFetchWithErrorHandling={ apiFetchWithErrorHandling }
+					setInFlightForAsync={ setInFlightForAsync }
 					inFlight={ inFlight }
 				/>
 			);

--- a/src/editor/testing/index.js
+++ b/src/editor/testing/index.js
@@ -2,14 +2,19 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import apiFetch from '@wordpress/api-fetch';
 import { withSelect, withDispatch } from '@wordpress/data';
 import { compose } from '@wordpress/compose';
 import { Fragment, useState } from '@wordpress/element';
 import { Button, TextControl } from '@wordpress/components';
 import { hasValidEmail } from '../utils';
 
+/**
+ * Internal dependencies
+ */
+import withApiHandler from '../../components/with-api-handler';
+
 export default compose( [
+	withApiHandler(),
 	withSelect( select => {
 		const { getCurrentPostId } = select( 'core/editor' );
 		return { postId: getCurrentPostId() };
@@ -20,11 +25,10 @@ export default compose( [
 			savePost,
 		};
 	} ),
-] )( ( { postId, savePost } ) => {
-	const [ inFlight, setInFlight ] = useState( false );
+] )( ( { apiFetchWithErrorHandling, inFlight, postId, savePost, setInFlightForAsync } ) => {
 	const [ testEmail, setTestEmail ] = useState( '' );
 	const sendMailchimpTest = async () => {
-		setInFlight( true );
+		setInFlightForAsync();
 		await savePost();
 		const params = {
 			path: `/newspack-newsletters/v1/mailchimp/${ postId }/test`,
@@ -33,7 +37,7 @@ export default compose( [
 			},
 			method: 'POST',
 		};
-		apiFetch( params ).then( () => setInFlight( false ) );
+		apiFetchWithErrorHandling( params );
 	};
 	return (
 		<Fragment>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

A series of merges caused a regression in the test email functionality, causing notification after successful tests (or errors) to fail. This branch corrects this. 

### How to test the changes in this Pull Request:

1. Create a Newsletter. 
2. Send a test to a real email address. Observe the success message when test is sent.
3. Send a test to `a@example.com`. Observe failure message.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
