### PR TITLE
Fix link colour and text-decoration

### DIFF
--- a/includes/email-template.mjml.php
+++ b/includes/email-template.mjml.php
@@ -9,56 +9,67 @@
 ?>
 
 <mjml>
-  <mj-head>
-    <mj-title><?php echo $title; ?></mj-title>
-    <mj-style>
-      /* Paragraph */
-      p {
-        margin-top: 0 !important;
-        margin-bottom: 0 !important;
-      }
+	<mj-head>
+		<mj-title><?php echo $title; ?></mj-title>
+		<mj-style>
+			/* Paragraph */
+			p {
+				margin-top: 0 !important;
+				margin-bottom: 0 !important;
+			}
 
-      /* Button */
-      .is-style-outline a {
-        background: none !important;
-        border: 2px solid !important;
-      }
+			/* Link */
+			a {
+				color: inherit;
+				text-decoration: underline;
+			}
+			a:active, a:focus, a:hover {
+				text-decoration: none;
+			}
+			a:focus {
+				outline: thin dotted #000;
+			}
 
-      /* Heading */
-      h1 { font-size: 2.64em; }
-      h2 { font-size: 2.15em; }
-      h3 { font-size: 1.76em; }
-      h4 { font-size: 1.45em; }
-      h5 { font-size: 1.2em; }
-      h6 { font-size: 1em; }
-      h1, h2, h3, h4, h5, h6 { line-height: 1.2; margin-top: 0; margin-bottom: 0.5em; }
-      h1 a, h2 a, h3 a, h4 a, h5 a, h6 a { text-decoration: none; color: inherit; }
+			/* Button */
+			.is-style-outline a {
+				background: none !important;
+				border: 2px solid !important;
+			}
 
-      /* Quote */
-      .wp-block-quote {
-        margin: 0 0 28px;
-        padding-left: 1em;
-      }
-      .wp-block-quote cite {
-        color: #6c7781;
-        font-size: 13px;
-      }
-      .wp-block-quote.is-style-default {
-        border-left: 4px solid #000;
-      }
-      .wp-block-quote.is-style-large p {
-        font-size: 24px;
-        font-style: italic;
-        line-height: 1.6;
-      }
+			/* Heading */
+			h1 { font-size: 2.64em; }
+			h2 { font-size: 2.15em; }
+			h3 { font-size: 1.76em; }
+			h4 { font-size: 1.45em; }
+			h5 { font-size: 1.2em; }
+			h6 { font-size: 1em; }
+			h1, h2, h3, h4, h5, h6 { line-height: 1.2; margin-top: 0; margin-bottom: 0.5em; }
 
-      /* Social links */
-      .social-element img {
-        border-radius: 0 !important;
-      }
-    </mj-style>
-  </mj-head>
-  <mj-body>
-    <?php echo $body; ?>
-  </mj-body>
+			/* Quote */
+			.wp-block-quote {
+				margin: 0 0 28px;
+				padding-left: 1em;
+			}
+			.wp-block-quote cite {
+				color: #6c7781;
+				font-size: 13px;
+			}
+			.wp-block-quote.is-style-default {
+				border-left: 4px solid #000;
+			}
+			.wp-block-quote.is-style-large p {
+				font-size: 24px;
+				font-style: italic;
+				line-height: 1.6;
+			}
+
+			/* Social links */
+			.social-element img {
+				border-radius: 0 !important;
+			}
+		</mj-style>
+	</mj-head>
+	<mj-body>
+		<?php echo $body; ?>
+	</mj-body>
 </mjml>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR applies some "default" style to links, making sure they inherit the colour of the parent element, that they have an underline and a focus state (important for accessibility!).

Closes #116 and #122

![1 editor](https://user-images.githubusercontent.com/177929/80085646-6cf38d00-8550-11ea-9fc8-e43dece1949b.png)
![2 preview](https://user-images.githubusercontent.com/177929/80085648-6f55e700-8550-11ea-861a-57f78b34ad14.png)

### How to test the changes in this Pull Request:

1. Change the colour of some links.
2. Publish the newsletter (or send test, or preview)
3. Links should be using the default's browser styles
4. Switch to this branch
5. Retry to send

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
