### PR TITLE
refactor: rework the blank template ui

### DIFF
--- a/src/components/template-modal/screens/api-keys/index.js
+++ b/src/components/template-modal/screens/api-keys/index.js
@@ -152,9 +152,11 @@ export default ( { onSetupStatus } ) => {
 					</p>
 				</div>
 			</div>
-			<Button isPrimary onClick={ commitSettings } disabled={ inFlight || ! canSubmit }>
-				{ __( 'Save settings', 'newspack-newsletter' ) }
-			</Button>
+			<div className="newspack-newsletters-modal__action-buttons">
+				<Button isPrimary onClick={ commitSettings } disabled={ inFlight || ! canSubmit }>
+					{ __( 'Save settings', 'newspack-newsletter' ) }
+				</Button>
+			</div>
 		</Fragment>
 	);
 };

--- a/src/components/template-modal/screens/template-picker/index.js
+++ b/src/components/template-modal/screens/template-picker/index.js
@@ -60,12 +60,15 @@ export default ( { onInsertTemplate, templates } ) => {
 					) }
 				</div>
 			</div>
-			<Button isSecondary onClick={ () => onInsertTemplate( 0 ) }>
-				{ __( 'Use empty layout', 'newspack-newsletters' ) }
-			</Button>
-			<Button isPrimary onClick={ () => onInsertTemplate( selectedTemplate ) }>
-				{ __( 'Use this layout', 'newspack-newsletters' ) }
-			</Button>
+			<div className="newspack-newsletters-modal__action-buttons">
+				<Button isSecondary onClick={ () => onInsertTemplate( 0 ) }>
+					{ __( 'Start From Scratch', 'newspack-newsletters' ) }
+				</Button>
+				<span className="separator">{ __( 'or', 'newspack-newsletters' ) }</span>
+				<Button isPrimary onClick={ () => onInsertTemplate( selectedTemplate ) }>
+					{ __( 'Use Selected Layout', 'newspack-newsletters' ) }
+				</Button>
+			</div>
 		</Fragment>
 	);
 };

--- a/src/components/template-modal/screens/template-picker/index.js
+++ b/src/components/template-modal/screens/template-picker/index.js
@@ -9,7 +9,7 @@ import { BlockPreview } from '@wordpress/block-editor';
 import { ENTER, SPACE } from '@wordpress/keycodes';
 
 export default ( { onInsertTemplate, templates } ) => {
-	const [ selectedTemplate, setSelectedTemplate ] = useState( 1 );
+	const [ selectedTemplate, setSelectedTemplate ] = useState( null );
 	const generateBlockPreview = () => {
 		return templates && templates[ selectedTemplate ]
 			? parse( templates[ selectedTemplate ].content )
@@ -65,7 +65,11 @@ export default ( { onInsertTemplate, templates } ) => {
 					{ __( 'Start From Scratch', 'newspack-newsletters' ) }
 				</Button>
 				<span className="separator">{ __( 'or', 'newspack-newsletters' ) }</span>
-				<Button isPrimary onClick={ () => onInsertTemplate( selectedTemplate ) }>
+				<Button
+					isPrimary
+					disabled={ selectedTemplate < 1 }
+					onClick={ () => onInsertTemplate( selectedTemplate ) }
+				>
 					{ __( 'Use Selected Layout', 'newspack-newsletters' ) }
 				</Button>
 			</div>

--- a/src/components/template-modal/screens/template-picker/index.js
+++ b/src/components/template-modal/screens/template-picker/index.js
@@ -9,7 +9,7 @@ import { BlockPreview } from '@wordpress/block-editor';
 import { ENTER, SPACE } from '@wordpress/keycodes';
 
 export default ( { onInsertTemplate, templates } ) => {
-	const [ selectedTemplate, setSelectedTemplate ] = useState( 0 );
+	const [ selectedTemplate, setSelectedTemplate ] = useState( 1 );
 	const generateBlockPreview = () => {
 		return templates && templates[ selectedTemplate ]
 			? parse( templates[ selectedTemplate ].content )
@@ -22,31 +22,33 @@ export default ( { onInsertTemplate, templates } ) => {
 			<div className="newspack-newsletters-modal__content">
 				<div className="newspack-newsletters-modal__patterns">
 					<div className="block-editor-patterns">
-						{ ( templates || [] ).map( ( { title, content }, index ) => (
-							<div
-								key={ index }
-								className={
-									selectedTemplate === index
-										? 'selected block-editor-patterns__item'
-										: 'block-editor-patterns__item'
-								}
-								onClick={ () => setSelectedTemplate( index ) }
-								onKeyDown={ event => {
-									if ( ENTER === event.keyCode || SPACE === event.keyCode ) {
-										event.preventDefault();
-										setSelectedTemplate( index );
+						{ ( templates || [] ).map( ( { title, content }, index ) =>
+							0 === index ? null : (
+								<div
+									key={ index }
+									className={
+										selectedTemplate === index
+											? 'selected block-editor-patterns__item'
+											: 'block-editor-patterns__item'
 									}
-								} }
-								role="button"
-								tabIndex="0"
-								aria-label={ title }
-							>
-								<div className="block-editor-patterns__item-preview">
-									<BlockPreview blocks={ parse( content ) } viewportWidth={ 568 } />
+									onClick={ () => setSelectedTemplate( index ) }
+									onKeyDown={ event => {
+										if ( ENTER === event.keyCode || SPACE === event.keyCode ) {
+											event.preventDefault();
+											setSelectedTemplate( index );
+										}
+									} }
+									role="button"
+									tabIndex="0"
+									aria-label={ title }
+								>
+									<div className="block-editor-patterns__item-preview">
+										<BlockPreview blocks={ parse( content ) } viewportWidth={ 568 } />
+									</div>
+									<div className="block-editor-patterns__item-title">{ title }</div>
 								</div>
-								<div className="block-editor-patterns__item-title">{ title }</div>
-							</div>
-						) ) }
+							)
+						) }
 					</div>
 				</div>
 
@@ -58,13 +60,12 @@ export default ( { onInsertTemplate, templates } ) => {
 					) }
 				</div>
 			</div>
-			{ selectedTemplate !== null && (
-				<Button isPrimary onClick={ () => onInsertTemplate( selectedTemplate ) }>
-					{ blockPreview && blockPreview.length > 0
-						? __( 'Use this layout', 'newspack-newsletters' )
-						: __( 'Use blank layout', 'newspack-newsletters' ) }
-				</Button>
-			) }
+			<Button isSecondary onClick={ () => onInsertTemplate( 0 ) }>
+				{ __( 'Use empty layout', 'newspack-newsletters' ) }
+			</Button>
+			<Button isPrimary onClick={ () => onInsertTemplate( selectedTemplate ) }>
+				{ __( 'Use this layout', 'newspack-newsletters' ) }
+			</Button>
 		</Fragment>
 	);
 };

--- a/src/components/template-modal/screens/template-picker/index.js
+++ b/src/components/template-modal/screens/template-picker/index.js
@@ -23,7 +23,7 @@ export default ( { onInsertTemplate, templates } ) => {
 				<div className="newspack-newsletters-modal__patterns">
 					<div className="block-editor-patterns">
 						{ ( templates || [] ).map( ( { title, content }, index ) =>
-							0 === index ? null : (
+							'' === content ? null : (
 								<div
 									key={ index }
 									className={

--- a/src/components/template-modal/style.scss
+++ b/src/components/template-modal/style.scss
@@ -46,6 +46,21 @@
 		top: 0;
 		transform: none;
 		width: 100%;
+
+		.components-modal__header-heading {
+			display: none;
+			font-size: 0.8rem;
+			line-height: 1.25;
+
+			@media only screen and ( min-width: 600px ) {
+				display: block;
+			}
+
+			@media only screen and ( min-width: 783px ) {
+				font-size: 1rem;
+				line-height: 1;
+			}
+		}
 	}
 
 	&__content {
@@ -73,12 +88,21 @@
 				top: 61px;
 			}
 		}
+	}
 
-		+ .is-primary {
-			position: absolute;
-			right: 24px;
-			top: 12px;
-			z-index: 11;
+	&__action-buttons {
+		align-items: center;
+		display: flex;
+		flex-wrap: wrap;
+		justify-content: flex-end;
+		position: absolute;
+		right: 24px;
+		top: 12px;
+		z-index: 11;
+
+		.separator {
+			margin-left: 6px;
+			margin-right: 6px;
 		}
 	}
 

--- a/src/editor/layout/index.js
+++ b/src/editor/layout/index.js
@@ -34,14 +34,16 @@ export default compose( [
 	const blockPreview = content ? parse( content ) : null;
 	return (
 		<Fragment>
-			<div className="block-editor-patterns newspack-newsletters__layout-panel-preview">
-				<div className="block-editor-patterns__item">
-					<div className="block-editor-patterns__item-preview">
-						<BlockPreview blocks={ blockPreview } viewportWidth={ 568 } />
+			{ templateId > 0 && (
+				<div className="block-editor-patterns newspack-newsletters__layout-panel-preview">
+					<div className="block-editor-patterns__item">
+						<div className="block-editor-patterns__item-preview">
+							<BlockPreview blocks={ blockPreview } viewportWidth={ 568 } />
+						</div>
+						<div className="block-editor-patterns__item-title">{ title }</div>
 					</div>
-					<div className="block-editor-patterns__item-title">{ title }</div>
 				</div>
-			</div>
+			) }
 			<Button isPrimary onClick={ () => setWarningModalVisible( true ) }>
 				{ __( 'Change Layout', 'newspack-newsletters' ) }
 			</Button>

--- a/src/editor/layout/index.js
+++ b/src/editor/layout/index.js
@@ -34,7 +34,7 @@ export default compose( [
 	const blockPreview = content ? parse( content ) : null;
 	return (
 		<Fragment>
-			{ templateId > 0 && (
+			{ blockPreview !== null && (
 				<div className="block-editor-patterns newspack-newsletters__layout-panel-preview">
 					<div className="block-editor-patterns__item">
 						<div className="block-editor-patterns__item-preview">


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Reworks the handling of blank templates. In the Template Picker blank template no longer has a thumbnail. Instead there is a button in the upper right that gives the user a blank canvas to work from. After selecting blank template, no thumbnail is shown in the sidebar either.

Closes https://github.com/Automattic/newspack-newsletters/issues/111

<img width="1535" alt="Screen Shot 2020-04-24 at 12 04 34 AM" src="https://user-images.githubusercontent.com/1477002/80173902-36089000-85bf-11ea-9ccd-eee409e4bfaa.png">

### How to test the changes in this Pull Request:

1. Create a Newsletter. Verify there are only 5 template thumbnails and blank is not one of them. 
2. Click `Start From Scratch`. Verify the modal disappears and a blank editor is shown.
3. In the Layout sidebar panel, verify there is no thumbnail.
4. Click Change Layout, then select one of the 5 templates.
5. Verify insertion works as expected, and that the thumbnail for the template is shown in the sidebar.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
