### PR TITLE
Prevent updating content of a sent campaign

### DIFF
--- a/includes/class-newspack-newsletters.php
+++ b/includes/class-newspack-newsletters.php
@@ -843,6 +843,11 @@ final class Newspack_Newsletters {
 				update_post_meta( $post->ID, 'mc_campaign_id', $mc_campaign_id );
 			}
 
+			// Prevent updating content of a sent campaign.
+			if ( ! in_array( $campaign_result['status'], [ 'sent', 'sending' ] ) ) {
+				return;
+			}
+
 			$renderer        = new Newspack_Newsletters_Renderer();
 			$content_payload = [
 				'html' => $renderer->render_html_email( $post ),

--- a/includes/class-newspack-newsletters.php
+++ b/includes/class-newspack-newsletters.php
@@ -844,7 +844,7 @@ final class Newspack_Newsletters {
 			}
 
 			// Prevent updating content of a sent campaign.
-			if ( ! in_array( $campaign_result['status'], [ 'sent', 'sending' ] ) ) {
+			if ( in_array( $campaign_result['status'], [ 'sent', 'sending' ] ) ) {
 				return;
 			}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Now that we have errors present, one issue has surfaced. It looks like the `sync_with_mailchimp`

### How to test the changes in this Pull Request:

1. [on `master` branch]
2. Create and send a newsletter 
3. Observe an error notice about setting content of a sent campaign being shown
3. Switch to this branch, repeat step 2
3. Observe no error notice being shown

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
