### PR TITLE
feat: improved permissions

### DIFF
--- a/src/components/template-modal/screens/api-keys/index.js
+++ b/src/components/template-modal/screens/api-keys/index.js
@@ -38,6 +38,20 @@ export default ( { onSetupStatus } ) => {
 			.catch( handleErrors );
 	};
 	const handleErrors = error => {
+		if ( 'newspack_rest_forbidden' === error.code ) {
+			setInFlight( false );
+			setErrors( {
+				newspack_newsletters_invalid_keys_mailchimp: __(
+					'Only administrators can set Mailchimp API keys.',
+					'newspack-newsletters'
+				),
+				newspack_newsletters_invalid_keys_mjml: __(
+					'Only administrators can set MJML credentials.',
+					'newspack-newsletters'
+				),
+			} );
+			return;
+		}
 		const allErrors = { [ error.code ]: error.message };
 		( error.additional_errors || [] ).forEach(
 			additionalError => ( allErrors[ additionalError.code ] = additionalError.message )


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Improved permissions for Newsletter features:

1) Administrators can do everything.
2) Editors do not see the Settings page.
3) If an editor sees the API keys modal, the fields will be blank and error messages will inform that only Administrators can set keys.
4) Editors can do everything else.
5) Users below Editor level don't even see the menu item, and can't do anything.

Closes https://github.com/Automattic/newspack-newsletters/issues/88

### How to test the changes in this Pull Request:

1. Log in as an administrator. Verify you can set keys and create/save/publish newsletters. 
2. Log in as an editor. Verify you can create/save/publish newsletters. 
3. Verify you don't see the Settings page.
4. Logged in as an admin, clear at least one of the API keys.
5. As an editor verify the error messages in the API keys modal.
6. Log in as an author. Verify you don't see anything newsletter related.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
