### PR TITLE
feat: throw error for unverified reply-to email

### DIFF
--- a/includes/class-newspack-newsletters.php
+++ b/includes/class-newspack-newsletters.php
@@ -492,7 +492,7 @@ final class Newspack_Newsletters {
 
 			if ( ! in_array( $domain, $verified_domains ) ) {
 				return new WP_Error(
-					'newspack_newsletters_incorrect_post_type',
+					'newspack_newsletters_unverified_sender_domain',
 					sprintf(
 						// Translators: explanation that current domain is not verified, list of verified options.
 						__( '%1$s is not a verified domain. Verified domains for the linked Mailchimp account are: %2$s.', 'newspack-newsletters' ),

--- a/src/components/with-api-handler/index.js
+++ b/src/components/with-api-handler/index.js
@@ -10,6 +10,7 @@ export default () =>
 	createHigherOrderComponent(
 		OriginalComponent => props => {
 			const [ inFlight, setInFlight ] = useState( false );
+			const [ errors, setErrors ] = useState( {} );
 			const { createSuccessNotice, createErrorNotice, removeNotice } = dispatch( 'core/notices' );
 			const { getNotices } = select( 'core/notices' );
 			const setInFlightForAsync = () => {
@@ -21,11 +22,12 @@ export default () =>
 					apiFetch( apiRequest )
 						.then( response => {
 							const { message } = response;
+							getNotices().forEach( notice => removeNotice( notice.id ) );
 							if ( message ) {
-								getNotices().forEach( notice => removeNotice( notice.id ) );
 								createSuccessNotice( message );
 							}
 							setInFlight( false );
+							setErrors( {} );
 							resolve( response );
 						} )
 						.catch( error => {
@@ -33,6 +35,7 @@ export default () =>
 							getNotices().forEach( notice => removeNotice( notice.id ) );
 							createErrorNotice( message );
 							setInFlight( false );
+							setErrors( { [ error.code ]: true } );
 							reject( error );
 						} );
 				} );
@@ -41,6 +44,7 @@ export default () =>
 				<OriginalComponent
 					{ ...props }
 					apiFetchWithErrorHandling={ apiFetchWithErrorHandling }
+					errors={ errors }
 					setInFlightForAsync={ setInFlightForAsync }
 					inFlight={ inFlight }
 				/>

--- a/src/editor/sidebar/index.js
+++ b/src/editor/sidebar/index.js
@@ -18,6 +18,7 @@ import {
  * External dependencies
  */
 import { get } from 'lodash';
+import classnames from 'classnames';
 
 /**
  * Internal dependencies
@@ -129,7 +130,16 @@ class Sidebar extends Component {
 	 * Render
 	 */
 	render() {
-		const { inFlight, campaign, lists, editPost, title, senderName, senderEmail } = this.props;
+		const {
+			inFlight,
+			campaign,
+			errors,
+			lists,
+			editPost,
+			title,
+			senderName,
+			senderEmail,
+		} = this.props;
 		const { senderDirty } = this.state;
 		if ( ! campaign ) {
 			return (
@@ -148,6 +158,10 @@ class Sidebar extends Component {
 				</Notice>
 			);
 		}
+		const senderEmailClasses = classnames(
+			'newspack-newsletters__email-textcontrol',
+			errors.newspack_newsletters_unverified_sender_domain && 'newspack-newsletters__error'
+		);
 		const { web_id: listWebId } = list_id && lists.find( ( { id } ) => list_id === id );
 		return (
 			<Fragment>
@@ -196,7 +210,7 @@ class Sidebar extends Component {
 				/>
 				<TextControl
 					label={ __( 'Email', 'newspack-newsletters' ) }
-					className="newspack-newsletters__email-textcontrol"
+					className={ senderEmailClasses }
 					value={ senderEmail }
 					type="email"
 					disabled={ inFlight }

--- a/src/editor/sidebar/style.scss
+++ b/src/editor/sidebar/style.scss
@@ -1,3 +1,5 @@
+@import '~@wordpress/base-styles/colors';
+
 .wp-block {
 	max-width: 568px;
 }
@@ -61,6 +63,10 @@
 		> li:last-child {
 			margin-bottom: 0;
 		}
+	}
+
+	&__error input.components-text-control__input {
+		border-color: $alert-red;
 	}
 }
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

The reply-to email address used in a Mailchimp campaign must be verified or the campaign will fail to send. More on domain verification: https://mailchimp.com/help/verify-a-domain/. When the sender email is set, all verified domains are fetched from Mailchimp and if the email address is not part of one of these, an error notification is displayed.

Closes https://github.com/Automattic/newspack-newsletters/issues/23

### How to test the changes in this Pull Request:

1. Create a Newsletter, select a template, set the From Email to an unverified domain (e.g. `test@unverifieddomain.com`)
2. Observe error notification like this: `unverifieddomain.com is not a verified domain. Verified domains for the linked Mailchimp account are: verifieddomain1.com, verifieddomain2.com, verifieddomain1.com.`
3. Set the From Email to a verified domain, observe the change goes through with no notifications.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
