### PR TITLE
Fix Posts Inserter infinite loop

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12475,11 +12475,6 @@
       "resolved": "https://registry.npmjs.org/memize/-/memize-1.1.0.tgz",
       "integrity": "sha512-K4FcPETOMTwe7KL2LK0orMhpOmWD2wRGwWWpbZy0fyArwsyIKR8YJVz8+efBAh3BO4zPqlSICu4vsLTRRqtFAg=="
     },
-    "memoize-one": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.1.1.tgz",
-      "integrity": "sha512-HKeeBpWvqiVJD57ZUAsJNm71eHTykffzcLZVYWiVfQeI1rJtuEaS7hQiEpWfVVk18donPwJEcFKIkCmPJNOhHA=="
-    },
     "memory-fs": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.4.1.tgz",

--- a/package.json
+++ b/package.json
@@ -111,7 +111,6 @@
     "@wordpress/url": "^2.13.0",
     "classnames": "^2.2.6",
     "lodash": "^4.17.15",
-    "memoize-one": "^5.1.1",
     "webpack": "^4.42.1"
   },
   "devDependencies": {

--- a/src/editor/blocks/posts-inserter/index.js
+++ b/src/editor/blocks/posts-inserter/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { isUndefined, pickBy, get, omit } from 'lodash';
+import { values, isUndefined, pickBy, get, omit } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -24,17 +24,15 @@ import { Fragment, useEffect } from '@wordpress/element';
  */
 import './style.scss';
 import Icon from './icon';
-import { getTemplateBlocksMemoized, convertBlockSerializationFormat } from './utils';
+import { getTemplateBlocks, convertBlockSerializationFormat } from './utils';
 import QueryControlsSettings from './query-controls';
 
 const PostsInserterBlock = ( { setAttributes, attributes, postList, replaceBlocks } ) => {
-	const templateBlocks = getTemplateBlocksMemoized(
-		postList,
-		omit( attributes, 'innerBlocksToInsert' )
-	);
-	useEffect(() => {
+	const templateBlocks = getTemplateBlocks( postList, attributes );
+
+	useEffect( () => {
 		setAttributes( { innerBlocksToInsert: templateBlocks.map( convertBlockSerializationFormat ) } );
-	}, [ templateBlocks ]);
+	}, values( omit( attributes, 'innerBlocksToInsert' ) ) );
 
 	useEffect(() => {
 		if ( attributes.areBlocksInserted ) {

--- a/src/editor/blocks/posts-inserter/utils.js
+++ b/src/editor/blocks/posts-inserter/utils.js
@@ -1,8 +1,7 @@
 /**
  * External dependencies
  */
-import { omit, isEqual } from 'lodash';
-import memoizeOne from 'memoize-one';
+import { omit } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -92,10 +91,8 @@ const createBlockTemplatesForPosts = ( posts, attributes ) =>
 		return [ ...blocks, ...createBlockTemplatesForSinglePost( post, attributes ) ];
 	}, [] );
 
-const getTemplateBlocks = ( postList, attributes ) =>
+export const getTemplateBlocks = ( postList, attributes ) =>
 	createBlockTemplatesForPosts( postList, attributes ).map( createBlockFromTemplate );
-
-export const getTemplateBlocksMemoized = memoizeOne( getTemplateBlocks, isEqual );
 
 /**
  * Converts a block object to a shape processable by the backend,


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [X] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Previous solution relied on memoization of `getTemplateBlocks` function in order to ensure the hook that calls `setAttributes` is only called if `templateBlocks` changes. Probably because of the comparison algorithm used by the hook (which compares the current and previous items in the dependencies array) this did not work as intended – hook function was called even though the contents of `templateBlocks` array stayed the same. 
The new solutions is based on realisation that the only thing that can change the intended content of `innerBlocksToInsert` are the block attributes.

Closes #146 

### How to test the changes in this Pull Request:

1. [on `master`]: Create a new newsletter, choose "Daily/Weekly" template
2. Observe that images in Posts Inserter block in layout preview flicker and an ever-increasing amount of requests is made for the images
3. Switch to this branch
4. Repeat 1, observe that the images flicker just a couple of times, not infinitely

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
