### PR TITLE
Remove support for background gradients

### DIFF
--- a/includes/class-newspack-newsletters.php
+++ b/includes/class-newspack-newsletters.php
@@ -43,10 +43,10 @@ final class Newspack_Newsletters {
 	 */
 	public function __construct() {
 		add_action( 'the_post', [ __CLASS__, 'remove_other_editor_modifications' ] );
+		add_action( 'the_post', [ __CLASS__, 'disable_gradients' ] );
 		add_action( 'init', [ __CLASS__, 'register_cpt' ] );
 		add_action( 'init', [ __CLASS__, 'register_meta' ] );
 		add_action( 'enqueue_block_editor_assets', [ __CLASS__, 'enqueue_block_editor_assets' ] );
-		add_action( 'enqueue_block_editor_assets', [ __CLASS__, 'disable_gradients' ] );
 		add_action( 'rest_api_init', [ __CLASS__, 'rest_api_init' ] );
 		add_action( 'default_title', [ __CLASS__, 'default_title' ], 10, 2 );
 		add_action( 'save_post_' . self::NEWSPACK_NEWSLETTERS_CPT, [ __CLASS__, 'save_post' ], 10, 3 );
@@ -129,8 +129,6 @@ final class Newspack_Newsletters {
 
 		remove_editor_styles();
 		remove_theme_support( 'editor-color-palette' );
-		add_theme_support( 'editor-gradient-presets', array() );
-		add_theme_support( 'disable-custom-gradients' );
 	}
 
 	/**

--- a/includes/class-newspack-newsletters.php
+++ b/includes/class-newspack-newsletters.php
@@ -129,6 +129,8 @@ final class Newspack_Newsletters {
 
 		remove_editor_styles();
 		remove_theme_support( 'editor-color-palette' );
+		add_theme_support( 'editor-gradient-presets', array() );
+		add_theme_support( 'disable-custom-gradients' );
 	}
 
 	/**
@@ -477,7 +479,7 @@ final class Newspack_Newsletters {
 
 			$verified_domains = array_filter(
 				array_map(
-					function( $domain ) { 
+					function( $domain ) {
 						return $domain['verified'] ? strtolower( trim( $domain['domain'] ) ) : null;
 					},
 					$result['domains']
@@ -756,7 +758,7 @@ final class Newspack_Newsletters {
 				);
 			}
 			$mc                  = new Mailchimp( self::mailchimp_api_key() );
-			$campaign            = self::validate_mailchimp_operation( 
+			$campaign            = self::validate_mailchimp_operation(
 				$mc->get( "campaigns/$mc_campaign_id" ),
 				__( 'Error retrieving Mailchimp campaign.', 'newspack_newsletters' )
 			);

--- a/includes/class-newspack-newsletters.php
+++ b/includes/class-newspack-newsletters.php
@@ -958,8 +958,7 @@ final class Newspack_Newsletters {
 	 * Disable gradients in Newsletter CPT.
 	 */
 	public static function disable_gradients() {
-		$screen = get_current_screen();
-		if ( ! $screen || self::NEWSPACK_NEWSLETTERS_CPT !== $screen->post_type ) {
+		if ( self::NEWSPACK_NEWSLETTERS_CPT != get_post_type() ) {
 			return;
 		}
 		add_theme_support( 'editor-gradient-presets', array() );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Background Gradients are not supported by MJML (`background-image`) so we shouldn't show the option.

Fixes #138 

### How to test the changes in this Pull Request:

1. To a group or button, change the background colour, check that you can select gradients
2. Switch to this branch
3. Gradients should be gone

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
