### PR TITLE
fix: rename list->audience to reflect mailchimp

### DIFF
--- a/src/editor/sidebar/index.js
+++ b/src/editor/sidebar/index.js
@@ -179,7 +179,7 @@ class Sidebar extends Component {
 					options={ [
 						{
 							value: null,
-							label: __( '-- Select a list --', 'newspack-newsletters' ),
+							label: __( '-- Select an audience --', 'newspack-newsletters' ),
 						},
 						...lists.map( ( { id, name } ) => ( {
 							value: id,
@@ -192,7 +192,7 @@ class Sidebar extends Component {
 				{ listWebId && (
 					<p>
 						<ExternalLink href={ `https://admin.mailchimp.com/lists/members/?id=${ listWebId }` }>
-							{ __( 'Manage list', 'newspack-newsletters' ) }
+							{ __( 'Manage audience', 'newspack-newsletters' ) }
 						</ExternalLink>
 					</p>
 				) }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Renames "list" to "audience," to reflect Mailchimp's naming convention.

Closes https://github.com/Automattic/newspack-newsletters/issues/148

### How to test the changes in this Pull Request:

1. Create a Newsletter, insert a template. Observe the list selection dropdown reads "-- Select an audience --" 
2. Make a list selection. Observe the convenience link below reads "Manage audience."

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
