### PR TITLE
Posts Inserter deduplication

### DIFF
--- a/src/components/template-modal/screens/template-picker/index.js
+++ b/src/components/template-modal/screens/template-picker/index.js
@@ -8,6 +8,11 @@ import { __ } from '@wordpress/i18n';
 import { BlockPreview } from '@wordpress/block-editor';
 import { ENTER, SPACE } from '@wordpress/keycodes';
 
+/**
+ * Internal dependencies
+ */
+import { setPreventDeduplicationForPostsInserter } from '../../../../editor/blocks/posts-inserter/utils';
+
 export default ( { onInsertTemplate, templates } ) => {
 	const [ selectedTemplate, setSelectedTemplate ] = useState( null );
 	const generateBlockPreview = () => {
@@ -43,7 +48,10 @@ export default ( { onInsertTemplate, templates } ) => {
 									aria-label={ title }
 								>
 									<div className="block-editor-patterns__item-preview">
-										<BlockPreview blocks={ parse( content ) } viewportWidth={ 568 } />
+										<BlockPreview
+											blocks={ setPreventDeduplicationForPostsInserter( parse( content ) ) }
+											viewportWidth={ 568 }
+										/>
 									</div>
 									<div className="block-editor-patterns__item-title">{ title }</div>
 								</div>

--- a/src/editor/blocks/posts-inserter/consts.js
+++ b/src/editor/blocks/posts-inserter/consts.js
@@ -1,0 +1,2 @@
+export const POSTS_INSERTER_BLOCK_NAME = 'newspack-newsletters/posts-inserter';
+export const POSTS_INSERTER_STORE_NAME = 'newspack-newsletters/posts-inserter-block';

--- a/src/editor/blocks/posts-inserter/deduplication.js
+++ b/src/editor/blocks/posts-inserter/deduplication.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { uniq, pick, flatten, values, flatMap, slice } from 'lodash';
+import { uniq, pick, flatten, values, flatMap, slice, without, omit } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -24,6 +24,12 @@ const actions = {
 			type: 'SET_HANDLED_POST_IDS',
 			handledPostIds: ids,
 			props,
+		};
+	},
+	removeBlock( clientId ) {
+		return {
+			type: 'REMOVE_BLOCK',
+			clientId,
 		};
 	},
 };
@@ -49,6 +55,12 @@ registerStore( POSTS_INSERTER_STORE_NAME, {
 						},
 						existingBlockIds
 					),
+				};
+			case 'REMOVE_BLOCK':
+				return {
+					...state,
+					existingBlockIds: without( state.existingBlockIds, action.clientId ),
+					postIdsByBlocks: omit( state.postIdsByBlocks, [ action.clientId ] ),
 				};
 		}
 

--- a/src/editor/blocks/posts-inserter/deduplication.js
+++ b/src/editor/blocks/posts-inserter/deduplication.js
@@ -1,0 +1,67 @@
+/**
+ * External dependencies
+ */
+import { uniq, pick, flatten, values, flatMap, slice } from 'lodash';
+
+/**
+ * WordPress dependencies
+ */
+import { registerStore } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import { POSTS_INSERTER_BLOCK_NAME, POSTS_INSERTER_STORE_NAME } from './consts';
+
+const DEFAULT_STATE = {
+	postIdsByBlocks: {},
+	existingBlockIds: [],
+};
+
+const actions = {
+	setHandledPostsIds( ids, props ) {
+		return {
+			type: 'SET_HANDLED_POST_IDS',
+			handledPostIds: ids,
+			props,
+		};
+	},
+};
+
+const getAllPostsInserterBlocksIds = blocks =>
+	flatMap( blocks, block => [
+		...( block.name === POSTS_INSERTER_BLOCK_NAME ? [ block.clientId ] : [] ),
+		...getAllPostsInserterBlocksIds( block.innerBlocks ),
+	] );
+
+registerStore( POSTS_INSERTER_STORE_NAME, {
+	reducer( state = DEFAULT_STATE, action ) {
+		switch ( action.type ) {
+			case 'SET_HANDLED_POST_IDS':
+				const { clientId, existingBlocks } = action.props;
+				const existingBlockIds = getAllPostsInserterBlocksIds( existingBlocks );
+				return {
+					existingBlockIds,
+					postIdsByBlocks: pick(
+						{
+							...state.postIdsByBlocks,
+							[ clientId ]: action.handledPostIds,
+						},
+						existingBlockIds
+					),
+				};
+		}
+
+		return state;
+	},
+
+	actions,
+
+	selectors: {
+		getHandledPostIds( { postIdsByBlocks, existingBlockIds }, blockClientId ) {
+			const blockIndex = existingBlockIds.indexOf( blockClientId );
+			const blocksBeforeIds = slice( existingBlockIds, 0, blockIndex );
+			return uniq( flatten( values( pick( postIdsByBlocks, blocksBeforeIds ) ) ) );
+		},
+	},
+} );

--- a/src/editor/blocks/posts-inserter/deduplication.js
+++ b/src/editor/blocks/posts-inserter/deduplication.js
@@ -15,7 +15,7 @@ import { POSTS_INSERTER_BLOCK_NAME, POSTS_INSERTER_STORE_NAME } from './consts';
 
 const DEFAULT_STATE = {
 	postIdsByBlocks: {},
-	existingBlockIds: [],
+	existingBlockIdsInOrder: [],
 };
 
 const actions = {
@@ -45,21 +45,21 @@ registerStore( POSTS_INSERTER_STORE_NAME, {
 		switch ( action.type ) {
 			case 'SET_HANDLED_POST_IDS':
 				const { clientId, existingBlocks } = action.props;
-				const existingBlockIds = getAllPostsInserterBlocksIds( existingBlocks );
+				const existingBlockIdsInOrder = getAllPostsInserterBlocksIds( existingBlocks );
 				return {
-					existingBlockIds,
+					existingBlockIdsInOrder,
 					postIdsByBlocks: pick(
 						{
 							...state.postIdsByBlocks,
 							[ clientId ]: action.handledPostIds,
 						},
-						existingBlockIds
+						existingBlockIdsInOrder
 					),
 				};
 			case 'REMOVE_BLOCK':
 				return {
 					...state,
-					existingBlockIds: without( state.existingBlockIds, action.clientId ),
+					existingBlockIdsInOrder: without( state.existingBlockIdsInOrder, action.clientId ),
 					postIdsByBlocks: omit( state.postIdsByBlocks, [ action.clientId ] ),
 				};
 		}
@@ -70,9 +70,9 @@ registerStore( POSTS_INSERTER_STORE_NAME, {
 	actions,
 
 	selectors: {
-		getHandledPostIds( { postIdsByBlocks, existingBlockIds }, blockClientId ) {
-			const blockIndex = existingBlockIds.indexOf( blockClientId );
-			const blocksBeforeIds = slice( existingBlockIds, 0, blockIndex );
+		getHandledPostIds( { postIdsByBlocks, existingBlockIdsInOrder }, blockClientId ) {
+			const blockIndex = existingBlockIdsInOrder.indexOf( blockClientId );
+			const blocksBeforeIds = slice( existingBlockIdsInOrder, 0, blockIndex );
 			return uniq( flatten( values( pick( postIdsByBlocks, blocksBeforeIds ) ) ) );
 		},
 	},

--- a/src/editor/blocks/posts-inserter/index.js
+++ b/src/editor/blocks/posts-inserter/index.js
@@ -35,6 +35,7 @@ const PostsInserterBlock = ( {
 	postList,
 	replaceBlocks,
 	setHandledPostsIds,
+	removeBlock,
 } ) => {
 	const templateBlocks = getTemplateBlocks( postList, attributes );
 
@@ -52,6 +53,7 @@ const PostsInserterBlock = ( {
 	useEffect(() => {
 		if ( ! attributes.preventDeduplication ) {
 			setHandledPostsIds( ids );
+			return removeBlock;
 		}
 	}, [ ids.join() ]);
 
@@ -174,12 +176,13 @@ const PostsInserterBlockWithSelect = compose( [
 	} ),
 	withDispatch( ( dispatch, props ) => {
 		const { replaceBlocks } = dispatch( 'core/block-editor' );
-		const { setHandledPostsIds } = dispatch( POSTS_INSERTER_STORE_NAME );
+		const { setHandledPostsIds, removeBlock } = dispatch( POSTS_INSERTER_STORE_NAME );
 		return {
 			replaceBlocks: blocks => {
 				replaceBlocks( props.selectedBlock.clientId, blocks );
 			},
 			setHandledPostsIds: ids => setHandledPostsIds( ids, props ),
+			removeBlock: () => removeBlock( props.clientId ),
 		};
 	} ),
 ] )( PostsInserterBlock );

--- a/src/editor/blocks/posts-inserter/index.js
+++ b/src/editor/blocks/posts-inserter/index.js
@@ -50,7 +50,9 @@ const PostsInserterBlock = ( {
 
 	const ids = postList.map( post => post.id );
 	useEffect(() => {
-		setHandledPostsIds( ids );
+		if ( ! attributes.preventDeduplication ) {
+			setHandledPostsIds( ids );
+		}
 	}, [ ids.join() ]);
 
 	const blockControlsImages = [

--- a/src/editor/layout/index.js
+++ b/src/editor/layout/index.js
@@ -13,6 +13,7 @@ import { Button, Modal } from '@wordpress/components';
  * Internal dependencies
  */
 import './style.scss';
+import { setPreventDeduplicationForPostsInserter } from '../blocks/posts-inserter/utils';
 
 export default compose( [
 	withDispatch( dispatch => {
@@ -32,13 +33,17 @@ export default compose( [
 	const currentTemplate = templates && templates[ templateId ] ? templates[ templateId ] : {};
 	const { content, title } = currentTemplate;
 	const blockPreview = content ? parse( content ) : null;
+
 	return (
 		<Fragment>
 			{ blockPreview !== null && (
 				<div className="block-editor-patterns newspack-newsletters__layout-panel-preview">
 					<div className="block-editor-patterns__item">
 						<div className="block-editor-patterns__item-preview">
-							<BlockPreview blocks={ blockPreview } viewportWidth={ 568 } />
+							<BlockPreview
+								blocks={ setPreventDeduplicationForPostsInserter( blockPreview ) }
+								viewportWidth={ 568 }
+							/>
 						</div>
 						<div className="block-editor-patterns__item-title">{ title }</div>
 					</div>


### PR DESCRIPTION
### All Submissions:

* [X] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [X] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Prevents duplicate posts when multiple instances of Posts Inserter block are on a post.

Closes #147 

### How to test the changes in this Pull Request:

1. Create or edit a newsletter, insert a couple of Posts Inserter blocks
2. Observe that the posts displayed are not duplicated
3. Experiment with adding/removing/changing parameters of the Posts Inserter blocks – all the time there should be no duplicated posts
4. Observe the posts are updated after a previous block is changed/removed – that is, if there are two Posts Inserter blocks with default settings, removing the top one should update posts in the remaining one with the three latest posts.

### Other information:

* [X] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [X] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
