### PR TITLE
Fix custom column width issue

### DIFF
--- a/includes/class-newspack-newsletters-renderer.php
+++ b/includes/class-newspack-newsletters-renderer.php
@@ -435,6 +435,20 @@ final class Newspack_Newsletters_Renderer {
 			 * Columns block.
 			 */
 			case 'core/columns':
+				// Some columns might have no width set.
+				$widths_sum            = 0;
+				$no_width_cols_indexes = [];
+				foreach ( $inner_blocks as $i => $block ) {
+					if ( isset( $block['attrs']['width'] ) ) {
+						$widths_sum += floatval( $block['attrs']['width'] );
+					} else {
+						array_push( $no_width_cols_indexes, $i );
+					}
+				};
+				foreach ( $no_width_cols_indexes as $no_width_cols_index ) {
+					$inner_blocks[ $no_width_cols_index ]['attrs']['width'] = ( 100 - $widths_sum ) / count( $no_width_cols_indexes );
+				};
+
 				if ( isset( $attrs['color'] ) ) {
 					$default_attrs['color'] = $attrs['color'];
 				}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes #162

### How to test the changes in this Pull Request:

1. Create a columns block with two columns
1. Set one of them to a custom width
1. Send a test email or campaign – columns should have the widths as in the editor

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
