### PR TITLE
Enable selecting specific post ids

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4071,11 +4071,11 @@
       }
     },
     "@wordpress/html-entities": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/html-entities/-/html-entities-2.6.0.tgz",
-      "integrity": "sha512-4TOMYtMwyWbDKhjn7YfhmhWg94eXwNwV7OMwEAJ2RgFGdklGyQz70KvWsU49RZlMXIVAEEPNhduT3/mmqgWeoA==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/html-entities/-/html-entities-2.7.0.tgz",
+      "integrity": "sha512-OmHZFHDl1Ai0LmRlqehRAt0broGigW1QCnRS1K82nurCFi9kz8x13C7GWv7wshA9TC4Qp/PLP9SEl/nzcJyIYg==",
       "requires": {
-        "@babel/runtime": "^7.8.3"
+        "@babel/runtime": "^7.9.2"
       }
     },
     "@wordpress/i18n": {

--- a/package.json
+++ b/package.json
@@ -105,6 +105,7 @@
     "@wordpress/edit-post": "^3.14.0",
     "@wordpress/element": "^2.12.0",
     "@wordpress/hooks": "^2.7.0",
+    "@wordpress/html-entities": "^2.7.0",
     "@wordpress/i18n": "^3.10.0",
     "@wordpress/keycodes": "^2.10.0",
     "@wordpress/plugins": "^2.13.0",

--- a/src/editor/blocks/posts-inserter/index.js
+++ b/src/editor/blocks/posts-inserter/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { values, isUndefined, pickBy, get, omit } from 'lodash';
+import { find, values, isUndefined, pickBy, get, omit } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -130,11 +130,9 @@ const PostsInserterBlockWithSelect = compose( [
 		const catIds = categories && categories.length > 0 ? categories.map( cat => cat.id ) : [];
 
 		let posts = [];
+		const isHandlingSpecificPosts = isDisplayingSpecificPosts && specificPosts.length > 0;
 
-		if (
-			! isDisplayingSpecificPosts ||
-			( isDisplayingSpecificPosts && specificPosts.length > 0 )
-		) {
+		if ( ! isDisplayingSpecificPosts || isHandlingSpecificPosts ) {
 			const postListQuery = isDisplayingSpecificPosts
 				? { include: specificPosts.map( post => post.id ) }
 				: pickBy(
@@ -148,6 +146,14 @@ const PostsInserterBlockWithSelect = compose( [
 				  );
 
 			posts = getEntityRecords( 'postType', 'post', postListQuery ) || [];
+		}
+
+		// Order posts in the order as they appear in the input
+		if ( isHandlingSpecificPosts ) {
+			posts = specificPosts.reduce( ( all, { id } ) => {
+				const found = find( posts, [ 'id', id ] );
+				return found ? [ ...all, found ] : all;
+			}, [] );
 		}
 
 		return {

--- a/src/editor/blocks/posts-inserter/query-controls.js
+++ b/src/editor/blocks/posts-inserter/query-controls.js
@@ -1,15 +1,43 @@
 /**
  * External dependencies
  */
-import { includes } from 'lodash';
+import { includes, debounce } from 'lodash';
 
 /**
  * WordPress dependencies
  */
-import { QueryControls } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { QueryControls, FormTokenField, ToggleControl, Spinner } from '@wordpress/components';
 import { addQueryArgs } from '@wordpress/url';
 import { useState, useEffect } from '@wordpress/element';
 import apiFetch from '@wordpress/api-fetch';
+import { decodeEntities } from '@wordpress/html-entities';
+
+const fetchPostSuggestions = search =>
+	apiFetch( {
+		path: addQueryArgs( '/wp/v2/search', {
+			search,
+			per_page: 20,
+			_fields: 'id,title',
+			subtype: 'post',
+		} ),
+	} ).then( posts =>
+		posts.map( post => ( {
+			id: post.id,
+			title: decodeEntities( post.title ) || __( '(no title)', 'newspack-newsletters' ),
+		} ) )
+	);
+
+const SEPARATOR = '--';
+const encodePosts = posts => posts.map( post => [ post.id, post.title ].join( SEPARATOR ) );
+const decodePost = encodedPost => {
+	// eslint-disable-next-line @wordpress/no-unused-vars-before-return, no-unused-vars
+	const match = encodedPost.match( new RegExp( `([\\d]*)${ SEPARATOR }(.*)` ) );
+	if ( match ) {
+		return [ match[ 1 ], match[ 2 ] ];
+	}
+	return encodedPost;
+};
 
 // NOTE: Mostly copied from Gutenberg's Posts Inserter block.
 // https://github.com/WordPress/gutenberg/blob/master/packages/block-library/src/posts-inserter/edit.js
@@ -24,14 +52,6 @@ const QueryControlsSettings = ( { attributes, setAttributes } ) => {
 		} ).then( setCategoriesList );
 	}, []);
 
-	const suggestions = categoriesList.reduce(
-		( accumulator, category ) => ( {
-			...accumulator,
-			[ category.name ]: category,
-		} ),
-		{}
-	);
-
 	const categorySuggestions = categoriesList.reduce(
 		( accumulator, category ) => ( {
 			...accumulator,
@@ -42,7 +62,7 @@ const QueryControlsSettings = ( { attributes, setAttributes } ) => {
 
 	const selectCategories = tokens => {
 		const hasNoSuggestion = tokens.some(
-			token => typeof token === 'string' && ! suggestions[ token ]
+			token => typeof token === 'string' && ! categorySuggestions[ token ]
 		);
 		if ( hasNoSuggestion ) {
 			return;
@@ -50,7 +70,7 @@ const QueryControlsSettings = ( { attributes, setAttributes } ) => {
 		// Categories that are already will be objects, while new additions will be strings (the name).
 		// allCategories nomalizes the array so that they are all objects.
 		const allCategories = tokens.map( token => {
-			return typeof token === 'string' ? suggestions[ token ] : token;
+			return typeof token === 'string' ? categorySuggestions[ token ] : token;
 		} );
 		// We do nothing if the category is not selected
 		// from suggestions.
@@ -60,21 +80,69 @@ const QueryControlsSettings = ( { attributes, setAttributes } ) => {
 		setAttributes( { categories: allCategories } );
 	};
 
+	const [ isFetchingPosts, setIsFetchingPosts ] = useState( false );
+	const [ foundPosts, setFoundPosts ] = useState( [] );
+	const handleSpecificPostsInput = search => {
+		if ( isFetchingPosts || search.length === 0 ) {
+			return;
+		}
+		setIsFetchingPosts( true );
+		fetchPostSuggestions( search ).then( posts => {
+			setIsFetchingPosts( false );
+			setFoundPosts( posts );
+		} );
+	};
+
+	const handleSpecificPostsSelection = postTitles => {
+		setAttributes( {
+			specificPosts: postTitles.map( encodedTitle => {
+				const [ id, title ] = decodePost( encodedTitle );
+				return { id, title };
+			} ),
+		} );
+	};
+
 	return (
-		<QueryControls
-			{ ...{ order: attributes.order, orderBy: attributes.orderBy } }
-			numberOfItems={ attributes.postsToShow }
-			onOrderChange={ value => setAttributes( { order: value } ) }
-			onOrderByChange={ value => setAttributes( { orderBy: value } ) }
-			onNumberOfItemsChange={ value => setAttributes( { postsToShow: value } ) }
-			categorySuggestions={ categorySuggestions }
-			onCategoryChange={ selectCategories }
-			selectedCategories={ attributes.categories }
-			// Support for legacy Gutenberg version.
-			categoriesList={ [] }
-			minItems={ 1 }
-			maxItems={ 10 }
-		/>
+		<div className="newspack-newsletters-query-controls">
+			<ToggleControl
+				label={ __( 'Display specific posts', 'newspack-newsletters' ) }
+				checked={ attributes.isDisplayingSpecificPosts }
+				onChange={ value => setAttributes( { isDisplayingSpecificPosts: value } ) }
+			/>
+			{ attributes.isDisplayingSpecificPosts ? (
+				<FormTokenField
+					label={
+						<div>
+							{ __( 'Add posts', 'newspack-newsletters' ) }
+							{ isFetchingPosts && <Spinner /> }
+						</div>
+					}
+					onChange={ handleSpecificPostsSelection }
+					value={ encodePosts( attributes.specificPosts ) }
+					suggestions={ encodePosts( foundPosts ) }
+					displayTransform={ string => {
+						const [ id, title ] = decodePost( string );
+						return title || id;
+					} }
+					onInputChange={ debounce( handleSpecificPostsInput, 400 ) }
+				/>
+			) : (
+				<QueryControls
+					{ ...{ order: attributes.order, orderBy: attributes.orderBy } }
+					numberOfItems={ attributes.postsToShow }
+					onOrderChange={ value => setAttributes( { order: value } ) }
+					onOrderByChange={ value => setAttributes( { orderBy: value } ) }
+					onNumberOfItemsChange={ value => setAttributes( { postsToShow: value } ) }
+					categorySuggestions={ categorySuggestions }
+					onCategoryChange={ selectCategories }
+					selectedCategories={ attributes.categories }
+					// Support for legacy Gutenberg version.
+					categoriesList={ [] }
+					minItems={ 1 }
+					maxItems={ 10 }
+				/>
+			) }
+		</div>
 	);
 };
 

--- a/src/editor/blocks/posts-inserter/query-controls.js
+++ b/src/editor/blocks/posts-inserter/query-controls.js
@@ -96,7 +96,7 @@ const QueryControlsSettings = ( { attributes, setAttributes } ) => {
 		setAttributes( {
 			specificPosts: postTitles.map( encodedTitle => {
 				const [ id, title ] = decodePost( encodedTitle );
-				return { id, title };
+				return { id: parseInt( id ), title };
 			} ),
 		} );
 	};

--- a/src/editor/blocks/posts-inserter/query-controls.js
+++ b/src/editor/blocks/posts-inserter/query-controls.js
@@ -31,8 +31,7 @@ const fetchPostSuggestions = search =>
 const SEPARATOR = '--';
 const encodePosts = posts => posts.map( post => [ post.id, post.title ].join( SEPARATOR ) );
 const decodePost = encodedPost => {
-	// eslint-disable-next-line @wordpress/no-unused-vars-before-return, no-unused-vars
-	const match = encodedPost.match( new RegExp( `([\\d]*)${ SEPARATOR }(.*)` ) );
+	const match = encodedPost.match( new RegExp( `^([\\d]*)${ SEPARATOR }(.*)` ) );
 	if ( match ) {
 		return [ match[ 1 ], match[ 2 ] ];
 	}

--- a/src/editor/blocks/posts-inserter/style.scss
+++ b/src/editor/blocks/posts-inserter/style.scss
@@ -51,3 +51,9 @@
 		position: relative;
 	}
 }
+
+.newspack-newsletters-query-controls {
+	.components-form-token-field__help {
+		display: none;
+	}
+}


### PR DESCRIPTION
### All Submissions:

* [X] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [X] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Enable selecting specific post ids

![image](https://user-images.githubusercontent.com/7383192/80635301-fe389700-8a5b-11ea-81a9-6999cf6f484c.png)


### How to test the changes in this Pull Request:

1. Create or edit a newsletter, add a Posts Inserter block
2. Toggle "Display specific posts", observe UI change to a token field
3. Choose some posts, observe only these are rendered in the Posts Inserter block

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
