### PR TITLE
Fix posts inserter no-insertion workflow

### DIFF
--- a/src/editor/blocks/posts-inserter/index.js
+++ b/src/editor/blocks/posts-inserter/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { values, isUndefined, pickBy, get, omit } from 'lodash';
+import { isUndefined, pickBy, get } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -30,9 +30,10 @@ import QueryControlsSettings from './query-controls';
 const PostsInserterBlock = ( { setAttributes, attributes, postList, replaceBlocks } ) => {
 	const templateBlocks = getTemplateBlocks( postList, attributes );
 
-	useEffect( () => {
-		setAttributes( { innerBlocksToInsert: templateBlocks.map( convertBlockSerializationFormat ) } );
-	}, values( omit( attributes, 'innerBlocksToInsert' ) ) );
+	const innerBlocksToInsert = templateBlocks.map( convertBlockSerializationFormat );
+	useEffect(() => {
+		setAttributes( { innerBlocksToInsert } );
+	}, [ JSON.stringify( innerBlocksToInsert ) ]);
 
 	useEffect(() => {
 		if ( attributes.areBlocksInserted ) {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Follow up to changes from #151, which is the problem of 
1. saving the Posts Inserter inner blocks in an attribute*
2. in a way that does not trigger an infinite loop

Which is basically the question of memoization. After trying out different approaches with regular memoization, I've settled on a perhaps ugly solution of using a stringified form of the attribute to be updated as the `useEffect` dependency. This means that the hook function will be fired only when the value of `innerBlocksToInsert` will _really_ change. It might be a new object on each render, but as long as the stringified version remains the same, there will be no inifinite loop.

*so it can be rendered without needing to duplicate attributes-to-posts logic on the backend

The wrong assumption behind changes in #151 was that the content might change only if _block attributes_ change. This is not true, because it takes time for the posts, and then their images, to be fetched. In other words, this component is not a pure function of the `attributes` prop (stuff manipulated in the sidebar), but also relies on the `postList` prop, which updates when data arrives.

### How to test the changes in this Pull Request:

1. Insert a Posts Inserter block
2. Make changes to block attributes to change the contents and layout, save draft – look up preview on MC or send a test email
3. Repeat that a few times
3. At no point should there be any discrepancy between the editor state and what's rendered in the email (in terms of content and layout)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
