### PR TITLE
Fix newsletter layouts preview thumbnails

### DIFF
--- a/src/components/template-modal/screens/template-picker/index.js
+++ b/src/components/template-modal/screens/template-picker/index.js
@@ -20,16 +20,16 @@ export default ( { onInsertTemplate, templates } ) => {
 	return (
 		<Fragment>
 			<div className="newspack-newsletters-modal__content">
-				<div className="newspack-newsletters-modal__patterns">
-					<div className="block-editor-patterns">
+				<div className="newspack-newsletters-modal__layouts">
+					<div className="newspack-newsletters-layouts">
 						{ ( templates || [] ).map( ( { title, content }, index ) =>
 							'' === content ? null : (
 								<div
 									key={ index }
 									className={
 										selectedTemplate === index
-											? 'selected block-editor-patterns__item'
-											: 'block-editor-patterns__item'
+											? 'newspack-newsletters-layouts__item is-active'
+											: 'newspack-newsletters-layouts__item'
 									}
 									onClick={ () => setSelectedTemplate( index ) }
 									onKeyDown={ event => {
@@ -42,10 +42,10 @@ export default ( { onInsertTemplate, templates } ) => {
 									tabIndex="0"
 									aria-label={ title }
 								>
-									<div className="block-editor-patterns__item-preview">
+									<div className="newspack-newsletters-layouts__item-preview">
 										<BlockPreview blocks={ parse( content ) } viewportWidth={ 568 } />
 									</div>
-									<div className="block-editor-patterns__item-title">{ title }</div>
+									<div className="newspack-newsletters-layouts__item-label">{ title }</div>
 								</div>
 							)
 						) }

--- a/src/components/template-modal/style.scss
+++ b/src/components/template-modal/style.scss
@@ -206,7 +206,7 @@
 				border: 1px solid $light-gray-500;
 				border-radius: 2px;
 				overflow: hidden;
-				padding: 0 0 100%;
+				padding: 0 0 calc( 100% - 2px );
 				position: relative;
 				width: 100%;
 

--- a/src/components/template-modal/style.scss
+++ b/src/components/template-modal/style.scss
@@ -64,7 +64,7 @@
 	}
 
 	&__content {
-		background: $light-gray-200;
+		background: white;
 		height: calc( 100% - 36px );
 		margin: -24px;
 		padding: 24px;
@@ -159,17 +159,16 @@
 		}
 	}
 
-	&__patterns {
+	&__layouts {
 		overflow-y: scroll;
-		padding: 3px;
-		margin: -3px;
-		max-height: calc( 100% + 6px );
+		max-height: 100%;
 
-		.block-editor-patterns {
+		.newspack-newsletters-layouts {
 			display: grid;
 			gap: 16px;
 			grid-template-columns: repeat( 2, 1fr );
 			grid-auto-rows: minmax( min-content, max-content );
+			overflow: hidden;
 			padding: 0;
 
 			@media only screen and ( min-width: 600px ) {
@@ -181,15 +180,31 @@
 			}
 
 			&__item {
+				cursor: pointer;
 				margin: 0;
+				width: 100%;
 
-				&.selected {
-					box-shadow: white 0 0 0 1px inset, $blue-medium-focus 0 0 0 2px;
+				&:hover,
+				&:focus {
+					.newspack-newsletters-layouts__item-preview {
+						border-color: $blue-medium-focus;
+					}
+				}
+
+				&.is-active {
 					pointer-events: none;
+
+					.newspack-newsletters-layouts__item-preview {
+						border-color: currentColor;
+						box-shadow: inset 0 0 0 1px;
+					}
 				}
 			}
 
 			&__item-preview {
+				background: white;
+				border: 1px solid $light-gray-500;
+				border-radius: 2px;
 				overflow: hidden;
 				padding: 0 0 100%;
 				position: relative;
@@ -197,7 +212,18 @@
 
 				.block-editor-block-preview__container {
 					position: absolute;
+					top: 0;
+
+					.block-editor-block-list__layout.is-root-container {
+						padding-left: 28px;
+						padding-right: 28px;
+					}
 				}
+			}
+
+			&__item-label {
+				padding: 4px 2px;
+				text-align: center;
 			}
 		}
 	}

--- a/src/editor/layout/index.js
+++ b/src/editor/layout/index.js
@@ -35,12 +35,12 @@ export default compose( [
 	return (
 		<Fragment>
 			{ blockPreview !== null && (
-				<div className="block-editor-patterns newspack-newsletters__layout-panel-preview">
-					<div className="block-editor-patterns__item">
-						<div className="block-editor-patterns__item-preview">
+				<div className="newspack-newsletters-layouts">
+					<div className="newspack-newsletters-layouts__item">
+						<div className="newspack-newsletters-layouts__item-preview">
 							<BlockPreview blocks={ blockPreview } viewportWidth={ 568 } />
 						</div>
-						<div className="block-editor-patterns__item-title">{ title }</div>
+						<div className="newspack-newsletters-layouts__item-label">{ title }</div>
 					</div>
 				</div>
 			) }
@@ -49,7 +49,7 @@ export default compose( [
 			</Button>
 			{ warningModalVisible && (
 				<Modal
-					className="newspack-newsletters__layout-panel-modal"
+					className="newspack-newsletters-layouts__modal"
 					title={ __( 'Overwrite newsletter content?', 'newspack-newsletters' ) }
 					onRequestClose={ () => setWarningModalVisible( false ) }
 				>

--- a/src/editor/layout/style.scss
+++ b/src/editor/layout/style.scss
@@ -1,24 +1,37 @@
-.newspack-newsletters__layout-panel {
-	&-preview {
-		background: transparent;
-		padding: 0;
-		pointer-events: none;
+@import '~@wordpress/base-styles/colors';
 
-		.block-editor-patterns {
-			&__item-preview {
-				overflow: hidden;
-				padding: 0 0 100%;
-				position: relative;
-				width: 100%;
+.newspack-newsletters-layouts {
+	&__item {
+		margin: 0 0 16px;
+		width: 100%;
+	}
 
-				.block-editor-block-preview__container {
-					position: absolute;
-				}
+	&__item-preview {
+		background: white;
+		border: 1px solid $light-gray-500;
+		border-radius: 2px;
+		overflow: hidden;
+		padding: 0 0 calc( 100% - 2px );
+		position: relative;
+		width: 100%;
+
+		.block-editor-block-preview__container {
+			position: absolute;
+			top: 0;
+
+			.block-editor-block-list__layout.is-root-container {
+				padding-left: 28px;
+				padding-right: 28px;
 			}
 		}
 	}
 
-	&-modal {
+	&__item-label {
+		padding: 4px 2px;
+		text-align: center;
+	}
+
+	&__modal {
 		max-width: 360px;
 
 		.components-button + .components-button {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Instead of relying on Gutenberg styles to display the different layouts – since it's constantly evolving – this PR adds its own set of styles for the layouts thumbnails

Closes #172

_Note: when Gutenberg is disabled, the modal header is slightly different which creates a slight bug by the "W" when fullscreen. I can't fix of an easy fix and it should be resolved when more Gutenberg updates are shipped directly into Core._

### How to test the changes in this Pull Request:

1. Follow instructions in #172
2. Switch to this branch
3. Repeat

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
