### PR TITLE
Handle color palette as it appears in the editor

### DIFF
--- a/includes/class-newspack-newsletters-renderer.php
+++ b/includes/class-newspack-newsletters-renderer.php
@@ -14,6 +14,13 @@ require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/vendor/autoload.php';
  */
 final class Newspack_Newsletters_Renderer {
 	/**
+	 * The color palette to be used.
+	 *
+	 * @var Object
+	 */
+	protected static $color_palette = null;
+
+	/**
 	 * Convert a list to HTML attributes.
 	 *
 	 * @param array $attributes Array of attributes.
@@ -67,32 +74,17 @@ final class Newspack_Newsletters_Renderer {
 	 */
 	private static function get_colors( $block_attrs ) {
 		$colors = array();
-		// Gutenberg's default color palette.
-		// https://github.com/WordPress/gutenberg/blob/359858da0675943d8a759a0a7c03e7b3846536f5/packages/block-editor/src/store/defaults.js#L30-L85 .
-		$colors_palette = array(
-			'pale-pink'             => '#f78da7',
-			'vivid-red'             => '#cf2e2e',
-			'luminous-vivid-orange' => '#ff6900',
-			'luminous-vivid-amber'  => '#fcb900',
-			'light-green-cyan'      => '#7bdcb5',
-			'vivid-green-cyan'      => '#00d084',
-			'pale-cyan-blue'        => '#8ed1fc',
-			'vivid-cyan-blue'       => '#0693e3',
-			'very-light-gray'       => '#eeeeee',
-			'cyan-bluish-gray'      => '#abb8c3',
-			'very-dark-gray'        => '#313131',
-		);
 
 		// For text.
-		if ( isset( $block_attrs['textColor'], $colors_palette[ $block_attrs['textColor'] ] ) ) {
-			$colors['color'] = $colors_palette[ $block_attrs['textColor'] ];
+		if ( isset( $block_attrs['textColor'], self::$color_palette[ $block_attrs['textColor'] ] ) ) {
+			$colors['color'] = self::$color_palette[ $block_attrs['textColor'] ];
 		}
 		// customTextColor is set inline, but it's passed here for consistency.
 		if ( isset( $block_attrs['customTextColor'] ) ) {
 			$colors['color'] = $block_attrs['customTextColor'];
 		}
-		if ( isset( $block_attrs['backgroundColor'], $colors_palette[ $block_attrs['backgroundColor'] ] ) ) {
-			$colors['background-color'] = $colors_palette[ $block_attrs['backgroundColor'] ];
+		if ( isset( $block_attrs['backgroundColor'], self::$color_palette[ $block_attrs['backgroundColor'] ] ) ) {
+			$colors['background-color'] = self::$color_palette[ $block_attrs['backgroundColor'] ];
 		}
 		// customBackgroundColor is set inline, but not on mjml wrapper element.
 		if ( isset( $block_attrs['customBackgroundColor'] ) ) {
@@ -100,8 +92,8 @@ final class Newspack_Newsletters_Renderer {
 		}
 
 		// For separators.
-		if ( isset( $block_attrs['color'], $colors_palette[ $block_attrs['color'] ] ) ) {
-			$colors['border-color'] = $colors_palette[ $block_attrs['color'] ];
+		if ( isset( $block_attrs['color'], self::$color_palette[ $block_attrs['color'] ] ) ) {
+			$colors['border-color'] = self::$color_palette[ $block_attrs['color'] ];
 		}
 		if ( isset( $block_attrs['customColor'] ) ) {
 			$colors['border-color'] = $block_attrs['customColor'];
@@ -503,9 +495,10 @@ final class Newspack_Newsletters_Renderer {
 	 * @return string MJML markup.
 	 */
 	private static function render_mjml( $post ) {
-		$title  = $post->post_title;
-		$blocks = parse_blocks( $post->post_content );
-		$body   = '';
+		self::$color_palette = get_post_meta( $post->ID, 'color_palette', true );
+		$title               = $post->post_title;
+		$blocks              = parse_blocks( $post->post_content );
+		$body                = '';
 		foreach ( $blocks as $block ) {
 			$block_content = self::render_mjml_component( $block );
 			if ( ! empty( $block_content ) ) {

--- a/includes/class-newspack-newsletters.php
+++ b/includes/class-newspack-newsletters.php
@@ -105,6 +105,30 @@ final class Newspack_Newsletters {
 				'auth_callback'  => '__return_true',
 			]
 		);
+		/**
+		 * The default color palette lives in the editor frontend and is not
+		 * retrievable on the backend. The workaround is to set it as post meta
+		 * so that it's available to the email renderer.
+		 */
+		\register_meta(
+			'post',
+			'color_palette',
+			[
+				'object_subtype' => self::NEWSPACK_NEWSLETTERS_CPT,
+				'show_in_rest'   => array(
+					'schema' => array(
+						'type'                 => 'object',
+						'properties'           => array(),
+						'additionalProperties' => array(
+							'type' => 'string',
+						),
+					),
+				),
+				'type'           => 'object',
+				'single'         => true,
+				'auth_callback'  => '__return_true',
+			]
+		);
 	}
 
 	/**

--- a/src/editor/editor/index.js
+++ b/src/editor/editor/index.js
@@ -25,13 +25,19 @@ const Editor = compose( [
 			isCleanNewPost,
 		} = select( 'core/editor' );
 		const { getActiveGeneralSidebarName } = select( 'core/edit-post' );
+		const { getSettings } = select( 'core/block-editor' );
 		const meta = getEditedPostAttribute( 'meta' );
+
 		return {
 			isCleanNewPost: isCleanNewPost(),
 			postId: getCurrentPostId(),
 			isReady: meta.campaignValidationErrors ? meta.campaignValidationErrors.length === 0 : false,
 			activeSidebarName: getActiveGeneralSidebarName(),
 			isPublishingOrSavingPost: isSavingPost() || isPublishingPost(),
+			colorPalette: getSettings().colors.reduce(
+				( colors, { slug, color } ) => ( { ...colors, [ slug ]: color } ),
+				{}
+			),
 		};
 	} ),
 	withDispatch( dispatch => {
@@ -59,6 +65,10 @@ const Editor = compose( [
 				} );
 		}
 	}, [ props.isPublishingOrSavingPost ]);
+
+	useEffect(() => {
+		props.editPost( { meta: { color_palette: props.colorPalette } } );
+	}, []);
 
 	// Lock or unlock post publishing.
 	useEffect(() => {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [X] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes #173


### How to test the changes in this Pull Request:

1. On `master` branch, create a newsletter and set color of something to "Vivid Purple"*
2. Send or preview email, observe that the color is not handled
3. Switch to this branch
3. Send or preview email, observe that the color is there

*
![image](https://user-images.githubusercontent.com/7383192/80706226-3e455b80-8ae8-11ea-8145-3d742e04651e.png)


### Other information:

* [X] Have you added an explanation of what your changes do and why you'd like us to include them?
* [X] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
