### PR TITLE
Update general padding of newsletter to increase white space

### DIFF
--- a/includes/class-newspack-newsletters-renderer.php
+++ b/includes/class-newspack-newsletters-renderer.php
@@ -152,6 +152,11 @@ final class Newspack_Newsletters_Renderer {
 			$attrs['full-width'] = 'full-width';
 			unset( $attrs['align'] );
 		}
+
+		if ( isset( $attrs['full-width'] ) && 'full-width' == $attrs['full-width'] && isset( $attrs['background-color'] ) ) {
+			$attrs['padding'] = '20px 0';
+		}
+
 		return $attrs;
 	}
 
@@ -190,7 +195,7 @@ final class Newspack_Newsletters_Renderer {
 		// Default attributes for the column which will envelop the component.
 		$column_attrs = array_merge(
 			array(
-				'padding' => '16px',
+				'padding' => '20px',
 			)
 		);
 
@@ -298,6 +303,8 @@ final class Newspack_Newsletters_Renderer {
 
 					$default_button_attrs = array(
 						'padding'       => '0',
+						'inner-padding' => '12px 24px',
+						'line-height'   => '1.8',
 						'href'          => $anchor->getAttribute( 'href' ),
 						'border-radius' => $border_radius . 'px',
 						'font-size'     => '18px',

--- a/includes/email-template.mjml.php
+++ b/includes/email-template.mjml.php
@@ -78,7 +78,12 @@
 			/* Has Background */
 			.mj-column-has-width .has-background,
 			.mj-column-per-50 .has-background {
-				padding: 16px;
+				padding: 20px;
+			}
+
+			/* Mailchimp Footer */
+			#canspamBarWrapper {
+				border: 0 !important;
 			}
 		</mj-style>
 	</mj-head>

--- a/src/components/template-modal/screens/template-picker/index.js
+++ b/src/components/template-modal/screens/template-picker/index.js
@@ -43,7 +43,7 @@ export default ( { onInsertTemplate, templates } ) => {
 									aria-label={ title }
 								>
 									<div className="newspack-newsletters-layouts__item-preview">
-										<BlockPreview blocks={ parse( content ) } viewportWidth={ 568 } />
+										<BlockPreview blocks={ parse( content ) } viewportWidth={ 560 } />
 									</div>
 									<div className="newspack-newsletters-layouts__item-label">{ title }</div>
 								</div>
@@ -54,7 +54,7 @@ export default ( { onInsertTemplate, templates } ) => {
 
 				<div className="newspack-newsletters-modal__preview">
 					{ blockPreview && blockPreview.length > 0 ? (
-						<BlockPreview blocks={ blockPreview } viewportWidth={ 568 } />
+						<BlockPreview blocks={ blockPreview } viewportWidth={ 560 } />
 					) : (
 						<p>{ __( 'Select a layout to preview.', 'newspack-newsletters' ) }</p>
 					) }

--- a/src/components/template-modal/style.scss
+++ b/src/components/template-modal/style.scss
@@ -246,7 +246,7 @@
 			&__container {
 				align-self: flex-start;
 				margin: 0 auto;
-				max-width: 568px;
+				max-width: 560px;
 			}
 		}
 	}

--- a/src/editor/blocks/posts-inserter/index.js
+++ b/src/editor/blocks/posts-inserter/index.js
@@ -106,7 +106,7 @@ const PostsInserterBlock = ( { setAttributes, attributes, postList, replaceBlock
 					<span>{ __( 'Posts Inserter', 'newspack-newsletters' ) }</span>
 				</div>
 				<div className="newspack-posts-inserter__preview">
-					<BlockPreview blocks={ templateBlocks } viewportWidth={ 566 } />
+					<BlockPreview blocks={ templateBlocks } viewportWidth={ 558 } />
 				</div>
 				<Button isPrimary onClick={ () => setAttributes( { areBlocksInserted: true } ) }>
 					{ __( 'Insert posts', 'newspack-newsletters' ) }

--- a/src/editor/editor/style.scss
+++ b/src/editor/editor/style.scss
@@ -1,5 +1,5 @@
 .wp-block {
-	max-width: 568px;
+	max-width: 560px;
 }
 
 .editor-post-title {
@@ -16,10 +16,10 @@
 }
 
 .wp-block-column {
-	padding-bottom: 16px;
+	padding-bottom: 20px;
 
 	> :first-child {
-		margin-top: 16px !important;
+		margin-top: 20px !important;
 
 		> .wp-block-image {
 			margin-top: 0;
@@ -27,7 +27,7 @@
 	}
 
 	> * {
-		margin-top: -32px !important;
+		margin-top: -40px !important;
 	}
 }
 
@@ -44,12 +44,16 @@
 	}
 
 	.block-editor-block-list__block {
-		margin-bottom: 32px;
-		margin-top: 32px;
+		margin-bottom: 40px;
+		margin-top: 40px;
 
 		&.wp-block-group {
 			&.has-background {
-				padding: 16px;
+				padding: 20px;
+
+				+ .has-background {
+					margin-top: 20px;
+				}
 
 				.block-editor-block-list__layout {
 					:first-child {
@@ -70,7 +74,7 @@
 			}
 
 			+ .wp-block-group {
-				margin-top: -16px;
+				margin-top: -20px;
 			}
 		}
 
@@ -78,8 +82,50 @@
 			padding-right: 0;
 		}
 
+		&[data-type='core/button'] {
+			margin-bottom: 0;
+			margin-top: 0;
+		}
+
+		&[data-type='core/separator'] {
+			margin-bottom: 40px;
+			margin-top: 40px;
+
+			hr {
+				margin: 0;
+			}
+		}
+
 		.block-library-spacer__resize-container {
-			margin-bottom: 16px;
+			margin-bottom: 20px;
+		}
+
+		&.has-background {
+			margin-bottom: -20px;
+			margin-top: -20px;
+
+			+ .has-background,
+			+ [data-align='full'] .wp-block-group.has-background {
+				margin-top: 20px;
+			}
+		}
+	}
+
+	[data-align='full'] {
+		.wp-block-group.has-background {
+			padding-bottom: 40px;
+			padding-top: 40px;
+		}
+
+		+ .has-background,
+		+ [data-align='full'] .wp-block-group.has-background {
+			margin-top: 20px;
+		}
+	}
+
+	[data-align='center'] {
+		figure.wp-block-image:not( .wp-block ) {
+			margin: 40px 0;
 		}
 	}
 
@@ -91,7 +137,7 @@
 	h6,
 	p {
 		&.has-background {
-			padding: 16px;
+			padding: 20px;
 		}
 	}
 }

--- a/src/editor/layout/index.js
+++ b/src/editor/layout/index.js
@@ -38,7 +38,7 @@ export default compose( [
 				<div className="newspack-newsletters-layouts">
 					<div className="newspack-newsletters-layouts__item">
 						<div className="newspack-newsletters-layouts__item-preview">
-							<BlockPreview blocks={ blockPreview } viewportWidth={ 568 } />
+							<BlockPreview blocks={ blockPreview } viewportWidth={ 560 } />
 						</div>
 						<div className="newspack-newsletters-layouts__item-label">{ title }</div>
 					</div>

--- a/src/editor/sidebar/style.scss
+++ b/src/editor/sidebar/style.scss
@@ -60,3 +60,9 @@
 		margin: 0;
 	}
 }
+
+.interface-interface-skeleton__sidebar {
+	.components-notice {
+		margin: 0;
+	}
+}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This increases the overall padding from 16px to 20px.
The PR also fixes some margin inconsistencies with blocks in the editor vs the actual email

screencast: https://cloudup.com/izPdpgD1Hac

### How to test the changes in this Pull Request:

1. Create a new newsletter, play with different blocks
2. Send a test and compare the editor with what you received

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
