### PR TITLE
Add pre-send confirmation

### DIFF
--- a/src/components/send-button/index.js
+++ b/src/components/send-button/index.js
@@ -34,7 +34,7 @@ export default compose( [
 			isSavingPost,
 			isEditedPostBeingScheduled,
 		} = select( 'core/editor' );
-		const { newsletterData, newsletterValidationErrors } = getEditedPostAttribute( 'meta' );
+		const { newsletterData = {}, newsletterValidationErrors } = getEditedPostAttribute( 'meta' );
 		return {
 			isPublishable: forceIsDirty || isEditedPostPublishable(),
 			isSaveable: isEditedPostSaveable(),
@@ -97,7 +97,7 @@ export default compose( [
 			savePost();
 		};
 
-		const [ modalVisible, setModalVisible ] = useState( true );
+		const [ modalVisible, setModalVisible ] = useState( false );
 
 		return (
 			<Fragment>

--- a/src/components/send-button/index.js
+++ b/src/components/send-button/index.js
@@ -137,15 +137,15 @@ export default compose( [
 						<p>
 							{ __( "You're about to send a newsletter to:", 'newspack-newsletters' ) }
 							<br />
-							<b>{ listData.name }</b>
+							<strong>{ listData.name }</strong>
 							<br />
 							{ listData.groupName && (
 								<Fragment>
-									{ __( 'Group:', 'newspack-newsletters' ) } <b>{ listData.groupName }</b>
+									{ __( 'Group:', 'newspack-newsletters' ) } <strong>{ listData.groupName }</strong>
 									<br />
 								</Fragment>
 							) }
-							<b>
+							<strong>
 								{ sprintf(
 									_n(
 										'%d subscriber',
@@ -155,7 +155,7 @@ export default compose( [
 									),
 									listData.subscribers
 								) }
-							</b>
+							</strong>
 						</p>
 						<Button
 							isPrimary

--- a/src/editor/editor/style.scss
+++ b/src/editor/editor/style.scss
@@ -95,3 +95,13 @@
 		}
 	}
 }
+
+.newspack-newsletters {
+	&__modal {
+		max-width: 360px;
+
+		.components-button + .components-button {
+			margin-left: 12px;
+		}
+	}
+}

--- a/src/editor/layout/index.js
+++ b/src/editor/layout/index.js
@@ -54,7 +54,7 @@ export default compose( [
 			</Button>
 			{ warningModalVisible && (
 				<Modal
-					className="newspack-newsletters-layouts__modal"
+					className="newspack-newsletters__modal"
 					title={ __( 'Overwrite newsletter content?', 'newspack-newsletters' ) }
 					onRequestClose={ () => setWarningModalVisible( false ) }
 				>

--- a/src/editor/layout/style.scss
+++ b/src/editor/layout/style.scss
@@ -30,12 +30,4 @@
 		padding: 4px 2px;
 		text-align: center;
 	}
-
-	&__modal {
-		max-width: 360px;
-
-		.components-button + .components-button {
-			margin-left: 12px;
-		}
-	}
 }

--- a/src/editor/sidebar/index.js
+++ b/src/editor/sidebar/index.js
@@ -17,13 +17,12 @@ import {
 /**
  * External dependencies
  */
-import { get } from 'lodash';
 import classnames from 'classnames';
 
 /**
  * Internal dependencies
  */
-import { getEditPostPayload, hasValidEmail } from '../utils';
+import { getEditPostPayload, hasValidEmail, getListInterestsSettings } from '../utils';
 import withApiHandler from '../../components/with-api-handler';
 import './style.scss';
 
@@ -77,51 +76,23 @@ class Sidebar extends Component {
 	};
 
 	interestCategories = () => {
-		const { campaign, inFlight, interestCategories } = this.props;
-		if (
-			! interestCategories ||
-			! interestCategories.categories ||
-			! interestCategories.categories.length
-		) {
+		const interestSettings = getListInterestsSettings( this.props );
+		if ( ! interestSettings ) {
 			return;
 		}
-		const options = interestCategories.categories.reduce( ( accumulator, item ) => {
-			const { title, interests, id } = item;
-			accumulator.push( {
-				label: title,
-				disabled: true,
-			} );
-			if ( interests && interests.interests && interests.interests.length ) {
-				interests.interests.forEach( interest => {
-					const isDisabled = parseInt( interest.subscriber_count ) === 0;
-					accumulator.push( {
-						label:
-							'- ' +
-							interest.name +
-							( isDisabled ? __( ' (no subscribers)', 'newspack-newsletters' ) : '' ),
-						value: 'interests-' + id + ':' + interest.id,
-						disabled: isDisabled,
-					} );
-				} );
-			}
-			return accumulator;
-		}, [] );
-		const field = get( campaign, 'recipients.segment_opts.conditions.[0].field' );
-		const interest_id = get( campaign, 'recipients.segment_opts.conditions.[0].value.[0]' );
-		const interestValue = field && interest_id ? field + ':' + interest_id : 0;
 		return (
 			<SelectControl
 				label={ __( 'Groups', 'newspack-newsletters' ) }
-				value={ interestValue }
+				value={ interestSettings.interestValue }
 				options={ [
 					{
 						label: __( '-- Select a group --', 'newspack-newsletters' ),
 						value: 'no_interests',
 					},
-					...options,
+					...interestSettings.options,
 				] }
 				onChange={ value => this.setInterest( value ) }
-				disabled={ inFlight }
+				disabled={ this.props.inFlight }
 			/>
 		);
 	};

--- a/src/editor/utils.js
+++ b/src/editor/utils.js
@@ -3,6 +3,11 @@
  */
 import { __ } from '@wordpress/i18n';
 
+/**
+ * External dependencies
+ */
+import { get, find } from 'lodash';
+
 const validateCampaign = campaign => {
 	const { recipients, settings, status } = campaign || {};
 	const { list_id: listId } = recipients || {};
@@ -49,3 +54,44 @@ export const getEditPostPayload = ( {
  * @return {boolean} True if it contains a valid email string.
  */
 export const hasValidEmail = string => /\S+@\S+/.test( string );
+
+/**
+ * Get interest settings for a Mailchimp campaign.
+ * An interest is a subset of a list.
+ */
+export const getListInterestsSettings = ( { campaign, interestCategories } ) => {
+	if (
+		! interestCategories ||
+		! interestCategories.categories ||
+		! interestCategories.categories.length
+	) {
+		return;
+	}
+	const options = interestCategories.categories.reduce( ( accumulator, item ) => {
+		const { title, interests, id } = item;
+		accumulator.push( {
+			label: title,
+			disabled: true,
+		} );
+		if ( interests && interests.interests && interests.interests.length ) {
+			interests.interests.forEach( interest => {
+				const isDisabled = parseInt( interest.subscriber_count ) === 0;
+				accumulator.push( {
+					label:
+						'- ' +
+						interest.name +
+						( isDisabled ? __( ' (no subscribers)', 'newspack-newsletters' ) : '' ),
+					value: 'interests-' + id + ':' + interest.id,
+					disabled: isDisabled,
+					rawInterest: interest,
+				} );
+			} );
+		}
+		return accumulator;
+	}, [] );
+	const field = get( campaign, 'recipients.segment_opts.conditions.[0].field' );
+	const interest_id = get( campaign, 'recipients.segment_opts.conditions.[0].value.[0]' );
+	const interestValue = field && interest_id ? field + ':' + interest_id : 0;
+
+	return { options, interestValue, setInterest: find( options, [ 'value', interestValue ] ) };
+};

--- a/src/service-providers/example/index.js
+++ b/src/service-providers/example/index.js
@@ -78,8 +78,22 @@ const ProviderSidebar = ( {
 	);
 };
 
+/**
+ * A function to render additional info in the pre-send confirmation modal.
+ * Can return null if no additional info is to be presented.
+ *
+ * @param {Object} newsletterData the data returned by getFetchDataConfig handler
+ * @return {any} A React component
+ */
+const renderPreSendInfo = ( newsletterData = {} ) => (
+	<p>
+		{ __( 'Sending newsletter to:', 'newspack-newsletters' ) } { newsletterData.listName }
+	</p>
+);
+
 export default {
 	validateNewsletter,
 	getFetchDataConfig,
 	ProviderSidebar,
+	renderPreSendInfo,
 };

--- a/src/service-providers/mailchimp/index.js
+++ b/src/service-providers/mailchimp/index.js
@@ -1,12 +1,19 @@
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { __, sprintf, _n } from '@wordpress/i18n';
+import { Fragment } from '@wordpress/element';
+
+/**
+ * External dependencies
+ */
+import { find } from 'lodash';
 
 /**
  * Internal dependencies
  */
 import ProviderSidebar from './ProviderSidebar';
+import { getListInterestsSettings } from './utils';
 
 const validateNewsletter = ( { campaign } ) => {
 	const { recipients, settings, status } = campaign || {};
@@ -36,8 +43,51 @@ const getFetchDataConfig = ( { postId } ) => ( {
 	path: `/newspack-newsletters/v1/mailchimp/${ postId }`,
 } );
 
+const renderPreSendInfo = newsletterData => {
+	let listData;
+	if ( newsletterData.campaign && newsletterData.lists ) {
+		const list = find( newsletterData.lists.lists, [
+			'id',
+			newsletterData.campaign.recipients.list_id,
+		] );
+		const interestSettings = getListInterestsSettings( newsletterData );
+
+		if ( list ) {
+			listData = { name: list.name, subscribers: parseInt( list.stats.member_count ) };
+			if ( interestSettings && interestSettings.setInterest ) {
+				listData.groupName = interestSettings.setInterest.rawInterest.name;
+				listData.subscribers = parseInt(
+					interestSettings.setInterest.rawInterest.subscriber_count
+				);
+			}
+		}
+	}
+
+	return (
+		<p>
+			{ __( "You're about to send a newsletter to:", 'newspack-newsletters' ) }
+			<br />
+			<strong>{ listData.name }</strong>
+			<br />
+			{ listData.groupName && (
+				<Fragment>
+					{ __( 'Group:', 'newspack-newsletters' ) } <strong>{ listData.groupName }</strong>
+					<br />
+				</Fragment>
+			) }
+			<strong>
+				{ sprintf(
+					_n( '%d subscriber', '%d subscribers', listData.subscribers, 'newspack-newsletters' ),
+					listData.subscribers
+				) }
+			</strong>
+		</p>
+	);
+};
+
 export default {
 	validateNewsletter,
 	getFetchDataConfig,
 	ProviderSidebar,
+	renderPreSendInfo,
 };

--- a/src/service-providers/mailchimp/index.js
+++ b/src/service-providers/mailchimp/index.js
@@ -44,6 +44,9 @@ const getFetchDataConfig = ( { postId } ) => ( {
 } );
 
 const renderPreSendInfo = newsletterData => {
+	if ( ! newsletterData.campaign ) {
+		return null;
+	}
 	let listData;
 	if ( newsletterData.campaign && newsletterData.lists ) {
 		const list = find( newsletterData.lists.lists, [

--- a/src/service-providers/mailchimp/utils.js
+++ b/src/service-providers/mailchimp/utils.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { sprintf, _n } from '@wordpress/i18n';
 
 /**
  * External dependencies
@@ -31,14 +31,16 @@ export const getListInterestsSettings = ( {
 		} );
 		if ( interests && interests.interests && interests.interests.length ) {
 			interests.interests.forEach( interest => {
-				const isDisabled = parseInt( interest.subscriber_count ) === 0;
+				const subscriberCount = parseInt( interest.subscriber_count );
+				const subscriberCountInfo = sprintf(
+					_n( '%d subscriber', '%d subscribers', subscriberCount, 'newspack-newsletters' ),
+					subscriberCount
+				);
+
 				accumulator.push( {
-					label:
-						'- ' +
-						interest.name +
-						( isDisabled ? __( ' (no subscribers)', 'newspack-newsletters' ) : '' ),
-					value: 'interests-' + id + ':' + interest.id,
-					disabled: isDisabled,
+					label: `- ${ interest.name } (${ subscriberCountInfo })`,
+					value: `interests-${ id }:${ interest.id }`,
+					disabled: subscriberCount === 0,
 					rawInterest: interest,
 				} );
 			} );


### PR DESCRIPTION
### All Submissions:

* [X] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [X] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes #139

### How to test the changes in this Pull Request:

1. Create a newsletter and fill settings so that it is valid ("Send" button is active) – set just list, without the group.
2. Click "Send" - observe a confirmation modal appears with the set list name and subscriber count
3. Cancel 
3. Set a group and click "Send" – observe that the modal now has information about the group and group's subscriber count
4. Send the campaign, observe that it is sent

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
