### PR TITLE
Prevent post flickering in template selection

### DIFF
--- a/src/editor/layout/index.js
+++ b/src/editor/layout/index.js
@@ -17,22 +17,32 @@ import { setPreventDeduplicationForPostsInserter } from '../blocks/posts-inserte
 
 export default compose( [
 	withDispatch( dispatch => {
+		const { replaceBlocks } = dispatch( 'core/block-editor' );
+		const { editPost } = dispatch( 'core/editor' );
 		return {
-			setTemplateIDMeta: templateId =>
-				dispatch( 'core/editor' ).editPost( { meta: { template_id: templateId } } ),
+			replaceBlocks,
+			setTemplateIDMeta: templateId => editPost( { meta: { template_id: templateId } } ),
 		};
 	} ),
 	withSelect( select => {
 		const { getEditedPostAttribute } = select( 'core/editor' );
+		const { getBlocks } = select( 'core/block-editor' );
 		const meta = getEditedPostAttribute( 'meta' );
 		const { template_id: templateId } = meta;
-		return { templateId };
+		const clientIds = getBlocks().map( ( { clientId } ) => clientId );
+		return { templateId, clientIds };
 	} ),
-] )( ( { setTemplateIDMeta, templateId, templates } ) => {
+] )( ( { setTemplateIDMeta, templateId, templates, replaceBlocks, clientIds } ) => {
 	const [ warningModalVisible, setWarningModalVisible ] = useState( false );
 	const currentTemplate = templates && templates[ templateId ] ? templates[ templateId ] : {};
 	const { content, title } = currentTemplate;
 	const blockPreview = content ? parse( content ) : null;
+
+	const clearPost = () => {
+		if ( clientIds && clientIds.length ) {
+			replaceBlocks( clientIds, [] );
+		}
+	};
 
 	return (
 		<Fragment>
@@ -67,6 +77,7 @@ export default compose( [
 					<Button
 						isPrimary
 						onClick={ () => {
+							clearPost();
 							setTemplateIDMeta( -1 );
 							setWarningModalVisible( false );
 						} }


### PR DESCRIPTION
### All Submissions:

* [X] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [X] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Prevent a bug occurring when there's a Posts Inserter block in post content, and the template modal on top of the post, with a Posts Inserter block in a preview.

### How to test the changes in this Pull Request:

1. On master branch:
1. Edit a newsletter with a Posts Inserter block, or create one
2. Change the layout, choose the "Daily/Weekly" layout
3. Observe Posts Inserter blocks in the preview flickering
1. Switch to this branch
1. Repeat 2, 3; observe no flickering

### Other information:

* [X] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [X] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
