### PR TITLE
fix: missing notice after campaign has been sent

### DIFF
--- a/src/service-providers/mailchimp/ProviderSidebar.js
+++ b/src/service-providers/mailchimp/ProviderSidebar.js
@@ -84,6 +84,8 @@ const ProviderSidebar = ( {
 		);
 	}
 
+	const { status } = campaign || {};
+
 	if ( 'sent' === status || 'sending' === status ) {
 		return (
 			<Notice status="success" isDismissible={ false }>
@@ -92,7 +94,6 @@ const ProviderSidebar = ( {
 		);
 	}
 
-	const { status } = campaign || {};
 	const { list_id } = campaign.recipients || {};
 	const { web_id: listWebId } = list_id && lists.find( ( { id } ) => list_id === id );
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes a regression that caused the Campaign Sent `Notice` to not be shown after sending.

Closes https://github.com/Automattic/newspack-newsletters/issues/188

### How to test the changes in this Pull Request:

1. Create a Newsletter, populate the fields, send it.
2. Verify the Newsletter sidebar panel displays a green Notice instead of the fields.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
