### PR TITLE
fix: when trashing post allow mailchimp api call to fail silently

### DIFF
--- a/includes/class-newspack-newsletters.php
+++ b/includes/class-newspack-newsletters.php
@@ -796,15 +796,22 @@ final class Newspack_Newsletters {
 			return;
 		}
 
-		$api_key  = self::mailchimp_api_key();
-		$mc       = new Mailchimp( $api_key );
-		$campaign = $mc->get( "campaigns/$mc_campaign_id" );
-		if ( $campaign ) {
-			$status = $campaign['status'];
-			if ( ! in_array( $status, [ 'sent', 'sending' ] ) ) {
-				$result = $mc->delete( "campaigns/$mc_campaign_id" );
-				delete_post_meta( $id, 'mc_campaign_id', $mc_campaign_id );
+		$api_key = self::mailchimp_api_key();
+		if ( ! $api_key ) {
+			return;
+		}
+		try {
+			$mc       = new Mailchimp( $api_key );
+			$campaign = $mc->get( "campaigns/$mc_campaign_id" );
+			if ( $campaign ) {
+				$status = $campaign['status'];
+				if ( ! in_array( $status, [ 'sent', 'sending' ] ) ) {
+					$result = $mc->delete( "campaigns/$mc_campaign_id" );
+					delete_post_meta( $id, 'mc_campaign_id', $mc_campaign_id );
+				}
 			}
+		} catch ( Exception $e ) {
+			return; // Fail silently.
 		}
 	}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Trashing a Newsletter will lead to a Fatal if the Mailchimp API key is invalid or missing. This branch allows the Mailchimp API request to fail silently.

Closes https://github.com/Automattic/newspack-newsletters/issues/206

### How to test the changes in this Pull Request:

1. On `master`, create a Newsletter.
2. In Newsletters->Settings, remove or mangle the Mailchimp API key. 
3. On the Newsletters list page, trash the post, observe fatal error. 
4. Switch to this branch, retry deletion. Observe post is trashed with no error. 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
