### PR TITLE
fix: situation that overwrote mc campaign id

### DIFF
--- a/src/newsletter-editor/editor/index.js
+++ b/src/newsletter-editor/editor/index.js
@@ -31,7 +31,6 @@ const Editor = compose( [
 
 		return {
 			isCleanNewPost: isCleanNewPost(),
-			meta,
 			postId: getCurrentPostId(),
 			isReady: meta.newsletterValidationErrors
 				? meta.newsletterValidationErrors.length === 0
@@ -65,16 +64,12 @@ const Editor = compose( [
 			props
 				.apiFetchWithErrorHandling( getFetchDataConfig( { postId: props.postId } ) )
 				.then( result => {
-					props.editPost( getEditPostPayload( result ) );
+					const postUpdate = getEditPostPayload( result );
+					postUpdate.meta.color_palette = props.colorPalette;
+					props.editPost( postUpdate );
 				} );
 		}
 	}, [ props.isPublishingOrSavingPost ]);
-
-	useEffect(() => {
-		if ( props.meta.mc_campaign_id.length > 0 ) {
-			props.editPost( { meta: { color_palette: props.colorPalette } } );
-		}
-	}, [ props.meta.mc_campaign_id ]);
 
 	// Lock or unlock post publishing.
 	useEffect(() => {

--- a/src/newsletter-editor/editor/index.js
+++ b/src/newsletter-editor/editor/index.js
@@ -31,6 +31,7 @@ const Editor = compose( [
 
 		return {
 			isCleanNewPost: isCleanNewPost(),
+			meta,
 			postId: getCurrentPostId(),
 			isReady: meta.newsletterValidationErrors
 				? meta.newsletterValidationErrors.length === 0
@@ -70,8 +71,10 @@ const Editor = compose( [
 	}, [ props.isPublishingOrSavingPost ]);
 
 	useEffect(() => {
-		props.editPost( { meta: { color_palette: props.colorPalette } } );
-	}, []);
+		if ( props.meta.mc_campaign_id.length > 0 ) {
+			props.editPost( { meta: { color_palette: props.colorPalette } } );
+		}
+	}, [ props.meta.mc_campaign_id ]);
 
 	// Lock or unlock post publishing.
 	useEffect(() => {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR addresses a regression introduced in https://github.com/Automattic/newspack-newsletters/pull/176. When creating the very first Newsletter, a sequence occurs which clears the Mailchimp Campaign ID field which leads to a confusing error message (`No Mailchimp campaign ID found for this Newsletter`) and creation of duplicate Mailchimp campaigns. The `useEffect` that sets the `color_palette` meta field executes before there is a campaign ID set. This leads to a sequence where the campaign ID is set, then unset, and multiple campaigns are created.

One side effect of this fix is that the colors may be incorrect the very first time a campaign is synced, but the post will always be saved again before testing or sending so this is not a serious issue. 

Closes https://github.com/Automattic/newspack-newsletters/issues/203
Closes https://github.com/Automattic/newspack-newsletters/issues/202

### How to test the changes in this Pull Request:

1. On `master` navigate to Newsletter->Settings, clear the Mailchimp key, and save.
2. Create a new Newsletter, paste in the MC key, choose a template. 
3. Observe `No Mailchimp campaign ID found for this Newsletter` error message.
4. Make changes and save the Newsletter.
5. In Mailchimp, observe that multiple campaigns have been created. 
6. Apply the patch and repeat all steps. 
7. Observe there is no error message and only one campaign is created.
8. Verify color palette aspects continue to work as described in https://github.com/Automattic/newspack-newsletters/pull/176. 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
