### PR TITLE
fix: resolve excerpt length issue

### DIFF
--- a/src/editor/blocks/posts-inserter/utils.js
+++ b/src/editor/blocks/posts-inserter/utils.js
@@ -37,8 +37,7 @@ const getExcerptBlockTemplate = ( post, { excerptLength } ) => {
 	excerptElement.innerHTML = excerpt;
 	excerpt = excerptElement.textContent || excerptElement.innerText || '';
 
-	const needsEllipsis =
-		excerptLength < excerpt.trim().split( ' ' ).length && post.excerpt.raw === '';
+	const needsEllipsis = excerptLength < excerpt.trim().split( ' ' ).length;
 
 	const postExcerpt = needsEllipsis
 		? `${ excerpt.split( ' ', excerptLength ).join( ' ' ) } […]`


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Correct a bug that occurs with posts that have an empty custom excerpt. The Posts Inserter block will display their full content as the excerpt, and the word count control does nothing.

Closes https://github.com/Automattic/newspack-newsletters/issues/204

h/t @adekbadek for the fix!

### How to test the changes in this Pull Request:

1. Edit the top post. In the Excerpt sidebar, put in a single space and Update the post. Do the same for the next few ones too.
2. While still on `master`, create a Newsletter from a template. Observe in the Posts Inserter blocks the edited posts show all of their content as the excerpt. 
3. Change the `Max number of words in excerpt` `RangeControl`. Observe this has no effect on the length of the excerpts.
4. Switch to this branch.
5. Observe the excerpts are displayed correctly and the `RangeControl` accurately controls excerpt length.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
