### PR TITLE
feat: font picker

### DIFF
--- a/includes/class-newspack-newsletters-renderer.php
+++ b/includes/class-newspack-newsletters-renderer.php
@@ -21,6 +21,20 @@ final class Newspack_Newsletters_Renderer {
 	protected static $color_palette = null;
 
 	/**
+	 * The header font.
+	 *
+	 * @var String
+	 */
+	protected static $font_header = null;
+
+	/**
+	 * The body font.
+	 *
+	 * @var String
+	 */
+	protected static $font_body = null;
+
+	/**
 	 * Convert a list to HTML attributes.
 	 *
 	 * @param array $attributes Array of attributes.
@@ -191,6 +205,8 @@ final class Newspack_Newsletters_Renderer {
 			)
 		);
 
+		$font_family = 'core/heading' === $block_name ? self::$font_header : self::$font_body;
+
 		switch ( $block_name ) {
 			/**
 			 * Paragraph, List, Heading blocks.
@@ -204,6 +220,7 @@ final class Newspack_Newsletters_Renderer {
 						'padding'     => '0',
 						'line-height' => '1.8',
 						'font-size'   => '16px',
+						'font-family' => $font_family,
 					),
 					$attrs
 				);
@@ -517,6 +534,8 @@ final class Newspack_Newsletters_Renderer {
 	 */
 	private static function render_mjml( $post ) {
 		self::$color_palette = get_post_meta( $post->ID, 'color_palette', true );
+		self::$font_header   = get_post_meta( $post->ID, 'font_header', true );
+		self::$font_body     = get_post_meta( $post->ID, 'font_body', true );
 		$title               = $post->post_title;
 		$blocks              = parse_blocks( $post->post_content );
 		$body                = '';

--- a/includes/class-newspack-newsletters-renderer.php
+++ b/includes/class-newspack-newsletters-renderer.php
@@ -536,9 +536,15 @@ final class Newspack_Newsletters_Renderer {
 		self::$color_palette = get_post_meta( $post->ID, 'color_palette', true );
 		self::$font_header   = get_post_meta( $post->ID, 'font_header', true );
 		self::$font_body     = get_post_meta( $post->ID, 'font_body', true );
-		$title               = $post->post_title;
-		$blocks              = parse_blocks( $post->post_content );
-		$body                = '';
+		if ( ! in_array( self::$font_header, Newspack_Newsletters::$supported_fonts ) ) {
+			self::$font_header = 'Arial';
+		}
+		if ( ! in_array( self::$font_body, Newspack_Newsletters::$supported_fonts ) ) {
+			self::$font_body = 'Georgia';
+		}
+		$title  = $post->post_title;
+		$blocks = parse_blocks( $post->post_content );
+		$body   = '';
 		foreach ( $blocks as $block ) {
 			$block_content = self::render_mjml_component( $block );
 			if ( ! empty( $block_content ) ) {

--- a/includes/class-newspack-newsletters-renderer.php
+++ b/includes/class-newspack-newsletters-renderer.php
@@ -284,9 +284,10 @@ final class Newspack_Newsletters_Renderer {
 
 				if ( $figcaption ) {
 					$caption_attrs = array(
-						'align'     => 'center',
-						'color'     => '#555d66',
-						'font-size' => '13px',
+						'align'       => 'center',
+						'color'       => '#555d66',
+						'font-size'   => '13px',
+						'font-family' => $font_family,
 					);
 					 // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
 					$markup .= '<mj-text ' . self::array_to_attributes( $caption_attrs ) . '>' . $figcaption->wholeText . '</mj-text>';
@@ -317,6 +318,7 @@ final class Newspack_Newsletters_Renderer {
 						'href'          => $anchor->getAttribute( 'href' ),
 						'border-radius' => $border_radius . 'px',
 						'font-size'     => '18px',
+						'font-family'   => $font_family,
 						// Default color - will be replaced by get_colors if there are colors set.
 						'color'         => $is_outlined ? '#32373c' : '#fff',
 					);

--- a/includes/class-newspack-newsletters.php
+++ b/includes/class-newspack-newsletters.php
@@ -28,7 +28,6 @@ final class Newspack_Newsletters {
 		'Tahoma',
 		'TrebuchetMS',
 		'Verdana',
-		'Serif',
 		'Georgia',
 		'Palatino',
 		'TimesNewRoman',

--- a/includes/class-newspack-newsletters.php
+++ b/includes/class-newspack-newsletters.php
@@ -19,6 +19,23 @@ final class Newspack_Newsletters {
 	const NEWSPACK_NEWSLETTERS_CPT = 'newspack_nl_cpt';
 
 	/**
+	 * Supported fonts.
+	 *
+	 * @var array
+	 */
+	public static $supported_fonts = [
+		'Arial',
+		'Tahoma',
+		'TrebuchetMS',
+		'Verdana',
+		'Serif',
+		'Georgia',
+		'Palatino',
+		'TimesNewRoman',
+		'Courier',
+	];
+
+	/**
 	 * The single instance of the class.
 	 *
 	 * @var Newspack_Newsletters
@@ -383,17 +400,7 @@ final class Newspack_Newsletters {
 	public static function validate_newsletter_typography_value( $key ) {
 		return in_array(
 			$key,
-			[
-				'Arial',
-				'Tahoma',
-				'TrebuchetMS',
-				'Verdana',
-				'Serif',
-				'Georgia',
-				'Palatino',
-				'TimesNewRoman',
-				'Courier',
-			]
+			self::$supported_fonts
 		);
 	}
 

--- a/includes/class-newspack-newsletters.php
+++ b/includes/class-newspack-newsletters.php
@@ -358,6 +358,10 @@ final class Newspack_Newsletters {
 
 	/**
 	 * Set typography meta.
+	 * The save_post action fires before post meta is updated.
+	 * This causes newsletters to be synced to the ESP before recent changes to custom fields have been recorded,
+	 * which leads to incorrect rendering. This is addressed through custom endpoints to update the typography fields
+	 * as soon as they are changed in the editor, so that the changes are available the next time sync to ESP occurs.
 	 *
 	 * @param WP_REST_Request $request API request object.
 	 */

--- a/includes/class-newspack-newsletters.php
+++ b/includes/class-newspack-newsletters.php
@@ -103,6 +103,28 @@ final class Newspack_Newsletters {
 				'auth_callback'  => '__return_true',
 			]
 		);
+		\register_meta(
+			'post',
+			'font_header',
+			[
+				'object_subtype' => self::NEWSPACK_NEWSLETTERS_CPT,
+				'show_in_rest'   => true,
+				'type'           => 'string',
+				'single'         => true,
+				'auth_callback'  => '__return_true',
+			]
+		);
+		\register_meta(
+			'post',
+			'font_body',
+			[
+				'object_subtype' => self::NEWSPACK_NEWSLETTERS_CPT,
+				'show_in_rest'   => true,
+				'type'           => 'string',
+				'single'         => true,
+				'auth_callback'  => '__return_true',
+			]
+		);
 		/**
 		 * The default color palette lives in the editor frontend and is not
 		 * retrievable on the backend. The workaround is to set it as post meta

--- a/includes/class-newspack-newsletters.php
+++ b/includes/class-newspack-newsletters.php
@@ -24,14 +24,14 @@ final class Newspack_Newsletters {
 	 * @var array
 	 */
 	public static $supported_fonts = [
-		'Arial',
-		'Tahoma',
-		'TrebuchetMS',
-		'Verdana',
-		'Georgia',
-		'Palatino',
-		'TimesNewRoman',
-		'Courier',
+		'Arial, Helvetica, sans-serif',
+		'Tahoma, sans-serif',
+		'Trebuchet MS, sans-serif',
+		'Verdana, sans-serif',
+		'Georgia, serif',
+		'Palatino, serif',
+		'Times New Roman, serif',
+		'Courier, monospace',
 	];
 
 	/**

--- a/includes/class-newspack-newsletters.php
+++ b/includes/class-newspack-newsletters.php
@@ -314,6 +314,87 @@ final class Newspack_Newsletters {
 				],
 			]
 		);
+		\register_rest_route(
+			'newspack-newsletters/v1/',
+			'typography/(?P<id>[\a-z]+)',
+			[
+				'methods'             => \WP_REST_Server::EDITABLE,
+				'callback'            => [ __CLASS__, 'api_set_typography' ],
+				'permission_callback' => [ __CLASS__, 'api_administration_permissions_check' ],
+				'args'                => [
+					'id'    => [
+						'validate_callback' => [ __CLASS__, 'validate_newsletter_id' ],
+						'sanitize_callback' => 'absint',
+					],
+					'key'   => [
+						'validate_callback' => [ __CLASS__, 'validate_newsletter_typography_key' ],
+						'sanitize_callback' => 'sanitize_text_field',
+					],
+					'value' => [
+						'validate_callback' => [ __CLASS__, 'validate_newsletter_typography_value' ],
+						'sanitize_callback' => 'sanitize_text_field',
+					],
+				],
+			]
+		);
+	}
+
+	/**
+	 * Set typography meta.
+	 *
+	 * @param WP_REST_Request $request API request object.
+	 */
+	public static function api_set_typography( $request ) {
+		$id    = $request['id'];
+		$key   = $request['key'];
+		$value = $request['value'];
+		update_post_meta( $id, $key, $value );
+	}
+
+	/**
+	 * Validate ID is a Newsletter post type.
+	 *
+	 * @param int $id Post ID.
+	 */
+	public static function validate_newsletter_id( $id ) {
+		return self::NEWSPACK_NEWSLETTERS_CPT === get_post_type( $id );
+	}
+
+	/**
+	 * Validate typography key.
+	 *
+	 * @param String $key Meta key.
+	 */
+	public static function validate_newsletter_typography_key( $key ) {
+		return in_array(
+			$key,
+			[
+				'font_header',
+				'font_body',
+			]
+		);
+	}
+
+	/**
+	 * Validate typography value (font name).
+	 *
+	 * @param String $key Meta value.
+	 */
+	public static function validate_newsletter_typography_value( $key ) {
+		return in_array(
+			$key,
+			[
+				'Arial',
+				'Tahoma',
+				'TrebuchetMS',
+				'Verdana',
+				'Serif',
+				'Georgia',
+				'Palatino',
+				'TimesNewRoman',
+				'Courier',
+			]
+		);
 	}
 
 	/**

--- a/src/components/select-control-with-optgroup/index.js
+++ b/src/components/select-control-with-optgroup/index.js
@@ -1,0 +1,75 @@
+/**
+ * External dependencies
+ */
+import { isEmpty } from 'lodash';
+
+/**
+ * WordPress dependencies
+ */
+import { useInstanceId } from '@wordpress/compose';
+import { BaseControl } from '@wordpress/components';
+
+/**
+ * SelectControl with optgroup support
+ */
+export default function SelectControlWithOptGroup( {
+	help,
+	label,
+	multiple = false,
+	onChange,
+	optgroups = [],
+	className,
+	hideLabelFromVision,
+	...props
+} ) {
+	const instanceId = useInstanceId( SelectControlWithOptGroup );
+	const id = `inspector-select-control-${ instanceId }`;
+	const onChangeValue = event => {
+		if ( multiple ) {
+			const selectedOptions = [ ...event.target.options ].filter( ( { selected } ) => selected );
+			const newValues = selectedOptions.map( ( { value } ) => value );
+			onChange( newValues );
+			return;
+		}
+		onChange( event.target.value );
+	};
+
+	// Disable reason: A select with an onchange throws a warning
+
+	/* eslint-disable jsx-a11y/no-onchange */
+	return (
+		! isEmpty( optgroups ) && (
+			<BaseControl
+				label={ label }
+				hideLabelFromVision={ hideLabelFromVision }
+				id={ id }
+				help={ help }
+				className={ className }
+			>
+				<select
+					id={ id }
+					className="components-select-control__input"
+					onChange={ onChangeValue }
+					aria-describedby={ !! help ? `${ id }__help` : undefined }
+					multiple={ multiple }
+					{ ...props }
+				>
+					{ optgroups.map( ( { label: optgroupLabel, options }, optgroupIndex ) => (
+						<optgroup label={ optgroupLabel } key={ optgroupIndex }>
+							{ options.map( ( option, optionIndex ) => (
+								<option
+									key={ `${ option.label }-${ option.value }-${ optionIndex }` }
+									value={ option.value }
+									disabled={ option.disabled }
+								>
+									{ option.label }
+								</option>
+							) ) }
+						</optgroup>
+					) ) }
+				</select>
+			</BaseControl>
+		)
+	);
+	/* eslint-enable jsx-a11y/no-onchange */
+}

--- a/src/components/select-control-with-optgroup/index.js
+++ b/src/components/select-control-with-optgroup/index.js
@@ -36,40 +36,42 @@ export default function SelectControlWithOptGroup( {
 
 	// Disable reason: A select with an onchange throws a warning
 
+	if ( isEmpty( optgroups ) ) {
+		return null;
+	}
+
 	/* eslint-disable jsx-a11y/no-onchange */
 	return (
-		! isEmpty( optgroups ) && (
-			<BaseControl
-				label={ label }
-				hideLabelFromVision={ hideLabelFromVision }
+		<BaseControl
+			label={ label }
+			hideLabelFromVision={ hideLabelFromVision }
+			id={ id }
+			help={ help }
+			className={ className }
+		>
+			<select
 				id={ id }
-				help={ help }
-				className={ className }
+				className="components-select-control__input"
+				onChange={ onChangeValue }
+				aria-describedby={ !! help ? `${ id }__help` : undefined }
+				multiple={ multiple }
+				{ ...props }
 			>
-				<select
-					id={ id }
-					className="components-select-control__input"
-					onChange={ onChangeValue }
-					aria-describedby={ !! help ? `${ id }__help` : undefined }
-					multiple={ multiple }
-					{ ...props }
-				>
-					{ optgroups.map( ( { label: optgroupLabel, options }, optgroupIndex ) => (
-						<optgroup label={ optgroupLabel } key={ optgroupIndex }>
-							{ options.map( ( option, optionIndex ) => (
-								<option
-									key={ `${ option.label }-${ option.value }-${ optionIndex }` }
-									value={ option.value }
-									disabled={ option.disabled }
-								>
-									{ option.label }
-								</option>
-							) ) }
-						</optgroup>
-					) ) }
-				</select>
-			</BaseControl>
-		)
+				{ optgroups.map( ( { label: optgroupLabel, options }, optgroupIndex ) => (
+					<optgroup label={ optgroupLabel } key={ optgroupIndex }>
+						{ options.map( ( option, optionIndex ) => (
+							<option
+								key={ `${ option.label }-${ option.value }-${ optionIndex }` }
+								value={ option.value }
+								disabled={ option.disabled }
+							>
+								{ option.label }
+							</option>
+						) ) }
+					</optgroup>
+				) ) }
+			</select>
+		</BaseControl>
 	);
 	/* eslint-enable jsx-a11y/no-onchange */
 }

--- a/src/editor/style.scss
+++ b/src/editor/style.scss
@@ -21,7 +21,9 @@
 
 		.newspack-posts-inserter__header span,
 		.components-button,
-		.block-editor-block-list__block .component-placeholder {
+		.block-editor-block-list__block .component-placeholder,
+		figcaption,
+		.wp-block-button .wp-block-button__link {
 			font-family: Ubuntu, helvetica, arial, sans-serif;
 		}
 

--- a/src/editor/style.scss
+++ b/src/editor/style.scss
@@ -1,3 +1,8 @@
+:root {
+	--header-font: helvetica, arial, sans-serif;
+	--body-font: helvetica, arial, sans-serif;
+}
+
 .wp-block {
 	max-width: 600px;
 	padding: 20px;
@@ -11,7 +16,20 @@
 		}
 
 		*:not( code ) {
-			font-family: Ubuntu, Helvetica, Arial, sans-serif !important;
+			font-family: var( --body-font );
+		}
+
+		.newspack-posts-inserter__header span {
+			font-family: Ubuntu, helvetica, arial, sans-serif;
+		}
+
+		h1,
+		h2,
+		h3,
+		h4,
+		h5,
+		h6 {
+			font-family: var( --header-font );
 		}
 
 		code {

--- a/src/editor/style.scss
+++ b/src/editor/style.scss
@@ -21,10 +21,9 @@
 
 		.newspack-posts-inserter__header span,
 		.components-button,
-		.block-editor-block-list__block .component-placeholder,
-		figcaption,
-		.wp-block-button .wp-block-button__link {
-			font-family: Ubuntu, helvetica, arial, sans-serif;
+		.block-editor-block-list__block .components-placeholder,
+		.block-editor-block-list__block .components-placeholder div {
+			font-family: 'Noto Serif', helvetica, arial, sans-serif;
 		}
 
 		h1,

--- a/src/editor/style.scss
+++ b/src/editor/style.scss
@@ -1,6 +1,6 @@
 :root {
-	--header-font: helvetica, arial, sans-serif;
-	--body-font: helvetica, arial, sans-serif;
+	--header-font: arial, sans-serif;
+	--body-font: georgia, serif;
 }
 
 .wp-block {

--- a/src/editor/style.scss
+++ b/src/editor/style.scss
@@ -34,6 +34,10 @@
 			font-family: var( --header-font );
 		}
 
+		a {
+			font-family: inherit;
+		}
+
 		code {
 			background: none;
 			color: inherit;

--- a/src/editor/style.scss
+++ b/src/editor/style.scss
@@ -19,7 +19,9 @@
 			font-family: var( --body-font );
 		}
 
-		.newspack-posts-inserter__header span {
+		.newspack-posts-inserter__header span,
+		.components-button,
+		.block-editor-block-list__block .component-placeholder {
 			font-family: Ubuntu, helvetica, arial, sans-serif;
 		}
 

--- a/src/newsletter-editor/index.js
+++ b/src/newsletter-editor/index.js
@@ -15,6 +15,7 @@ import InitModal from '../components/init-modal';
 import Layout from './layout/';
 import Sidebar from './sidebar/';
 import Testing from './testing/';
+import Typography from './typography/';
 import registerEditorPlugin from './editor/';
 
 registerEditorPlugin();
@@ -35,6 +36,12 @@ const NewsletterEdit = ( { layoutId } ) => {
 				title={ __( 'Newsletter', 'newspack-newsletters' ) }
 			>
 				<Sidebar />
+			</PluginDocumentSettingPanel>
+			<PluginDocumentSettingPanel
+				name="newsletters-typography-panel"
+				title={ __( 'Typography', 'newspack-newsletters' ) }
+			>
+				<Typography />
 			</PluginDocumentSettingPanel>
 			<PluginDocumentSettingPanel
 				name="newsletters-testing-panel"

--- a/src/newsletter-editor/typography/index.js
+++ b/src/newsletter-editor/typography/index.js
@@ -4,7 +4,7 @@
 import { compose } from '@wordpress/compose';
 import { __ } from '@wordpress/i18n';
 import { withDispatch, withSelect } from '@wordpress/data';
-import { Fragment } from '@wordpress/element';
+import { Fragment, useEffect } from '@wordpress/element';
 import { SelectControl } from '@wordpress/components';
 
 const fontOptions = [
@@ -75,6 +75,12 @@ export default compose( [
 		};
 	} ),
 ] )( ( { editPost, fontBody, fontHeader } ) => {
+	useEffect(() => {
+		document.documentElement.style.setProperty( '--body-font', fontBody );
+	}, [ fontBody ]);
+	useEffect(() => {
+		document.documentElement.style.setProperty( '--header-font', fontHeader );
+	}, [ fontHeader ]);
 	return (
 		<Fragment>
 			<SelectControl

--- a/src/newsletter-editor/typography/index.js
+++ b/src/newsletter-editor/typography/index.js
@@ -6,55 +6,57 @@ import { compose } from '@wordpress/compose';
 import { __ } from '@wordpress/i18n';
 import { withDispatch, withSelect } from '@wordpress/data';
 import { Fragment, useEffect } from '@wordpress/element';
-import { SelectControl } from '@wordpress/components';
+import SelectControlWithOptGroup from '../../components/select-control-with-optgroup/';
 
-const fontOptions = [
+const fontOptgroups = [
 	{
-		value: null,
 		label: __( 'Sans Serif', 'newspack-newsletters' ),
-		disabled: true,
+		options: [
+			{
+				value: 'Arial',
+				label: __( 'Arial', 'newspack-newsletters' ),
+			},
+			{
+				value: 'Tahoma',
+				label: __( 'Tahoma', 'newspack-newsletters' ),
+			},
+			{
+				value: 'TrebuchetMS',
+				label: __( 'Trebuchet', 'newspack-newsletters' ),
+			},
+			{
+				value: 'Verdana',
+				label: __( 'Verdana', 'newspack-newsletters' ),
+			},
+		],
 	},
+
 	{
-		value: 'Arial',
-		label: __( 'Arial', 'newspack-newsletters' ),
-	},
-	{
-		value: 'Tahoma',
-		label: __( 'Tahoma', 'newspack-newsletters' ),
-	},
-	{
-		value: 'TrebuchetMS',
-		label: __( 'Trebuchet', 'newspack-newsletters' ),
-	},
-	{
-		value: 'Verdana',
-		label: __( 'Verdana', 'newspack-newsletters' ),
-	},
-	{
-		value: null,
 		label: __( 'Serif', 'newspack-newsletters' ),
-		disabled: true,
+		options: [
+			{
+				value: 'Georgia',
+				label: __( 'Georgia', 'newspack-newsletters' ),
+			},
+			{
+				value: 'Palatino',
+				label: __( 'Palatino', 'newspack-newsletters' ),
+			},
+			{
+				value: 'TimesNewRoman',
+				label: __( 'Times New Roman', 'newspack-newsletters' ),
+			},
+		],
 	},
+
 	{
-		value: 'Georgia',
-		label: __( 'Georgia', 'newspack-newsletters' ),
-	},
-	{
-		value: 'Palatino',
-		label: __( 'Palatino', 'newspack-newsletters' ),
-	},
-	{
-		value: 'TimesNewRoman',
-		label: __( 'Times New Roman', 'newspack-newsletters' ),
-	},
-	{
-		value: null,
 		label: __( 'Monospace', 'newspack-newsletters' ),
-		disabled: true,
-	},
-	{
-		value: 'Courier',
-		label: __( 'Courier New', 'newspack-newsletters' ),
+		options: [
+			{
+				value: 'Courier',
+				label: __( 'Courier New', 'newspack-newsletters' ),
+			},
+		],
 	},
 ];
 
@@ -89,16 +91,16 @@ export default compose( [
 	}, [ fontHeader ]);
 	return (
 		<Fragment>
-			<SelectControl
+			<SelectControlWithOptGroup
 				label={ __( 'Headings', 'newspack-newsletters' ) }
 				value={ fontHeader || 'Arial' }
-				options={ fontOptions }
+				optgroups={ fontOptgroups }
 				onChange={ value => updateFontValue( 'font_header', value ) }
 			/>
-			<SelectControl
+			<SelectControlWithOptGroup
 				label={ __( 'Body', 'newspack-newsletters' ) }
 				value={ fontBody || 'Georgia' }
-				options={ fontOptions }
+				optgroups={ fontOptgroups }
 				onChange={ value => updateFontValue( 'font_body', value ) }
 			/>
 		</Fragment>

--- a/src/newsletter-editor/typography/index.js
+++ b/src/newsletter-editor/typography/index.js
@@ -91,13 +91,13 @@ export default compose( [
 		<Fragment>
 			<SelectControl
 				label={ __( 'Headings', 'newspack-newsletters' ) }
-				value={ fontHeader }
+				value={ fontHeader || 'Arial' }
 				options={ fontOptions }
 				onChange={ value => updateFontValue( 'font_header', value ) }
 			/>
 			<SelectControl
 				label={ __( 'Body', 'newspack-newsletters' ) }
-				value={ fontBody }
+				value={ fontBody || 'Georgia' }
 				options={ fontOptions }
 				onChange={ value => updateFontValue( 'font_body', value ) }
 			/>

--- a/src/newsletter-editor/typography/index.js
+++ b/src/newsletter-editor/typography/index.js
@@ -18,10 +18,6 @@ const fontOptions = [
 		label: __( 'Arial', 'newspack-newsletters' ),
 	},
 	{
-		value: 'System',
-		label: __( 'System', 'newspack-newsletters' ),
-	},
-	{
 		value: 'Tahoma',
 		label: __( 'Tahoma', 'newspack-newsletters' ),
 	},

--- a/src/newsletter-editor/typography/index.js
+++ b/src/newsletter-editor/typography/index.js
@@ -1,0 +1,94 @@
+/**
+ * WordPress dependencies
+ */
+import { compose } from '@wordpress/compose';
+import { __ } from '@wordpress/i18n';
+import { withDispatch, withSelect } from '@wordpress/data';
+import { Fragment } from '@wordpress/element';
+import { SelectControl } from '@wordpress/components';
+
+const fontOptions = [
+	{
+		value: null,
+		label: __( 'Sans Serif', 'newspack-newsletters' ),
+		disabled: true,
+	},
+	{
+		value: 'Arial',
+		label: __( 'Arial', 'newspack-newsletters' ),
+	},
+	{
+		value: 'System',
+		label: __( 'System', 'newspack-newsletters' ),
+	},
+	{
+		value: 'Tahoma',
+		label: __( 'Tahoma', 'newspack-newsletters' ),
+	},
+	{
+		value: '"Trebuchet MS"',
+		label: __( 'Trebuchet MS', 'newspack-newsletters' ),
+	},
+	{
+		value: 'Verdana',
+		label: __( 'Verdana', 'newspack-newsletters' ),
+	},
+	{
+		value: null,
+		label: __( 'Serif', 'newspack-newsletters' ),
+		disabled: true,
+	},
+	{
+		value: 'Georgia',
+		label: __( 'Georgia', 'newspack-newsletters' ),
+	},
+	{
+		value: 'Palatino',
+		label: __( 'Palatino', 'newspack-newsletters' ),
+	},
+	{
+		value: 'TimesNewRoman',
+		label: __( 'Times New Roman', 'newspack-newsletters' ),
+	},
+	{
+		value: null,
+		label: __( 'Monospace', 'newspack-newsletters' ),
+		disabled: true,
+	},
+	{
+		value: 'Courier',
+		label: __( 'Courier New', 'newspack-newsletters' ),
+	},
+];
+
+export default compose( [
+	withDispatch( dispatch => {
+		const { editPost } = dispatch( 'core/editor' );
+		return { editPost };
+	} ),
+	withSelect( select => {
+		const { getEditedPostAttribute } = select( 'core/editor' );
+		const meta = getEditedPostAttribute( 'meta' );
+		return {
+			fontBody: meta.font_body || '',
+			fontHeader: meta.font_header || '',
+		};
+	} ),
+] )( ( { editPost, fontBody, fontHeader } ) => {
+	return (
+		<Fragment>
+			<SelectControl
+				label={ __( 'Headings', 'newspack-newsletters' ) }
+				value={ fontHeader }
+				options={ fontOptions }
+				onChange={ value => editPost( { meta: { font_header: value } } ) }
+			/>
+			<SelectControl
+				label={ __( 'Body', 'newspack-newsletters' ) }
+				value={ fontBody }
+				options={ fontOptions }
+				onChange={ value => editPost( { meta: { font_body: value } } ) }
+			/>
+		</Fragment>
+	);
+} );

--- a/src/newsletter-editor/typography/index.js
+++ b/src/newsletter-editor/typography/index.js
@@ -13,19 +13,19 @@ const fontOptgroups = [
 		label: __( 'Sans Serif', 'newspack-newsletters' ),
 		options: [
 			{
-				value: 'Arial',
+				value: 'Arial, Helvetica, sans-serif',
 				label: __( 'Arial', 'newspack-newsletters' ),
 			},
 			{
-				value: 'Tahoma',
+				value: 'Tahoma, sans-serif',
 				label: __( 'Tahoma', 'newspack-newsletters' ),
 			},
 			{
-				value: 'TrebuchetMS',
+				value: 'Trebuchet MS, sans-serif',
 				label: __( 'Trebuchet', 'newspack-newsletters' ),
 			},
 			{
-				value: 'Verdana',
+				value: 'Verdana, sans-serif',
 				label: __( 'Verdana', 'newspack-newsletters' ),
 			},
 		],
@@ -35,15 +35,15 @@ const fontOptgroups = [
 		label: __( 'Serif', 'newspack-newsletters' ),
 		options: [
 			{
-				value: 'Georgia',
+				value: 'Georgia, serif',
 				label: __( 'Georgia', 'newspack-newsletters' ),
 			},
 			{
-				value: 'Palatino',
+				value: 'Palatino, serif',
 				label: __( 'Palatino', 'newspack-newsletters' ),
 			},
 			{
-				value: 'TimesNewRoman',
+				value: 'Times New Roman, serif',
 				label: __( 'Times New Roman', 'newspack-newsletters' ),
 			},
 		],
@@ -53,8 +53,8 @@ const fontOptgroups = [
 		label: __( 'Monospace', 'newspack-newsletters' ),
 		options: [
 			{
-				value: 'Courier',
-				label: __( 'Courier New', 'newspack-newsletters' ),
+				value: 'Courier, monospace',
+				label: __( 'Courier', 'newspack-newsletters' ),
 			},
 		],
 	},


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Add font selection to the Newsletters plugin. Adds a Typography sidebar panel with `SelectControl`s for choosing body and header fonts. The options are all web-safe fonts, described in screenshots in https://github.com/Automattic/newspack-newsletters/issues/198. Selected fonts will immediately be used in the editor and in rendered emails. 

Note: the editor font switching uses CSS variables, which are not supported in IE11: https://caniuse.com/#feat=css-variables.

Closes https://github.com/Automattic/newspack-newsletters/issues/198

<img width="280" alt="Screen Shot 2020-05-26 at 8 45 54 AM" src="https://user-images.githubusercontent.com/1477002/82902447-75632d00-9f2d-11ea-85d2-dc361fb49d50.png">

### How to test the changes in this Pull Request:

1. Create a Newsletter.
2. Experiment with different changes to the Header and Body fonts in the Typography sidebar panel.
3. Observe the typography in the editor changes to reflect the selections.
4. Send yourself a test email, observe the correct fonts are used.
5. View test emails in a variety of email clients. Verify the correct fonts are seen everywhere.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
