### PR TITLE
Prevent empty featured image rendering

### DIFF
--- a/src/editor/blocks/posts-inserter/utils.js
+++ b/src/editor/blocks/posts-inserter/utils.js
@@ -64,7 +64,9 @@ const createBlockTemplatesForSinglePost = (
 		postContentBlocks.push( getExcerptBlockTemplate( post, { excerptLength } ) );
 	}
 
-	if ( displayFeaturedImage ) {
+	const hasFeaturedImage = post.featuredImageLargeURL || post.featuredImageMediumURL;
+
+	if ( displayFeaturedImage && hasFeaturedImage ) {
 		const getImageBlock = ( alignCenter = false ) => [
 			'core/image',
 			{


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes #201

### How to test the changes in this Pull Request:

1. On master,
2. Create a post without a featured image, then add a new newsletter
2. Observe the templates that use Posts Inserter block display an empty image block in place of the featured image
3. Switch to this branch, rebuild
4. Redo step 2, observe that there is no empty image block in Posts Inserter block

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
