### PR TITLE
Prevent deduplication in layout picker preview

### DIFF
--- a/src/editor/blocks/posts-inserter/index.js
+++ b/src/editor/blocks/posts-inserter/index.js
@@ -145,6 +145,7 @@ const PostsInserterBlockWithSelect = compose( [
 			categories,
 			isDisplayingSpecificPosts,
 			specificPosts,
+			preventDeduplication,
 		} = props.attributes;
 		const { getEntityRecords, getMedia } = select( 'core' );
 		const { getSelectedBlock, getBlocks } = select( 'core/block-editor' );
@@ -165,7 +166,7 @@ const PostsInserterBlockWithSelect = compose( [
 							order,
 							orderby: orderBy,
 							per_page: postsToShow,
-							exclude,
+							exclude: preventDeduplication ? [] : exclude,
 						},
 						value => ! isUndefined( value )
 				  );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes #199.

### How to test the changes in this Pull Request:

1. On master
2. Create a new newsletter. Wait until the previews load Posts Inserter blocks and you see one in "Breaking News" layout preview
3. Click on "Daily/Weekly" layout preview
4. Observe that the Posts Inserter in "Breaking News" layout preview is updated
5. Switch to this branch and rebuild
6. Redo steps 2-3, observe that the Posts Inserter in "Breaking News" layout preview is not updated

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
