### PR TITLE
Fix: image height on smaller screens

### DIFF
--- a/includes/email-template.mjml.php
+++ b/includes/email-template.mjml.php
@@ -75,6 +75,13 @@
 				line-height: 1.6;
 			}
 
+			/* Image */
+			@media all and (max-width: 590px) {
+				img {
+					height: auto !important;
+				}
+			}
+
 			/* Social links */
 			.social-element img {
 				border-radius: 0 !important;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

On smaller screens, disregard explicit image height.

Closes #221

### How to test the changes in this Pull Request:

1. Create a newsletter with an image. Set the image dimensions, but keep the aspect ratio so it still looks ok.
2. Send a test email and open it on GMail and Outlook apps on iOS device with a screen smaller than 590px (e.g. iPhone 8). 
3. Observe the image preserves aspect ratio (is not squished)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
