### PR TITLE
fix: raise list limit to maximum

### DIFF
--- a/includes/class-newspack-newsletters.php
+++ b/includes/class-newspack-newsletters.php
@@ -846,7 +846,12 @@ final class Newspack_Newsletters {
 
 			return [
 				'lists'               => self::validate_mailchimp_operation(
-					$mc->get( 'lists' ),
+					$mc->get(
+						'lists',
+						[
+							'count' => 1000,
+						]
+					),
 					__( 'Error retrieving Mailchimp lists.', 'newspack_newsletters' )
 				),
 				'campaign'            => $campaign,

--- a/src/service-providers/mailchimp/ProviderSidebar.js
+++ b/src/service-providers/mailchimp/ProviderSidebar.js
@@ -95,7 +95,8 @@ const ProviderSidebar = ( {
 	}
 
 	const { list_id } = campaign.recipients || {};
-	const { web_id: listWebId } = list_id && lists.find( ( { id } ) => list_id === id );
+	const list = list_id && lists.find( ( { id } ) => list_id === id );
+	const { web_id: listWebId } = list || {};
 
 	return (
 		<Fragment>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

The Mailchimp lists endpoint defaults to returning ten items. For customers with more than ten lists, they have no way to select a list. This PR raises the limit to 1000, the maximum. Additionally it contains a fix for a crash that occurs if a Newsletter's `list_id` isn't found in the lists array. This doesn't address the case of a Mailchimp account with more than 1000 lists, but that feels like a very extreme case, especially considering typical segmentation strategies.

Closes https://github.com/Automattic/newspack-newsletters/issues/220

### How to test the changes in this Pull Request:

1. Add more than 10 lists to Mailchimp account, or switch API key to an account with more than 10 lists.
2. On `master`, create a Newsletter. Observe only the first 10 lists are shown in the `SelectControl` in the Newsletter sidebar panel.
3. Switch to this branch. Observe all lists are shown.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
