### PR TITLE
Handle column middle alignment

### DIFF
--- a/includes/class-newspack-newsletters-renderer.php
+++ b/includes/class-newspack-newsletters-renderer.php
@@ -436,8 +436,13 @@ final class Newspack_Newsletters_Renderer {
 			 */
 			case 'core/column':
 				if ( isset( $attrs['verticalAlignment'] ) ) {
-					$column_attrs['vertical-align'] = $attrs['verticalAlignment'];
+					if ( 'center' === $attrs['verticalAlignment'] ) {
+						$column_attrs['vertical-align'] = 'middle';
+					} else {
+						$column_attrs['vertical-align'] = $attrs['verticalAlignment'];
+					}
 				}
+
 				if ( isset( $attrs['width'] ) ) {
 					$column_attrs['width']     = $attrs['width'] . '%';
 					$column_attrs['css-class'] = 'mj-column-has-width';

--- a/src/editor/blocks-validation/blocks-filters.js
+++ b/src/editor/blocks-validation/blocks-filters.js
@@ -1,9 +1,15 @@
 /**
+ * External dependencies
+ */
+import { every, some } from 'lodash';
+
+/**
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
 import { addFilter } from '@wordpress/hooks';
 import { createHigherOrderComponent } from '@wordpress/compose';
+import { select } from '@wordpress/data';
 
 const handleSideAlignment = ( warnings, props ) => {
 	if ( props.attributes.align === 'left' || props.attributes.align === 'right' ) {
@@ -11,6 +17,8 @@ const handleSideAlignment = ( warnings, props ) => {
 	}
 	return warnings;
 };
+
+const isCenterAligned = block => block.attributes.verticalAlignment === 'center';
 
 const getWarnings = props => {
 	let warnings = [];
@@ -21,12 +29,32 @@ const getWarnings = props => {
 			}
 			break;
 
+		// `vertical-align='middle'` will only work if all columns are middle-aligned.
+		// This is different in Gutenberg, because it uses flexbox layout (not available in email HTML).
+		//
+		// If a user chooses middle-alignment of a column, they will be prompted to
+		// middle-align all of the columns.
+		//
+		// Middle alignment option should be removed from the UI for a single column, when that's
+		// handled by the block editor filters.
+		case 'core/columns':
+			const { getBlock } = select( 'core/block-editor' );
+			const { innerBlocks } = getBlock( props.block.clientId );
+			const isAnyColumnCenterAligned = some( innerBlocks, isCenterAligned );
+			const areAllColumnsCenterAligned = every( innerBlocks, isCenterAligned );
+			if ( isAnyColumnCenterAligned && ! areAllColumnsCenterAligned ) {
+				warnings.push(
+					__(
+						'Unequal middle alignment. All or none of the columns should be middle-aligned.',
+						'newspack-newsletters'
+					)
+				);
+			}
+			break;
+
 		case 'core/column':
 			if ( props.attributes.__nestedColumnWarning ) {
 				warnings.push( __( 'Nested columns', 'newspack-newsletters' ) );
-			}
-			if ( props.attributes.verticalAlignment === 'center' ) {
-				warnings.push( __( 'Middle alignment', 'newspack-newsletters' ) );
 			}
 			break;
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

As discussed in #231, column middle alignment is a tricky issue because Gutenberg uses flexbox, and MJML uses `vertical-align` CSS property. Recreating flexbox somehow is a bigger undertaking, so as a compromise the possibility of an all-column-middle-aligned layout is introduced in this PR. Before, middle alignment of columns was not possible in any configuration. 

Closes #231 

### How to test the changes in this Pull Request:

1. Create a newsletter, insert a columns block with some columns
2. Set the column**s** block to middle vertical alignment (the content should be of different heights for the effect to be visible) – send a test email and observe the content is indeed middle-aligned, as in the editor.
3. Change one of the columns to a non-middle alignment – observe a warning being shown.
4. Fix the error by either setting the columns to middle alignment one by one, or by setting middle alignment on the columns block

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
