### PR TITLE
Fix: apply custom styles even if styling tab in sidebar is closed

### DIFF
--- a/src/newsletter-editor/index.js
+++ b/src/newsletter-editor/index.js
@@ -15,7 +15,7 @@ import InitModal from '../components/init-modal';
 import Layout from './layout/';
 import Sidebar from './sidebar/';
 import Testing from './testing/';
-import Styling from './styling/';
+import { Styling, ApplyStyling } from './styling/';
 import registerEditorPlugin from './editor/';
 
 registerEditorPlugin();
@@ -55,6 +55,8 @@ const NewsletterEdit = ( { layoutId } ) => {
 			>
 				<Layout />
 			</PluginDocumentSettingPanel>
+
+			<ApplyStyling />
 		</Fragment>
 	);
 };

--- a/src/newsletter-editor/styling/index.js
+++ b/src/newsletter-editor/styling/index.js
@@ -61,19 +61,42 @@ const fontOptgroups = [
 	},
 ];
 
-export default compose( [
+const customStylesSelector = select => {
+	const { getEditedPostAttribute } = select( 'core/editor' );
+	const meta = getEditedPostAttribute( 'meta' );
+	return {
+		fontBody: meta.font_body || '',
+		fontHeader: meta.font_header || '',
+		backgroundColor: meta.background_color || '',
+	};
+};
+
+export const ApplyStyling = withSelect( customStylesSelector )(
+	( { fontBody, fontHeader, backgroundColor } ) => {
+		useEffect(() => {
+			document.documentElement.style.setProperty( '--body-font', fontBody );
+		}, [ fontBody ]);
+		useEffect(() => {
+			document.documentElement.style.setProperty( '--header-font', fontHeader );
+		}, [ fontHeader ]);
+		useEffect(() => {
+			document.querySelector( '.edit-post-visual-editor' ).style.backgroundColor = backgroundColor;
+		}, [ backgroundColor ]);
+
+		return null;
+	}
+);
+
+export const Styling = compose( [
 	withDispatch( dispatch => {
 		const { editPost } = dispatch( 'core/editor' );
 		return { editPost };
 	} ),
 	withSelect( select => {
-		const { getEditedPostAttribute, getCurrentPostId } = select( 'core/editor' );
-		const meta = getEditedPostAttribute( 'meta' );
+		const { getCurrentPostId } = select( 'core/editor' );
 		return {
 			postId: getCurrentPostId(),
-			fontBody: meta.font_body || '',
-			fontHeader: meta.font_header || '',
-			backgroundColor: meta.background_color || '',
+			...customStylesSelector( select ),
 		};
 	} ),
 ] )( ( { editPost, fontBody, fontHeader, backgroundColor, postId } ) => {
@@ -85,16 +108,6 @@ export default compose( [
 			path: `/newspack-newsletters/v1/styling/${ postId }`,
 		} );
 	};
-
-	useEffect(() => {
-		document.documentElement.style.setProperty( '--body-font', fontBody );
-	}, [ fontBody ]);
-	useEffect(() => {
-		document.documentElement.style.setProperty( '--header-font', fontHeader );
-	}, [ fontHeader ]);
-	useEffect(() => {
-		document.querySelector( '.edit-post-visual-editor' ).style.backgroundColor = backgroundColor;
-	}, [ backgroundColor ]);
 
 	const instanceId = useInstanceId( SelectControlWithOptGroup );
 	const id = `inspector-select-control-${ instanceId }`;


### PR DESCRIPTION
### All Submissions:

* [X] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [X] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes a subtle bug, see below

### How to test the changes in this Pull Request:

1. On `master`
2. Create a newsletter, apply custom styling in the Styling panel in Sidebar, **close** the panel and refresh the page
3. Observe that the custom styling is not applied until the Styling panel is opened
4. Switch to this branch, rebuild
4. Redo step 2, refresh the page – observe that the custom styling is applied

### Other information:

* [X] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [X] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
