### PR TITLE
Mailchimp: tags segmentation

### DIFF
--- a/includes/class-newspack-newsletters.php
+++ b/includes/class-newspack-newsletters.php
@@ -884,7 +884,7 @@ final class Newspack_Newsletters {
 			$tags = [];
 			if ( $list_id ) {
 				$tags_response = self::validate_mailchimp_operation(
-					$mc->get( "lists/$list_id/segments" ),
+					$mc->get( "lists/$list_id/segments?count=1000" ),
 					__( 'Error retrieving Mailchimp tags.', 'newspack_newsletters' )
 				);
 				$tags          = $tags_response['segments'];

--- a/includes/class-newspack-newsletters.php
+++ b/includes/class-newspack-newsletters.php
@@ -283,8 +283,14 @@ final class Newspack_Newsletters {
 				'callback'            => [ __CLASS__, 'api_set_mailchimp_segments' ],
 				'permission_callback' => [ __CLASS__, 'api_authoring_permissions_check' ],
 				'args'                => [
-					'id' => [
+					'id'          => [
 						'sanitize_callback' => 'absint',
+					],
+					'interest_id' => [
+						'sanitize_callback' => 'esc_attr',
+					],
+					'tag_ids'     => [
+						'sanitize_callback' => 'wp_parse_list',
 					],
 				],
 			]

--- a/includes/class-newspack-newsletters.php
+++ b/includes/class-newspack-newsletters.php
@@ -720,7 +720,7 @@ final class Newspack_Newsletters {
 
 			if ( $has_interest || $tag_ids_param ) {
 				$segment_opts = [
-					'match'      => 'any',
+					'match'      => 'all',
 					'conditions' => [],
 				];
 

--- a/includes/class-newspack-newsletters.php
+++ b/includes/class-newspack-newsletters.php
@@ -685,8 +685,8 @@ final class Newspack_Newsletters {
 			$is_unsetting_interest = 'no_interests' === $interest_id_param;
 			if ( ! $is_unsetting_interest && ( ! $field || ! $interest_id ) ) {
 				return new WP_Error(
-					'newspack_newsletters_incorrect_post_type',
-					__( 'Invalid Mailchimp Interest .', 'newspack-newsletters' )
+					'newspack_newsletters_invalid_mailchimp_interest',
+					__( 'Invalid Mailchimp Interest.', 'newspack-newsletters' )
 				);
 			}
 		}

--- a/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp-controller.php
+++ b/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp-controller.php
@@ -106,10 +106,10 @@ class Newspack_Newsletters_Mailchimp_Controller extends Newspack_Newsletters_Ser
 		);
 		\register_rest_route(
 			$this->service_provider::BASE_NAMESPACE . $this->service_provider->service,
-			'(?P<id>[\a-z]+)/interest/(?P<interest_id>[\a-z]+)',
+			'(?P<id>[\a-z]+)/segments',
 			[
 				'methods'             => \WP_REST_Server::EDITABLE,
-				'callback'            => [ $this, 'api_interest' ],
+				'callback'            => [ $this, 'api_segments' ],
 				'permission_callback' => [ $this->service_provider, 'api_authoring_permissions_check' ],
 				'args'                => [
 					'id'          => [
@@ -118,6 +118,9 @@ class Newspack_Newsletters_Mailchimp_Controller extends Newspack_Newsletters_Ser
 					],
 					'interest_id' => [
 						'sanitize_callback' => 'esc_attr',
+					],
+					'tag_ids'     => [
+						'sanitize_callback' => 'wp_parse_list',
 					],
 				],
 			]
@@ -183,15 +186,16 @@ class Newspack_Newsletters_Mailchimp_Controller extends Newspack_Newsletters_Ser
 	}
 
 	/**
-	 * Set Mailchimp interest (group) for a campaign.
+	 * Set Mailchimp audience segments for a campaign.
 	 *
 	 * @param WP_REST_Request $request API request object.
 	 * @return WP_REST_Response|mixed API response or error.
 	 */
-	public function api_interest( $request ) {
-		$response = $this->service_provider->interest(
+	public function api_segments( $request ) {
+		$response = $this->service_provider->audience_segments(
 			$request['id'],
-			$request['interest_id']
+			$request['interest_id'],
+			$request['tag_ids']
 		);
 		return \rest_ensure_response( $response );
 	}

--- a/src/components/send-button/index.js
+++ b/src/components/send-button/index.js
@@ -3,7 +3,7 @@
  */
 import { withDispatch, withSelect } from '@wordpress/data';
 import { compose } from '@wordpress/compose';
-import { Button, Modal } from '@wordpress/components';
+import { Button, Modal, Notice } from '@wordpress/components';
 import { Fragment, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 
@@ -16,6 +16,7 @@ import { get } from 'lodash';
  * Internal dependencies
  */
 import { getServiceProvider } from '../../service-providers';
+import './style.scss';
 
 const { renderPreSendInfo } = getServiceProvider();
 
@@ -55,18 +56,14 @@ export default compose( [
 		isSaving,
 		savePost,
 		status,
-		validationErrors,
+		validationErrors = [],
 		isEditedPostBeingScheduled,
 		hasPublishAction,
 		visibility,
 		newsletterData,
 	} ) => {
 		const isButtonEnabled =
-			( isPublishable || isEditedPostBeingScheduled ) &&
-			isSaveable &&
-			validationErrors &&
-			! validationErrors.length &&
-			'publish' !== status;
+			( isPublishable || isEditedPostBeingScheduled ) && isSaveable && 'publish' !== status;
 		let label;
 		if ( 'publish' === status ) {
 			label = isSaving
@@ -118,8 +115,22 @@ export default compose( [
 						onRequestClose={ () => setModalVisible( false ) }
 					>
 						{ renderPreSendInfo( newsletterData ) }
+						{ validationErrors.length ? (
+							<Notice status="error" isDismissible={ false }>
+								{ __(
+									'The following errors prevent the newsletter from being sent:',
+									'newspack-newsletters'
+								) }
+								<ul>
+									{ validationErrors.map( ( error, i ) => (
+										<li key={ i }>{ error }</li>
+									) ) }
+								</ul>
+							</Notice>
+						) : null }
 						<Button
 							isPrimary
+							disabled={ validationErrors.length > 0 }
 							onClick={ () => {
 								triggerCampaignSend();
 								setModalVisible( false );

--- a/src/components/send-button/style.scss
+++ b/src/components/send-button/style.scss
@@ -1,0 +1,9 @@
+.newspack-newsletters__modal {
+	.components-notice {
+		margin: 0 0 1em;
+		ul {
+			list-style-type: disc;
+			margin-left: 1.3em;
+		}
+	}
+}

--- a/src/service-providers/mailchimp/ProviderSidebar.js
+++ b/src/service-providers/mailchimp/ProviderSidebar.js
@@ -182,7 +182,7 @@ const ProviderSidebar = ( {
 				chosenInterestId={ interestSettings.interestValue }
 				availableInterests={ interestSettings.options }
 				chosenTags={ chosenTags }
-				availableTags={ newsletterData.tags }
+				availableTags={ newsletterData.tags.filter( tag => tag.member_count > 0 ) }
 				apiFetch={ apiFetch }
 				inFlight={ inFlight }
 				onUpdate={ updateSegments }

--- a/src/service-providers/mailchimp/ProviderSidebar.js
+++ b/src/service-providers/mailchimp/ProviderSidebar.js
@@ -48,7 +48,7 @@ const SegmentsSelection = ( {
 
 	return (
 		<Fragment>
-			{ availableInterests.length && (
+			{ availableInterests.length ? (
 				<SelectControl
 					label={ __( 'Groups', 'newspack-newsletters' ) }
 					value={ segmentsData.interest_id }
@@ -62,8 +62,8 @@ const SegmentsSelection = ( {
 					onChange={ interest_id => updateSegmentsData( { interest_id } ) }
 					disabled={ inFlight }
 				/>
-			) }
-			{ availableTags.length && (
+			) : null }
+			{ availableTags.length ? (
 				<FormTokenField
 					label={ __( 'Tags', 'newspack-newsletters' ) }
 					value={ getTagNames( segmentsData.tag_ids, availableTags ) }
@@ -73,7 +73,7 @@ const SegmentsSelection = ( {
 					}
 					disabled={ inFlight }
 				/>
-			) }
+			) : null }
 		</Fragment>
 	);
 };
@@ -177,17 +177,15 @@ const ProviderSidebar = ( {
 				</p>
 			) }
 
-			{ interestSettings && (
-				<SegmentsSelection
-					chosenInterestId={ interestSettings.interestValue }
-					availableInterests={ interestSettings.options }
-					chosenTags={ chosenTags }
-					availableTags={ newsletterData.tags }
-					apiFetch={ apiFetch }
-					inFlight={ inFlight }
-					onUpdate={ updateSegments }
-				/>
-			) }
+			<SegmentsSelection
+				chosenInterestId={ interestSettings.interestValue }
+				availableInterests={ interestSettings.options }
+				chosenTags={ chosenTags }
+				availableTags={ newsletterData.tags }
+				apiFetch={ apiFetch }
+				inFlight={ inFlight }
+				onUpdate={ updateSegments }
+			/>
 
 			{ renderFrom( { handleSenderUpdate: setSender } ) }
 		</Fragment>

--- a/src/service-providers/mailchimp/ProviderSidebar.js
+++ b/src/service-providers/mailchimp/ProviderSidebar.js
@@ -2,13 +2,81 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { Fragment, useEffect } from '@wordpress/element';
-import { ExternalLink, SelectControl, Spinner, Notice } from '@wordpress/components';
+import { Fragment, useEffect, useState } from '@wordpress/element';
+import {
+	ExternalLink,
+	SelectControl,
+	Spinner,
+	Notice,
+	FormTokenField,
+} from '@wordpress/components';
 
 /**
  * Internal dependencies
  */
-import { getListInterestsSettings } from './utils';
+import { getListInterestsSettings, getListTags, getTagNames, getTagIds } from './utils';
+
+const SegmentsSelection = ( {
+	onUpdate,
+	inFlight,
+	chosenInterestId,
+	availableInterests,
+	chosenTags,
+	availableTags,
+} ) => {
+	const [ segmentsData, setSegmentsData ] = useState( {
+		interest_id: chosenInterestId,
+		tag_ids: chosenTags,
+	} );
+	const updateSegmentsData = data => setSegmentsData( { ...segmentsData, ...data } );
+
+	// Update with real data after local (optimistic) update.
+	useEffect(() => {
+		setSegmentsData( {
+			interest_id: chosenInterestId,
+			tag_ids: chosenTags,
+		} );
+	}, [ chosenInterestId, chosenTags.join() ]);
+
+	const [ isInitial, setIsInitial ] = useState( true );
+	useEffect(() => {
+		if ( ! isInitial ) {
+			onUpdate( segmentsData );
+		}
+		setIsInitial( false );
+	}, [ segmentsData.interest_id, segmentsData.tag_ids.join() ]);
+
+	return (
+		<Fragment>
+			{ availableInterests.length && (
+				<SelectControl
+					label={ __( 'Groups', 'newspack-newsletters' ) }
+					value={ segmentsData.interest_id }
+					options={ [
+						{
+							label: __( '-- Select a group --', 'newspack-newsletters' ),
+							value: 'no_interests',
+						},
+						...availableInterests,
+					] }
+					onChange={ interest_id => updateSegmentsData( { interest_id } ) }
+					disabled={ inFlight }
+				/>
+			) }
+			{ availableTags.length && (
+				<FormTokenField
+					label={ __( 'Tags', 'newspack-newsletters' ) }
+					value={ getTagNames( segmentsData.tag_ids, availableTags ) }
+					suggestions={ availableTags.map( tag => tag.name ) }
+					onChange={ updatedTagsNames =>
+						updateSegmentsData( { tag_ids: getTagIds( updatedTagsNames, availableTags ) } )
+					}
+					disabled={ inFlight }
+				/>
+			) }
+		</Fragment>
+	);
+};
 
 const ProviderSidebar = ( {
 	renderSubject,
@@ -28,10 +96,11 @@ const ProviderSidebar = ( {
 			method: 'POST',
 		} );
 
-	const setInterest = interestId =>
+	const updateSegments = updatedData =>
 		apiFetch( {
-			path: `/newspack-newsletters/v1/mailchimp/${ postId }/interest/${ interestId }`,
+			path: `/newspack-newsletters/v1/mailchimp/${ postId }/segments`,
 			method: 'POST',
+			data: updatedData,
 		} );
 
 	const setSender = ( { senderName, senderEmail } ) =>
@@ -52,28 +121,6 @@ const ProviderSidebar = ( {
 			} );
 		}
 	}, [ campaign ]);
-
-	const renderInterestCategories = () => {
-		const interestSettings = getListInterestsSettings( newsletterData );
-		if ( ! interestSettings ) {
-			return;
-		}
-		return (
-			<SelectControl
-				label={ __( 'Groups', 'newspack-newsletters' ) }
-				value={ interestSettings.interestValue }
-				options={ [
-					{
-						label: __( '-- Select a group --', 'newspack-newsletters' ),
-						value: 'no_interests',
-					},
-					...interestSettings.options,
-				] }
-				onChange={ setInterest }
-				disabled={ inFlight }
-			/>
-		);
-	};
 
 	if ( ! campaign ) {
 		return (
@@ -97,6 +144,9 @@ const ProviderSidebar = ( {
 	const { list_id } = campaign.recipients || {};
 	const list = list_id && lists.find( ( { id } ) => list_id === id );
 	const { web_id: listWebId } = list || {};
+
+	const interestSettings = getListInterestsSettings( newsletterData );
+	const chosenTags = getListTags( newsletterData );
 
 	return (
 		<Fragment>
@@ -126,7 +176,18 @@ const ProviderSidebar = ( {
 					</ExternalLink>
 				</p>
 			) }
-			{ renderInterestCategories() }
+
+			{ interestSettings && (
+				<SegmentsSelection
+					chosenInterestId={ interestSettings.interestValue }
+					availableInterests={ interestSettings.options }
+					chosenTags={ chosenTags }
+					availableTags={ newsletterData.tags }
+					apiFetch={ apiFetch }
+					inFlight={ inFlight }
+					onUpdate={ updateSegments }
+				/>
+			) }
 
 			{ renderFrom( { handleSenderUpdate: setSender } ) }
 		</Fragment>

--- a/src/service-providers/mailchimp/ProviderSidebar.js
+++ b/src/service-providers/mailchimp/ProviderSidebar.js
@@ -65,6 +65,7 @@ const SegmentsSelection = ( {
 			) : null }
 			{ availableTags.length ? (
 				<FormTokenField
+					className="newspack-newsletters__mailchimp-tags"
 					label={ __( 'Tags', 'newspack-newsletters' ) }
 					value={ getTagNames( segmentsData.tag_ids, availableTags ) }
 					suggestions={ availableTags.map( tag => tag.name ) }

--- a/src/service-providers/mailchimp/index.js
+++ b/src/service-providers/mailchimp/index.js
@@ -13,7 +13,6 @@ import { find } from 'lodash';
  * Internal dependencies
  */
 import ProviderSidebar from './ProviderSidebar';
-import { getListInterestsSettings } from './utils';
 import './style.scss';
 
 const validateNewsletter = ( { campaign } ) => {
@@ -54,16 +53,11 @@ const renderPreSendInfo = newsletterData => {
 			'id',
 			newsletterData.campaign.recipients.list_id,
 		] );
-		const interestSettings = getListInterestsSettings( newsletterData );
-
 		if ( list ) {
-			listData = { name: list.name, subscribers: parseInt( list.stats.member_count ) };
-			if ( interestSettings.setInterest ) {
-				listData.groupName = interestSettings.setInterest.rawInterest.name;
-				listData.subscribers = parseInt(
-					interestSettings.setInterest.rawInterest.subscriber_count
-				);
-			}
+			listData = {
+				name: list.name,
+				subscribers: parseInt( newsletterData.campaign.recipients.recipient_count ),
+			};
 		}
 	}
 

--- a/src/service-providers/mailchimp/index.js
+++ b/src/service-providers/mailchimp/index.js
@@ -17,10 +17,13 @@ import './style.scss';
 
 const validateNewsletter = ( { campaign } ) => {
 	const { recipients, settings, status } = campaign || {};
-	const { list_id: listId } = recipients || {};
+	const { list_id: listId, recipient_count: recipientCount } = recipients || {};
 	const { from_name: senderName, reply_to: senderEmail } = settings || {};
 
 	const messages = [];
+	if ( recipientCount === 0 ) {
+		messages.push( __( 'There are no contacts in the chosen audience.', 'newspack-newsletters' ) );
+	}
 	if ( 'sent' === status || 'sending' === status ) {
 		messages.push( __( 'Newsletter has already been sent.', 'newspack-newsletters' ) );
 	}

--- a/src/service-providers/mailchimp/index.js
+++ b/src/service-providers/mailchimp/index.js
@@ -57,7 +57,7 @@ const renderPreSendInfo = newsletterData => {
 
 		if ( list ) {
 			listData = { name: list.name, subscribers: parseInt( list.stats.member_count ) };
-			if ( interestSettings && interestSettings.setInterest ) {
+			if ( interestSettings.setInterest ) {
 				listData.groupName = interestSettings.setInterest.rawInterest.name;
 				listData.subscribers = parseInt(
 					interestSettings.setInterest.rawInterest.subscriber_count

--- a/src/service-providers/mailchimp/index.js
+++ b/src/service-providers/mailchimp/index.js
@@ -14,6 +14,7 @@ import { find } from 'lodash';
  */
 import ProviderSidebar from './ProviderSidebar';
 import { getListInterestsSettings } from './utils';
+import './style.scss';
 
 const validateNewsletter = ( { campaign } ) => {
 	const { recipients, settings, status } = campaign || {};

--- a/src/service-providers/mailchimp/style.scss
+++ b/src/service-providers/mailchimp/style.scss
@@ -1,4 +1,5 @@
 .newspack-newsletters__mailchimp-tags {
+	margin-bottom: 1em;
 	+ .components-form-token-field__help {
 		display: none;
 	}

--- a/src/service-providers/mailchimp/style.scss
+++ b/src/service-providers/mailchimp/style.scss
@@ -1,0 +1,5 @@
+.newspack-newsletters__mailchimp-tags {
+	+ .components-form-token-field__help {
+		display: none;
+	}
+}

--- a/src/service-providers/mailchimp/utils.js
+++ b/src/service-providers/mailchimp/utils.js
@@ -53,3 +53,21 @@ export const getListInterestsSettings = ( {
 
 	return { options, interestValue, setInterest: find( options, [ 'value', interestValue ] ) };
 };
+
+export const getListTags = ( { campaign } ) => {
+	const conditions = get( campaign, 'recipients.segment_opts.conditions' );
+	if ( ! conditions ) {
+		return [];
+	}
+	return conditions.reduce( ( tagIds, condition ) => {
+		if ( condition.condition_type === 'StaticSegment' ) {
+			tagIds.push( condition.value );
+		}
+		return tagIds;
+	}, [] );
+};
+
+export const getTagIds = ( tagNames, allTags ) =>
+	tagNames.map( tagName => find( allTags, [ 'name', tagName ] ).id );
+export const getTagNames = ( tagIds, allTags ) =>
+	tagIds.map( id => find( allTags, [ 'id', id ] ).name );

--- a/src/service-providers/mailchimp/utils.js
+++ b/src/service-providers/mailchimp/utils.js
@@ -21,7 +21,10 @@ export const getListInterestsSettings = ( {
 		! interestCategories.categories ||
 		! interestCategories.categories.length
 	) {
-		return;
+		return {
+			interestValue: null,
+			options: [],
+		};
 	}
 	const options = interestCategories.categories.reduce( ( accumulator, item ) => {
 		const { title, interests, id } = item;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Adds Mailchimp segmentation via tags. Tag creation will be handled in a separate PR. 

Closes #21

### How to test the changes in this Pull Request:

1. Create a newsletter, after selecting a list observe a new input below Groups selection – Tags
2. (Create some tags in Mailchimp if there are none)
3. Start typing a tag name, observe autocomplete in action, choose a tag
4. Observe the tag is added to the campaign on Mailchimp

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
