### PR TITLE
Fix Posts Inserter columns warning

### DIFF
--- a/src/editor/blocks-validation/blocks-filters.js
+++ b/src/editor/blocks-validation/blocks-filters.js
@@ -39,16 +39,19 @@ const getWarnings = props => {
 		// handled by the block editor filters.
 		case 'core/columns':
 			const { getBlock } = select( 'core/block-editor' );
-			const { innerBlocks } = getBlock( props.block.clientId );
-			const isAnyColumnCenterAligned = some( innerBlocks, isCenterAligned );
-			const areAllColumnsCenterAligned = every( innerBlocks, isCenterAligned );
-			if ( isAnyColumnCenterAligned && ! areAllColumnsCenterAligned ) {
-				warnings.push(
-					__(
-						'Unequal middle alignment. All or none of the columns should be middle-aligned.',
-						'newspack-newsletters'
-					)
-				);
+			const block = getBlock( props.block.clientId );
+			if ( block ) {
+				const { innerBlocks } = block;
+				const isAnyColumnCenterAligned = some( innerBlocks, isCenterAligned );
+				const areAllColumnsCenterAligned = every( innerBlocks, isCenterAligned );
+				if ( isAnyColumnCenterAligned && ! areAllColumnsCenterAligned ) {
+					warnings.push(
+						__(
+							'Unequal middle alignment. All or none of the columns should be middle-aligned.',
+							'newspack-newsletters'
+						)
+					);
+				}
 			}
 			break;
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

#235 Introduced a regression, this PR fixes it.

### How to test the changes in this Pull Request:

1. On `master`, 
2. Insert a Posts Inserter block in a fresh newsletter
2. Observe block rendering failing in the editor
3. Switch to this branch and rebuild
4. Redo 2, observe block rendering as expected

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
