### PR TITLE
Fix Posts Inserter flickering

### DIFF
--- a/src/editor/blocks/posts-inserter/index.js
+++ b/src/editor/blocks/posts-inserter/index.js
@@ -38,6 +38,7 @@ const PostsInserterBlock = ( {
 	setInsertedPostsIds,
 	removeBlock,
 } ) => {
+	// Stringify added to minimize flicker.
 	const templateBlocks = useMemo( () => getTemplateBlocks( postList, attributes ), [
 		JSON.stringify( postList ),
 		attributes,

--- a/src/editor/blocks/posts-inserter/index.js
+++ b/src/editor/blocks/posts-inserter/index.js
@@ -39,7 +39,7 @@ const PostsInserterBlock = ( {
 	removeBlock,
 } ) => {
 	const templateBlocks = useMemo( () => getTemplateBlocks( postList, attributes ), [
-		postList,
+		JSON.stringify( postList ),
 		attributes,
 	] );
 
@@ -188,6 +188,7 @@ const PostsInserterBlockWithSelect = compose( [
 		}
 
 		return {
+			// Not used by the component, but needed in deduplication.
 			existingBlocks: getBlocks(),
 			selectedBlock: getSelectedBlock(),
 			postList: posts.map( post => {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes #236.

### How to test the changes in this Pull Request:

1. Try to reproduce #236, observe the flickering situation is greatly improved*

\* The posts in Posts Inserter flicker only when loading the images

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
