### PR TITLE
Show spinner until layout previews are fully loaded

### DIFF
--- a/src/components/newsletter-preview/index.js
+++ b/src/components/newsletter-preview/index.js
@@ -16,26 +16,30 @@ const NewsletterPreview = ( { meta = {}, ...props } ) => {
 	const ELEMENT_ID = useMemo( () => `preview-${ Math.round( Math.random() * 1000 ) }`, [] );
 
 	/**
-	 * This hook does the work of an "onReady" callback for each BlockPreview element.
-	 * Currently, BlockPreview loads scaled elements directly into the DOM, resulting in
-	 * a flash of unstyled content when loading images.
+	 * This hook does the work of an "onReady" callback for each BlockPreview
+	 * element. Currently, BlockPreview loads elements directly into the DOM,
+	 * resulting in a flash of unstyled content when loading images.
 	 *
-	 * This hook checks whether the blocks passed to the BlockPreview contains featured images,
-	 * and if so, uses a MutationObserver to attach a 'load' event listener before providing
-	 * the "ready" style.
+	 * This hook checks whether the blocks passed to the BlockPreview contain
+	 * featured images, and if so, uses a MutationObserver to attach a 'load'
+	 * event listener before providing the "ready" style.
 	 *
-	 * If the blocks do not contain a featured image, we can show them immediately.
+	 * If the blocks do not contain a featured image, we can show them
+	 * immediately.
 	 */
 	useEffect(() => {
 		const config = { attributes: false, childList: true, subtree: true };
-		const hasFeaturedImage =
-			-1 !== JSON.stringify( props.blocks ).indexOf( '"displayFeaturedImage":true' ); // Lazy way of checking for a deeply nested value.
 
-		// If the block preview contains featured images, use a MutationObserver to listen for images being added to the DOM.
+		// Lazy way of checking for a deeply nested value.
+		const hasFeaturedImage =
+			-1 !== JSON.stringify( props.blocks ).indexOf( '"displayFeaturedImage":true' );
+
+		// If the block preview contains featured images, listen for images being added to the DOM.
 		const observer = new MutationObserver( mutationsList => {
 			for ( const mutation of mutationsList ) {
 				if ( mutation.addedNodes.length > 0 ) {
-					const nodes = Array.prototype.slice.call( mutation.addedNodes ); // convert NodeList to Array for IE11.
+					// Convert NodeList to Array for IE11.
+					const nodes = Array.prototype.slice.call( mutation.addedNodes );
 
 					nodes.forEach( node => {
 						if ( node.classList && node.classList.contains( 'wp-block' ) ) {

--- a/src/components/newsletter-preview/style.scss
+++ b/src/components/newsletter-preview/style.scss
@@ -1,5 +1,13 @@
-.newspack-newsletters__layout-preview {
+.newspack-newsletters__layout-preview,
+.newspack-newsletters__layout-preview-spinner {
 	width: 100%;
 	height: 100%;
 	position: absolute;
+}
+
+.newspack-newsletters__layout-preview-spinner {
+	align-items: center;
+	background-color: white;
+	display: flex;
+	justify-content: center;
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

When layout block previews are rendered, images may take time to load, resulting in a flash of unstyled content (FOUC) before they're loaded. Since the `BlockPreview` element doesn't currently support props for a `onReady` callback, we can use a `MutationObserver` to look for changes in the `BlockPreview` DOM tree, watch for featured images, and attach event listeners to the `load` event to tell when images in the preview are finished loading.

Unfortunately, this solution doesn't detect whether the featured image is actually visible in the preview, but that would add a lot more complexity.

If `BlockPreview` does end up supporting an `onReady` callback prop (one is apparently [in the works](https://github.com/WordPress/gutenberg/tree/master/packages/block-editor/src/components/block-preview#__experimentalonready)), we should be able to deprecate this home-grown solution in favor of the prop.

Closes #200.

### How to test the changes in this Pull Request:

1. On the master branch, create a new Newsletter.
2. In the Layout selector UI that appears, observe the FOUC as the featured image loads in the upper-left default layout.
3. Check out this branch. Refresh the new Newsletter page (or create a new Newsletter again).
4. This time, observe that the layout previews are covered with a spinner animation until all block preview elements are fully loaded.

Note: I tested in Chrome, Firefox, and Safari. [`MutationObserver`](https://developer.mozilla.org/en-US/docs/Web/API/MutationObserver) has full support back to IE11. 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
