### PR TITLE
Ads: allow no expiry date

### DIFF
--- a/includes/class-newspack-newsletters-renderer.php
+++ b/includes/class-newspack-newsletters-renderer.php
@@ -568,10 +568,15 @@ final class Newspack_Newsletters_Renderer {
 			$ads        = $ads_query->get_posts();
 			$ads_markup = '';
 			foreach ( $ads as $ad ) {
-				$now_date    = new DateTime();
 				$expiry_date = new DateTime( get_post_meta( $ad->ID, 'expiry_date', true ) );
-				if ( ! $expiry_date || $expiry_date > $now_date ) {
+				if ( ! $expiry_date ) {
 					$ads_markup .= self::post_to_mjml_components( $ad, false );
+				} else {
+					$now_date    = gmdate( 'Y-m-d' );
+					$expiry_date = $expiry_date->format( 'Y-m-d' );
+					if ( $expiry_date >= $now_date ) {
+						$ads_markup .= self::post_to_mjml_components( $ad, false );
+					}
 				}
 			}
 			$body .= $ads_markup;

--- a/includes/class-newspack-newsletters-renderer.php
+++ b/includes/class-newspack-newsletters-renderer.php
@@ -563,21 +563,16 @@ final class Newspack_Newsletters_Renderer {
 				array(
 					'post_type'      => Newspack_Newsletters_Ads::NEWSPACK_NEWSLETTERS_ADS_CPT,
 					'posts_per_page' => -1,
-					'meta_query'     => array( // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
-						array(
-							'key'     => 'expiry_date',
-							'value'   => gmdate( 'Y-m-d' ),
-							'compare' => '>=',
-							'type'    => 'DATE',
-						),
-					),
 				)
 			);
 			$ads        = $ads_query->get_posts();
 			$ads_markup = '';
 			foreach ( $ads as $ad ) {
+				$now_date    = new DateTime();
 				$expiry_date = new DateTime( get_post_meta( $ad->ID, 'expiry_date', true ) );
-				$ads_markup .= self::post_to_mjml_components( $ad, false );
+				if ( ! $expiry_date || $expiry_date > $now_date ) {
+					$ads_markup .= self::post_to_mjml_components( $ad, false );
+				}
 			}
 			$body .= $ads_markup;
 		}

--- a/src/ads-admin/AdsManager/index.js
+++ b/src/ads-admin/AdsManager/index.js
@@ -37,6 +37,15 @@ const AdCard = ( { adPost, deleteAd } ) => {
 	if ( expiry_date ) {
 		isExpired = ! isInTheFuture( expiry_date );
 	}
+	let description = null;
+	if ( expiry_date ) {
+		const formattedExpiryDate = format( 'M j Y', expiry_date );
+		description = isExpired
+			? `${ __( 'Expired', 'newspack-newsletters' ) } ${ formattedExpiryDate }.`
+			: `${ __( 'Will expire', 'newspack-newsletters' ) } ${ formattedExpiryDate }.`;
+	} else if ( ! isExpired ) {
+		description = __( 'No expiry date set.', 'newspack-newsletters' );
+	}
 	return (
 		<Fragment>
 			<ActionCard
@@ -56,16 +65,7 @@ const AdCard = ( { adPost, deleteAd } ) => {
 					e.preventDefault();
 					return false;
 				} }
-				description={
-					// eslint-disable-next-line no-nested-ternary
-					expiry_date
-						? `${
-								isExpired
-									? __( 'Expired', 'newspack-newsletters' )
-									: __( 'Will expire', 'newspack-newsletters' )
-						  } ${ format( 'M j Y', expiry_date ) }`
-						: null
-				}
+				description={ description }
 			/>
 			{ modalVisible && (
 				<Modal

--- a/src/ads-admin/editor/index.js
+++ b/src/ads-admin/editor/index.js
@@ -4,36 +4,26 @@
 import { __ } from '@wordpress/i18n';
 import { withSelect, withDispatch } from '@wordpress/data';
 import { compose } from '@wordpress/compose';
-import { Fragment, useEffect } from '@wordpress/element';
+import { Fragment } from '@wordpress/element';
 import { PluginDocumentSettingPanel, PluginPrePublishPanel } from '@wordpress/edit-post';
 import { registerPlugin } from '@wordpress/plugins';
 import { DatePicker, Notice } from '@wordpress/components';
 import { format, isInTheFuture } from '@wordpress/date';
 
-const AdEdit = ( { expiryDate, editPost, lockPostSaving, unlockPostSaving } ) => {
-	// Lock post saving if expiry date is not set
-	useEffect(() => {
-		if ( expiryDate ) {
-			unlockPostSaving( 'no-expiry-lock' );
-		} else {
-			lockPostSaving( 'no-expiry-lock' );
-		}
-	}, [ expiryDate ]);
-
-	const noticeProps = {
-		children: __( 'Set an expiry date to publish the ad.', 'newspack-newsletters' ),
-		status: 'error',
-	};
+const AdEdit = ( { expiryDate, editPost } ) => {
+	let noticeProps;
 	if ( expiryDate ) {
 		const formattedExpiryDate = format( 'M j Y', expiryDate );
 		const isExpiryInTheFuture = isInTheFuture( expiryDate );
-		noticeProps.children = isExpiryInTheFuture
-			? `${ __( 'This ad will expire on ', 'newspack-newsletters' ) } ${ formattedExpiryDate }.`
-			: __(
-					'The expiration date is set in the past. This ad will not be displayed.',
-					'newspack-newsletters'
-			  );
-		noticeProps.status = isExpiryInTheFuture ? 'info' : 'warning';
+		noticeProps = {
+			children: isExpiryInTheFuture
+				? `${ __( 'This ad will expire on ', 'newspack-newsletters' ) } ${ formattedExpiryDate }.`
+				: __(
+						'The expiration date is set in the past. This ad will not be displayed.',
+						'newspack-newsletters'
+				  ),
+			status: isExpiryInTheFuture ? 'info' : 'warning',
+		};
 	}
 
 	return (
@@ -47,9 +37,11 @@ const AdEdit = ( { expiryDate, editPost, lockPostSaving, unlockPostSaving } ) =>
 					onChange={ expiry_date => editPost( { meta: { expiry_date } } ) }
 				/>
 			</PluginDocumentSettingPanel>
-			<PluginPrePublishPanel>
-				<Notice isDismissible={ false } { ...noticeProps } />
-			</PluginPrePublishPanel>
+			{ noticeProps ? (
+				<PluginPrePublishPanel>
+					<Notice isDismissible={ false } { ...noticeProps } />
+				</PluginPrePublishPanel>
+			) : null }
 		</Fragment>
 	);
 };
@@ -61,8 +53,8 @@ const AdEditWithSelect = compose( [
 		return { expiryDate: meta.expiry_date };
 	} ),
 	withDispatch( dispatch => {
-		const { editPost, lockPostSaving, unlockPostSaving } = dispatch( 'core/editor' );
-		return { editPost, lockPostSaving, unlockPostSaving };
+		const { editPost } = dispatch( 'core/editor' );
+		return { editPost };
 	} ),
 ] )( AdEdit );
 

--- a/src/ads-admin/editor/index.js
+++ b/src/ads-admin/editor/index.js
@@ -7,7 +7,7 @@ import { compose } from '@wordpress/compose';
 import { Fragment } from '@wordpress/element';
 import { PluginDocumentSettingPanel, PluginPrePublishPanel } from '@wordpress/edit-post';
 import { registerPlugin } from '@wordpress/plugins';
-import { DatePicker, Notice } from '@wordpress/components';
+import { DatePicker, Notice, Button } from '@wordpress/components';
 import { format, isInTheFuture } from '@wordpress/date';
 
 const AdEdit = ( { expiryDate, editPost } ) => {
@@ -36,6 +36,18 @@ const AdEdit = ( { expiryDate, editPost } ) => {
 					currentDate={ expiryDate }
 					onChange={ expiry_date => editPost( { meta: { expiry_date } } ) }
 				/>
+				{ expiryDate ? (
+					<div style={ { textAlign: 'center' } }>
+						<Button
+							isSecondary
+							isLink
+							isDestructive
+							onClick={ () => editPost( { meta: { expiry_date: null } } ) }
+						>
+							{ __( 'Remove expiry date', 'newspack-newsletters' ) }
+						</Button>
+					</div>
+				) : null }
 			</PluginDocumentSettingPanel>
 			{ noticeProps ? (
 				<PluginPrePublishPanel>

--- a/src/ads-admin/utils.js
+++ b/src/ads-admin/utils.js
@@ -4,10 +4,13 @@
 import { isInTheFuture, date } from '@wordpress/date';
 
 export const isAdActive = ad => {
-	if ( ad.status === 'publish' && ad.meta.expiry_date ) {
-		const adDayDate = date( 'Y-m-d', ad.meta.expiry_date );
-		const todayDate = date( 'Y-m-d' );
-		return adDayDate === todayDate || isInTheFuture( adDayDate );
+	if ( ad.status === 'publish' ) {
+		if ( ad.meta.expiry_date ) {
+			const adDayDate = date( 'Y-m-d', ad.meta.expiry_date );
+			const todayDate = date( 'Y-m-d' );
+			return adDayDate === todayDate || isInTheFuture( adDayDate );
+		}
+		return true;
 	}
 	return false;
 };


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes #251.

### How to test the changes in this Pull Request:

1. Create a newsletter ad, do not an expiry date, publish
2. Observe that it's listed as active in the newsletter ads view, with a note about not expiration date set
3. Publish a newsletter, observe the ad is appended to the bottom

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
