### PR TITLE
feat: support linked images

### DIFF
--- a/includes/class-newspack-newsletters-renderer.php
+++ b/includes/class-newspack-newsletters-renderer.php
@@ -273,8 +273,12 @@ final class Newspack_Newsletters_Renderer {
 				}
 				if ( isset( $attrs['linkDestination'] ) ) {
 					$img_attrs['href'] = $attrs['linkDestination'];
+				} else {
+					$maybe_link = $img->parentNode;// phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+					if ( $maybe_link && 'a' === $maybe_link->nodeName && $maybe_link->getAttribute( 'href' ) ) { // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+						$img_attrs['href'] = trim( $maybe_link->getAttribute( 'href' ) );
+					}
 				}
-
 				if ( isset( $attrs['className'] ) && strpos( $attrs['className'], 'is-style-rounded' ) !== false ) {
 					$img_attrs['border-radius'] = '999px';
 				}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Links applied to Image blocks don't render in emails. 

Closes https://github.com/Automattic/newspack-newsletters/issues/253

### How to test the changes in this Pull Request:

1. On `master` with latest Gutenberg plugin create a Newsletter, add an image, apply a link to it.
2. Send a test email to yourself. Observe the image is not linked.
3. Switch to this branch. Save and send another test. Observe the image is linked as expected.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
