### PR TITLE
fix: resolve php notices

### DIFF
--- a/includes/service-providers/class-newspack-newsletters-service-provider-controller.php
+++ b/includes/service-providers/class-newspack-newsletters-service-provider-controller.php
@@ -17,7 +17,7 @@ abstract class Newspack_Newsletters_Service_Provider_Controller extends \WP_REST
 	 *
 	 * @var Newspack_Newsletters_Service_Provider $service_provider
 	 */
-	private static $service_provider;
+	private $service_provider;
 
 	/**
 	 * Newspack_Newsletters_Service_Provider_Controller constructor.

--- a/includes/service-providers/class-newspack-newsletters-service-provider.php
+++ b/includes/service-providers/class-newspack-newsletters-service-provider.php
@@ -19,7 +19,7 @@ abstract class Newspack_Newsletters_Service_Provider implements Newspack_Newslet
 	 *
 	 * @var \WP_REST_Controller.
 	 */
-	private static $controller;
+	private $controller;
 
 	/**
 	 * Name of the service.


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Resolves some PHP notices.

Closes https://github.com/Automattic/newspack-newsletters/issues/250

### How to test the changes in this Pull Request:

1. On `master` create a new release.
2. Spin up a Jurassic Ninja instance, install and activate the release.
3. Observe PHP notices are sent to the browser.
4. Switch to this branch, create a new release.
5. Replace the plugin on the JN site with the new release.
6. Observe the notices go away.
7. Create a newsletter, paste in API keys.
8. Send a test email to yourself, be sure it works as expected.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
