### PR TITLE
MJML: handle social icons block aligment options

### DIFF
--- a/includes/class-newspack-newsletters-renderer.php
+++ b/includes/class-newspack-newsletters-renderer.php
@@ -403,14 +403,18 @@ final class Newspack_Newsletters_Renderer {
 				);
 
 				$social_wrapper_attrs = array(
-					'align'         => isset( $attrs['align'] ) && 'center' == $attrs['align'] ? 'center' : 'left',
 					'icon-size'     => '22px',
 					'mode'          => 'horizontal',
 					'padding'       => '0',
 					'border-radius' => '999px',
 					'icon-padding'  => '8px',
 				);
-				$markup               = '<mj-social ' . self::array_to_attributes( $social_wrapper_attrs ) . '>';
+				if ( isset( $attrs['align'] ) ) {
+					$social_wrapper_attrs['align'] = $attrs['align'];
+				} else {
+					$social_wrapper_attrs['align'] = 'left';
+				}
+				$markup = '<mj-social ' . self::array_to_attributes( $social_wrapper_attrs ) . '>';
 				foreach ( $inner_blocks as $link_block ) {
 					if ( isset( $link_block['attrs']['url'] ) ) {
 						$url = $link_block['attrs']['url'];

--- a/src/editor/index.js
+++ b/src/editor/index.js
@@ -27,12 +27,7 @@ domReady( () => {
 
 addFilter( 'blocks.registerBlockType', 'newspack-newsletters/core-blocks', ( settings, name ) => {
 	/* Remove left/right alignment options wherever possible */
-	if (
-		'core/paragraph' === name ||
-		'core/social-links' === name ||
-		'core/buttons' === name ||
-		'core/columns' === name
-	) {
+	if ( 'core/paragraph' === name || 'core/buttons' === name || 'core/columns' === name ) {
 		settings.supports = { ...settings.supports, align: [] };
 	}
 	if ( 'core/group' === name ) {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Enables alignment options for social icons block.

### How to test the changes in this Pull Request:

1. Add a newsletter, insert a social icons block
2. Test with different alignment options – in the email the alignment should work as in the editor

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
