### PR TITLE
Ads: handle setting ad position

### DIFF
--- a/includes/class-newspack-newsletters-ads.php
+++ b/includes/class-newspack-newsletters-ads.php
@@ -47,6 +47,7 @@ final class Newspack_Newsletters_Ads {
 	public function __construct() {
 		add_action( 'init', [ __CLASS__, 'register_ads_cpt' ] );
 		add_action( 'init', [ __CLASS__, 'register_meta' ] );
+		add_action( 'save_post_' . self::NEWSPACK_NEWSLETTERS_ADS_CPT, [ __CLASS__, 'ad_default_fields' ], 10, 3 );
 		add_action( 'admin_menu', [ __CLASS__, 'add_ads_page' ] );
 		add_action( 'admin_enqueue_scripts', [ __CLASS__, 'admin_enqueue_scripts' ] );
 	}
@@ -62,6 +63,17 @@ final class Newspack_Newsletters_Ads {
 				'object_subtype' => self::NEWSPACK_NEWSLETTERS_ADS_CPT,
 				'show_in_rest'   => true,
 				'type'           => 'string',
+				'single'         => true,
+				'auth_callback'  => '__return_true',
+			]
+		);
+		\register_meta(
+			'post',
+			'position_in_content',
+			[
+				'object_subtype' => self::NEWSPACK_NEWSLETTERS_ADS_CPT,
+				'show_in_rest'   => true,
+				'type'           => 'integer',
 				'single'         => true,
 				'auth_callback'  => '__return_true',
 			]
@@ -139,5 +151,19 @@ final class Newspack_Newsletters_Ads {
 		\register_post_type( self::NEWSPACK_NEWSLETTERS_ADS_CPT, $cpt_args );
 	}
 
+	/**
+	 * Set default fields when Ad is created.
+	 *
+	 * @param int     $post_id ID of post being saved.
+	 * @param WP_POST $post The post being saved.
+	 * @param bool    $update True if this is an update, false if a newly created post.
+	 */
+	public static function ad_default_fields( $post_id, $post, $update ) {
+		// Set meta only if this is a newly created post.
+		if ( $update ) {
+			return;
+		}
+		update_post_meta( $post_id, 'position_in_content', 100 );
+	}
 }
 Newspack_Newsletters_Ads::instance();

--- a/includes/class-newspack-newsletters-editor.php
+++ b/includes/class-newspack-newsletters-editor.php
@@ -120,6 +120,14 @@ final class Newspack_Newsletters_Editor {
 				filemtime( NEWSPACK_NEWSLETTERS_PLUGIN_FILE . 'dist/adsEditor.js' ),
 				true
 			);
+			wp_register_style(
+				Newspack_Newsletters_Ads::NEWSPACK_NEWSLETTERS_ADS_PAGE,
+				plugins_url( '../dist/adsEditor.css', __FILE__ ),
+				[],
+				filemtime( NEWSPACK_NEWSLETTERS_PLUGIN_FILE . 'dist/adsEditor.css' )
+			);
+			wp_style_add_data( Newspack_Newsletters_Ads::NEWSPACK_NEWSLETTERS_ADS_PAGE, 'rtl', 'replace' );
+			wp_enqueue_style( Newspack_Newsletters_Ads::NEWSPACK_NEWSLETTERS_ADS_PAGE );
 		}
 
 		if ( ! self::is_editing_newsletter() ) {

--- a/includes/class-newspack-newsletters-renderer.php
+++ b/includes/class-newspack-newsletters-renderer.php
@@ -564,7 +564,7 @@ final class Newspack_Newsletters_Renderer {
 				return null !== $block['blockName'];
 			}
 		);
-		$total_length = strlen( $post->post_content );
+		$total_length = strlen( wp_strip_all_tags( $post->post_content ) );
 
 		// Gather ads.
 		$ads_to_insert = [];
@@ -597,7 +597,7 @@ final class Newspack_Newsletters_Renderer {
 			$block_content     = self::render_mjml_component( $block );
 			$current_position += strlen( wp_strip_all_tags( $block_content ) );
 			foreach ( $ads_to_insert as &$ad_to_insert ) {
-				if ( ! $ad_to_insert['is_inserted'] && $current_position > $ad_to_insert['precise_position'] ) {
+				if ( ! $ad_to_insert['is_inserted'] && $current_position >= $ad_to_insert['precise_position'] ) {
 					$body                       .= $ad_to_insert['markup'];
 					$ad_to_insert['is_inserted'] = true;
 				}

--- a/includes/class-newspack-newsletters-renderer.php
+++ b/includes/class-newspack-newsletters-renderer.php
@@ -568,7 +568,7 @@ final class Newspack_Newsletters_Renderer {
 
 		// Gather ads.
 		$ads_to_insert = [];
-		if ( $include_ads ) {
+		if ( $include_ads && ! get_post_meta( $post->ID, 'diable_ads', true ) ) {
 			$ads_query = new WP_Query(
 				array(
 					'post_type'      => Newspack_Newsletters_Ads::NEWSPACK_NEWSLETTERS_ADS_CPT,

--- a/src/ads-admin/AdsManager/style.scss
+++ b/src/ads-admin/AdsManager/style.scss
@@ -17,3 +17,9 @@ a.newspack-button {
 		cursor: pointer;
 	}
 }
+
+.newspack-newsletters__modal {
+	.components-button + .components-button {
+		margin-left: 12px;
+	}
+}

--- a/src/ads-admin/editor/index.js
+++ b/src/ads-admin/editor/index.js
@@ -7,10 +7,10 @@ import { compose } from '@wordpress/compose';
 import { Fragment } from '@wordpress/element';
 import { PluginDocumentSettingPanel, PluginPrePublishPanel } from '@wordpress/edit-post';
 import { registerPlugin } from '@wordpress/plugins';
-import { DatePicker, Notice, Button } from '@wordpress/components';
+import { DatePicker, Notice, Button, RangeControl } from '@wordpress/components';
 import { format, isInTheFuture } from '@wordpress/date';
 
-const AdEdit = ( { expiryDate, editPost } ) => {
+const AdEdit = ( { expiryDate, positionInContent, editPost } ) => {
 	let noticeProps;
 	if ( expiryDate ) {
 		const formattedExpiryDate = format( 'M j Y', expiryDate );
@@ -30,8 +30,15 @@ const AdEdit = ( { expiryDate, editPost } ) => {
 		<Fragment>
 			<PluginDocumentSettingPanel
 				name="newsletters-ads-settings-panel"
-				title={ __( 'Expiry date', 'newspack-newsletters' ) }
+				title={ __( 'Ad settings', 'newspack-newsletters' ) }
 			>
+				<RangeControl
+					label={ __( 'Approximate position (in percent)' ) }
+					value={ positionInContent }
+					onChange={ position_in_content => editPost( { meta: { position_in_content } } ) }
+					min={ 0 }
+					max={ 100 }
+				/>
 				<DatePicker
 					currentDate={ expiryDate }
 					onChange={ expiry_date => editPost( { meta: { expiry_date } } ) }
@@ -62,7 +69,7 @@ const AdEditWithSelect = compose( [
 	withSelect( select => {
 		const { getEditedPostAttribute } = select( 'core/editor' );
 		const meta = getEditedPostAttribute( 'meta' );
-		return { expiryDate: meta.expiry_date };
+		return { expiryDate: meta.expiry_date, positionInContent: meta.position_in_content };
 	} ),
 	withDispatch( dispatch => {
 		const { editPost } = dispatch( 'core/editor' );

--- a/src/ads-admin/editor/index.js
+++ b/src/ads-admin/editor/index.js
@@ -7,8 +7,13 @@ import { compose } from '@wordpress/compose';
 import { Fragment } from '@wordpress/element';
 import { PluginDocumentSettingPanel, PluginPrePublishPanel } from '@wordpress/edit-post';
 import { registerPlugin } from '@wordpress/plugins';
-import { DatePicker, Notice, Button, RangeControl } from '@wordpress/components';
+import { DatePicker, BaseControl, Notice, Button, RangeControl } from '@wordpress/components';
 import { format, isInTheFuture } from '@wordpress/date';
+
+/**
+ * Internal dependencies
+ */
+import './style.scss';
 
 const AdEdit = ( { expiryDate, positionInContent, editPost } ) => {
 	let noticeProps;
@@ -39,22 +44,28 @@ const AdEdit = ( { expiryDate, positionInContent, editPost } ) => {
 					min={ 0 }
 					max={ 100 }
 				/>
-				<DatePicker
-					currentDate={ expiryDate }
-					onChange={ expiry_date => editPost( { meta: { expiry_date } } ) }
-				/>
-				{ expiryDate ? (
-					<div style={ { textAlign: 'center' } }>
-						<Button
-							isSecondary
-							isLink
-							isDestructive
-							onClick={ () => editPost( { meta: { expiry_date: null } } ) }
-						>
-							{ __( 'Remove expiry date', 'newspack-newsletters' ) }
-						</Button>
-					</div>
-				) : null }
+				{ /* eslint-disable-next-line @wordpress/no-base-control-with-label-without-id */ }
+				<BaseControl
+					className="newspack-newsletters__date-picker"
+					label={ __( 'Expiration Date', 'newspack-newsletters' ) }
+				>
+					<DatePicker
+						currentDate={ expiryDate }
+						onChange={ expiry_date => editPost( { meta: { expiry_date } } ) }
+					/>
+					{ expiryDate ? (
+						<div style={ { textAlign: 'center' } }>
+							<Button
+								isSecondary
+								isLink
+								isDestructive
+								onClick={ () => editPost( { meta: { expiry_date: null } } ) }
+							>
+								{ __( 'Remove expiry date', 'newspack-newsletters' ) }
+							</Button>
+						</div>
+					) : null }
+				</BaseControl>
 			</PluginDocumentSettingPanel>
 			{ noticeProps ? (
 				<PluginPrePublishPanel>

--- a/src/ads-admin/editor/index.js
+++ b/src/ads-admin/editor/index.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import classnames from 'classnames';
+
+/**
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
@@ -46,7 +51,9 @@ const AdEdit = ( { expiryDate, positionInContent, editPost } ) => {
 				/>
 				{ /* eslint-disable-next-line @wordpress/no-base-control-with-label-without-id */ }
 				<BaseControl
-					className="newspack-newsletters__date-picker"
+					className={ classnames( 'newspack-newsletters__date-picker', {
+						'newspack-newsletters__date-picker--has-no-date': ! expiryDate,
+					} ) }
 					label={ __( 'Expiration Date', 'newspack-newsletters' ) }
 				>
 					<DatePicker

--- a/src/ads-admin/editor/style.scss
+++ b/src/ads-admin/editor/style.scss
@@ -1,0 +1,5 @@
+.newspack-newsletters__date-picker {
+	.CalendarMonth {
+		padding: 0 !important;
+	}
+}

--- a/src/ads-admin/editor/style.scss
+++ b/src/ads-admin/editor/style.scss
@@ -1,4 +1,12 @@
 .newspack-newsletters__date-picker {
+	&--has-no-date {
+		.CalendarDay__selected {
+			background: #c3c3c3;
+			&:hover {
+				background: #9e9e9e;
+			}
+		}
+	}
 	.CalendarMonth {
 		padding: 0 !important;
 	}

--- a/src/newsletter-editor/sidebar/index.js
+++ b/src/newsletter-editor/sidebar/index.js
@@ -5,7 +5,7 @@ import { __ } from '@wordpress/i18n';
 import { compose } from '@wordpress/compose';
 import { withSelect, withDispatch } from '@wordpress/data';
 import { useState, Fragment } from '@wordpress/element';
-import { Button, TextControl } from '@wordpress/components';
+import { Button, TextControl, CheckboxControl } from '@wordpress/components';
 
 /**
  * External dependencies
@@ -27,6 +27,7 @@ const Sidebar = ( {
 	errors,
 	editPost,
 	title,
+	disableAds,
 	senderName,
 	senderEmail,
 	newsletterData,
@@ -93,16 +94,34 @@ const Sidebar = ( {
 		</Fragment>
 	);
 
+	const updateMetaValue = ( key, value ) => {
+		editPost( { meta: { [ key ]: value } } );
+		apiFetch( {
+			data: { key, value },
+			method: 'POST',
+			path: `/newspack-newsletters/v1/post-meta/${ postId }`,
+		} );
+	};
+
 	return (
-		<ProviderSidebar
-			postId={ postId }
-			newsletterData={ newsletterData }
-			inFlight={ inFlight }
-			apiFetch={ apiFetch }
-			renderSubject={ renderSubject }
-			renderFrom={ renderFrom }
-			updateMeta={ meta => editPost( { meta } ) }
-		/>
+		<Fragment>
+			<ProviderSidebar
+				postId={ postId }
+				newsletterData={ newsletterData }
+				inFlight={ inFlight }
+				apiFetch={ apiFetch }
+				renderSubject={ renderSubject }
+				renderFrom={ renderFrom }
+				updateMeta={ meta => editPost( { meta } ) }
+			/>
+			<CheckboxControl
+				label={ __( 'Disable ads for this newsletter.', 'newspack-newsletters' ) }
+				className="newspack-newsletters__disable-ads"
+				checked={ disableAds }
+				disabled={ inFlight }
+				onChange={ value => updateMetaValue( 'diable_ads', value ) }
+			/>
+		</Fragment>
 	);
 };
 
@@ -117,6 +136,7 @@ export default compose( [
 			senderEmail: meta.senderEmail || '',
 			senderName: meta.senderName || '',
 			newsletterData: meta.newsletterData || {},
+			disableAds: meta.diable_ads,
 		};
 	} ),
 	withDispatch( dispatch => {

--- a/src/newsletter-editor/sidebar/style.scss
+++ b/src/newsletter-editor/sidebar/style.scss
@@ -48,6 +48,10 @@
 	&__error input.components-text-control__input {
 		border-color: $alert-red;
 	}
+
+	&__disable-ads {
+		margin-top: 2em;
+	}
 }
 
 .editor-post-publish-panel__prepublish {

--- a/src/newsletter-editor/styling/index.js
+++ b/src/newsletter-editor/styling/index.js
@@ -105,7 +105,7 @@ export const Styling = compose( [
 		apiFetch( {
 			data: { key, value },
 			method: 'POST',
-			path: `/newspack-newsletters/v1/styling/${ postId }`,
+			path: `/newspack-newsletters/v1/post-meta/${ postId }`,
 		} );
 	};
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes #237. Also, fixes a small visual bug in the ad removal modal.

### How to test the changes in this Pull Request:

1. Add some newsletter ads, set positions in sidebar settings
2. Observe that an ad has 100% position (bottom of content) by default
3. Observe that the ads are placed accordingly in newsletter HTML
4. _Additional thing_: Click "Delete" on an ad in ad manager to remove it. Observe the buttons in the modal have some spacing between.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
