### PR TITLE
feat: show spinner while Post Inserter is loading image blocks

### DIFF
--- a/src/editor/blocks/posts-inserter/index.js
+++ b/src/editor/blocks/posts-inserter/index.js
@@ -45,7 +45,7 @@ const PostsInserterBlock = ( {
 	setInsertedPostsIds,
 	removeBlock,
 } ) => {
-	const [ ready, setReady ] = useState( ! attributes.displayFeaturedImage );
+	const [ isReady, setIsReady ] = useState( ! attributes.displayFeaturedImage );
 
 	// Stringify added to minimize flicker.
 	const templateBlocks = useMemo( () => getTemplateBlocks( postList, attributes ), [
@@ -58,16 +58,16 @@ const PostsInserterBlock = ( {
 
 		// No spinner if we're not dealing with images.
 		if ( ! attributes.displayFeaturedImage ) {
-			return setReady( true );
+			return setIsReady( true );
 		}
 
 		// No spinner if we're in the middle of selecting a specific post.
 		if ( isDisplayingSpecificPosts && 0 === specificPosts.length ) {
-			return setReady( true );
+			return setIsReady( true );
 		}
 
 		// Reset ready state.
-		setReady( false );
+		setIsReady( false );
 
 		// If we have a post to show, check for featured image blocks.
 		if ( 0 < postList.length ) {
@@ -77,7 +77,7 @@ const PostsInserterBlock = ( {
 
 			// If no posts have featured media, skip loading state.
 			if ( 0 === images.length ) {
-				return setReady( true );
+				return setIsReady( true );
 			}
 
 			// Wait for image blocks to be added to the BlockPreview.
@@ -85,7 +85,7 @@ const PostsInserterBlock = ( {
 
 			// Preview is ready once all image blocks are accounted for.
 			if ( imageBlocks.length === images.length ) {
-				setReady( true );
+				setIsReady( true );
 			}
 		}
 	}, [ JSON.stringify( postList ), JSON.stringify( templateBlocks ) ]);
@@ -176,7 +176,11 @@ const PostsInserterBlock = ( {
 					<span>{ __( 'Posts Inserter', 'newspack-newsletters' ) }</span>
 				</div>
 				<div className="newspack-posts-inserter__preview">
-					{ ready ? <BlockPreview blocks={ templateBlocks } viewportWidth={ 558 } /> : <Spinner /> }
+					{ isReady ? (
+						<BlockPreview blocks={ templateBlocks } viewportWidth={ 558 } />
+					) : (
+						<Spinner />
+					) }
 				</div>
 				<div className="newspack-posts-inserter__footer">
 					<Button isPrimary onClick={ () => setAttributes( { areBlocksInserted: true } ) }>

--- a/src/editor/blocks/posts-inserter/index.js
+++ b/src/editor/blocks/posts-inserter/index.js
@@ -46,12 +46,15 @@ const PostsInserterBlock = ( {
 	removeBlock,
 } ) => {
 	const [ isReady, setIsReady ] = useState( ! attributes.displayFeaturedImage );
+	const stringifiedPostList = JSON.stringify( postList );
 
 	// Stringify added to minimize flicker.
 	const templateBlocks = useMemo( () => getTemplateBlocks( postList, attributes ), [
-		JSON.stringify( postList ),
+		stringifiedPostList,
 		attributes,
 	] );
+
+	const stringifiedTemplateBlocks = JSON.stringify( templateBlocks );
 
 	useEffect(() => {
 		const { isDisplayingSpecificPosts, specificPosts } = attributes;
@@ -81,14 +84,14 @@ const PostsInserterBlock = ( {
 			}
 
 			// Wait for image blocks to be added to the BlockPreview.
-			const imageBlocks = templateBlocks.filter( block => 'core/image' === block.name );
+			const imageBlocks = stringifiedTemplateBlocks.match( /\"name\":\"core\/image\"/g ) || [];
 
 			// Preview is ready once all image blocks are accounted for.
 			if ( imageBlocks.length === images.length ) {
 				setIsReady( true );
 			}
 		}
-	}, [ JSON.stringify( postList ), JSON.stringify( templateBlocks ) ]);
+	}, [ stringifiedPostList, stringifiedTemplateBlocks ]);
 
 	const innerBlocksToInsert = templateBlocks.map( convertBlockSerializationFormat );
 	useEffect(() => {

--- a/src/editor/blocks/posts-inserter/index.js
+++ b/src/editor/blocks/posts-inserter/index.js
@@ -54,24 +54,41 @@ const PostsInserterBlock = ( {
 	] );
 
 	useEffect(() => {
-		if ( 0 < postList.length && attributes.displayFeaturedImage ) {
-			const images = [];
+		const { isDisplayingSpecificPosts, specificPosts } = attributes;
 
+		// No spinner if we're not dealing with images.
+		if ( ! attributes.displayFeaturedImage ) {
+			return setReady( true );
+		}
+
+		// No spinner if we're in the middle of selecting a specific post.
+		if ( isDisplayingSpecificPosts && 0 === specificPosts.length ) {
+			return setReady( true );
+		}
+
+		// Reset ready state.
+		setReady( false );
+
+		// If we have a post to show, check for featured image blocks.
+		if ( 0 < postList.length ) {
+			// Find all the featured images.
+			const images = [];
 			postList.map( post => post.featured_media && images.push( post.featured_media ) );
 
+			// If no posts have featured media, skip loading state.
 			if ( 0 === images.length ) {
-				// If no posts have featured media, skip loading state.
 				return setReady( true );
 			}
 
+			// Wait for image blocks to be added to the BlockPreview.
 			const imageBlocks = templateBlocks.filter( block => 'core/image' === block.name );
 
-			// Preview is ready once all image blocks are inserted.
+			// Preview is ready once all image blocks are accounted for.
 			if ( imageBlocks.length === images.length ) {
 				setReady( true );
 			}
 		}
-	}, [ JSON.stringify( templateBlocks ) ]);
+	}, [ JSON.stringify( postList ), JSON.stringify( templateBlocks ) ]);
 
 	const innerBlocksToInsert = templateBlocks.map( convertBlockSerializationFormat );
 	useEffect(() => {

--- a/src/editor/blocks/posts-inserter/style.scss
+++ b/src/editor/blocks/posts-inserter/style.scss
@@ -31,6 +31,7 @@
 
 		&:empty {
 			border: 0;
+			min-height: 0;
 		}
 
 		.block-editor-block-preview {

--- a/src/editor/blocks/posts-inserter/style.scss
+++ b/src/editor/blocks/posts-inserter/style.scss
@@ -1,5 +1,4 @@
 @import '~@wordpress/base-styles/colors';
-
 .newspack-posts-inserter {
 	border: 1px solid $dark-gray-primary;
 	border-radius: 2px;
@@ -22,9 +21,13 @@
 	}
 
 	&__preview {
+		align-items: center;
 		border: 0 solid $dark-gray-primary;
 		border-width: 1px 0;
+		display: flex;
+		justify-content: center;
 		margin: 1em 0;
+		min-height: 4rem;
 
 		&:empty {
 			border: 0;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

In the Post Inserter block, images sometime take a while to get inserted into the `BlockPreview`. This adds a "loading" state with the WP spinner component while image blocks are still being inserted. Note that there may be a very brief delay after the blocks are shown while the image actually loads—this is unavoidable unless we attach event listeners to the actual DOM for image `load` events, which gets messy fast since the `BlockPreview` elements get rendered inside iframes and don't currently support any on ready callbacks. I tried testing this in #248, but after doing this refactor I believe we should avoid mixing virtual DOM and true DOM logic as a best practice.

Since the preview blocks are built from post data using array mapping functions instead of true asynchronous behavior, the logic goes like this:

* On mount or when the array of posts to be displayed changes, we show a loading spinner.
* Once we have an array of posts, we count all of the featured images for those posts.
* While the preview blocks are being built, we keep a running count of image blocks being inserted into the preview.
* Once the number of inserted preview image blocks matches the number of featured images, we consider the preview "ready" and remove the spinner.
* If the block is set to not show featured images, we can skip the loading logic, since text-based blocks render almost instantly.

Closes #200.

Replaces #248, which handled the loading state in the Layout preview dialogue but not in the actual Post Inserter block.

### How to test the changes in this Pull Request:

1. Create a new Newsletter.
2. In the Layout dialogue, confirm that any layouts that contain a Post Inserter will show a loading spinner until the featured images in the preview are finished loading.
3. Select a layout that contains a Post Inserter block. In the actual block editor, the Post Inserter's default settings show the most recent post with featured images enabled. If this post has a featured image, observe a loading spinner until the preview blocks are finished loading.
4. In the Post Inserter sidebar settings, enable **Display Specific Posts**. Confirm that the block displays as empty without a spinner.
5. Enter a post title in the auto-complete input and select at least one post. Confirm that the spinner reappears until the preview is finished loading.
6. In the Post Inserter sidebar settings, increase the number of items shown. Confirm that the spinner appears and remains until all post preview blocks are finished loading.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
