### PR TITLE
Add spinner while sending test emails

### DIFF
--- a/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp.php
+++ b/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp.php
@@ -577,6 +577,9 @@ final class Newspack_Newsletters_Mailchimp extends \Newspack_Newsletters_Service
 		}
 		if ( ! empty( $result['status'] ) && in_array( $result['status'], [ 400, 404 ] ) ) {
 			if ( $preferred_error && ! Newspack_Newsletters::debug_mode() ) {
+				if ( ! empty( $result['detail'] ) ) {
+					$preferred_error .= ' ' . $result['detail'];
+				}
 				throw new Exception( $preferred_error );
 			}
 			$messages = [];

--- a/src/components/with-api-handler/index.js
+++ b/src/components/with-api-handler/index.js
@@ -25,8 +25,11 @@ export default () =>
 						.then( response => {
 							const { message } = response;
 							getNotices().forEach( notice => {
-								// Don't remove the "Campaign sent" notice.
-								if ( 'success' !== notice.status || -1 === notice.content.indexOf( successNote ) ) {
+								// Don't remove the "Campaign sent" notice or error messages from async ops.
+								if (
+									'error' !== notice.status &&
+									( 'success' !== notice.status || -1 === notice.content.indexOf( successNote ) )
+								) {
 									removeNotice( notice.id );
 								}
 							} );
@@ -40,8 +43,11 @@ export default () =>
 						.catch( error => {
 							const { message } = error;
 							getNotices().forEach( notice => {
-								// Don't remove the "Campaign sent" notice.
-								if ( 'success' !== notice.status || -1 === notice.content.indexOf( successNote ) ) {
+								// Don't remove the "Campaign sent" notice or error messages from async ops.
+								if (
+									'error' !== notice.status &&
+									( 'success' !== notice.status || -1 === notice.content.indexOf( successNote ) )
+								) {
 									removeNotice( notice.id );
 								}
 							} );

--- a/src/newsletter-editor/testing/index.js
+++ b/src/newsletter-editor/testing/index.js
@@ -12,6 +12,7 @@ import { hasValidEmail } from '../utils';
  * Internal dependencies
  */
 import withApiHandler from '../../components/with-api-handler';
+import './style.scss';
 
 export default compose( [
 	withApiHandler(),
@@ -48,16 +49,18 @@ export default compose( [
 				onChange={ setTestEmail }
 				help={ __( 'Use commas to separate multiple emails.', 'newspack-newsletters' ) }
 			/>
-			<Button
-				isPrimary
-				onClick={ sendTestEmail }
-				disabled={ inFlight || ! hasValidEmail( testEmail ) }
-			>
-				{ inFlight
-					? __( 'Sending Test Email...', 'newspack-newsletters' )
-					: __( 'Send a Test Email', 'newspack-newsletters' ) }
-			</Button>
-			{ inFlight && <Spinner /> }
+			<div className="newspack-newsletters__testing-controls">
+				<Button
+					isPrimary
+					onClick={ sendTestEmail }
+					disabled={ inFlight || ! hasValidEmail( testEmail ) }
+				>
+					{ inFlight
+						? __( 'Sending Test Email...', 'newspack-newsletters' )
+						: __( 'Send a Test Email', 'newspack-newsletters' ) }
+				</Button>
+				{ inFlight && <Spinner /> }
+			</div>
 		</Fragment>
 	);
 } );

--- a/src/newsletter-editor/testing/index.js
+++ b/src/newsletter-editor/testing/index.js
@@ -5,7 +5,7 @@ import { __ } from '@wordpress/i18n';
 import { withSelect, withDispatch } from '@wordpress/data';
 import { compose } from '@wordpress/compose';
 import { Fragment, useState } from '@wordpress/element';
-import { Button, TextControl } from '@wordpress/components';
+import { Button, Spinner, TextControl } from '@wordpress/components';
 import { hasValidEmail } from '../utils';
 
 /**
@@ -53,8 +53,11 @@ export default compose( [
 				onClick={ sendTestEmail }
 				disabled={ inFlight || ! hasValidEmail( testEmail ) }
 			>
-				{ __( 'Send a Test Email', 'newspack-newsletters' ) }
+				{ inFlight
+					? __( 'Sending Test Email...', 'newspack-newsletters' )
+					: __( 'Send a Test Email', 'newspack-newsletters' ) }
 			</Button>
+			{ inFlight && <Spinner /> }
 		</Fragment>
 	);
 } );

--- a/src/newsletter-editor/testing/style.scss
+++ b/src/newsletter-editor/testing/style.scss
@@ -1,0 +1,7 @@
+.newspack-newsletters {
+	&__testing-controls {
+		align-items: center;
+		display: flex;
+		justify-content: flex-start;
+	}
+}


### PR DESCRIPTION
Sending a test email is an async op. This adds a spinner to the Testing panel while the op is still in progress. It also improves the error messaging if the test fails to send.

### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

This adds a spinner animation while sending a test email (an async op) is still in progress:

https://d.pr/i/NG4WDY

It also improves the error messaging so that a.) the message sticks around after being displayed, and b.) it appends the error message returned from Mailchimp to help inform the user:

https://d.pr/i/PP1vjl

Closes #158.

### How to test the changes in this Pull Request:

1. Check out this branch and rebuild JS.
2. Draft a new Newsletter.
3. Send a test email using the Testing UI in the sidebar. The first few sends should be successful.
4. Keep sending tests until Mailchimp starts returning rate limit errors. Observe the error messaging when that happens.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
