### PR TITLE
feat: constant contact integration

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,8 @@
   "description": "Newsletter authoring plugin.",
   "type": "wordpress-plugin",
   "require": {
-    "drewm/mailchimp-api": "^2.5"
+    "drewm/mailchimp-api": "^2.5",
+    "constantcontact/constantcontact": "2.1.*"
   },
   "require-dev": {
     "automattic/vipwpcs": "^2.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,57 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "578ece2762a04bfc340bc16f2bd233c1",
+    "content-hash": "605fd29e14d085257b8f8a4808020e1a",
     "packages": [
+        {
+            "name": "constantcontact/constantcontact",
+            "version": "2.1.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/constantcontact/php-sdk.git",
+                "reference": "4546700862f7832aa3d18e02cf77bf5d3c2ab277"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/constantcontact/php-sdk/zipball/4546700862f7832aa3d18e02cf77bf5d3c2ab277",
+                "reference": "4546700862f7832aa3d18e02cf77bf5d3c2ab277",
+                "shasum": ""
+            },
+            "require": {
+                "ext-curl": "*",
+                "guzzlehttp/guzzle": "^5.1.0",
+                "php": ">=5.4.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "4.4.1"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-0": {
+                    "Ctct": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Constant Contact Web Services",
+                    "email": "webservices@constantcontact.com",
+                    "homepage": "http://developer.constantcontact.com"
+                }
+            ],
+            "description": "Constant Contact PHP SDK for v2",
+            "homepage": "http://developer.constantcontact.com",
+            "keywords": [
+                "constant contact",
+                "constantcontact",
+                "ctct",
+                "email marketing"
+            ],
+            "time": "2016-02-17T14:19:57+00:00"
+        },
         {
             "name": "drewm/mailchimp-api",
             "version": "v2.5.4",
@@ -49,35 +98,237 @@
             "description": "Super-simple, minimum abstraction MailChimp API v3 wrapper",
             "homepage": "https://github.com/drewm/mailchimp-api",
             "time": "2019-08-06T09:24:58+00:00"
+        },
+        {
+            "name": "guzzlehttp/guzzle",
+            "version": "5.3.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/guzzle/guzzle.git",
+                "reference": "b87eda7a7162f95574032da17e9323c9899cb6b2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/b87eda7a7162f95574032da17e9323c9899cb6b2",
+                "reference": "b87eda7a7162f95574032da17e9323c9899cb6b2",
+                "shasum": ""
+            },
+            "require": {
+                "guzzlehttp/ringphp": "^1.1",
+                "php": ">=5.4.0",
+                "react/promise": "^2.2"
+            },
+            "require-dev": {
+                "ext-curl": "*",
+                "phpunit/phpunit": "^4.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "GuzzleHttp\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Michael Dowling",
+                    "email": "mtdowling@gmail.com",
+                    "homepage": "https://github.com/mtdowling"
+                }
+            ],
+            "description": "Guzzle is a PHP HTTP client library and framework for building RESTful web service clients",
+            "homepage": "http://guzzlephp.org/",
+            "keywords": [
+                "client",
+                "curl",
+                "framework",
+                "http",
+                "http client",
+                "rest",
+                "web service"
+            ],
+            "time": "2019-10-30T09:32:00+00:00"
+        },
+        {
+            "name": "guzzlehttp/ringphp",
+            "version": "1.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/guzzle/RingPHP.git",
+                "reference": "5e2a174052995663dd68e6b5ad838afd47dd615b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/guzzle/RingPHP/zipball/5e2a174052995663dd68e6b5ad838afd47dd615b",
+                "reference": "5e2a174052995663dd68e6b5ad838afd47dd615b",
+                "shasum": ""
+            },
+            "require": {
+                "guzzlehttp/streams": "~3.0",
+                "php": ">=5.4.0",
+                "react/promise": "~2.0"
+            },
+            "require-dev": {
+                "ext-curl": "*",
+                "phpunit/phpunit": "~4.0"
+            },
+            "suggest": {
+                "ext-curl": "Guzzle will use specific adapters if cURL is present"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.1-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "GuzzleHttp\\Ring\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Michael Dowling",
+                    "email": "mtdowling@gmail.com",
+                    "homepage": "https://github.com/mtdowling"
+                }
+            ],
+            "description": "Provides a simple API and specification that abstracts away the details of HTTP into a single PHP function.",
+            "abandoned": true,
+            "time": "2018-07-31T13:22:33+00:00"
+        },
+        {
+            "name": "guzzlehttp/streams",
+            "version": "3.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/guzzle/streams.git",
+                "reference": "47aaa48e27dae43d39fc1cea0ccf0d84ac1a2ba5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/guzzle/streams/zipball/47aaa48e27dae43d39fc1cea0ccf0d84ac1a2ba5",
+                "reference": "47aaa48e27dae43d39fc1cea0ccf0d84ac1a2ba5",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.4.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "GuzzleHttp\\Stream\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Michael Dowling",
+                    "email": "mtdowling@gmail.com",
+                    "homepage": "https://github.com/mtdowling"
+                }
+            ],
+            "description": "Provides a simple abstraction over streams of data",
+            "homepage": "http://guzzlephp.org/",
+            "keywords": [
+                "Guzzle",
+                "stream"
+            ],
+            "abandoned": true,
+            "time": "2014-10-12T19:18:40+00:00"
+        },
+        {
+            "name": "react/promise",
+            "version": "v2.8.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/reactphp/promise.git",
+                "reference": "f3cff96a19736714524ca0dd1d4130de73dbbbc4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/reactphp/promise/zipball/f3cff96a19736714524ca0dd1d4130de73dbbbc4",
+                "reference": "f3cff96a19736714524ca0dd1d4130de73dbbbc4",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.4.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^7.0 || ^6.5 || ^5.7 || ^4.8.36"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "React\\Promise\\": "src/"
+                },
+                "files": [
+                    "src/functions_include.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jan Sorgalla",
+                    "email": "jsorgalla@gmail.com"
+                }
+            ],
+            "description": "A lightweight implementation of CommonJS Promises/A for PHP",
+            "keywords": [
+                "promise",
+                "promises"
+            ],
+            "time": "2020-05-12T15:16:56+00:00"
         }
     ],
     "packages-dev": [
         {
             "name": "automattic/vipwpcs",
-            "version": "2.0.0",
+            "version": "2.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Automattic/VIP-Coding-Standards.git",
-                "reference": "fc02f491dc9f51da7c32941ac579f70b9ed300c5"
+                "reference": "03e75ddd0261b675dece60fb67fc2e9c6af4ad35"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Automattic/VIP-Coding-Standards/zipball/fc02f491dc9f51da7c32941ac579f70b9ed300c5",
-                "reference": "fc02f491dc9f51da7c32941ac579f70b9ed300c5",
+                "url": "https://api.github.com/repos/Automattic/VIP-Coding-Standards/zipball/03e75ddd0261b675dece60fb67fc2e9c6af4ad35",
+                "reference": "03e75ddd0261b675dece60fb67fc2e9c6af4ad35",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.6",
-                "squizlabs/php_codesniffer": "^3.3.1",
-                "wp-coding-standards/wpcs": "^2.1"
+                "php": ">=5.4",
+                "squizlabs/php_codesniffer": "^3.5.5",
+                "wp-coding-standards/wpcs": "^2.3"
             },
             "require-dev": {
-                "dealerdirect/phpcodesniffer-composer-installer": "^0.5",
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.7",
                 "phpcompatibility/php-compatibility": "^9",
-                "phpunit/phpunit": "^5 || ^6 || ^7"
+                "phpunit/phpunit": "^4 || ^5 || ^6 || ^7"
             },
             "suggest": {
-                "dealerdirect/phpcodesniffer-composer-installer": "^0.5 || This Composer plugin will sort out the PHPCS 'installed_paths' automatically."
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.7 || This Composer plugin will manage the PHPCS 'installed_paths' automatically."
             },
             "type": "phpcodesniffer-standard",
             "notification-url": "https://packagist.org/downloads/",
@@ -96,7 +347,7 @@
                 "standards",
                 "wordpress"
             ],
-            "time": "2019-07-12T08:47:36+00:00"
+            "time": "2020-07-07T07:48:04+00:00"
         },
         {
             "name": "brainmaestro/composer-git-hooks",
@@ -495,44 +746,42 @@
         },
         {
             "name": "symfony/console",
-            "version": "v5.1.2",
+            "version": "v4.4.11",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "34ac555a3627e324b660e318daa07572e1140123"
+                "reference": "55d07021da933dd0d633ffdab6f45d5b230c7e02"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/34ac555a3627e324b660e318daa07572e1140123",
-                "reference": "34ac555a3627e324b660e318daa07572e1140123",
+                "url": "https://api.github.com/repos/symfony/console/zipball/55d07021da933dd0d633ffdab6f45d5b230c7e02",
+                "reference": "55d07021da933dd0d633ffdab6f45d5b230c7e02",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.2.5",
+                "php": ">=7.1.3",
                 "symfony/polyfill-mbstring": "~1.0",
                 "symfony/polyfill-php73": "^1.8",
                 "symfony/polyfill-php80": "^1.15",
-                "symfony/service-contracts": "^1.1|^2",
-                "symfony/string": "^5.1"
+                "symfony/service-contracts": "^1.1|^2"
             },
             "conflict": {
-                "symfony/dependency-injection": "<4.4",
-                "symfony/dotenv": "<5.1",
-                "symfony/event-dispatcher": "<4.4",
+                "symfony/dependency-injection": "<3.4",
+                "symfony/event-dispatcher": "<4.3|>=5",
                 "symfony/lock": "<4.4",
-                "symfony/process": "<4.4"
+                "symfony/process": "<3.3"
             },
             "provide": {
                 "psr/log-implementation": "1.0"
             },
             "require-dev": {
                 "psr/log": "~1.0",
-                "symfony/config": "^4.4|^5.0",
-                "symfony/dependency-injection": "^4.4|^5.0",
-                "symfony/event-dispatcher": "^4.4|^5.0",
+                "symfony/config": "^3.4|^4.0|^5.0",
+                "symfony/dependency-injection": "^3.4|^4.0|^5.0",
+                "symfony/event-dispatcher": "^4.3",
                 "symfony/lock": "^4.4|^5.0",
-                "symfony/process": "^4.4|^5.0",
-                "symfony/var-dumper": "^4.4|^5.0"
+                "symfony/process": "^3.4|^4.0|^5.0",
+                "symfony/var-dumper": "^4.3|^5.0"
             },
             "suggest": {
                 "psr/log": "For using the console logger",
@@ -543,7 +792,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "5.1-dev"
+                    "dev-master": "4.4-dev"
                 }
             },
             "autoload": {
@@ -584,243 +833,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-06-15T12:59:21+00:00"
-        },
-        {
-            "name": "symfony/polyfill-ctype",
-            "version": "v1.17.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/polyfill-ctype.git",
-                "reference": "e94c8b1bbe2bc77507a1056cdb06451c75b427f9"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/e94c8b1bbe2bc77507a1056cdb06451c75b427f9",
-                "reference": "e94c8b1bbe2bc77507a1056cdb06451c75b427f9",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.3.3"
-            },
-            "suggest": {
-                "ext-ctype": "For best performance"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.17-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Symfony\\Polyfill\\Ctype\\": ""
-                },
-                "files": [
-                    "bootstrap.php"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Gert de Pagter",
-                    "email": "BackEndTea@gmail.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Symfony polyfill for ctype functions",
-            "homepage": "https://symfony.com",
-            "keywords": [
-                "compatibility",
-                "ctype",
-                "polyfill",
-                "portable"
-            ],
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2020-05-12T16:14:59+00:00"
-        },
-        {
-            "name": "symfony/polyfill-intl-grapheme",
-            "version": "v1.17.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/polyfill-intl-grapheme.git",
-                "reference": "e094b0770f7833fdf257e6ba4775be4e258230b2"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-intl-grapheme/zipball/e094b0770f7833fdf257e6ba4775be4e258230b2",
-                "reference": "e094b0770f7833fdf257e6ba4775be4e258230b2",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.3.3"
-            },
-            "suggest": {
-                "ext-intl": "For best performance"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.17-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Symfony\\Polyfill\\Intl\\Grapheme\\": ""
-                },
-                "files": [
-                    "bootstrap.php"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Nicolas Grekas",
-                    "email": "p@tchwork.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Symfony polyfill for intl's grapheme_* functions",
-            "homepage": "https://symfony.com",
-            "keywords": [
-                "compatibility",
-                "grapheme",
-                "intl",
-                "polyfill",
-                "portable",
-                "shim"
-            ],
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2020-05-12T16:47:27+00:00"
-        },
-        {
-            "name": "symfony/polyfill-intl-normalizer",
-            "version": "v1.17.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/polyfill-intl-normalizer.git",
-                "reference": "1357b1d168eb7f68ad6a134838e46b0b159444a9"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-intl-normalizer/zipball/1357b1d168eb7f68ad6a134838e46b0b159444a9",
-                "reference": "1357b1d168eb7f68ad6a134838e46b0b159444a9",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.3.3"
-            },
-            "suggest": {
-                "ext-intl": "For best performance"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.17-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Symfony\\Polyfill\\Intl\\Normalizer\\": ""
-                },
-                "files": [
-                    "bootstrap.php"
-                ],
-                "classmap": [
-                    "Resources/stubs"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Nicolas Grekas",
-                    "email": "p@tchwork.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Symfony polyfill for intl's Normalizer class and related functions",
-            "homepage": "https://symfony.com",
-            "keywords": [
-                "compatibility",
-                "intl",
-                "normalizer",
-                "polyfill",
-                "portable",
-                "shim"
-            ],
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2020-05-12T16:14:59+00:00"
+            "time": "2020-07-06T13:18:39+00:00"
         },
         {
             "name": "symfony/polyfill-mbstring",
-            "version": "v1.17.0",
+            "version": "v1.18.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-mbstring.git",
-                "reference": "fa79b11539418b02fc5e1897267673ba2c19419c"
+                "reference": "a6977d63bf9a0ad4c65cd352709e230876f9904a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/fa79b11539418b02fc5e1897267673ba2c19419c",
-                "reference": "fa79b11539418b02fc5e1897267673ba2c19419c",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/a6977d63bf9a0ad4c65cd352709e230876f9904a",
+                "reference": "a6977d63bf9a0ad4c65cd352709e230876f9904a",
                 "shasum": ""
             },
             "require": {
@@ -832,7 +858,11 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.17-dev"
+                    "dev-master": "1.18-dev"
+                },
+                "thanks": {
+                    "name": "symfony/polyfill",
+                    "url": "https://github.com/symfony/polyfill"
                 }
             },
             "autoload": {
@@ -880,20 +910,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-05-12T16:47:27+00:00"
+            "time": "2020-07-14T12:35:20+00:00"
         },
         {
             "name": "symfony/polyfill-php73",
-            "version": "v1.17.0",
+            "version": "v1.18.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php73.git",
-                "reference": "a760d8964ff79ab9bf057613a5808284ec852ccc"
+                "reference": "fffa1a52a023e782cdcc221d781fe1ec8f87fcca"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php73/zipball/a760d8964ff79ab9bf057613a5808284ec852ccc",
-                "reference": "a760d8964ff79ab9bf057613a5808284ec852ccc",
+                "url": "https://api.github.com/repos/symfony/polyfill-php73/zipball/fffa1a52a023e782cdcc221d781fe1ec8f87fcca",
+                "reference": "fffa1a52a023e782cdcc221d781fe1ec8f87fcca",
                 "shasum": ""
             },
             "require": {
@@ -902,7 +932,11 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.17-dev"
+                    "dev-master": "1.18-dev"
+                },
+                "thanks": {
+                    "name": "symfony/polyfill",
+                    "url": "https://github.com/symfony/polyfill"
                 }
             },
             "autoload": {
@@ -952,20 +986,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-05-12T16:47:27+00:00"
+            "time": "2020-07-14T12:35:20+00:00"
         },
         {
             "name": "symfony/polyfill-php80",
-            "version": "v1.17.0",
+            "version": "v1.18.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php80.git",
-                "reference": "5e30b2799bc1ad68f7feb62b60a73743589438dd"
+                "reference": "d87d5766cbf48d72388a9f6b85f280c8ad51f981"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php80/zipball/5e30b2799bc1ad68f7feb62b60a73743589438dd",
-                "reference": "5e30b2799bc1ad68f7feb62b60a73743589438dd",
+                "url": "https://api.github.com/repos/symfony/polyfill-php80/zipball/d87d5766cbf48d72388a9f6b85f280c8ad51f981",
+                "reference": "d87d5766cbf48d72388a9f6b85f280c8ad51f981",
                 "shasum": ""
             },
             "require": {
@@ -974,7 +1008,11 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.17-dev"
+                    "dev-master": "1.18-dev"
+                },
+                "thanks": {
+                    "name": "symfony/polyfill",
+                    "url": "https://github.com/symfony/polyfill"
                 }
             },
             "autoload": {
@@ -1028,24 +1066,24 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-05-12T16:47:27+00:00"
+            "time": "2020-07-14T12:35:20+00:00"
         },
         {
             "name": "symfony/service-contracts",
-            "version": "v2.1.2",
+            "version": "v1.1.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/service-contracts.git",
-                "reference": "66a8f0957a3ca54e4f724e49028ab19d75a8918b"
+                "reference": "b776d18b303a39f56c63747bcb977ad4b27aca26"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/66a8f0957a3ca54e4f724e49028ab19d75a8918b",
-                "reference": "66a8f0957a3ca54e4f724e49028ab19d75a8918b",
+                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/b776d18b303a39f56c63747bcb977ad4b27aca26",
+                "reference": "b776d18b303a39f56c63747bcb977ad4b27aca26",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.2.5",
+                "php": ">=7.1.3",
                 "psr/container": "^1.0"
             },
             "suggest": {
@@ -1054,7 +1092,11 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.1-dev"
+                    "dev-master": "1.1-dev"
+                },
+                "thanks": {
+                    "name": "symfony/contracts",
+                    "url": "https://github.com/symfony/contracts"
                 }
             },
             "autoload": {
@@ -1100,92 +1142,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-05-20T17:43:50+00:00"
-        },
-        {
-            "name": "symfony/string",
-            "version": "v5.1.2",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/string.git",
-                "reference": "ac70459db781108db7c6d8981dd31ce0e29e3298"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/string/zipball/ac70459db781108db7c6d8981dd31ce0e29e3298",
-                "reference": "ac70459db781108db7c6d8981dd31ce0e29e3298",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.2.5",
-                "symfony/polyfill-ctype": "~1.8",
-                "symfony/polyfill-intl-grapheme": "~1.0",
-                "symfony/polyfill-intl-normalizer": "~1.0",
-                "symfony/polyfill-mbstring": "~1.0",
-                "symfony/polyfill-php80": "~1.15"
-            },
-            "require-dev": {
-                "symfony/error-handler": "^4.4|^5.0",
-                "symfony/http-client": "^4.4|^5.0",
-                "symfony/translation-contracts": "^1.1|^2",
-                "symfony/var-exporter": "^4.4|^5.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "5.1-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Symfony\\Component\\String\\": ""
-                },
-                "files": [
-                    "Resources/functions.php"
-                ],
-                "exclude-from-classmap": [
-                    "/Tests/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Nicolas Grekas",
-                    "email": "p@tchwork.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Symfony String component",
-            "homepage": "https://symfony.com",
-            "keywords": [
-                "grapheme",
-                "i18n",
-                "string",
-                "unicode",
-                "utf-8",
-                "utf8"
-            ],
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2020-06-11T12:16:36+00:00"
+            "time": "2020-07-06T13:19:58+00:00"
         },
         {
             "name": "wp-coding-standards/wpcs",

--- a/includes/class-newspack-newsletters.php
+++ b/includes/class-newspack-newsletters.php
@@ -632,6 +632,7 @@ final class Newspack_Newsletters {
 	 * @return string Name of the Email Service Provider.
 	 */
 	public static function service_provider() {
+		// TODO: UI for user input of API key in keys modal and settings page.
 		if (
 			defined( 'NEWSPACK_NEWSLETTERS_CONSTANT_CONTACT_API_KEY' ) &&
 			defined( 'NEWSPACK_NEWSLETTERS_CONSTANT_CONTACT_ACCESS_TOKEN' ) &&

--- a/includes/class-newspack-newsletters.php
+++ b/includes/class-newspack-newsletters.php
@@ -73,6 +73,9 @@ final class Newspack_Newsletters {
 			case 'mailchimp':
 				self::$provider = Newspack_Newsletters_Mailchimp::instance();
 				break;
+			case 'constant_contact':
+				self::$provider = Newspack_Newsletters_Constant_Contact::instance();
+				break;
 		}
 
 		$needs_nag = is_admin() &&
@@ -93,6 +96,17 @@ final class Newspack_Newsletters {
 		\register_meta(
 			'post',
 			'mc_campaign_id',
+			[
+				'object_subtype' => self::NEWSPACK_NEWSLETTERS_CPT,
+				'show_in_rest'   => true,
+				'type'           => 'string',
+				'single'         => true,
+				'auth_callback'  => '__return_true',
+			]
+		);
+		\register_meta(
+			'post',
+			'cc_campaign_id',
 			[
 				'object_subtype' => self::NEWSPACK_NEWSLETTERS_CPT,
 				'show_in_rest'   => true,
@@ -618,6 +632,14 @@ final class Newspack_Newsletters {
 	 * @return string Name of the Email Service Provider.
 	 */
 	public static function service_provider() {
+		if (
+			defined( 'NEWSPACK_NEWSLETTERS_CONSTANT_CONTACT_API_KEY' ) &&
+			defined( 'NEWSPACK_NEWSLETTERS_CONSTANT_CONTACT_ACCESS_TOKEN' ) &&
+			NEWSPACK_NEWSLETTERS_CONSTANT_CONTACT_API_KEY &&
+			NEWSPACK_NEWSLETTERS_CONSTANT_CONTACT_ACCESS_TOKEN
+		) {
+			return 'constant_contact';
+		}
 		return 'mailchimp'; // For now, Mailchimp is the only choice.
 	}
 }

--- a/includes/service-providers/constant_contact/class-newspack-newsletters-constant-contact-controller.php
+++ b/includes/service-providers/constant_contact/class-newspack-newsletters-constant-contact-controller.php
@@ -1,0 +1,189 @@
+<?php
+/**
+ * Constant Contact ESP Service Controller.
+ *
+ * @package Newspack
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * API Controller for Newspack Constant Contact ESP service.
+ */
+class Newspack_Newsletters_Constant_Contact_Controller extends Newspack_Newsletters_Service_Provider_Controller {
+	/**
+	 * Newspack_Newsletters_Constant_Contact_Controller constructor.
+	 *
+	 * @param \Newspack_Newsletters_Constant_Contact $constant_contact The service provider class.
+	 */
+	public function __construct( $constant_contact ) {
+		$this->service_provider = $constant_contact;
+		add_action( 'rest_api_init', [ $this, 'register_routes' ] );
+		parent::__construct( $constant_contact );
+	}
+
+	/**
+	 * Register API endpoints unique to Constant Contact.
+	 */
+	public function register_routes() {
+
+		// Register common ESP routes from \Newspack_Newsletters_Service_Provider_Controller::register_routes.
+		parent::register_routes();
+
+		\register_rest_route(
+			$this->service_provider::BASE_NAMESPACE . $this->service_provider->service,
+			'(?P<id>[\a-z]+)',
+			[
+				'methods'             => \WP_REST_Server::READABLE,
+				'callback'            => [ $this, 'api_retrieve' ],
+				'permission_callback' => [ $this->service_provider, 'api_authoring_permissions_check' ],
+				'args'                => [
+					'id' => [
+						'sanitize_callback' => 'absint',
+						'validate_callback' => [ 'Newspack_Newsletters', 'validate_newsletter_id' ],
+					],
+				],
+			]
+		);
+		\register_rest_route(
+			$this->service_provider::BASE_NAMESPACE . $this->service_provider->service,
+			'(?P<id>[\a-z]+)/test',
+			[
+				'methods'             => \WP_REST_Server::EDITABLE,
+				'callback'            => [ $this, 'api_test' ],
+				'permission_callback' => [ $this->service_provider, 'api_authoring_permissions_check' ],
+				'args'                => [
+					'id'         => [
+						'sanitize_callback' => 'absint',
+						'validate_callback' => [ 'Newspack_Newsletters', 'validate_newsletter_id' ],
+					],
+					'test_email' => [
+						'sanitize_callback' => 'sanitize_text_field',
+					],
+				],
+			]
+		);
+		\register_rest_route(
+			$this->service_provider::BASE_NAMESPACE . $this->service_provider->service,
+			'(?P<id>[\a-z]+)/sender',
+			[
+				'methods'             => \WP_REST_Server::EDITABLE,
+				'callback'            => [ $this, 'api_sender' ],
+				'permission_callback' => [ $this->service_provider, 'api_authoring_permissions_check' ],
+				'args'                => [
+					'id'        => [
+						'sanitize_callback' => 'absint',
+						'validate_callback' => [ 'Newspack_Newsletters', 'validate_newsletter_id' ],
+					],
+					'from_name' => [
+						'sanitize_callback' => 'sanitize_text_field',
+					],
+					'reply_to'  => [
+						'sanitize_callback' => 'sanitize_email',
+					],
+				],
+			]
+		);
+		\register_rest_route(
+			$this->service_provider::BASE_NAMESPACE . $this->service_provider->service,
+			'(?P<id>[\a-z]+)/list/(?P<list_id>[\a-z]+)',
+			[
+				'methods'             => \WP_REST_Server::EDITABLE,
+				'callback'            => [ $this, 'api_list' ],
+				'permission_callback' => [ $this->service_provider, 'api_authoring_permissions_check' ],
+				'args'                => [
+					'id'      => [
+						'sanitize_callback' => 'absint',
+						'validate_callback' => [ 'Newspack_Newsletters', 'validate_newsletter_id' ],
+					],
+					'list_id' => [
+						'sanitize_callback' => 'esc_attr',
+					],
+				],
+			]
+		);
+		\register_rest_route(
+			$this->service_provider::BASE_NAMESPACE . $this->service_provider->service,
+			'(?P<id>[\a-z]+)/list/(?P<list_id>[\a-z]+)',
+			[
+				'methods'             => \WP_REST_Server::DELETABLE,
+				'callback'            => [ $this, 'api_list' ],
+				'permission_callback' => [ $this->service_provider, 'api_authoring_permissions_check' ],
+				'args'                => [
+					'id'      => [
+						'sanitize_callback' => 'absint',
+						'validate_callback' => [ 'Newspack_Newsletters', 'validate_newsletter_id' ],
+					],
+					'list_id' => [
+						'sanitize_callback' => 'esc_attr',
+					],
+				],
+			]
+		);
+	}
+
+	/**
+	 * Get campaign data.
+	 *
+	 * @param WP_REST_Request $request API request object.
+	 * @return WP_REST_Response|mixed API response or error.
+	 */
+	public function api_retrieve( $request ) {
+		$response = $this->service_provider->retrieve( $request['id'] );
+		return \rest_ensure_response( $response );
+	}
+
+	/**
+	 * Test campaign.
+	 *
+	 * @param WP_REST_Request $request API request object.
+	 * @return WP_REST_Response|mixed API response or error.
+	 */
+	public function api_test( $request ) {
+		$emails = explode( ',', $request['test_email'] );
+		foreach ( $emails as &$email ) {
+			$email = sanitize_email( trim( $email ) );
+		}
+		$response = $this->service_provider->test(
+			$request['id'],
+			$emails
+		);
+		return \rest_ensure_response( $response );
+	}
+
+	/**
+	 * Set the sender name and email for the campaign.
+	 *
+	 * @param WP_REST_Request $request API request object.
+	 * @return WP_REST_Response|mixed API response or error.
+	 */
+	public function api_sender( $request ) {
+		$response = $this->service_provider->sender(
+			$request['id'],
+			$request['from_name'],
+			$request['reply_to']
+		);
+		return \rest_ensure_response( $response );
+	}
+
+	/**
+	 * Set list for a campaign.
+	 *
+	 * @param WP_REST_Request $request API request object.
+	 * @return WP_REST_Response|mixed API response or error.
+	 */
+	public function api_list( $request ) {
+		if ( 'DELETE' === $request->get_method() ) {
+			$response = $this->service_provider->unset_list(
+				$request['id'],
+				$request['list_id']
+			);
+		} else {
+			$response = $this->service_provider->list(
+				$request['id'],
+				$request['list_id']
+			);
+		}
+		return \rest_ensure_response( $response );
+	}
+}

--- a/includes/service-providers/constant_contact/class-newspack-newsletters-constant-contact.php
+++ b/includes/service-providers/constant_contact/class-newspack-newsletters-constant-contact.php
@@ -14,7 +14,7 @@ use Ctct\ConstantContact;
 use Ctct\Exceptions\CtctException;
 
 /**
- * Main Newspack Newsletters Class.
+ * Main Newspack Newsletters Class for Constant Contact ESP.
  */
 final class Newspack_Newsletters_Constant_Contact extends \Newspack_Newsletters_Service_Provider {
 
@@ -70,16 +70,10 @@ final class Newspack_Newsletters_Constant_Contact extends \Newspack_Newsletters_
 	 * @return object|WP_Error API API Response or error.
 	 */
 	public function list( $post_id, $list_id ) {
-		$cc_campaign_id = get_post_meta( $post_id, 'cc_campaign_id', true );
-		if ( ! $cc_campaign_id ) {
-			return new WP_Error(
-				'newspack_newsletters_no_campaign_id',
-				__( 'Constant Contact campaign ID not found.', 'newspack-newsletters' )
-			);
-		}
-
 		try {
-			$cc       = new ConstantContact( $this->api_key() );
+			$cc_campaign_id = $this->retrieve_campaign_id( $post_id );
+			$cc             = new ConstantContact( $this->api_key() );
+
 			$campaign = $cc->emailMarketingService->getCampaign( $this->access_token(), $cc_campaign_id ); //phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
 
 			$campaign->addList( $list_id );
@@ -108,16 +102,10 @@ final class Newspack_Newsletters_Constant_Contact extends \Newspack_Newsletters_
 	 * @return object|WP_Error API API Response or error.
 	 */
 	public function unset_list( $post_id, $list_id ) {
-		$cc_campaign_id = get_post_meta( $post_id, 'cc_campaign_id', true );
-		if ( ! $cc_campaign_id ) {
-			return new WP_Error(
-				'newspack_newsletters_no_campaign_id',
-				__( 'Constant Contact campaign ID not found.', 'newspack-newsletters' )
-			);
-		}
-
 		try {
-			$cc       = new ConstantContact( $this->api_key() );
+			$cc_campaign_id = $this->retrieve_campaign_id( $post_id );
+			$cc             = new ConstantContact( $this->api_key() );
+
 			$campaign = $cc->emailMarketingService->getCampaign( $this->access_token(), $cc_campaign_id ); //phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
 
 			$campaign->sent_to_contact_lists = array_filter(
@@ -160,14 +148,8 @@ final class Newspack_Newsletters_Constant_Contact extends \Newspack_Newsletters_
 			);
 		}
 		try {
-			$cc_campaign_id = get_post_meta( $post_id, 'cc_campaign_id', true );
-			if ( ! $cc_campaign_id ) {
-				return new WP_Error(
-					'newspack_newsletters_constant_contact_error',
-					__( 'No Constant Contact campaign ID found for this Newsletter', 'newspack-newsletter' )
-				);
-			}
-			$cc = new ConstantContact( $this->api_key() );
+			$cc_campaign_id = $this->retrieve_campaign_id( $post_id );
+			$cc             = new ConstantContact( $this->api_key() );
 
 			$campaign = $cc->emailMarketingService->getCampaign( $this->access_token(), $cc_campaign_id ); //phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
 
@@ -198,15 +180,9 @@ final class Newspack_Newsletters_Constant_Contact extends \Newspack_Newsletters_
 	 * @return object|WP_Error API Response or error.
 	 */
 	public function sender( $post_id, $from_name, $reply_to ) {
-		$cc_campaign_id = get_post_meta( $post_id, 'cc_campaign_id', true );
-		if ( ! $cc_campaign_id ) {
-			return new WP_Error(
-				'newspack_newsletters_no_campaign_id',
-				__( 'Constant Contact campaign ID not found.', 'newspack-newsletters' )
-			);
-		}
 		try {
-			$cc = new ConstantContact( $this->api_key() );
+			$cc_campaign_id = $this->retrieve_campaign_id( $post_id );
+			$cc             = new ConstantContact( $this->api_key() );
 
 			$campaign = $cc->emailMarketingService->getCampaign( $this->access_token(), $cc_campaign_id ); //phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
 
@@ -238,15 +214,10 @@ final class Newspack_Newsletters_Constant_Contact extends \Newspack_Newsletters_
 	 * @return object|WP_Error API Response or error.
 	 */
 	public function test( $post_id, $emails ) {
-		$cc_campaign_id = get_post_meta( $post_id, 'cc_campaign_id', true );
-		if ( ! $cc_campaign_id ) {
-			return new WP_Error(
-				'newspack_newsletters_no_campaign_id',
-				__( 'Constant Contact campaign ID not found.', 'newspack-newsletters' )
-			);
-		}
 		try {
-			$cc     = new ConstantContact( $this->api_key() );
+			$cc_campaign_id = $this->retrieve_campaign_id( $post_id );
+			$cc             = new ConstantContact( $this->api_key() );
+
 			$result = $cc->campaignScheduleService->sendTest( //phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
 				$this->access_token(),
 				$cc_campaign_id,
@@ -441,6 +412,21 @@ final class Newspack_Newsletters_Constant_Contact extends \Newspack_Newsletters_
 		} catch ( Exception $e ) {
 			return; // Fail silently.
 		}
+	}
+
+	/**
+	 * Convenience method to retrieve the Constant Contact campaign ID for a post or throw an error.
+	 *
+	 * @param string $post_id Numeric ID of the campaign.
+	 * @return string Constant Contact campaign ID.
+	 * @throws Exception Error message.
+	 */
+	public function retrieve_campaign_id( $post_id ) {
+		$cc_campaign_id = get_post_meta( $post_id, 'cc_campaign_id', true );
+		if ( ! $cc_campaign_id ) {
+			throw new Exception( __( 'Constant Contact campaign ID not found.', 'newspack-newsletters' ) );
+		}
+		return $cc_campaign_id;
 	}
 
 	/**

--- a/includes/service-providers/constant_contact/class-newspack-newsletters-constant-contact.php
+++ b/includes/service-providers/constant_contact/class-newspack-newsletters-constant-contact.php
@@ -1,0 +1,465 @@
+<?php
+/**
+ * Service Provider: Constant Contact Implementation
+ *
+ * @package Newspack
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+use Ctct\Components\EmailMarketing\Campaign;
+use Ctct\Components\EmailMarketing\Schedule;
+use Ctct\Components\EmailMarketing\TestSend;
+use Ctct\ConstantContact;
+use Ctct\Exceptions\CtctException;
+
+/**
+ * Main Newspack Newsletters Class.
+ */
+final class Newspack_Newsletters_Constant_Contact extends \Newspack_Newsletters_Service_Provider {
+
+	/**
+	 * Class constructor.
+	 */
+	public function __construct() {
+		$this->service    = 'constant_contact';
+		$this->controller = new Newspack_Newsletters_Constant_Contact_Controller( $this );
+
+		add_action( 'save_post_' . Newspack_Newsletters::NEWSPACK_NEWSLETTERS_CPT, [ $this, 'save' ], 10, 3 );
+		add_action( 'publish_' . Newspack_Newsletters::NEWSPACK_NEWSLETTERS_CPT, [ $this, 'send' ], 10, 2 );
+		add_action( 'wp_trash_post', [ $this, 'trash' ], 10, 1 );
+
+		parent::__construct( $this );
+	}
+
+	/**
+	 * Get API key for service provider.
+	 *
+	 * @return String Stored API key for the service provider.
+	 */
+	public function api_key() {
+		// TODO: UI for user input of API key in keys modal and settings page.
+		return defined( 'NEWSPACK_NEWSLETTERS_CONSTANT_CONTACT_API_KEY' ) ? NEWSPACK_NEWSLETTERS_CONSTANT_CONTACT_API_KEY : null;
+	}
+
+	/**
+	 * Get Access Token key for service provider.
+	 *
+	 * @return String Stored Access Token key for the service provider.
+	 */
+	public function access_token() {
+		// TODO: UI for user input of access token in keys modal and settings page.
+		return defined( 'NEWSPACK_NEWSLETTERS_CONSTANT_CONTACT_ACCESS_TOKEN' ) ? NEWSPACK_NEWSLETTERS_CONSTANT_CONTACT_ACCESS_TOKEN : null;
+	}
+
+	/**
+	 * Set the API key for the service provider.
+	 *
+	 * @param string $key API key.
+	 */
+	public function set_api_key( $key ) {
+		// TODO: UI for user input of Constant Contact API credentials.
+		return null;
+	}
+
+	/**
+	 * Set list for a campaign.
+	 *
+	 * @param string $post_id Campaign Id.
+	 * @param string $list_id ID of the list.
+	 * @return object|WP_Error API API Response or error.
+	 */
+	public function list( $post_id, $list_id ) {
+		$cc_campaign_id = get_post_meta( $post_id, 'cc_campaign_id', true );
+		if ( ! $cc_campaign_id ) {
+			return new WP_Error(
+				'newspack_newsletters_no_campaign_id',
+				__( 'Constant Contact campaign ID not found.', 'newspack-newsletters' )
+			);
+		}
+
+		try {
+			$cc       = new ConstantContact( $this->api_key() );
+			$campaign = $cc->emailMarketingService->getCampaign( $this->access_token(), $cc_campaign_id ); //phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+
+			$campaign->addList( $list_id );
+
+			$campaign_result = $cc->emailMarketingService->updateCampaign( $this->access_token(), $campaign ); //phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+
+			$data           = $this->retrieve( $post_id );
+			$data['result'] = $campaign_result;
+			return \rest_ensure_response( $data );
+
+		} catch ( CtctException $e ) {
+			return $this->manage_ctct_exception( $e );
+		} catch ( Exception $e ) {
+			return new WP_Error(
+				'newspack_newsletters_constant_contact_error',
+				$e->getMessage()
+			);
+		}
+	}
+
+	/**
+	 * Unset list for a campaign.
+	 *
+	 * @param string $post_id Campaign Id.
+	 * @param string $list_id ID of the list.
+	 * @return object|WP_Error API API Response or error.
+	 */
+	public function unset_list( $post_id, $list_id ) {
+		$cc_campaign_id = get_post_meta( $post_id, 'cc_campaign_id', true );
+		if ( ! $cc_campaign_id ) {
+			return new WP_Error(
+				'newspack_newsletters_no_campaign_id',
+				__( 'Constant Contact campaign ID not found.', 'newspack-newsletters' )
+			);
+		}
+
+		try {
+			$cc       = new ConstantContact( $this->api_key() );
+			$campaign = $cc->emailMarketingService->getCampaign( $this->access_token(), $cc_campaign_id ); //phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+
+			$campaign->sent_to_contact_lists = array_filter(
+				$campaign->sent_to_contact_lists,
+				function( $list ) use ( $list_id ) {
+					return $list->id !== $list_id;
+				}
+			);
+
+			$campaign_result = $cc->emailMarketingService->updateCampaign( $this->access_token(), $campaign ); //phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+
+			$data           = $this->retrieve( $post_id );
+			$data['result'] = $campaign_result;
+			return \rest_ensure_response( $data );
+
+		} catch ( CtctException $e ) {
+			return $this->manage_ctct_exception( $e );
+		} catch ( Exception $e ) {
+			return new WP_Error(
+				'newspack_newsletters_constant_contact_error',
+				$e->getMessage()
+			);
+		}
+	}
+
+	/**
+	 * Retrieve a campaign.
+	 *
+	 * @param integer $post_id Numeric ID of the Newsletter post.
+	 * @return object|WP_Error API Response or error.
+	 */
+	public function retrieve( $post_id ) {
+		$transient       = sprintf( 'newspack_newsletters_error_%s_%s', $post_id, get_current_user_id() );
+		$persisted_error = get_transient( $transient );
+		if ( $persisted_error ) {
+			delete_transient( $transient );
+			return new WP_Error(
+				'newspack_newsletters_constant_contact_error',
+				$persisted_error
+			);
+		}
+		try {
+			$cc_campaign_id = get_post_meta( $post_id, 'cc_campaign_id', true );
+			if ( ! $cc_campaign_id ) {
+				return new WP_Error(
+					'newspack_newsletters_constant_contact_error',
+					__( 'No Constant Contact campaign ID found for this Newsletter', 'newspack-newsletter' )
+				);
+			}
+			$cc = new ConstantContact( $this->api_key() );
+
+			$campaign = $cc->emailMarketingService->getCampaign( $this->access_token(), $cc_campaign_id ); //phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+
+			$lists = $cc->listService->getLists( $this->access_token() ); //phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+
+			return [
+				'lists'       => $lists,
+				'campaign'    => $campaign,
+				'campaign_id' => $cc_campaign_id,
+			];
+
+		} catch ( CtctException $e ) {
+			return $this->manage_ctct_exception( $e );
+		} catch ( Exception $e ) {
+			return new WP_Error(
+				'newspack_newsletters_constant_contact_error',
+				$e->getMessage()
+			);
+		}
+	}
+
+	/**
+	 * Set sender data.
+	 *
+	 * @param string $post_id Numeric ID of the campaign.
+	 * @param string $from_name Sender name.
+	 * @param string $reply_to Reply to email address.
+	 * @return object|WP_Error API Response or error.
+	 */
+	public function sender( $post_id, $from_name, $reply_to ) {
+		$cc_campaign_id = get_post_meta( $post_id, 'cc_campaign_id', true );
+		if ( ! $cc_campaign_id ) {
+			return new WP_Error(
+				'newspack_newsletters_no_campaign_id',
+				__( 'Constant Contact campaign ID not found.', 'newspack-newsletters' )
+			);
+		}
+		try {
+			$cc = new ConstantContact( $this->api_key() );
+
+			$campaign = $cc->emailMarketingService->getCampaign( $this->access_token(), $cc_campaign_id ); //phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+
+			$campaign->from_email     = $reply_to;
+			$campaign->reply_to_email = $reply_to;
+			$campaign->from_name      = $from_name;
+
+			$campaign_result = $cc->emailMarketingService->updateCampaign( $this->access_token(), $campaign ); //phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+
+			$data           = $this->retrieve( $post_id );
+			$data['result'] = $campaign_result;
+
+			return \rest_ensure_response( $data );
+		} catch ( CtctException $e ) {
+			return $this->manage_ctct_exception( $e );
+		} catch ( Exception $e ) {
+			return new WP_Error(
+				'newspack_newsletters_constant_contact_error',
+				$e->getMessage()
+			);
+		}
+	}
+
+	/**
+	 * Send test email or emails.
+	 *
+	 * @param integer $post_id Numeric ID of the Newsletter post.
+	 * @param array   $emails Array of email addresses to send to.
+	 * @return object|WP_Error API Response or error.
+	 */
+	public function test( $post_id, $emails ) {
+		$cc_campaign_id = get_post_meta( $post_id, 'cc_campaign_id', true );
+		if ( ! $cc_campaign_id ) {
+			return new WP_Error(
+				'newspack_newsletters_no_campaign_id',
+				__( 'Constant Contact campaign ID not found.', 'newspack-newsletters' )
+			);
+		}
+		try {
+			$cc     = new ConstantContact( $this->api_key() );
+			$result = $cc->campaignScheduleService->sendTest( //phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+				$this->access_token(),
+				$cc_campaign_id,
+				TestSend::create(
+					[
+						'format'          => 'HTML',
+						'email_addresses' => $emails,
+					]
+				)
+			);
+
+			$data            = $this->retrieve( $post_id );
+			$data['result']  = $result;
+			$data['message'] = sprintf(
+			// translators: Message after successful test email.
+				__( 'Constant Contact test sent successfully to %s.', 'newspack-newsletters' ),
+				implode( ', ', $emails )
+			);
+
+			return \rest_ensure_response( $data );
+
+		} catch ( CtctException $e ) {
+			return $this->manage_ctct_exception( $e );
+		} catch ( Exception $e ) {
+			return new WP_Error(
+				'newspack_newsletters_constant_contact_error',
+				$e->getMessage()
+			);
+		}
+	}
+
+	/**
+	 * Synchronize post with corresponding ESP campaign.
+	 *
+	 * @param WP_POST $post Post to synchronize.
+	 * @return object|null API Response or error.
+	 * @throws Exception Error message.
+	 */
+	public function sync( $post ) {
+		$api_key = $this->api_key();
+		if ( ! $api_key ) {
+			return new WP_Error(
+				'newspack_newsletters_incorrect_post_type',
+				__( 'No Constant Contact API key available.', 'newspack-newsletters' )
+			);
+		}
+		try {
+			$cc             = new ConstantContact( $api_key );
+			$cc_campaign_id = get_post_meta( $post->ID, 'cc_campaign_id', true );
+			$renderer       = new Newspack_Newsletters_Renderer();
+			$content        = $renderer->render_html_email( $post );
+			if ( $cc_campaign_id ) {
+				$campaign = $cc->emailMarketingService->getCampaign( $this->access_token(), $cc_campaign_id ); //phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+
+				$campaign->subject       = $post->post_title;
+				$campaign->email_content = $content;
+
+				$campaign_result = $cc->emailMarketingService->updateCampaign( $this->access_token(), $campaign ); //phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+
+			} else {
+
+				$account_info = $cc->accountService->getAccountInfo( $this->access_token() ); //phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+
+				$initial_sender = __( 'Sender Name', 'newspack-newsletters' );
+				if ( $account_info->organization_name ) {
+					$initial_sender = $account_info->organization_name;
+				} elseif ( $account_info->first_name && $account_info->last_name ) {
+					$initial_sender = $account_info->first_name . ' ' . $account_info->last_name;
+				}
+
+				$verified_email_addresses = $cc->accountService->getVerifiedEmailAddresses( $this->access_token() ); //phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+
+				if ( empty( $verified_email_addresses ) ) {
+					throw new Exception( __( 'There are no verified email addresses in the Constant Contact account.', 'newspack-newsletters' ) );
+				}
+
+				$initial_email_address = $verified_email_addresses[0]->email_address;
+
+				$campaign                       = new Campaign();
+				$campaign->name                 = uniqid();
+				$campaign->subject              = $post->post_title;
+				$campaign->from_email           = $initial_email_address;
+				$campaign->reply_to_email       = $initial_email_address;
+				$campaign->from_name            = $initial_sender;
+				$campaign->email_content        = $content;
+				$campaign->text_content         = $content;
+				$campaign->email_content_format = 'HTML';
+
+				$campaign_result = $cc->emailMarketingService->addCampaign( $this->access_token(), $campaign ); //phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+
+				update_post_meta( $post->ID, 'cc_campaign_id', $campaign_result->id );
+			}
+
+			return [
+				'campaign_result' => $campaign_result,
+			];
+
+		} catch ( CtctException $e ) {
+			return $this->manage_ctct_exception( $e );
+		} catch ( Exception $e ) {
+			$transient = sprintf( 'newspack_newsletters_error_%s_%s', $post->ID, get_current_user_id() );
+			set_transient( $transient, $e->getMessage(), 45 );
+			return;
+		}
+	}
+
+	/**
+	 * Update ESP campaign after post save.
+	 *
+	 * @param string  $post_id Numeric ID of the campaign.
+	 * @param WP_Post $post The complete post object.
+	 * @param boolean $update Whether this is an existing post being updated or not.
+	 */
+	public function save( $post_id, $post, $update ) {
+		if ( ! $update ) {
+			update_post_meta( $post_id, 'template_id', -1 );
+		}
+		$status = get_post_status( $post_id );
+		if ( 'trash' === $status ) {
+			return;
+		}
+		$this->sync( $post );
+	}
+
+	/**
+	 * Send a campaign.
+	 *
+	 * @param integer $post_id Post ID to send.
+	 * @param WP_POST $post Post to send.
+	 */
+	public function send( $post_id, $post ) {
+		if ( ! Newspack_Newsletters::validate_newsletter_id( $post_id ) ) {
+			return new WP_Error(
+				'newspack_newsletters_incorrect_post_type',
+				__( 'Post is not a Newsletter.', 'newspack-newsletters' )
+			);
+		}
+
+		try {
+			$sync_result = $this->sync( $post );
+
+			if ( is_wp_error( $sync_result ) ) {
+				return $sync_result;
+			}
+
+			$cc_campaign_id = get_post_meta( $post_id, 'cc_campaign_id', true );
+			if ( ! $cc_campaign_id ) {
+				return new WP_Error(
+					'newspack_newsletters_no_campaign_id',
+					__( 'Constant Contact campaign ID not found.', 'newspack-newsletters' )
+				);
+			}
+
+			$cc       = new ConstantContact( $this->api_key() );
+			$schedule = new Schedule();
+
+			$cc->campaignScheduleService->addSchedule( $this->access_token(), $cc_campaign_id, $schedule ); //phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+		} catch ( CtctException $e ) {
+			return $this->manage_ctct_exception( $e );
+		} catch ( Exception $e ) {
+			$transient = sprintf( 'newspack_newsletters_error_%s_%s', $post->ID, get_current_user_id() );
+			set_transient( $transient, $e->getMessage(), 45 );
+			return;
+		}
+	}
+
+	/**
+	 * After Newsletter post is deleted, clean up by deleting corresponding ESP campaign.
+	 *
+	 * @param string $post_id Numeric ID of the campaign.
+	 */
+	public function trash( $post_id ) {
+		if ( Newspack_Newsletters::NEWSPACK_NEWSLETTERS_CPT !== get_post_type( $post_id ) ) {
+			return;
+		}
+		$cc_campaign_id = get_post_meta( $post_id, 'cc_campaign_id', true );
+		if ( ! $cc_campaign_id ) {
+			return;
+		}
+
+		$api_key = $this->api_key();
+		if ( ! $api_key ) {
+			return;
+		}
+		try {
+			$cc       = new ConstantContact( $this->api_key() );
+			$campaign = $cc->emailMarketingService->getCampaign( $this->access_token(), $cc_campaign_id ); //phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+			if ( $campaign && 'DRAFT' === $campaign->status ) {
+				$result = $cc->emailMarketingService->deleteCampaign( $this->access_token(), $cc_campaign_id ); //phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+				delete_post_meta( $post_id, 'cc_campaign_id', $cc_campaign_id );
+			}
+		} catch ( Exception $e ) {
+			return; // Fail silently.
+		}
+	}
+
+	/**
+	 * Format and handle Constant Contact error messages.
+	 *
+	 * @param CtctException $e Error.
+	 */
+	public function manage_ctct_exception( $e ) {
+		return new WP_Error(
+			'newspack_newsletters_constant_contact_error',
+			implode(
+				' ',
+				array_map(
+					function( $error ) {
+						return $error->error_message;
+					},
+					$e->getErrors()
+				)
+			)
+		);
+	}
+}

--- a/includes/service-providers/constant_contact/class-newspack-newsletters-constant-contact.php
+++ b/includes/service-providers/constant_contact/class-newspack-newsletters-constant-contact.php
@@ -316,7 +316,10 @@ final class Newspack_Newsletters_Constant_Contact extends \Newspack_Newsletters_
 			];
 
 		} catch ( CtctException $e ) {
-			return $this->manage_ctct_exception( $e );
+			$wp_error  = $this->manage_ctct_exception( $e );
+			$transient = sprintf( 'newspack_newsletters_error_%s_%s', $post->ID, get_current_user_id() );
+			set_transient( $transient, implode( ' ', $wp_error->get_error_messages() ), 45 );
+			return $wp_error;
 		} catch ( Exception $e ) {
 			$transient = sprintf( 'newspack_newsletters_error_%s_%s', $post->ID, get_current_user_id() );
 			set_transient( $transient, $e->getMessage(), 45 );
@@ -376,7 +379,10 @@ final class Newspack_Newsletters_Constant_Contact extends \Newspack_Newsletters_
 
 			$cc->campaignScheduleService->addSchedule( $this->access_token(), $cc_campaign_id, $schedule ); //phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
 		} catch ( CtctException $e ) {
-			return $this->manage_ctct_exception( $e );
+			$wp_error  = $this->manage_ctct_exception( $e );
+			$transient = sprintf( 'newspack_newsletters_error_%s_%s', $post->ID, get_current_user_id() );
+			set_transient( $transient, implode( ' ', $wp_error->get_error_messages() ), 45 );
+			return $wp_error;
 		} catch ( Exception $e ) {
 			$transient = sprintf( 'newspack_newsletters_error_%s_%s', $post->ID, get_current_user_id() );
 			set_transient( $transient, $e->getMessage(), 45 );

--- a/includes/service-providers/constant_contact/class-newspack-newsletters-constant-contact.php
+++ b/includes/service-providers/constant_contact/class-newspack-newsletters-constant-contact.php
@@ -297,7 +297,7 @@ final class Newspack_Newsletters_Constant_Contact extends \Newspack_Newsletters_
 				$initial_email_address = $verified_email_addresses[0]->email_address;
 
 				$campaign                       = new Campaign();
-				$campaign->name                 = uniqid();
+				$campaign->name                 = __( 'Newspack Newsletters', 'newspack-newsletters' ) . ' ' . uniqid();
 				$campaign->subject              = $post->post_title;
 				$campaign->from_email           = $initial_email_address;
 				$campaign->reply_to_email       = $initial_email_address;

--- a/includes/service-providers/constant_contact/class-newspack-newsletters-constant-contact.php
+++ b/includes/service-providers/constant_contact/class-newspack-newsletters-constant-contact.php
@@ -260,7 +260,7 @@ final class Newspack_Newsletters_Constant_Contact extends \Newspack_Newsletters_
 		$api_key = $this->api_key();
 		if ( ! $api_key ) {
 			return new WP_Error(
-				'newspack_newsletters_incorrect_post_type',
+				'newspack_newsletters_missing_api_key',
 				__( 'No Constant Contact API key available.', 'newspack-newsletters' )
 			);
 		}

--- a/newspack-newsletters.php
+++ b/newspack-newsletters.php
@@ -27,6 +27,8 @@ require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/service-providers/cla
 require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/service-providers/class-newspack-newsletters-service-provider-controller.php';
 require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp.php';
 require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp-controller.php';
+require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/service-providers/constant_contact/class-newspack-newsletters-constant-contact.php';
+require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/service-providers/constant_contact/class-newspack-newsletters-constant-contact-controller.php';
 require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/class-newspack-newsletters-editor.php';
 require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/class-newspack-newsletters-layouts.php';
 require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/class-newspack-newsletters-settings.php';

--- a/src/newsletter-editor/testing/index.js
+++ b/src/newsletter-editor/testing/index.js
@@ -29,10 +29,14 @@ export default compose( [
 ] )( ( { apiFetchWithErrorHandling, inFlight, postId, savePost, setInFlightForAsync } ) => {
 	const [ testEmail, setTestEmail ] = useState( '' );
 	const sendTestEmail = async () => {
+		const serviceProvider =
+			window &&
+			window.newspack_newsletters_data &&
+			window.newspack_newsletters_data.service_provider;
 		setInFlightForAsync();
 		await savePost();
 		const params = {
-			path: `/newspack-newsletters/v1/mailchimp/${ postId }/test`,
+			path: `/newspack-newsletters/v1/${ serviceProvider }/${ postId }/test`,
 			data: {
 				test_email: testEmail,
 			},

--- a/src/service-providers/constant_contact/ProviderSidebar.js
+++ b/src/service-providers/constant_contact/ProviderSidebar.js
@@ -1,0 +1,88 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { Fragment, useEffect } from '@wordpress/element';
+import { BaseControl, CheckboxControl, Spinner, Notice } from '@wordpress/components';
+
+const ProviderSidebar = ( {
+	renderSubject,
+	renderFrom,
+	inFlight,
+	newsletterData,
+	apiFetch,
+	postId,
+	updateMeta,
+} ) => {
+	const campaign = newsletterData.campaign;
+	const lists = newsletterData.lists ? newsletterData.lists : [];
+
+	const setList = ( listId, value ) => {
+		const method = value ? 'PUT' : 'DELETE';
+		apiFetch( {
+			path: `/newspack-newsletters/v1/constant_contact/${ postId }/list/${ listId }`,
+			method,
+		} );
+	};
+
+	const setSender = ( { senderName, senderEmail } ) =>
+		apiFetch( {
+			path: `/newspack-newsletters/v1/constant_contact/${ postId }/sender`,
+			data: {
+				from_name: senderName,
+				reply_to: senderEmail,
+			},
+			method: 'POST',
+		} );
+
+	useEffect(() => {
+		if ( campaign ) {
+			updateMeta( {
+				senderName: campaign.from_name,
+				senderEmail: campaign.from_email,
+			} );
+		}
+	}, [ campaign ]);
+
+	if ( ! campaign ) {
+		return (
+			<div className="newspack-newsletters__loading-data">
+				{ __( 'Retrieving Constant Contact data...', 'newspack-newsletters' ) }
+				<Spinner />
+			</div>
+		);
+	}
+
+	const { status } = campaign || {};
+	if ( 'SCHEDULED' === status || 'SENT' === status ) {
+		return (
+			<Notice status="success" isDismissible={ false }>
+				{ __( 'Campaign has been sent.', 'newspack-newsletters' ) }
+			</Notice>
+		);
+	}
+
+	return (
+		<Fragment>
+			{ renderSubject() }
+			<BaseControl
+				id="newspack-newsletters-constant_contact-lists"
+				label={ __( 'Lists', 'newspack-newsletters' ) }
+			>
+				{ lists.map( ( { id, name } ) => (
+					<CheckboxControl
+						key={ id }
+						label={ name }
+						value={ id }
+						checked={ campaign.sent_to_contact_lists.some( list => list.id === id ) }
+						onChange={ value => setList( id, value ) }
+						disabled={ inFlight }
+					/>
+				) ) }
+			</BaseControl>
+			{ renderFrom( { handleSenderUpdate: setSender } ) }
+		</Fragment>
+	);
+};
+
+export default ProviderSidebar;

--- a/src/service-providers/constant_contact/ProviderSidebar.js
+++ b/src/service-providers/constant_contact/ProviderSidebar.js
@@ -54,7 +54,7 @@ const ProviderSidebar = ( {
 	}
 
 	const { status } = campaign || {};
-	if ( 'SCHEDULED' === status || 'SENT' === status ) {
+	if ( 'DRAFT' !== status ) {
 		return (
 			<Notice status="success" isDismissible={ false }>
 				{ __( 'Campaign has been sent.', 'newspack-newsletters' ) }

--- a/src/service-providers/constant_contact/index.js
+++ b/src/service-providers/constant_contact/index.js
@@ -1,0 +1,77 @@
+/**
+ * WordPress dependencies
+ */
+import { __, sprintf, _n } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import ProviderSidebar from './ProviderSidebar';
+
+const validateNewsletter = ( { campaign } ) => {
+	const messages = [];
+
+	if ( 'DRAFT' !== campaign.status ) {
+		messages.push( __( 'Newsletter has already been sent.', 'newspack-newsletters' ) );
+	}
+	if ( ! campaign.sent_to_contact_lists.length ) {
+		messages.push(
+			__(
+				'At least one Constant Contact list must be selected before publishing.',
+				'newspack-newsletters'
+			)
+		);
+	}
+	if ( campaign.from_name.length < 1 ) {
+		messages.push( __( 'Sender name must be set.', 'newspack-newsletters' ) );
+	}
+	if ( campaign.from_email.length < 1 || campaign.reply_to_email.length < 1 ) {
+		messages.push( __( 'Sender email must be set.', 'newspack-newsletters' ) );
+	}
+
+	return messages;
+};
+
+const getFetchDataConfig = ( { postId } ) => ( {
+	path: `/newspack-newsletters/v1/constant_contact/${ postId }`,
+} );
+
+const renderPreSendInfo = newsletterData => {
+	if ( ! newsletterData.campaign ) {
+		return null;
+	}
+	let subscriberCount = 0;
+	const listNames = [];
+	newsletterData.lists.forEach( ( { id, name, contact_count } ) => {
+		if (
+			newsletterData.campaign.sent_to_contact_lists.some(
+				( { id: usedListId } ) => usedListId === id
+			)
+		) {
+			listNames.push( name );
+			subscriberCount += contact_count;
+		}
+	} );
+
+	return (
+		<p>
+			{ __( "You're about to send a newsletter to:", 'newspack-newsletters' ) }
+			<br />
+			<strong>{ listNames.join( ', ' ) }</strong>
+			<br />
+			<strong>
+				{ sprintf(
+					_n( '%d subscriber', '%d subscribers', subscriberCount, 'newspack-newsletters' ),
+					subscriberCount
+				) }
+			</strong>
+		</p>
+	);
+};
+
+export default {
+	validateNewsletter,
+	getFetchDataConfig,
+	ProviderSidebar,
+	renderPreSendInfo,
+};

--- a/src/service-providers/constant_contact/index.js
+++ b/src/service-providers/constant_contact/index.js
@@ -22,13 +22,6 @@ const validateNewsletter = ( { campaign } ) => {
 			)
 		);
 	}
-	if ( campaign.from_name.length < 1 ) {
-		messages.push( __( 'Sender name must be set.', 'newspack-newsletters' ) );
-	}
-	if ( campaign.from_email.length < 1 || campaign.reply_to_email.length < 1 ) {
-		messages.push( __( 'Sender email must be set.', 'newspack-newsletters' ) );
-	}
-
 	return messages;
 };
 

--- a/src/service-providers/index.js
+++ b/src/service-providers/index.js
@@ -1,9 +1,11 @@
 import example from './example';
 import mailchimp from './mailchimp';
+import constant_contact from './constant_contact';
 
 const SERVICE_PROVIDERS = {
 	example,
 	mailchimp,
+	constant_contact,
 };
 
 export const getServiceProvider = () => {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Adds support for Constant Contact. 

To avoid overcomplicating this PR, the branch doesn't include UI for selecting ESP and inputting Constant Contact API key and access token. This will be tackled in another PR immediately after this one lands. Temporarily, API key and access token are set as `wp-config` constants.

The implementation uses the V2 API and requires an API key and Access Token. The V3 API seems to require an oAuth flow which wouldn't be appropriate for this use case since there is no centralized application. If this proves problematic we could rearchitect with a WordPress.com endpoint, but this doesn't seem warranted at the moment. 

Here are a few differences between the Constant Contact and Mailchimp implementations:

- Besides list selection, there is no segmentation support in this implementation. 
- Constant Contact throws an error if the campaign name is a duplicate. To get around this I use a unique ID for the list name. This is a pretty strange and unfriendly approach, and I'd be interested in alternative ideas.
- Constant Contact allows sending to multiple lists, so the lists are presented as a set of `CheckboxControl`s rather than a `SelectControl`. This also requires an additional endpoint to unset a list.
- Constant Contact's campaign object supports seprate`reply_to_email` and `from_email` email addresses. In this implementation the two will always be the same.
- Unlike Mailchimp Constant Contact throws an error if a campaign doesn't have a subject or verified sender email. Because of this, new campaigns are initialized with sender (either the CC account's organization name, the name of the account owner, or a fallback) and the first verified email address. This is actually kind of nice, and might be worth implementing in Mailchimp too. 
- Constant Contact's errors are generally pretty clear, so I did away with the `validate()` function used in the Mailchimp implementation and simply display the errors as returned.

Some resources about the Constant Contact V2:

- Docs: https://developer.constantcontact.com/docs/developer-guides/overview-of-api-endpoints.html
- Tester: https://constantcontact.mashery.com/io-docs
- PHP Library: https://github.com/constantcontact/php-sdk
- PHP Library documentation: http://constantcontact.github.io/php-sdk/

A few questions for consideration about the multiple-ESP architecture in general:

- Should the Test sidebar also be ESP-specific? I had to make a small change so that it uses the correct endpoint, but it is conceivable that other ESPs will require slightly different UI. For example, an ESP that supports sending to only one email at a time.
- The API endpoint registration contains a lot of duplication. Should the endpoint definitions be moved into the parent class `Newspack_Newsletters_Service_Provider_Controller` for endpoints that are universal? cc: @iuravic 
- I opted to keep the Mailchimp and Constant Contact campaign ID meta fields distinct, which conceivably means a customer could switch back and forth between ESPs. This lead me to wonder if the Meta registration of these fields should be moved to the ESP classes?

### How to test the changes in this Pull Request:

You will need a Constant Contact account, an API key, and an Access Token to test.

1. Sign up for a Constant Contact account here: https://www.constantcontact.com/
2. Get an API key here: https://constantcontact.mashery.com/
3. Get an Access token by going [here](https://constantcontact.mashery.com/io-docs), pasting the API key in and clicking Get Access Token.
4. Add API key and Access Token to `wp-config` as follows - the presence of these two keys will cause the plugin to use the Constant Contact implementation:
```
define( 'NEWSPACK_NEWSLETTERS_CONSTANT_CONTACT_API_KEY', 'YOUR-API-KEY' );
define( 'NEWSPACK_NEWSLETTERS_CONSTANT_CONTACT_ACCESS_TOKEN', 'YOUR-ACCESS-TOKEN' );
```
5. Check out the branch and run `composer update` (there is a new dependency). 
6. Test all normal flows: create a newsletter, send tests, change the sender info, change the subject, select and deselect lists, send the campaign. 
7. Try setting invalid API key and Access Token to observe errors. 
8. Verify the appearance of Newsletters is roughly the same in Mailchimp and Constant Contact.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
