### PR TITLE
fix: corrected flow after setting esp in modal

### DIFF
--- a/includes/service-providers/constant_contact/class-newspack-newsletters-constant-contact.php
+++ b/includes/service-providers/constant_contact/class-newspack-newsletters-constant-contact.php
@@ -167,6 +167,9 @@ final class Newspack_Newsletters_Constant_Contact extends \Newspack_Newsletters_
 	 * @return object|WP_Error API Response or error.
 	 */
 	public function retrieve( $post_id ) {
+		if ( ! $this->has_api_credentials() ) {
+			return [];
+		}
 		$transient       = sprintf( 'newspack_newsletters_error_%s_%s', $post_id, get_current_user_id() );
 		$persisted_error = get_transient( $transient );
 		if ( $persisted_error ) {

--- a/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp.php
+++ b/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp.php
@@ -132,6 +132,9 @@ final class Newspack_Newsletters_Mailchimp extends \Newspack_Newsletters_Service
 	 * @return object|WP_Error API Response or error.
 	 */
 	public function retrieve( $post_id ) {
+		if ( ! $this->has_api_credentials() ) {
+			return [];
+		}
 		$transient       = sprintf( 'newspack_newsletters_error_%s_%s', $post_id, get_current_user_id() );
 		$persisted_error = get_transient( $transient );
 		if ( $persisted_error ) {

--- a/src/newsletter-editor/editor/index.js
+++ b/src/newsletter-editor/editor/index.js
@@ -77,11 +77,13 @@ const Editor = compose( [
 	// Fetch data from service provider.
 	useEffect(() => {
 		if ( ! props.isCleanNewPost && ! props.isPublishingOrSavingPost ) {
-			props
-				.apiFetchWithErrorHandling( getFetchDataConfig( { postId: props.postId } ) )
-				.then( result => {
-					props.editPost( getEditPostPayload( result ) );
-				} );
+			const params = getFetchDataConfig( { postId: props.postId } );
+			if ( 0 === params.path.indexOf( '/newspack-newsletters/v1/example/' ) ) {
+				return;
+			}
+			props.apiFetchWithErrorHandling( params ).then( result => {
+				props.editPost( getEditPostPayload( result ) );
+			} );
 		}
 	}, [ props.isPublishingOrSavingPost ]);
 

--- a/src/newsletter-editor/sidebar/index.js
+++ b/src/newsletter-editor/sidebar/index.js
@@ -20,8 +20,6 @@ import { getServiceProvider } from '../../service-providers';
 import withApiHandler from '../../components/with-api-handler';
 import './style.scss';
 
-const { ProviderSidebar } = getServiceProvider();
-
 const Sidebar = ( {
 	inFlight,
 	errors,
@@ -124,7 +122,7 @@ const Sidebar = ( {
 			path: `/newspack-newsletters/v1/post-meta/${ postId }`,
 		} );
 	};
-
+	const { ProviderSidebar } = getServiceProvider();
 	return (
 		<Fragment>
 			<ProviderSidebar


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This branch fixes two issues that occur after selecting the Email Service Provider for the first time. 

1. Selecting ESP in the modal occurs too late to update the Service Provider sidebar. As a result, the ESP's sidebar is not correctly loaded.
2. API calls with be made to `/example/` endpoints.

Closes https://github.com/Automattic/newspack-newsletters/issues/298

### How to test the changes in this Pull Request:

#### Issue 1

1. On `master`, navigate to Newsletter->Settings. Remove ESP key, set the Service Provider to "Select service provider," and Save.
2. Create a new Newsletter.
3. In the modal, choose Mailchimp and input Mailchimp API key.
4. Select a Layout.
5. Observe the Newsletter sidebar does not show Mailchimp lists Select.

#### Issue 2

1. On `master` create a Newsletter.
2. Navigate to Newsletter->Settings, remove ESP key and set Service Provider to "Select service provider."
3. Edit the previously created Newsletter.
4. In the modal, choose Mailchimp and input Mailchimp API key. 
5. Observe `No route was found matching the URL and request method` error.

Switch to this branch, repeat these two sequences. Observe there are no errors and all functionality is as expected.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
