### PR TITLE
CI: reset alpha after release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,6 +55,20 @@ jobs:
           name: Release new version
           command: npm run release
 
+  # Reset alpha branch after a release
+  post_release:
+    docker:
+      - image: circleci/php:7.2-node-browsers
+    steps:
+      - checkout_with_workspace
+      - run:
+          name: Set tip of alpha branch on top of release and force-push it to remote
+          command: |
+            git pull origin release
+            git checkout alpha
+            git reset --hard release --
+            git push "https://$GITHUB_TOKEN@github.com/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME.git" --force
+
 workflows:
   version: 2
   main:
@@ -71,3 +85,10 @@ workflows:
               only:
                 - release
                 - alpha
+      - post_release:
+          requires:
+            - release
+          filters:
+            branches:
+              only:
+                - release


### PR DESCRIPTION
After a release, the tag on `release` branch is incremented, but the last tag on `alpha` is not. In order to get proper version on the next alpha release, the `alpha` branch should be reset (on top of `release` after a release). 
No real way to test it, but the same configuration is on `newspack-theme` and can be [seen in action here](https://app.circleci.com/pipelines/github/Automattic/newspack-theme/521/workflows/3a3bb8b7-2c82-4735-a026-c50618314011/jobs/994).