### PR TITLE
Reduce padding between elements in newsletter emails

### DIFF
--- a/includes/class-newspack-newsletters-renderer.php
+++ b/includes/class-newspack-newsletters-renderer.php
@@ -167,7 +167,7 @@ final class Newspack_Newsletters_Renderer {
 		}
 
 		if ( isset( $attrs['full-width'] ) && 'full-width' == $attrs['full-width'] && isset( $attrs['background-color'] ) ) {
-			$attrs['padding'] = '20px 0';
+			$attrs['padding'] = '12px 0';
 		}
 
 		return $attrs;
@@ -230,7 +230,7 @@ final class Newspack_Newsletters_Renderer {
 		// Default attributes for the column which will envelop the component.
 		$column_attrs = array_merge(
 			array(
-				'padding' => '20px',
+				'padding' => '12px',
 			)
 		);
 

--- a/includes/email-template.mjml.php
+++ b/includes/email-template.mjml.php
@@ -63,7 +63,7 @@
 				color: #767676;
 			}
 			.wp-block-quote p {
-				padding-bottom: 20px;
+				padding-bottom: 12px;
 			}
 			.wp-block-quote.is-style-large {
 				border-left: 0;
@@ -90,7 +90,7 @@
 			/* Has Background */
 			.mj-column-has-width .has-background,
 			.mj-column-per-50 .has-background {
-				padding: 20px;
+				padding: 12px;
 			}
 
 			/* Mailchimp Footer */

--- a/src/editor/style.scss
+++ b/src/editor/style.scss
@@ -5,7 +5,7 @@
 
 .wp-block {
 	max-width: 600px;
-	padding: 20px;
+	padding: 12px;
 }
 
 .editor-styles-wrapper {
@@ -57,7 +57,7 @@
 		h6,
 		p {
 			&.has-background {
-				padding: 20px;
+				padding: 12px;
 			}
 		}
 
@@ -102,7 +102,7 @@
 			padding-left: 20px;
 
 			p {
-				margin: 0 0 20px;
+				margin: 0 0 12px;
 			}
 
 			&__citation {
@@ -139,15 +139,15 @@
 				padding: 0;
 
 				&.has-background {
-					padding: 20px;
+					padding: 12px;
 				}
 			}
 		}
 
 		.wp-block {
 			&[data-type='core/list'] {
-				padding: 20px;
-				padding-left: calc( 20px + 1.3em );
+				padding: 12px;
+				padding-left: calc( 12px + 1.3em );
 
 				ol,
 				ul {
@@ -165,8 +165,8 @@
 			}
 
 			&[data-type='core/separator'] {
-				padding-bottom: 20px;
-				padding-top: 20px;
+				padding-bottom: 12px;
+				padding-top: 12px;
 
 				hr {
 					margin-bottom: 0;
@@ -185,8 +185,8 @@
 				padding: 0;
 
 				.wp-block-group.has-background {
-					padding-top: 20px;
-					padding-bottom: 20px;
+					padding-top: 12px;
+					padding-bottom: 12px;
 				}
 			}
 		}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Originally, the newsletters added 20px padding around each element, which means there's typically 40px between things like paragraphs in the newsletters. This feels like a bit too much -- for comparison, the theme has 32px between elements, and the fonts are larger, so it's less space relative to how large the fonts are.

This PR reduces the padding to 12px, leaving a 24px gap between elements, which feels like it fits a bit more.

Closes #281.

### How to test the changes in this Pull Request:

1. Draft up an email, using one of the pre-made layouts, so you have a good variety of elements. Send a test email to yourself.
2. View the email in the editor, and your email client, and note the spacing:

**Editor:**
<img width="1147" alt="image" src="https://user-images.githubusercontent.com/177561/91080702-e1bbfe00-e5fa-11ea-8c64-7154a01d8638.png">

**Email:**
<img width="1024" alt="image" src="https://user-images.githubusercontent.com/177561/91080776-03b58080-e5fb-11ea-8030-94a8298a8587.png">

3. Apply the PR and run `npm run build`.
4. Refresh the editor and send a new fresh test email; confirm that the spacing has been reduced for both:

**Editor:**
<img width="1142" alt="image" src="https://user-images.githubusercontent.com/177561/91080356-462a8d80-e5fa-11ea-8aaa-37a90ae07417.png">

**Email:**
<img width="1025" alt="image" src="https://user-images.githubusercontent.com/177561/91080843-1e87f500-e5fb-11ea-9440-54208e1dba64.png">


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
