### PR TITLE
Fix modal margin and header height

### DIFF
--- a/src/components/init-modal/style.scss
+++ b/src/components/init-modal/style.scss
@@ -17,7 +17,7 @@
 				top: 0;
 
 				.components-modal__header {
-					height: 61px;
+					height: 60px;
 				}
 			}
 		}
@@ -80,12 +80,12 @@
 			// Fullscreen mode
 			.is-fullscreen-mode & {
 				bottom: 0;
-				height: calc( 100vh - 61px );
+				height: calc( 100vh - 60px );
 				left: 0;
 				margin: 0;
 				position: fixed;
 				right: 0;
-				top: 61px;
+				top: 60px;
 			}
 		}
 	}
@@ -117,12 +117,13 @@
 
 		&-wrapper {
 			flex: 0 0 100%;
+			max-width: 600px;
+			padding-left: 24px;
+			padding-right: 24px;
 			position: relative;
 
-			@media only screen and ( min-width: 600px ) {
-				margin-left: auto;
-				margin-right: auto;
-				max-width: 600px;
+			@media only screen and ( min-width: 648px ) {
+				max-width: 648px;
 			}
 		}
 
@@ -146,7 +147,9 @@
 			}
 		}
 
-		select.components-select-control__input {
+		.components-text-control__input,
+		.components-select-control__input {
+			margin: 0;
 			max-width: 100%;
 			width: 100%;
 		}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR fixes the modal header which was off by 1px and make sure the settings have the correct margin on small screens.

### How to test the changes in this Pull Request:

1. Remove your API keys.
2. Create a Newsletter -- notice the header border bottom slightly off
3. On the settings screen, resize your screen at 600px
4. Switch to this branch
5. Refresh and check again

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
