### PR TITLE
feat: option to specify public newsletters slug

### DIFF
--- a/includes/class-newspack-newsletters.php
+++ b/includes/class-newspack-newsletters.php
@@ -239,6 +239,8 @@ final class Newspack_Newsletters {
 	 * Register the custom post type.
 	 */
 	public static function register_cpt() {
+		$public_slug = get_option( 'newspack_newsletters_public_posts_slug', 'newsletter' );
+
 		$labels = [
 			'name'               => _x( 'Newsletters', 'post type general name', 'newspack-newsletters' ),
 			'singular_name'      => _x( 'Newsletter', 'post type singular name', 'newspack-newsletters' ),
@@ -257,12 +259,12 @@ final class Newspack_Newsletters {
 		];
 
 		$cpt_args = [
-			'has_archive'      => true,
+			'has_archive'      => $public_slug,
 			'labels'           => $labels,
 			'public'           => true,
 			'public_queryable' => true,
 			'query_var'        => true,
-			'rewrite'          => [ 'slug' => 'newsletter' ],
+			'rewrite'          => [ 'slug' => $public_slug ],
 			'show_ui'          => true,
 			'show_in_rest'     => true,
 			'supports'         => [ 'editor', 'title', 'custom-fields' ],


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Adds a setting to select the public newsletter slug. The default is `newsletter`. After changing the slug, permalinks will be flushed automatically.

Closes https://github.com/Automattic/newspack-newsletters/issues/318

### How to test the changes in this Pull Request:

1. Create a Page and set the permalink to `newsletter`.
2. Create at least one Newsletter, switch on `Make newsletter page public?`, and publish. 
3. On the frontend, navigate to `/newsletter`. Observe the Newsletter archive page, not the Page created.
4. Navigate to Newsletter->Settings, change `Public Newsletter Posts Slug` to `newsletter-archive`
5. On the frontend navigate to `/newsletter` and observe the Page created in step 1.
6. Navigate to `/newsletter-archive`, observe the Newsletter archive page.
7. Click to view a Newsletter, and observe that `newsletter-archive` is a path component.
8. Input various invalid slugs (e.g. "Not A 'Real' Slug). Observe the text is converted to a valid slug.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
