### PR TITLE
Harden post type checks

### DIFF
--- a/includes/class-newspack-newsletters-editor.php
+++ b/includes/class-newspack-newsletters-editor.php
@@ -154,16 +154,14 @@ final class Newspack_Newsletters_Editor {
 	 * Is editing a newsletter?
 	 */
 	public static function is_editing_newsletter() {
-		$post_type = get_post()->post_type;
-		return Newspack_Newsletters::NEWSPACK_NEWSLETTERS_CPT === $post_type;
+		return Newspack_Newsletters::NEWSPACK_NEWSLETTERS_CPT === get_post_type();
 	}
 
 	/**
 	 * Is editing a newsletter ad?
 	 */
 	public static function is_editing_newsletter_ad() {
-		$post_type = get_post()->post_type;
-		return Newspack_Newsletters_Ads::NEWSPACK_NEWSLETTERS_ADS_CPT === $post_type;
+		return Newspack_Newsletters_Ads::NEWSPACK_NEWSLETTERS_ADS_CPT === get_post_type();
 	}
 }
 Newspack_Newsletters_Editor::instance();


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

I noticed the following errors are thrown when saving events calendar events:

```
[02-Sep-2020 17:48:21 UTC] PHP Notice:  Trying to get property 'post_type' of non-object in /wordpress/plugins/newspack-newsletters/1.11.0/includes/class-newspack-newsletters-editor.php on line 157
[02-Sep-2020 17:48:21 UTC] PHP Notice:  Trying to get property 'post_type' of non-object in /wordpress/plugins/newspack-newsletters/1.11.0/includes/class-newspack-newsletters-editor.php on line 165
```

`get_post` can potentially return `null`, so the code should verify that a post was returned before getting fields from the post. This PR simplifies the post type check and prevents those sorts of issues from happening.

I have a patch for this same issue in Newspack Sponsors at https://github.com/Automattic/newspack-sponsors/pull/42. I'm not sure if these sorts of checks need updating in our other plugins, but it would be worth double-checking.

### How to test the changes in this Pull Request:

1. Newsletters, newsletter ads, events (if you're using events), posts, etc. should save without throwing a notice.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
