### PR TITLE
Posts Inserter: remove empty category select

### DIFF
--- a/src/editor/blocks/posts-inserter/query-controls.js
+++ b/src/editor/blocks/posts-inserter/query-controls.js
@@ -135,8 +135,6 @@ const QueryControlsSettings = ( { attributes, setAttributes } ) => {
 					categorySuggestions={ categorySuggestions }
 					onCategoryChange={ selectCategories }
 					selectedCategories={ attributes.categories }
-					// Support for legacy Gutenberg version.
-					categoriesList={ [] }
 					minItems={ 1 }
 					maxItems={ 20 }
 				/>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

I've tested on Gutenberg versions from `8.5.0` to current (`8.9.2`) and the issue (component crashing without the `categoriesList` prop supplied) is not reproducible, which seems like a good enough buffer. Contrary to what I wrote in #285, it must've been fixed earlier than `8.5.0`.

Closes #285.

### How to test the changes in this Pull Request:

1. Create a Newsletter, insert a Posts Inserter block
2. Observe that there is no empty category select field (issue #285)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
