### PR TITLE
Fix: gate editor with settings modal when no MJML creds are set

### DIFF
--- a/includes/class-newspack-newsletters.php
+++ b/includes/class-newspack-newsletters.php
@@ -717,8 +717,12 @@ final class Newspack_Newsletters {
 
 		if ( self::$provider ) {
 			$response['credentials'] = self::$provider->api_credentials();
-			$response['status']      = self::$provider->has_api_credentials();
 		}
+
+		if ( self::$provider->has_api_credentials() && $mjml_api_key && $mjml_api_secret ) {
+			$response['status'] = true;
+		}
+
 		return $response;
 	}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes a regressions introduced with the ESP selection UI. 

### How to test the changes in this Pull Request:

1. On `master`, remove MJML credentials in the plugin settings
2. Create a new newsletter – observe that there is no settings modal preventing you from doing so
3. Switch to this branch and rebuild
4. Create a new newsletter – observe a settings modal prompting to input MJML credentials

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
