### PR TITLE
Chore: remove author URI

### DIFF
--- a/newspack-newsletters.php
+++ b/newspack-newsletters.php
@@ -4,7 +4,6 @@
  * Plugin URI:      https://newspack.pub
  * Description:     Newsletter authoring using the Gutenberg editor.
  * Author:          Automattic
- * Author URI:      https://newspack.pub
  * Text Domain:     newspack-newsletters
  * Domain Path:     /languages
  * Version:         1.0.0


### PR DESCRIPTION
Because of this error while submitting to WPORG:

> Error: Your plugin and author URIs are the same. Your plugin headers in the main plugin file headers have the same value for both the plugin and author URI (Uniform Resource Identifier). A plugin URI is a webpage that provides details about this specific plugin. An author URI is a webpage that provides information about the author of the plugin. Those two must be different. You are not required to provide both, so pick the one that best applies to your situation.