### PR TITLE
Fix: handle updated gutenberg colors setting

### DIFF
--- a/src/newsletter-editor/editor/index.js
+++ b/src/newsletter-editor/editor/index.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { get, isEmpty } from 'lodash';
+
+/**
  * WordPress dependencies
  */
 import { compose } from '@wordpress/compose';
@@ -30,6 +35,14 @@ const Editor = compose( [
 		const meta = getEditedPostAttribute( 'meta' );
 		const status = getEditedPostAttribute( 'status' );
 		const sentDate = getEditedPostAttribute( 'date' );
+		const settings = getSettings();
+		const experimentalSettingsColors = get( settings, [
+			'__experimentalFeatures',
+			'global',
+			'color',
+			'palette',
+		] );
+		const colors = settings.colors || experimentalSettingsColors || [];
 
 		return {
 			isCleanNewPost: isCleanNewPost(),
@@ -39,8 +52,8 @@ const Editor = compose( [
 				: false,
 			activeSidebarName: getActiveGeneralSidebarName(),
 			isPublishingOrSavingPost: isSavingPost() || isPublishingPost(),
-			colorPalette: getSettings().colors.reduce(
-				( colors, { slug, color } ) => ( { ...colors, [ slug ]: color } ),
+			colorPalette: colors.reduce(
+				( _colors, { slug, color } ) => ( { ..._colors, [ slug ]: color } ),
 				{}
 			),
 			status,
@@ -67,12 +80,15 @@ const Editor = compose( [
 
 	// Set color palette option.
 	useEffect(() => {
+		if ( isEmpty( props.colorPalette ) ) {
+			return;
+		}
 		props.apiFetchWithErrorHandling( {
 			path: `/newspack-newsletters/v1/color-palette`,
 			data: props.colorPalette,
 			method: 'POST',
 		} );
-	}, []);
+	}, [ isEmpty( props.colorPalette ) ]);
 
 	// Fetch data from service provider.
 	useEffect(() => {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Handles breaking changes introduced in https://github.com/WordPress/gutenberg/pull/25419/files#diff-984d8e4bc7759027f99c018c4217d51fa6b563f2c47ed4d5291bac1cd3f305b7R7

Closes #358.

### How to test the changes in this Pull Request:

1. Ensure Gutenberg version is 9.1.1
1. Create or edit a newsletter, set colors of something to some color paletter values (*not* custom colors)
2. Observe that the colors are displayed properly in an email
3. Switch Gutenberg to < 9.0.0
4. Repeat 2, 3

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
