### PR TITLE
feat: setting to opt-in to mailchimp tags

### DIFF
--- a/includes/class-newspack-newsletters-settings.php
+++ b/includes/class-newspack-newsletters-settings.php
@@ -102,6 +102,13 @@ class Newspack_Newsletters_Settings {
 			);
 		}
 
+		$settings_list[] = array(
+			'description' => __( 'Use Mailchimp Tags?', 'newspack-newsletters' ),
+			'key'         => 'newspack_newsletters_use_mailchimp_tags',
+			'type'        => 'checkbox',
+			'provider'    => 'mailchimp',
+		);
+
 		return $settings_list;
 	}
 
@@ -148,6 +155,9 @@ class Newspack_Newsletters_Settings {
 			'newspack-newsletters-settings-admin'
 		);
 		foreach ( self::get_settings_list() as $setting ) {
+			if ( isset( $setting['provider'] ) && get_option( 'newspack_newsletters_service_provider', null ) !== $setting['provider'] ) {
+				continue;
+			}
 			$args = [
 				'sanitize_callback' => ! empty( $setting['sanitize_callback'] ) ? $setting['sanitize_callback'] : 'sanitize_text_field',
 			];

--- a/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp.php
+++ b/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp.php
@@ -173,8 +173,10 @@ final class Newspack_Newsletters_Mailchimp extends \Newspack_Newsletters_Service
 				}
 			}
 
+			$newspack_newsletters_use_mailchimp_tags = get_option( 'newspack_newsletters_use_mailchimp_tags', false );
+
 			$tags = [];
-			if ( $list_id ) {
+			if ( $list_id && $newspack_newsletters_use_mailchimp_tags ) {
 				$tags_response = $this->validate(
 					$mc->get( "lists/$list_id/segments?count=1000", [], 20 ),
 					__( 'Error retrieving Mailchimp tags.', 'newspack_newsletters' )


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Adds a settings checkbox to opt-in to use Mailchimp tags. If unchecked (the default) tags will not be retrieved, and the UI will not be shown. 

Closes https://github.com/Automattic/newspack-newsletters/issues/378

### How to test the changes in this Pull Request:

1. Navigate to Newsletter->Settings. If Mailchimp is the selected provider observe new `Use Mailchimp Tags?` checkbox.
2. Switch to a different provider and save. Observe the checkbox is only visible if Mailchimp is selected.
3. With the checkbox off, create a Newsletter, and select a list. Observe no tags UI is shown.
4. Switch the checkbox on, create  Newsletter and select a list. Assuming there are tags created in the Mailchimp account, you should now see the UI and it should work as it always has.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
