### PR TITLE
Improve MJML request error handling

### DIFF
--- a/includes/class-newspack-newsletters-renderer.php
+++ b/includes/class-newspack-newsletters-renderer.php
@@ -777,10 +777,14 @@ final class Newspack_Newsletters_Renderer {
 					'timeout' => 45, // phpcs:ignore WordPressVIPMinimum.Performance.RemoteRequestTimeout.timeout_timeout
 				)
 			);
-			if ( 401 === intval( $request['response']['code'] ) ) {
-				throw new Exception( __( 'MJML rendering error.', 'newspack_newsletters' ) );
+			if ( is_wp_error( $request ) ) {
+				return $request;
+			} else {
+				if ( 401 === intval( $request['response']['code'] ) ) {
+					throw new Exception( __( 'MJML rendering error.', 'newspack_newsletters' ) );
+				}
+				return json_decode( $request['body'] )->html;
 			}
-			return is_wp_error( $request ) ? $request : json_decode( $request['body'] )->html;
 		}
 	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

If the MJML API request failed, first a PHP would throw with `Uncaught Error: Cannot use object of type WP_Error`. This PR fixes it by doing the `is_wp_error` check first.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
