### PR TITLE
fix: longer timeout for test send

### DIFF
--- a/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp.php
+++ b/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp.php
@@ -309,7 +309,8 @@ final class Newspack_Newsletters_Mailchimp extends \Newspack_Newsletters_Service
 			$result  = $this->validate(
 				$mc->post(
 					"campaigns/$mc_campaign_id/actions/test",
-					$payload
+					$payload,
+					60
 				),
 				__( 'Error sending test email.', 'newspack_newsletters' )
 			);


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Sending a test email often fails with no useful error message, although the email is sent anyway. This is most likely due to an API timeout. This branch simply increases the timeout for test sends to 60s, which is much higher than before.

Closes https://github.com/Automattic/newspack-newsletters/issues/140

### How to test the changes in this Pull Request:

This one is difficult to test.  Just try sending a bunch of test emails from a slow environment and verify there is always a success message.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
