### PR TITLE
fix: alignment for elements using textAlign

### DIFF
--- a/includes/class-newspack-newsletters-renderer.php
+++ b/includes/class-newspack-newsletters-renderer.php
@@ -161,6 +161,11 @@ final class Newspack_Newsletters_Renderer {
 			$attrs['padding'] = '0';
 		}
 
+		if ( isset( $attrs['textAlign'] ) && ! isset( $attrs['align'] ) ) {
+			$attrs['align'] = $attrs['textAlign'];
+			unset( $attrs['textAlign'] );
+		}
+
 		if ( isset( $attrs['align'] ) && 'full' == $attrs['align'] ) {
 			$attrs['full-width'] = 'full-width';
 			unset( $attrs['align'] );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Alignment changes in `Heading` and `Paragraph` blocks recently stopped working in emails, probably due to https://github.com/WordPress/gutenberg/pull/26492. This branch converts `textAlign` attributes to `align`, resolving the issue.

### How to test the changes in this Pull Request:

1. On `master` create a Newsletter with a variety of paragraph and heading alignments.
2. Send a test to yourself, observe the alignment choices are ignored.
3. Switch to this branch, resend the test.
4. Observe correct alignments in the email.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
