### PR TITLE
feat: add support for homepage posts block

### DIFF
--- a/includes/class-newspack-newsletters.php
+++ b/includes/class-newspack-newsletters.php
@@ -80,7 +80,7 @@ final class Newspack_Newsletters {
 		add_filter( 'jetpack_relatedposts_filter_options', [ __CLASS__, 'disable_jetpack_related_posts' ] );
 		add_action( 'save_post_' . self::NEWSPACK_NEWSLETTERS_CPT, [ __CLASS__, 'save' ], 10, 3 );
 		add_action( 'admin_enqueue_scripts', [ __CLASS__, 'branding_scripts' ] );
-
+		add_action( 'pre_get_posts', [ __CLASS__, 'adjust_wp_query_for_public_newsletters' ] );
 		self::set_service_provider( self::service_provider() );
 
 		$needs_nag = is_admin() && ! self::is_service_provider_configured() && ! get_option( 'newspack_newsletters_activation_nag_viewed', false );
@@ -1161,6 +1161,35 @@ final class Newspack_Newsletters {
 	 */
 	public static function service_provider() {
 		return get_option( 'newspack_newsletters_service_provider', false );
+	}
+
+	/**
+	 * Add meta query elements to check if Newsletter is public.
+	 *
+	 * @param object $query The query.
+	 * @return object $query The query.
+	 */
+	public static function adjust_wp_query_for_public_newsletters( $query ) {
+		if ( is_admin() ) {
+			return;
+		}
+		$post_type = $query->get( 'post_type', '' );
+		if ( self::NEWSPACK_NEWSLETTERS_CPT === $post_type || ( is_array( $post_type ) && in_array( self::NEWSPACK_NEWSLETTERS_CPT, $post_type ) ) ) {
+			$meta_query   = $query->get( 'meta_query', [] ); // phpcs:ignore WordPressVIPMinimum.Hooks.PreGetPosts.PreGetPosts
+			$meta_query[] = [
+				'relation' => 'OR',
+				[
+					'key'     => 'is_public',
+					'value'   => true, // This might need to be '1', not sure if it converts it automatically.
+					'compare' => '=',
+				],
+				[
+					'key'     => 'is_public',
+					'compare' => 'NOT EXISTS',
+				],
+			];
+			$query->set( 'meta_query', $meta_query ); // phpcs:ignore WordPressVIPMinimum.Hooks.PreGetPosts.PreGetPosts
+		}
 	}
 }
 Newspack_Newsletters::instance();

--- a/includes/class-newspack-newsletters.php
+++ b/includes/class-newspack-newsletters.php
@@ -1180,7 +1180,7 @@ final class Newspack_Newsletters {
 				'relation' => 'OR',
 				[
 					'key'     => 'is_public',
-					'value'   => true, // This might need to be '1', not sure if it converts it automatically.
+					'value'   => true,
 					'compare' => '=',
 				],
 				[

--- a/includes/class-newspack-newsletters.php
+++ b/includes/class-newspack-newsletters.php
@@ -450,7 +450,7 @@ final class Newspack_Newsletters {
 			'rewrite'          => [ 'slug' => $public_slug ],
 			'show_ui'          => true,
 			'show_in_rest'     => true,
-			'supports'         => [ 'author', 'editor', 'title', 'custom-fields' ],
+			'supports'         => [ 'author', 'editor', 'title', 'custom-fields', 'newspack_blocks' ],
 			'taxonomies'       => [],
 			'menu_icon'        => 'data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIGhlaWdodD0iMjQiIHZpZXdCb3g9IjAgMCAyNCAyNCIgd2lkdGg9IjI0Ij48cGF0aCB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIGQ9Ik0yMS45OSA4YzAtLjcyLS4zNy0xLjM1LS45NC0xLjdMMTIgMSAyLjk1IDYuM0MyLjM4IDYuNjUgMiA3LjI4IDIgOHYxMGMwIDEuMS45IDIgMiAyaDE2YzEuMSAwIDItLjkgMi0ybC0uMDEtMTB6TTEyIDEzTDMuNzQgNy44NCAxMiAzbDguMjYgNC44NEwxMiAxM3oiIGZpbGw9IiNhMGE1YWEiLz48L3N2Zz4K',
 		];


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Adds support for displaying Newsletters in Homepage Posts block. 

<img width="1396" alt="Screen Shot 2021-01-17 at 11 02 37 PM" src="https://user-images.githubusercontent.com/1477002/104871152-58de8f80-5918-11eb-8900-df2f82d21dfd.png">

### How to test the changes in this Pull Request:

1. `newspack-blocks` should be current (https://github.com/Automattic/newspack-blocks/pull/663 should be merged in)
2. Create several public Newsletters.
3. Create a page, add Homepage Posts block. At the bottom of the block sidebar check Newsletters and uncheck Posts.
4. Observe recent Newsletters populate the block.
5. Publish, observe the same Newsletters appear in the front end.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
