### PR TITLE
feat: make Newsletters use post categories + tags

### DIFF
--- a/src/components/send-button/index.js
+++ b/src/components/send-button/index.js
@@ -133,8 +133,8 @@ export default compose( [
 
 		const [ modalVisible, setModalVisible ] = useState( false );
 
-		// For public and published newsletters, display the generic button text.
-		if ( isPublished && is_public ) {
+		// For sent newsletters, display the generic button text.
+		if ( isPublished ) {
 			return (
 				<Button
 					className="editor-post-publish-button"


### PR DESCRIPTION
Also: deprecate the custom taxonomy (migration strategy TBD). Also: allow Newsletters to be saved/updated after they've been sent, whether or not they've been set to be public.

### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Deprecates the custom taxonomies for the Newsletter CPT in favor of regular post categories and tags. This will make it easier to make newsletters appear in Homepage Posts blocks with the right settings, and will also allow public newsletters to appear in category and tag archives alongside regular posts.

Also fixes a tangentially related bug where once you've sent a newsletter and set it to be publicly visible, you could never change the option to make it non-public.

Closes #397.

### How to test the changes in this Pull Request:

1. Check out this branch and run `npm run build`.
2. In the WP admin dashboard, hover over the Newsletters menu item and confirm that the Categories and Tags links now go to the taxonomy admin pages for post categories and tags, respectively.
3. Edit a newsletter and apply a post category and tag. ENABLE the "Make newsletter page public?" option and send the newsletter to publish it.
4. Edit a page and add a Homepage Posts block. Set the post types to enable both Posts and Newsletters, and set the category to the category you added to your published newsletter. Confirm that the newsletter is shown in both the editor and on the front-end of the block.
5. Change the Homepage Posts block attributes to use the tag you assigned to the newsletter instead of the category. Confirm that the newsletter is still shown in both the editor and on the front-end of the block.
6. View the front-end category and tag archives for the category and tag you assigned to the newsletter. Confirm that you see the newsletter on both archive pages.
7. Edit the newsletter and DISABLE the "Make newsletter page public?" option. Confirm that you can update the post to save the change.
8. Repeat steps 4-6, but this time confirm that you do NOT see the newsletter at any step since it's no longer set to be publicly visible.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
