### PR TITLE
Provide settings' values early

### DIFF
--- a/includes/class-newspack-newsletters-settings.php
+++ b/includes/class-newspack-newsletters-settings.php
@@ -109,6 +109,15 @@ class Newspack_Newsletters_Settings {
 			'provider'    => 'mailchimp',
 		);
 
+		$settings_list = array_map(
+			function ( $item ) {
+				$default       = ! empty( $item['default'] ) ? $item['default'] : false;
+				$item['value'] = get_option( $item['key'], $default );
+				return $item;
+			},
+			$settings_list
+		);
+
 		return $settings_list;
 	}
 
@@ -186,8 +195,7 @@ class Newspack_Newsletters_Settings {
 		$key         = $setting['key'];
 		$type        = $setting['type'];
 		$description = $setting['description'];
-		$default     = ! empty( $setting['default'] ) ? $setting['default'] : false;
-		$value       = get_option( $key, $default );
+		$value       = $setting['value'];
 
 		if ( 'select' === $type ) {
 			$options     = $setting['options'];


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

For settings consumption by other plugins.

### How to test the changes in this Pull Request:

1. Visit the plugin settings, observe the values are displayed correctly
2. Update some of them, refresh the page, observe it working as expected 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
