### PR TITLE
Add settings update method

### DIFF
--- a/includes/class-newspack-newsletters-settings.php
+++ b/includes/class-newspack-newsletters-settings.php
@@ -259,8 +259,8 @@ class Newspack_Newsletters_Settings {
 	 * @param string $settings Update.
 	 */
 	public static function update_settings( $settings ) {
-		foreach ($settings as $key => $value) {
-			update_option($key, $value);
+		foreach ( $settings as $key => $value ) {
+			update_option( $key, $value );
 		}
 	}
 }

--- a/includes/class-newspack-newsletters-settings.php
+++ b/includes/class-newspack-newsletters-settings.php
@@ -54,26 +54,31 @@ class Newspack_Newsletters_Settings {
 				'description' => __( 'Mailchimp API Key', 'newspack-newsletters' ),
 				'key'         => 'newspack_newsletters_mailchimp_api_key',
 				'type'        => 'text',
+				'provider'    => 'mailchimp',
 			),
 			array(
 				'description' => __( 'Constant Contact API Key', 'newspack-newsletters' ),
 				'key'         => 'newspack_newsletters_constant_contact_api_key',
 				'type'        => 'text',
+				'provider'    => 'constant_contact',
 			),
 			array(
 				'description' => __( 'Constant Contact API Access token', 'newspack-newsletters' ),
 				'key'         => 'newspack_newsletters_constant_contact_api_access_token',
 				'type'        => 'text',
+				'provider'    => 'constant_contact',
 			),
 			array(
 				'description' => __( 'Campaign Monitor API Key', 'newspack-newsletters' ),
 				'key'         => 'newspack_newsletters_campaign_monitor_api_key',
 				'type'        => 'text',
+				'provider'    => 'campaign_monitor',
 			),
 			array(
 				'description' => __( 'Campaign Monitor Client ID', 'newspack-newsletters' ),
 				'key'         => 'newspack_newsletters_campaign_monitor_client_id',
 				'type'        => 'text',
+				'provider'    => 'campaign_monitor',
 			),
 			array(
 				'description' => __( 'MJML Application ID', 'newspack-newsletters' ),
@@ -164,9 +169,6 @@ class Newspack_Newsletters_Settings {
 			'newspack-newsletters-settings-admin'
 		);
 		foreach ( self::get_settings_list() as $setting ) {
-			if ( isset( $setting['provider'] ) && get_option( 'newspack_newsletters_service_provider', null ) !== $setting['provider'] ) {
-				continue;
-			}
 			$args = [
 				'sanitize_callback' => ! empty( $setting['sanitize_callback'] ) ? $setting['sanitize_callback'] : 'sanitize_text_field',
 			];
@@ -249,6 +251,17 @@ class Newspack_Newsletters_Settings {
 	public static function update_option_newspack_newsletters_public_posts_slug( $old_value, $new_value ) {
 		Newspack_Newsletters::register_cpt();
 		flush_rewrite_rules(); // phpcs:ignore
+	}
+
+	/**
+	 * Update settings.
+	 *
+	 * @param string $settings Update.
+	 */
+	public static function update_settings( $settings ) {
+		foreach ($settings as $key => $value) {
+			update_option($key, $value);
+		}
 	}
 }
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Adds a method to update settings (externally). 

### How to test the changes in this Pull Request:

1. Visit the settings page, observe all settings inputs are present, regardless of the chosen provider
2. Verify settings updating works as expected

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
