### PR TITLE
Fix theme colors in editor

### DIFF
--- a/includes/class-newspack-newsletters-editor.php
+++ b/includes/class-newspack-newsletters-editor.php
@@ -45,7 +45,6 @@ final class Newspack_Newsletters_Editor {
 	/**
 	 * Remove all editor enqueued assets besides this plugins' and disable some editor features.
 	 * This is to prevent theme styles being loaded in the editor.
-	 * Remove editor color palette theme supports - the MJML parser uses a static list of default editor colors.
 	 */
 	public static function strip_editor_modifications() {
 		if ( ! self::is_editing_newsletter() && ! self::is_editing_newsletter_ad() ) {
@@ -63,7 +62,6 @@ final class Newspack_Newsletters_Editor {
 		}
 
 		remove_editor_styles();
-		remove_theme_support( 'editor-color-palette' );
 		add_theme_support( 'editor-gradient-presets', array() );
 		add_theme_support( 'disable-custom-gradients' );
 	}

--- a/src/newsletter-editor/editor/index.js
+++ b/src/newsletter-editor/editor/index.js
@@ -90,7 +90,7 @@ const Editor = compose( [
 			data: props.colorPalette,
 			method: 'POST',
 		} );
-	}, [ isEmpty( props.colorPalette ) ]);
+	}, [ JSON.stringify( props.colorPalette ) ]);
 
 	// Fetch data from service provider.
 	useEffect(() => {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Probably due to some Gutenberg changes, the color settings in the editor were updated later than it was expected. This PR changes it so the color palette is updated on every color settings change.

Closes #414.

### How to test the changes in this Pull Request:

1. Ensure you have custom colors set in theme options
2. Edit a newsletter, observe any block color settings are using the custom colors
3. Send a test email or the newsletter with some blocks colored w/ custom colors - observe the colors are applied

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
