### PR TITLE
Fix: colors of headings with links; top block space in editor

### DIFF
--- a/includes/email-template.mjml.php
+++ b/includes/email-template.mjml.php
@@ -20,7 +20,7 @@
 
 			/* Link */
 			a {
-				color: inherit;
+				color: inherit !important;
 				text-decoration: underline;
 			}
 			a:active, a:focus, a:hover {

--- a/src/newsletter-editor/editor/index.js
+++ b/src/newsletter-editor/editor/index.js
@@ -129,10 +129,13 @@ const Editor = compose( [
 	}, [ props.status ]);
 
 	useEffect(() => {
-		// Unhide post title if the newsletter is a public post.
-		document.querySelector( '.editor-post-title' ).style.display = props.isPublic
-			? 'initial'
-			: 'none';
+		// Hide post title if the newsletter is a not a public post.
+		const editorTitleEl = document.querySelector( '.editor-post-title' );
+		if ( editorTitleEl ) {
+			editorTitleEl.classList[ props.isPublic ? 'remove' : 'add' ](
+				'newspack-newsletters-post-title-hidden'
+			);
+		}
 	}, [ props.isPublic ]);
 
 	return createPortal( <SendButton />, publishEl );

--- a/src/newsletter-editor/editor/style.scss
+++ b/src/newsletter-editor/editor/style.scss
@@ -1,6 +1,10 @@
 .post-type-newspack_nl_cpt {
 	.editor-post-title {
-		display: none;
+		&.newspack-newsletters-post-title-hidden {
+			height: 0;
+			opacity: 0;
+			pointer-events: none;
+		}
 	}
 
 	.components-button.editor-post-publish-button__button.is-primary {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes #409.

### How to test the changes in this Pull Request:

1. On `master`, create or edit a newsletter. Insert a heading block followed by a posts inserter block. Set some nice colors on the headings in the latter.
2. Observe that the block toolbar is not visible when the top block is selected
3. Send a test email - observe the headings in posts inserter are not colored (at least in Gmail web client)
4. Switch to this branch, observe both issues are resolved

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
