### PR TITLE
feat: featured images and pre_get_posts refactor

### DIFF
--- a/includes/class-newspack-newsletters-editor.php
+++ b/includes/class-newspack-newsletters-editor.php
@@ -55,7 +55,7 @@ final class Newspack_Newsletters_Editor {
 		foreach ( $enqueue_block_editor_assets_filters as $index => $filter ) {
 			$action_handlers = array_keys( $filter );
 			foreach ( $action_handlers as $handler ) {
-				if ( __CLASS__ . '::enqueue_block_editor_assets' != $handler ) {
+				if ( __CLASS__ . '::enqueue_block_editor_assets' != $handler && 'newspack_enqueue_scripts' !== $handler ) {
 					remove_action( 'enqueue_block_editor_assets', $handler, $index );
 				}
 			}

--- a/includes/class-newspack-newsletters.php
+++ b/includes/class-newspack-newsletters.php
@@ -78,6 +78,7 @@ final class Newspack_Newsletters {
 		add_action( 'save_post_' . self::NEWSPACK_NEWSLETTERS_CPT, [ __CLASS__, 'save' ], 10, 3 );
 		add_action( 'admin_enqueue_scripts', [ __CLASS__, 'branding_scripts' ] );
 		add_action( 'pre_get_posts', [ __CLASS__, 'adjust_wp_query_for_public_newsletters' ] );
+		add_filter( 'newspack_theme_featured_image_post_types', [ __CLASS__, 'support_featured_image_options' ] );
 		self::set_service_provider( self::service_provider() );
 
 		$needs_nag = is_admin() && ! self::is_service_provider_configured() && ! get_option( 'newspack_newsletters_activation_nag_viewed', false );
@@ -452,7 +453,7 @@ final class Newspack_Newsletters {
 			'rewrite'          => [ 'slug' => $public_slug ],
 			'show_ui'          => true,
 			'show_in_rest'     => true,
-			'supports'         => [ 'author', 'editor', 'title', 'custom-fields', 'newspack_blocks', 'revisions' ],
+			'supports'         => [ 'author', 'editor', 'title', 'custom-fields', 'newspack_blocks', 'revisions', 'thumbnail' ],
 			'taxonomies'       => [ 'category', 'post_tag' ],
 			'menu_icon'        => 'data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIGhlaWdodD0iMjQiIHZpZXdCb3g9IjAgMCAyNCAyNCIgd2lkdGg9IjI0Ij48cGF0aCB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIGQ9Ik0yMS45OSA4YzAtLjcyLS4zNy0xLjM1LS45NC0xLjdMMTIgMSAyLjk1IDYuM0MyLjM4IDYuNjUgMiA3LjI4IDIgOHYxMGMwIDEuMS45IDIgMiAyaDE2YzEuMSAwIDItLjkgMi0ybC0uMDEtMTB6TTEyIDEzTDMuNzQgNy44NCAxMiAzbDguMjYgNC44NEwxMiAxM3oiIGZpbGw9IiNhMGE1YWEiLz48L3N2Zz4K',
 		];
@@ -1165,6 +1166,19 @@ final class Newspack_Newsletters {
 			];
 			$query->set( 'meta_query', $meta_query ); // phpcs:ignore WordPressVIPMinimum.Hooks.PreGetPosts.PreGetPosts
 		}
+	}
+
+	/**
+	 * If using a Newspack theme, add support for featured image options to all listings.
+	 *
+	 * @param array $post_types Array of supported post types.
+	 * @return array Filtered array of supported post types.
+	 */
+	public static function support_featured_image_options( $post_types ) {
+		return array_merge(
+			$post_types,
+			[ self::NEWSPACK_NEWSLETTERS_CPT ]
+		);
 	}
 }
 Newspack_Newsletters::instance();

--- a/includes/class-newspack-newsletters.php
+++ b/includes/class-newspack-newsletters.php
@@ -1143,7 +1143,7 @@ final class Newspack_Newsletters {
 	}
 
 	/**
-	 * If using a Newspack theme, add support for featured image options to all listings.
+	 * If using a Newspack theme, add support for featured image options.
 	 *
 	 * @param array $post_types Array of supported post types.
 	 * @return array Filtered array of supported post types.


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Adds support for featured images to Newsletter posts. If using a Newspack theme, also adds support for the featured image options from the theme, and respects the default featured image set for posts in Customizer.

Also includes a slight refactor of two redundant `pre_get_posts` filters which each affected category/tag archives and newsletter CPT archives in slightly different ways. Now there's just a single callback that handles both cases.

Closes #423.

### How to test the changes in this Pull Request:

#### Featured image and settings

1. In Customizer > Template Settings > Post Settings, update the "Featured Image Default Position" setting and publish.
2. Create a new newsletter or edit an existing one.
3. Expand the Featured Image panel and confirm that the option selected by default matches your Customizer selection.
4. Add a featured image and enable the "Make newsletter page public" option. Send/publish the newsletter.
5. View on the front-end, confirm that the featured image is shown with the selected style.
6. Test each featured image style and confirm that all work as expected.

#### `pre_get_posts` refactor

This is a pure refactor and shouldn't result in any behavioral changes. But since it's a fairly complex feature to begin with, I'm posting testing instructions again:

1. Ensure that you have sent several newsletters, some with the "Make newsletter page public" option enabled, others with it disabled. Make sure some of the public newsletters have categories and tags.
2. While not logged in, view the newsletter CPT archive at your newsletter slug (`newsletter` by default). Confirm that the archive only shows newsletters that were sent and with the "Make newsletter page public" option enabled. Also confirm that all published newsletters with the option enabled are shown.
3. Confirm that as a non-logged-in user, you can see any published newsletters with the "Make newsletter page public" option ENABLED.
4. Confirm that as a non-logged-in user, you can't see any published newsletters with the "Make newsletter page public" option DISABLED.
5. View the archive pages for regular post categories and tags that you've applied to public newsletters.
6. Confirm that the archives show both regular posts as well as published newsletters with both the corresponding term and the "Make newsletter page public" option enabled.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
