### PR TITLE
fix: respect excerpt length setting while not messing up site excerpts

### DIFF
--- a/includes/class-newspack-newsletters-editor.php
+++ b/includes/class-newspack-newsletters-editor.php
@@ -21,6 +21,13 @@ final class Newspack_Newsletters_Editor {
 	protected static $instance = null;
 
 	/**
+	 * Closure for excerpt filtering that can be added and removed.
+	 *
+	 * @var newspack_newsletters_excerpt_length_filter
+	 */
+	public static $newspack_newsletters_excerpt_length_filter = null;
+
+	/**
 	 * Main Newspack Newsletter Editor Instance.
 	 * Ensures only one instance of Newspack Editor Instance is loaded or can be loaded.
 	 *
@@ -40,6 +47,8 @@ final class Newspack_Newsletters_Editor {
 		add_action( 'the_post', [ __CLASS__, 'strip_editor_modifications' ] );
 		add_action( 'enqueue_block_editor_assets', [ __CLASS__, 'enqueue_block_editor_assets' ] );
 		add_filter( 'allowed_block_types', [ __CLASS__, 'newsletters_allowed_block_types' ], 10, 2 );
+		add_action( 'rest_post_query', [ __CLASS__, 'maybe_filter_excerpt_length' ], 10, 2 );
+		add_filter( 'the_posts', [ __CLASS__, 'maybe_reset_excerpt_length' ] );
 	}
 
 	/**
@@ -160,6 +169,80 @@ final class Newspack_Newsletters_Editor {
 	 */
 	public static function is_editing_newsletter_ad() {
 		return Newspack_Newsletters_Ads::NEWSPACK_NEWSLETTERS_ADS_CPT === get_post_type();
+	}
+
+	/**
+	 * If excerpt length is set in Post Inserter block attributes, override the site's excerpt length using the setting.
+	 *
+	 * @param array           $args Request arguments.
+	 * @param WP_REST_Request $request The original REST request params.
+	 *
+	 * @return null Don't modify the request.
+	 */
+	public static function maybe_filter_excerpt_length( $args, $request ) {
+		$params = $request->get_params();
+
+		if ( isset( $params['excerpt_length'] ) ) {
+			self::filter_excerpt_length( intval( $params['excerpt_length'] ) );
+		}
+
+		return null;
+	}
+
+	/**
+	 * After fetching posts, reset the excerpt length.
+	 *
+	 * @param array $posts Array of posts.
+	 *
+	 * @return array Unmodified array of posts.
+	 */
+	public static function maybe_reset_excerpt_length( $posts ) {
+		if ( self::$newspack_newsletters_excerpt_length_filter ) {
+			self::remove_excerpt_length_filter();
+		}
+
+		return $posts;
+	}
+
+	/**
+	 * Filter for excerpt length.
+	 *
+	 * @param int $excerpt_length Excerpt length to set.
+	 */
+	public static function filter_excerpt_length( $excerpt_length ) {
+		// If showing excerpt, filter the length using the block attribute.
+		if ( is_int( $excerpt_length ) ) {
+			self::$newspack_newsletters_excerpt_length_filter = add_filter(
+				'excerpt_length',
+				function() use ( $excerpt_length ) {
+					return $excerpt_length;
+				},
+				999
+			);
+			add_filter( 'wc_memberships_trimmed_restricted_excerpt', [ __CLASS__, 'remove_wc_memberships_excerpt_limit' ], 999 );
+		}
+	}
+
+	/**
+	 * Remove excerpt length filter after newsletters post loop.
+	 */
+	public static function remove_excerpt_length_filter() {
+		remove_filter(
+			'excerpt_length',
+			self::$newspack_newsletters_excerpt_length_filter,
+			999
+		);
+		remove_filter( 'wc_memberships_trimmed_restricted_excerpt', [ __CLASS__, 'remove_wc_memberships_excerpt_limit' ] );
+	}
+
+	/**
+	 * Function to override WooCommerce Membership's Excerpt Length filter.
+	 *
+	 * @return string Current post's original excerpt.
+	 */
+	public static function remove_wc_memberships_excerpt_limit() {
+		$excerpt = get_the_excerpt( get_the_id() );
+		return $excerpt;
 	}
 }
 Newspack_Newsletters_Editor::instance();

--- a/includes/class-newspack-newsletters-editor.php
+++ b/includes/class-newspack-newsletters-editor.php
@@ -177,7 +177,7 @@ final class Newspack_Newsletters_Editor {
 	 * @param array           $args Request arguments.
 	 * @param WP_REST_Request $request The original REST request params.
 	 *
-	 * @return null Don't modify the request.
+	 * @return array Unmodified request args.
 	 */
 	public static function maybe_filter_excerpt_length( $args, $request ) {
 		$params = $request->get_params();
@@ -186,7 +186,7 @@ final class Newspack_Newsletters_Editor {
 			self::filter_excerpt_length( intval( $params['excerpt_length'] ) );
 		}
 
-		return null;
+		return $args;
 	}
 
 	/**

--- a/src/editor/blocks/posts-inserter/index.js
+++ b/src/editor/blocks/posts-inserter/index.js
@@ -244,6 +244,7 @@ const PostsInserterBlockWithSelect = compose( [
 			tags,
 			tagExclusions,
 			categoryExclusions,
+			excerptLength,
 		} = props.attributes;
 		const { getEntityRecords, getMedia } = select( 'core' );
 		const { getSelectedBlock, getBlocks, getSettings } = select( 'core/block-editor' );
@@ -268,6 +269,7 @@ const PostsInserterBlockWithSelect = compose( [
 							exclude: preventDeduplication ? [] : exclude,
 							categories_exclude: categoryExclusions,
 							tags_exclude: tagExclusions,
+							excerpt_length: excerptLength,
 						},
 						value => ! isUndefined( value )
 				  );

--- a/src/editor/blocks/posts-inserter/index.js
+++ b/src/editor/blocks/posts-inserter/index.js
@@ -120,19 +120,19 @@ const PostsInserterBlock = ( {
 	const blockControlsImages = [
 		{
 			icon: 'align-none',
-			title: __( 'Show image on top', 'newspack-blocks' ),
+			title: __( 'Show image on top', 'newspack-newsletters' ),
 			isActive: attributes.featuredImageAlignment === 'top',
 			onClick: () => setAttributes( { featuredImageAlignment: 'top' } ),
 		},
 		{
 			icon: 'align-pull-left',
-			title: __( 'Show image on left', 'newspack-blocks' ),
+			title: __( 'Show image on left', 'newspack-newsletters' ),
 			isActive: attributes.featuredImageAlignment === 'left',
 			onClick: () => setAttributes( { featuredImageAlignment: 'left' } ),
 		},
 		{
 			icon: 'align-pull-right',
-			title: __( 'Show image on right', 'newspack-blocks' ),
+			title: __( 'Show image on right', 'newspack-newsletters' ),
 			isActive: attributes.featuredImageAlignment === 'right',
 			onClick: () => setAttributes( { featuredImageAlignment: 'right' } ),
 		},


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Filters the excerpt length server-side so that the length set in Posts Inserter block attributes can override the site's excerpt length.

Because Newsletters uses standard REST API endpoints and not custom endpoints, we need to hook into `rest_post_query` and `the_posts` hooks to know when to set and reset the excerpt length, respectively.

Should behave similarly to https://github.com/Automattic/newspack-blocks/pull/701.

Closes #424.

### How to test the changes in this Pull Request:

1. Create or edit a newsletter, add a Posts Inserter block.
2. Turn on the "Display post excerpt" option and set an excerpt length to something much longer than the default (55), such as `100`.
3. On `master`, observe that in the block preview and a sent test email, the excerpts shown in the block don't exceed 55 words even though the block attribute is set to 100.
4. Check out this branch and run `npm run build`.
5. Refresh the newsletter and confirm that now, the excerpt lengths match the block attribute setting, even if it exceeds 55. Send the test letter and confirm the same is true in the sent email.
6. View some pages showing post excerpts, such as an archive page and a page with Homepage Posts blocks. Verify that the Posts Inserter excerpt length setting doesn't affect the excerpts in these other contexts, because the filter is removed as soon as the newsletter posts query returns posts.
7. Retest 4-6 with a very short excerpt length setting (such as `10`). Confirm again that the excerpts rendered in all contexts (newsletter editor, newsletter email, Homepage Posts block, archive pages) have the expected lengths.
8. (Optional) Follow testing instructions for https://github.com/Automattic/newspack-blocks/pull/701 and https://github.com/Automattic/newspack-blocks/pull/694 and confirm that excerpts still behave as expected in all contexts.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
