### PR TITLE
fix: avoid potentially undefined nested property

### DIFF
--- a/src/service-providers/constant_contact/ProviderSidebar.js
+++ b/src/service-providers/constant_contact/ProviderSidebar.js
@@ -15,7 +15,7 @@ const ProviderSidebar = ( {
 	updateMeta,
 } ) => {
 	const campaign = newsletterData.campaign;
-	const lists = newsletterData.lists ? newsletterData.lists : [];
+	const lists = newsletterData.lists || [];
 
 	const setList = ( listId, value ) => {
 		const method = value ? 'PUT' : 'DELETE';

--- a/src/service-providers/mailchimp/ProviderSidebar.js
+++ b/src/service-providers/mailchimp/ProviderSidebar.js
@@ -89,7 +89,7 @@ const ProviderSidebar = ( {
 	updateMeta,
 } ) => {
 	const campaign = newsletterData.campaign;
-	const lists = newsletterData.lists ? newsletterData.lists.lists : [];
+	const lists = newsletterData.lists?.lists || [];
 
 	const setList = listId =>
 		apiFetch( {

--- a/src/service-providers/mailchimp/index.js
+++ b/src/service-providers/mailchimp/index.js
@@ -52,10 +52,8 @@ const renderPreSendInfo = newsletterData => {
 	}
 	let listData;
 	if ( newsletterData.campaign && newsletterData.lists ) {
-		const list = find( newsletterData.lists.lists, [
-			'id',
-			newsletterData.campaign.recipients.list_id,
-		] );
+		const lists = newsletterData.lists?.lists || [];
+		const list = find( lists, [ 'id', newsletterData.campaign.recipients.list_id ] );
 		if ( list ) {
 			listData = {
 				name: list.name,


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Should avoid a mysterious error reported by a publisher that resulted in a hard editor crash:

```
TypeError: Cannot read property 'map' of undefined
    at ProviderSidebar (webpack:///./src/service-providers/mailchimp/ProviderSidebar.js?:185:101)
    at we (https://newspack.test/wp-includes/js/dist/vendor/react-dom.min.js?ver=16.13.1:84:293)
    at He (https://newspack.test/wp-includes/js/dist/vendor/react-dom.min.js?ver=16.13.1:97:464)
    at zj (https://newspack.test/wp-includes/js/dist/vendor/react-dom.min.js?ver=16.13.1:228:406)
    at Th (https://newspack.test/wp-includes/js/dist/vendor/react-dom.min.js?ver=16.13.1:152:223)
    at tj (https://newspack.test/wp-includes/js/dist/vendor/react-dom.min.js?ver=16.13.1:152:152)
    at Te (https://newspack.test/wp-includes/js/dist/vendor/react-dom.min.js?ver=16.13.1:146:151)
    at https://newspack.test/wp-includes/js/dist/vendor/react-dom.min.js?ver=16.13.1:61:68
    at unstable_runWithPriority (https://newspack.test/wp-includes/js/dist/vendor/react.min.js?ver=16.13.1:25:260)
    at Da (https://newspack.test/wp-includes/js/dist/vendor/react-dom.min.js?ver=16.13.1:60:280)
```

I had a hard time replicating the bug through normal means, but [this variable assignment](https://github.com/Automattic/newspack-newsletters/blob/master/src/service-providers/mailchimp/ProviderSidebar.js#L92):

```
const lists = newsletterData.lists ? newsletterData.lists.lists : [];
```

means that it's possible that `lists` could end up being `undefined` if `newsletterData.lists` exists but without the second nested `lists` property. Using [optional chaining syntax](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Optional_chaining) instead ensures that `lists` always ends up being an array, avoiding errors such as the above even if the API request to get newsletter data from the service provider results in malformed data.

We might consider showing an error notice in this situation, too, but I didn't implement that here.

### How to test the changes in this Pull Request:

1. Spoof the value of the `lists` property [here](https://github.com/Automattic/newspack-newsletters/blob/master/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp.php#L188) to be some garbage but truthy value, such as a string, or an object without a `lists` property. This could happen if the [Mailchimp API request to fetch lists](https://mailchimp.com/developer/marketing/api/lists/get-lists-info/) returns an error response with a non-4XX status code.
2. In Newsletter settings, make sure your Service Provider is set to Mailchimp and you have a Mailchimp account connected to your site.
3. Create or edit a newsletter and observe a hard editor crash and a JS error similar to the above (it might say `Cannot read property 'find' of undefined` instead—I actually couldn't replicate a situation in which the `find` [here](https://github.com/Automattic/newspack-newsletters/blob/master/src/service-providers/mailchimp/ProviderSidebar.js#L146) would evaluate but the `map` [here](https://github.com/Automattic/newspack-newsletters/blob/master/src/service-providers/mailchimp/ProviderSidebar.js#L165) would fail, the situation which would result in the reported error).
4. Check out this branch, run `npm run build`.
5. Refresh the newsletter editor and this time observe that the editor doesn't crash, and the Mailchimp lists dropdown degrades gracefully with empty options.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
