### PR TITLE
fix (posts inserter): display authors attribute

### DIFF
--- a/includes/class-newspack-newsletters-editor.php
+++ b/includes/class-newspack-newsletters-editor.php
@@ -48,6 +48,7 @@ final class Newspack_Newsletters_Editor {
 		add_action( 'enqueue_block_editor_assets', [ __CLASS__, 'enqueue_block_editor_assets' ] );
 		add_filter( 'allowed_block_types', [ __CLASS__, 'newsletters_allowed_block_types' ], 10, 2 );
 		add_action( 'rest_post_query', [ __CLASS__, 'maybe_filter_excerpt_length' ], 10, 2 );
+		add_action( 'rest_api_init', [ __CLASS__, 'add_newspack_author_info' ] );
 		add_filter( 'the_posts', [ __CLASS__, 'maybe_reset_excerpt_length' ] );
 	}
 
@@ -190,6 +191,26 @@ final class Newspack_Newsletters_Editor {
 	}
 
 	/**
+	 * Append author info to the posts REST response so we can append Coauthors, if they exist.
+	 */
+	public static function add_newspack_author_info() {
+		/* Add author info source */
+		register_rest_field(
+			'post',
+			'newspack_author_info',
+			[
+				'get_callback' => [ __CLASS__, 'newspack_get_author_info' ],
+				'schema'       => [
+					'context' => [
+						'edit',
+					],
+					'type'    => 'array',
+				],
+			]
+		);
+	}
+
+	/**
 	 * After fetching posts, reset the excerpt length.
 	 *
 	 * @param array $posts Array of posts.
@@ -243,6 +264,47 @@ final class Newspack_Newsletters_Editor {
 	public static function remove_wc_memberships_excerpt_limit() {
 		$excerpt = get_the_excerpt( get_the_id() );
 		return $excerpt;
+	}
+
+	/**
+	 * Append author data to the REST /posts response, so we can include Coauthors, link and display names.
+	 *
+	 * @param object $post Post object for the post being returned.
+	 * @return object Formatted data for all authors associated with the post.
+	 */
+	public static function newspack_get_author_info( $post ) {
+		$author_data = [];
+
+		if ( function_exists( 'get_coauthors' ) ) {
+			$authors = get_coauthors();
+
+			foreach ( $authors as $author ) {
+				$author_link = null;
+				if ( function_exists( 'coauthors_posts_links' ) ) {
+					$author_link = get_author_posts_url( $author->ID, $author->user_nicename );
+				}
+				$author_data[] = [
+					/* Get the author name */
+					'display_name' => esc_html( $author->display_name ),
+					/* Get the author ID */
+					'id'           => $author->ID,
+					/* Get the author Link */
+					'author_link'  => $author_link,
+				];
+			}
+		} else {
+			$author_data[] = [
+				/* Get the author name */
+				'display_name' => get_the_author_meta( 'display_name', $post['author'] ),
+				/* Get the author ID */
+				'id'           => $post['author'],
+				/* Get the author Link */
+				'author_link'  => get_author_posts_url( $post['author'] ),
+			];
+		}
+
+		/* Return the author data */
+		return $author_data;
 	}
 }
 Newspack_Newsletters_Editor::instance();

--- a/src/editor/blocks/posts-inserter/utils.js
+++ b/src/editor/blocks/posts-inserter/utils.js
@@ -71,7 +71,7 @@ const getAuthorBlockTemplate = ( post, { textFontSize, textColor } ) => {
 			if ( author_link && display_name ) {
 				const comma =
 					newspack_author_info.length > 2 && index < newspack_author_info.length - 1
-						? _x( ', ', 'comma separator for multiple authors', 'newspack-newsletters' )
+						? _x( ',', 'comma separator for multiple authors', 'newspack-newsletters' )
 						: '';
 				const and =
 					newspack_author_info.length > 1 && index === newspack_author_info.length - 1

--- a/src/editor/blocks/posts-inserter/utils.js
+++ b/src/editor/blocks/posts-inserter/utils.js
@@ -6,7 +6,7 @@ import { omit } from 'lodash';
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { __, _x } from '@wordpress/i18n';
 import { createBlock, getBlockContent } from '@wordpress/blocks';
 import { dateI18n, __experimentalGetSettings } from '@wordpress/date';
 
@@ -62,16 +62,33 @@ const getExcerptBlockTemplate = ( post, { excerptLength, textFontSize, textColor
 };
 
 const getAuthorBlockTemplate = ( post, { textFontSize, textColor } ) => {
-	if (
-		Array.isArray( post.newspack_author_info ) &&
-		post.newspack_author_info.length &&
-		post.newspack_author_info[ 0 ].display_name
-	) {
+	const { newspack_author_info } = post;
+
+	if ( Array.isArray( newspack_author_info ) && newspack_author_info.length ) {
+		const authorLinks = newspack_author_info.reduce( ( acc, author, index ) => {
+			const { author_link, display_name } = author;
+
+			if ( author_link && display_name ) {
+				const comma =
+					newspack_author_info.length > 2 && index < newspack_author_info.length - 1
+						? _x( ', ', 'comma separator for multiple authors', 'newspack-newsletters' )
+						: '';
+				const and =
+					newspack_author_info.length > 1 && index === newspack_author_info.length - 1
+						? __( 'and ', 'newspack-newsletters' )
+						: '';
+				acc.push( `${ and }<a href="${ author_link }">${ display_name }</a>${ comma }` );
+			}
+
+			return acc;
+		}, [] );
+
 		return [
-			'core/paragraph',
+			'core/heading',
 			assignFontSize( textFontSize, {
-				content: __( 'By ', 'newspack-newsletters' ) + post.newspack_author_info[ 0 ].display_name,
+				content: __( 'By ', 'newspack-newsletters' ) + authorLinks.join( ' ' ),
 				fontSize: 'normal',
+				level: 6,
 				style: { color: { text: textColor } },
 			} ),
 		];


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

https://github.com/Automattic/newspack-blocks/pull/725 broke the display of authors in the Posts Inserter block, exposing a dependency on the Newspack Blocks plugin. This PR gets author info in the Newsletters plugin so there's no dependency. Works both with and without Co-Authors Plus.

### How to test the changes in this Pull Request:

1. On `master` create or edit a newsletter draft and insert a Posts Inserter block.
2. In the block attributes, turn on the "Display author" option. Observe that the author bylines are not rendered in either the preview (both before and after clicking "Insert posts") or the sent email after sending yourself a test.
3. Check out this branch, run `npm run build`.
4. Refresh the newsletter. This time confirm that the author bylines are displayed with each post when the "Display author" option is on, both in the preview (both before and after clicking "Insert posts") and in the sent email after sending yourself a test.
5. Test with both Co-Authors Plus activated and not activated; make sure some of the posts shown in the Posts Inserter block have multiple authors assigned via Co-Authors Plus. (If Co-Authors Plus is not activated, only one author will be shown per post.)
6. Test with one author, two authors, and more authors. With Co-Authors Plus activated, all authors should be shown with appropriate separators:
  - "Author 1" in the case of one author
  - "Author 1 and Author 2" in the case of two authors
  - "Author 1, Author 2, and Author 3" in the case of three or more authors
7. Send the email and enable the "Make newsletter page public" option.
8. View the newsletter on the site front-end and confirm that the author bylines display as expected, both with and without Co-Authors Plus.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
