### PR TITLE
fix: minor bugfixes

### DIFF
--- a/includes/class-newspack-newsletters-renderer.php
+++ b/includes/class-newspack-newsletters-renderer.php
@@ -351,7 +351,7 @@ final class Newspack_Newsletters_Renderer {
 					$anchor        = $xpath->query( '//a' )[0];
 					$attrs         = $button_block['attrs'];
 					$text          = $anchor->textContent; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
-					$border_radius = isset( $attrs['borderRadius'] ) ? $attrs['borderRadius'] : 28;
+					$border_radius = isset( $attrs['borderRadius'] ) ? $attrs['borderRadius'] : 5;
 					$is_outlined   = isset( $attrs['className'] ) && 'is-style-outline' == $attrs['className'];
 
 					$default_button_attrs = array(
@@ -362,8 +362,9 @@ final class Newspack_Newsletters_Renderer {
 						'border-radius' => $border_radius . 'px',
 						'font-size'     => '18px',
 						'font-family'   => $font_family,
+						'font-weight'   => 'bold',
 						// Default color - will be replaced by get_colors if there are colors set.
-						'color'         => $is_outlined ? '#32373c' : '#fff',
+						'color'         => $is_outlined ? '#32373c' : '#fff !important',
 					);
 					if ( $is_outlined ) {
 						$default_button_attrs['background-color'] = 'transparent';

--- a/includes/class-newspack-newsletters-renderer.php
+++ b/includes/class-newspack-newsletters-renderer.php
@@ -492,7 +492,7 @@ final class Newspack_Newsletters_Renderer {
 				}
 
 				if ( isset( $attrs['width'] ) ) {
-					$column_attrs['width']     = $attrs['width'] . '%';
+					$column_attrs['width']     = $attrs['width'];
 					$column_attrs['css-class'] = 'mj-column-has-width';
 				}
 
@@ -518,7 +518,7 @@ final class Newspack_Newsletters_Renderer {
 					}
 				};
 				foreach ( $no_width_cols_indexes as $no_width_cols_index ) {
-					$inner_blocks[ $no_width_cols_index ]['attrs']['width'] = ( 100 - $widths_sum ) / count( $no_width_cols_indexes );
+					$inner_blocks[ $no_width_cols_index ]['attrs']['width'] = ( 100 - $widths_sum ) / count( $no_width_cols_indexes ) . '%';
 				};
 
 				if ( isset( $attrs['color'] ) ) {

--- a/src/editor/blocks/posts-inserter/index.js
+++ b/src/editor/blocks/posts-inserter/index.js
@@ -235,6 +235,8 @@ const PostsInserterBlockWithSelect = compose( [
 	withSelect( ( select, props ) => {
 		const {
 			postsToShow,
+			order,
+			orderBy,
 			categories,
 			isDisplayingSpecificPosts,
 			specificPosts,
@@ -261,6 +263,8 @@ const PostsInserterBlockWithSelect = compose( [
 						{
 							categories: catIds,
 							tags,
+							order,
+							orderby: orderBy,
 							per_page: postsToShow,
 							exclude: preventDeduplication ? [] : exclude,
 							categories_exclude: categoryExclusions,

--- a/src/editor/blocks/posts-inserter/index.js
+++ b/src/editor/blocks/posts-inserter/index.js
@@ -235,8 +235,6 @@ const PostsInserterBlockWithSelect = compose( [
 	withSelect( ( select, props ) => {
 		const {
 			postsToShow,
-			order,
-			orderBy,
 			categories,
 			isDisplayingSpecificPosts,
 			specificPosts,
@@ -263,8 +261,6 @@ const PostsInserterBlockWithSelect = compose( [
 						{
 							categories: catIds,
 							tags,
-							order,
-							orderby: orderBy,
 							per_page: postsToShow,
 							exclude: preventDeduplication ? [] : exclude,
 							categories_exclude: categoryExclusions,

--- a/src/editor/blocks/posts-inserter/query-controls.js
+++ b/src/editor/blocks/posts-inserter/query-controls.js
@@ -11,6 +11,7 @@ import {
 	Button,
 	QueryControls,
 	FormTokenField,
+	SelectControl,
 	ToggleControl,
 	Spinner,
 } from '@wordpress/components';
@@ -264,6 +265,40 @@ const QueryControlsSettings = ( { attributes, setAttributes } ) => {
 								fetchSuggestions={ fetchTagSuggestions }
 								fetchSavedInfo={ fetchSavedTags }
 								label={ __( 'Excluded Tags', 'newspack-newsletters' ) }
+							/>
+							<SelectControl
+								key="query-controls-order-select"
+								label={ __( 'Order by' ) }
+								value={ `${ attributes.orderBy }/${ attributes.order }` }
+								options={ [
+									{
+										label: __( 'Newest to oldest' ),
+										value: 'date/desc',
+									},
+									{
+										label: __( 'Oldest to newest' ),
+										value: 'date/asc',
+									},
+									{
+										/* translators: label for ordering posts by title in ascending order */
+										label: __( 'A → Z' ),
+										value: 'title/asc',
+									},
+									{
+										/* translators: label for ordering posts by title in descending order */
+										label: __( 'Z → A' ),
+										value: 'title/desc',
+									},
+								] }
+								onChange={ value => {
+									const [ newOrderBy, newOrder ] = value.split( '/' );
+									if ( newOrder !== attributes.order ) {
+										setAttributes( { order: newOrder } );
+									}
+									if ( newOrderBy !== attributes.orderBy ) {
+										setAttributes( { orderBy: newOrderBy } );
+									}
+								} }
 							/>
 						</Fragment>
 					) }

--- a/src/editor/blocks/posts-inserter/query-controls.js
+++ b/src/editor/blocks/posts-inserter/query-controls.js
@@ -224,10 +224,7 @@ const QueryControlsSettings = ( { attributes, setAttributes } ) => {
 			) : (
 				<Fragment>
 					<QueryControls
-						{ ...{ order: attributes.order, orderBy: attributes.orderBy } }
 						numberOfItems={ attributes.postsToShow }
-						onOrderChange={ value => setAttributes( { order: value } ) }
-						onOrderByChange={ value => setAttributes( { orderBy: value } ) }
 						onNumberOfItemsChange={ value => setAttributes( { postsToShow: value } ) }
 						categorySuggestions={ categorySuggestions }
 						onCategoryChange={ selectCategories }

--- a/src/editor/blocks/posts-inserter/utils.js
+++ b/src/editor/blocks/posts-inserter/utils.js
@@ -117,9 +117,11 @@ const createBlockTemplatesForSinglePost = ( post, attributes ) => {
 	const hasFeaturedImage = post.featuredImageLargeURL || post.featuredImageMediumURL;
 
 	if ( attributes.displayFeaturedImage && hasFeaturedImage ) {
+		const featuredImageId = post.featured_media;
 		const getImageBlock = ( alignCenter = false ) => [
 			'core/image',
 			{
+				id: featuredImageId,
 				url: alignCenter ? post.featuredImageLargeURL : post.featuredImageMediumURL,
 				href: post.link,
 				...( alignCenter ? { align: 'center' } : {} ),


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Some low-hanging fixes for various minor issues.

### How to test the changes in this Pull Request:

#### Fix column rendering

Column blocks with a `width` attribute were getting converted to MJML with an extra `%`, breaking their styling in the sent email. Fixes #432.

1. Insert two sets of Columns blocks into a newsletter. One should have columns with no set width, the other should have width values (such as 50%/50% or 33%/66%—the exact values don't matter).
2. On `master`, send yourself a test email. Confirm that the rendering of the second set of columns (with column widths set) is as described in #432.
3. Check out this branch, send another test.
4. Confirm that both sets of columns now render as expected, respecting the widths defined in block settings.

#### Move sort options for Posts Inserter to Advanced Filters

Closes #427.

1. Insert a Posts Inserter block in a newsletter. Confirm that there is no longer an "Order by" option in the sidebar attributes.
2. Click "Show Advanced Filters". Confirm that the "Order by" dropdown now lives under the Tag/Category Exclusion options, and that it still functions as expected.

#### Make images editable after inserting posts from Posts Inserter

Sets the `id` attribute on image blocks created by the Posts Inserter, enabling standard editing features. Closes #438.

1. On `master`, insert a Posts Inserter block into a newsletter. Make sure the "Display featured image" option is enabled and that it's showing featured images in the preview.
2. Click "Insert Posts" to convert the query preview to blocks.
3. Select one of the images created from the Posts Inserter—confirm that the toolbar lacks the edit options available when you insert an image block manually.
4. Repeat steps 1-3 with this branch, but this time confirm that images are editable with the same toolbar options as when you insert an image block manually.

#### Tweak default button attributes to more closely resemble theme styles

When a newsletter is previewed or viewed as a public page, it takes on theme styles, which may differ from the default styles set MJML. The difference is unavoidable without importing theme CSS to the MJML (which I think would be too heavy-handed), but is especially noticeable for buttons. This tweaks the default attributes for buttons rendered by MJML to more closely resemble the button styles set by the theme, so at least the default border radius and the default white text color match. Closes #434.

1. Insert a button into a newsletter without changing the border radius or color settings.
2. On `master`, note the disparity in button styles between the editor, the previewed page, and the sent email. It will likely look something like this:

In editor:
<img width="172" alt="Screen Shot 2021-04-19 at 3 29 25 PM" src="https://user-images.githubusercontent.com/2230142/115305777-13eb1480-a124-11eb-9519-d53ebeba4efd.png">

In previewed page:
<img width="162" alt="Screen Shot 2021-04-19 at 3 30 39 PM" src="https://user-images.githubusercontent.com/2230142/115305868-3bda7800-a124-11eb-9331-1622d0fad673.png">

In sent email:
<img width="181" alt="Screen Shot 2021-04-19 at 3 27 50 PM" src="https://user-images.githubusercontent.com/2230142/115305882-40069580-a124-11eb-9502-c19606021c73.png">

3. Check out this branch, refresh the email in the editor. Confirm that button styles are now closer across all three contexts, if not exactly identical:

In editor and sent email:
<img width="197" alt="Screen Shot 2021-04-19 at 3 27 30 PM" src="https://user-images.githubusercontent.com/2230142/115305991-6b898000-a124-11eb-9c62-72d936301428.png">

In previewed page:
<img width="162" alt="Screen Shot 2021-04-19 at 3 30 39 PM" src="https://user-images.githubusercontent.com/2230142/115306003-6fb59d80-a124-11eb-8fcd-2989107b623b.png">


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
