### PR TITLE
Fix: use full post object in renderer

### DIFF
--- a/includes/class-newspack-newsletters.php
+++ b/includes/class-newspack-newsletters.php
@@ -785,14 +785,11 @@ final class Newspack_Newsletters {
 	 * @param WP_REST_Request $request API request object.
 	 */
 	public static function api_get_mjml( $request ) {
-		if ( empty( $request['title'] ) ) {
-			$request['title'] = get_the_title( $request['id'] );
+		$post = get_post( $request['id'] );
+		if ( ! empty( $request['title'] ) ) {
+			$post->post_title = $request['title'];
 		}
-		$post = (object) [
-			'post_title'   => $request['title'],
-			'post_content' => $request['content'],
-			'ID'           => $request['id'],
-		];
+		$post->post_content = $request['content'];
 		return \rest_ensure_response( [ 'mjml' => Newspack_Newsletters_Renderer::render_post_to_mjml( $post ) ] );
 	}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Recent changes changed what is passed to the MJML-rendering method from a full WP Post to a post-like object. To be safe and ready for other integrations (#399) this PR ensures a full post is passed to the method.

### How to test the changes in this Pull Request:

This is a refactor, email processing should work as expected.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->