### PR TITLE
feat: register posts inserter block if editing a reusable block

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -37,6 +37,7 @@ node_modules
 .git
 .github
 .circleci
-/src
+/src/**/*.js
+/src/**/*.scss
 /tests
 /bin

--- a/includes/class-newspack-newsletters-editor.php
+++ b/includes/class-newspack-newsletters-editor.php
@@ -138,9 +138,29 @@ final class Newspack_Newsletters_Editor {
 			wp_enqueue_style( 'newspack-newsletters-ads-page' );
 		}
 
+		// If it's a reusable block, register this plugin's blocks.
+		if ( 'wp_block' === get_post_type() ) {
+			\wp_enqueue_script(
+				'newspack-newsletters-blocks',
+				plugins_url( '../dist/blocks.js', __FILE__ ),
+				[],
+				filemtime( NEWSPACK_NEWSLETTERS_PLUGIN_FILE . 'dist/blocks.js' ),
+				true
+			);
+			wp_register_style(
+				'newspack-newsletters-blocks',
+				plugins_url( '../dist/blocks.css', __FILE__ ),
+				[],
+				filemtime( NEWSPACK_NEWSLETTERS_PLUGIN_FILE . 'dist/blocks.css' )
+			);
+			wp_style_add_data( 'newspack-newsletters-blocks', 'rtl', 'replace' );
+			wp_enqueue_style( 'newspack-newsletters-blocks' );
+		}
+
 		if ( ! self::is_editing_newsletter() ) {
 			return;
 		}
+
 		\wp_enqueue_script(
 			'newspack-newsletters',
 			plugins_url( '../dist/editor.js', __FILE__ ),

--- a/includes/class-newspack-newsletters.php
+++ b/includes/class-newspack-newsletters.php
@@ -495,10 +495,16 @@ final class Newspack_Newsletters {
 	 * Register blocks server-side for front-end rendering.
 	 */
 	public static function register_blocks() {
+		$block_definition = json_decode(
+			file_get_contents( __DIR__ . '/../src/editor/blocks/posts-inserter/block.json' ), // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
+			true
+		);
 		register_block_type(
-			'newspack-newsletters/posts-inserter',
+			$block_definition['name'],
 			[
 				'render_callback' => [ __CLASS__, 'render_posts_inserter_block' ],
+				'attributes'      => $block_definition['attributes'],
+				'supports'        => $block_definition['supports'],
 			]
 		);
 	}

--- a/src/editor/blocks/index.js
+++ b/src/editor/blocks/index.js
@@ -1,0 +1,6 @@
+/**
+ * Internal dependencies
+ */
+import registerPostsInserterBlock from './posts-inserter';
+
+registerPostsInserterBlock();

--- a/src/editor/blocks/posts-inserter/block.json
+++ b/src/editor/blocks/posts-inserter/block.json
@@ -1,0 +1,85 @@
+{
+  "name": "newspack-newsletters/posts-inserter",
+  "category": "widgets",
+  "supports": [
+    "align"
+  ],
+  "attributes": {
+		"areBlocksInserted": {
+			"type": "boolean",
+			"default": false
+		},
+		"postsToShow": {
+			"type": "number",
+			"default": 3
+		},
+		"displayPostExcerpt": {
+			"type": "boolean",
+			"default": true
+		},
+		"excerptLength": {
+			"type": "number",
+			"default": 15
+		},
+		"displayPostDate": {
+			"type": "boolean",
+			"default": false
+		},
+		"displayFeaturedImage": {
+			"type": "boolean",
+			"default": true
+		},
+		"displayContinueReading": {
+			"type": "boolean",
+			"default": false
+		},
+		"innerBlocksToInsert": {
+			"type": "array",
+			"default": []
+		},
+		"featuredImageAlignment": {
+			"type": "string",
+			"default": "left"
+		},
+		"isDisplayingSpecificPosts": {
+			"type": "boolean",
+			"default": false
+		},
+		"specificPosts": {
+			"type": "array",
+			"default": []
+		},
+		"textFontSize": {
+			"type": "number",
+			"default": 16
+		},
+		"headingFontSize": {
+			"type": "number",
+			"default": 25
+		},
+		"textColor": {
+			"type": "string",
+			"default": "#000"
+		},
+		"headingColor": {
+			"type": "string",
+			"default": "#000"
+		},
+		"tags": {
+			"type": "array",
+			"default": []
+		},
+		"tagExclusions": {
+			"type": "array",
+			"default": []
+		},
+		"categories": {
+			"type": "array",
+			"default": []
+		},
+		"categoryExclusions": {
+			"type": "array",
+			"default": []
+		}
+  }
+}

--- a/src/editor/blocks/posts-inserter/index.js
+++ b/src/editor/blocks/posts-inserter/index.js
@@ -33,6 +33,7 @@ import { Fragment, useEffect, useMemo, useState } from '@wordpress/element';
  */
 import './style.scss';
 import './deduplication';
+import blockDefinition from './block.json';
 import Icon from './icon';
 import { getTemplateBlocks, convertBlockSerializationFormat } from './utils';
 import QueryControlsSettings from './query-controls';
@@ -329,84 +330,10 @@ const PostsInserterBlockWithSelect = compose( [
 
 export default () => {
 	registerBlockType( POSTS_INSERTER_BLOCK_NAME, {
+		...blockDefinition,
 		title: 'Posts Inserter',
-		category: 'widgets',
 		icon: Icon,
 		edit: PostsInserterBlockWithSelect,
-		attributes: {
-			areBlocksInserted: {
-				type: 'boolean',
-				default: false,
-			},
-			postsToShow: {
-				type: 'number',
-				default: 3,
-			},
-			displayPostExcerpt: {
-				type: 'boolean',
-				default: true,
-			},
-			excerptLength: {
-				type: 'number',
-				default: 15,
-			},
-			displayPostDate: {
-				type: 'boolean',
-				default: false,
-			},
-			displayFeaturedImage: {
-				type: 'boolean',
-				default: true,
-			},
-			displayAuthor: {
-				type: 'boolean',
-				default: false,
-			},
-			innerBlocksToInsert: {
-				type: 'array',
-				default: '',
-			},
-			featuredImageAlignment: {
-				type: 'string',
-				default: 'left',
-			},
-			isDisplayingSpecificPosts: {
-				type: 'boolean',
-				default: false,
-			},
-			specificPosts: {
-				type: 'array',
-				default: [],
-			},
-			textFontSize: {
-				type: 'number',
-				default: 16,
-			},
-			headingFontSize: {
-				type: 'number',
-				default: 25,
-			},
-			textColor: {
-				type: 'string',
-				default: '#000',
-			},
-			headingColor: {
-				type: 'string',
-				default: '#000',
-			},
-			tags: {
-				type: 'array',
-				default: [],
-			},
-			tagExclusions: {
-				type: 'array',
-				default: [],
-			},
-			categoryExclusions: {
-				type: 'array',
-				default: [],
-			},
-		},
 		save: () => <InnerBlocks.Content />,
 	} );
 };

--- a/src/editor/blocks/posts-inserter/style.scss
+++ b/src/editor/blocks/posts-inserter/style.scss
@@ -1,4 +1,5 @@
 @import '~@wordpress/base-styles/colors';
+
 .newspack-posts-inserter {
 	border: 1px solid $dark-gray-primary;
 	border-radius: 2px;

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -16,6 +16,7 @@ const editor = path.join( __dirname, 'src', 'editor' );
 const admin = path.join( __dirname, 'src', 'admin' );
 const adsEditor = path.join( __dirname, 'src', 'ads-admin', 'editor' );
 const branding = path.join( __dirname, 'src', 'branding' );
+const blocks = path.join( __dirname, 'src', 'editor', 'blocks' );
 
 const webpackConfig = getBaseWebpackConfig(
 	{ WP: true },
@@ -25,6 +26,7 @@ const webpackConfig = getBaseWebpackConfig(
 			admin,
 			adsEditor,
 			branding,
+			blocks,
 		},
 		'output-path': path.join( __dirname, 'dist' ),
 	}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes #451 

### How to test the changes in this Pull Request:

1. Edit a newsletter, create a reusable block containing Posts Inserter
2. Edit the reusable block, observe the Posts Inserter is loading 
3. Ensure all blocks settings are carried over after being edited as the reusable block

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->