### PR TITLE
Prevent Gravity Forms scripts from being injected into newsletter markup

### DIFF
--- a/includes/class-newspack-newsletters.php
+++ b/includes/class-newspack-newsletters.php
@@ -79,6 +79,7 @@ final class Newspack_Newsletters {
 		add_action( 'save_post_' . self::NEWSPACK_NEWSLETTERS_CPT, [ __CLASS__, 'save' ], 10, 3 );
 		add_action( 'admin_enqueue_scripts', [ __CLASS__, 'branding_scripts' ] );
 		add_filter( 'newspack_theme_featured_image_post_types', [ __CLASS__, 'support_featured_image_options' ] );
+		add_filter( 'gform_force_hooks_js_output', [ __CLASS__, 'suppress_gravityforms_js_on_newsletters' ] );
 		self::set_service_provider( self::service_provider() );
 
 		$needs_nag = is_admin() && ! self::is_service_provider_configured() && ! get_option( 'newspack_newsletters_activation_nag_viewed', false );
@@ -1134,6 +1135,20 @@ final class Newspack_Newsletters {
 			$post_types,
 			[ self::NEWSPACK_NEWSLETTERS_CPT ]
 		);
+	}
+
+	/**
+	 * Prevent Gravityforms from injecting scripts into the newsletter markup.
+	 *
+	 * @param bool $force_js Whether to force GF to inject scripts (default: true).
+	 * @return bool Modified $force_js.
+	 */
+	public static function suppress_gravityforms_js_on_newsletters( $force_js ) {
+		if ( self::NEWSPACK_NEWSLETTERS_CPT === get_post_type() ) {
+			return false;
+		}
+
+		return $force_js;
 	}
 }
 Newspack_Newsletters::instance();


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes #467 

Gravity Forms was injecting un-escaped scripts into the newsletter markup, breaking the JSON. Since newsletters don't need and can't have any scripts, this PR prevents Gravity Forms from injecting their scripts on newsletters.

### How to test the changes in this Pull Request:

1. Install and activate Gravityforms.
2. Save a draft newsletter. Observe "Update failed" message.

![Screen Shot 2021-05-29 at 9 06 31 AM](https://user-images.githubusercontent.com/7317227/121225944-de6ac980-c83e-11eb-81ec-55e0bd198f95.png)

3. Activate this PR. Save a draft newsletter. Observe no "Update failed" message

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
