### PR TITLE
Feature/bulk action

### DIFF
--- a/includes/class-newspack-newsletters.php
+++ b/includes/class-newspack-newsletters.php
@@ -1258,7 +1258,7 @@ final class Newspack_Newsletters {
 				'ajaxurl' => get_admin_url() . 'admin-ajax.php',
 			]
 		);
-		wp_enque_script( $script );
+        wp_enqueue_script( $script );
 	}
 
 	/**

--- a/includes/class-newspack-newsletters.php
+++ b/includes/class-newspack-newsletters.php
@@ -1258,7 +1258,7 @@ final class Newspack_Newsletters {
 				'ajaxurl' => get_admin_url() . 'admin-ajax.php',
 			]
 		);
-		wp_2ue_script( $script );
+		wp_enque_script( $script );
 	}
 
 	/**

--- a/src/quickedit/index.js
+++ b/src/quickedit/index.js
@@ -1,0 +1,33 @@
+jQuery(function($){
+
+	// it is a copy of the inline edit function
+	var wp_inline_edit_function = inlineEditPost.edit;
+
+	// we overwrite the it with our own
+	inlineEditPost.edit = function( post_id ) {
+
+		// let's merge arguments of the original function
+		wp_inline_edit_function.apply( this, arguments );
+
+		// get the post ID from the argument
+		var id = 0;
+		if ( typeof( post_id ) == 'object' ) { // if it is object, get the ID number
+			id = parseInt( this.getId( post_id ) );
+		}
+
+		//if post id exists
+		if ( id > 0 ) {
+			// add rows to variables
+			var specific_post_edit_row = $( '#edit-' + id ),
+					specific_post_row = $( '#post-' + id ),
+					public_val = false; // let's say by default checkbox is unchecked
+
+			// check if the Featured Product column says Yes
+			if( $( '.column-public', specific_post_row ).text() == 'Yes' ) public_val = true;
+
+			// populate the inputs with column data
+			
+			$( ':input[name="npublic"]', specific_post_edit_row ).prop('checked', public_val );
+		}
+	}
+});

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -16,6 +16,7 @@ const editor = path.join( __dirname, 'src', 'editor' );
 const admin = path.join( __dirname, 'src', 'admin' );
 const adsEditor = path.join( __dirname, 'src', 'ads-admin', 'editor' );
 const branding = path.join( __dirname, 'src', 'branding' );
+const quickedit = path.join( __dirname, 'src', 'quickedit' );
 const blocks = path.join( __dirname, 'src', 'editor', 'blocks' );
 
 const webpackConfig = getBaseWebpackConfig(
@@ -26,6 +27,7 @@ const webpackConfig = getBaseWebpackConfig(
 			admin,
 			adsEditor,
 			branding,
+			quickedit,
 			blocks,
 		},
 		'output-path': path.join( __dirname, 'dist' ),


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

- [x] Added, "Make Newsletters Public" and "Make Newsletters Non-public" options in Bulk action.
- [x]On click of "Make Newsletters Public", it will make Newsletters public, and on click of "Make Newsletters Non-public" will make Newsletters non-public
- [x] Added Quick edit option for Newsletters fields. 
- [x] Added Column "Published as a post" to display public and non-public newsletters pages.
- [x] On quick edit, Administrator user can check/uncheck the option to make newsletters public which will make newsletters display as public  / non-public.
- [x] Added admin notice on click of bulk action 

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Enhancement of Bulk action feature where admin user can update newsletters page to public/non-public from bulk actions or from quick edit.
### How to test the changes in this Pull Request:

1. After cloning this latest repo. Please follow the below commands 
 composer update
npm install
npm run build
2.Admin >> Newsletters >> listing: When admin user will select bulk newsletters from listing and select "Make Newsletters Public" option from Bulk action dropdown and click on the "Apply" button it will make those newsletters public. It will also update column "Published as a post" in table listing with Yes. Same way if the admin user will select "Make Newsletters Non-public", it will update the column value to No.
3.Admin user can also go to edit page and check "Make Newsletters Public " toggle from the sidebar is on / off based on public / non-public selection.4. Admin can also go to quick edit and check the checkbox for making newsletters public and uncheck the checkbox "Make Newsletters Public" to make newsletters non-public.

<!-- Mark completed items with an [x] -->
