### PR TITLE
fix: allow editor users to edit and send newsletters

### DIFF
--- a/includes/class-newspack-newsletters-ads.php
+++ b/includes/class-newspack-newsletters-ads.php
@@ -82,7 +82,7 @@ final class Newspack_Newsletters_Ads {
 			'edit.php?post_type=' . Newspack_Newsletters::NEWSPACK_NEWSLETTERS_CPT,
 			__( 'Newsletters Ads', 'newspack-newsletters' ),
 			__( 'Ads', 'newspack-newsletters' ),
-			'manage_options',
+			'edit_others_posts',
 			'/edit.php?post_type=' . self::NEWSPACK_NEWSLETTERS_ADS_CPT,
 			null,
 			2

--- a/includes/class-newspack-newsletters.php
+++ b/includes/class-newspack-newsletters.php
@@ -741,7 +741,7 @@ final class Newspack_Newsletters {
 			[
 				'methods'             => \WP_REST_Server::EDITABLE,
 				'callback'            => [ __CLASS__, 'api_set_color_palette' ],
-				'permission_callback' => [ __CLASS__, 'api_administration_permissions_check' ],
+				'permission_callback' => [ __CLASS__, 'api_authoring_permissions_check' ],
 			]
 		);
 		\register_rest_route(
@@ -750,7 +750,7 @@ final class Newspack_Newsletters {
 			[
 				'methods'             => \WP_REST_Server::EDITABLE,
 				'callback'            => [ __CLASS__, 'api_get_mjml' ],
-				'permission_callback' => [ __CLASS__, 'api_administration_permissions_check' ],
+				'permission_callback' => [ __CLASS__, 'api_authoring_permissions_check' ],
 				'args'                => [
 					'id'      => [
 						'required'          => true,


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Editor users currently have only partial access to the newsletters plugin. They can view newsletter posts, but they don't have access to the MJML renderer (so they can't send emails) and they can't see newsletter ads in the dashboard. This PR updates permissions to allow editors to fully edit newsletters, send test and live email campaigns, and view and edit newsletter ads. It still blocks access to the Newsletter Settings page, which seems like it was an intentional choice.

### How to test the changes in this Pull Request:

1. Log into a test site as an editor user (not admin).
2. Observe that in the dashboard, the "Newsletters" menu item only has the following submenu items: All Newsletters, Add New, Categories, Tags (no Ads or Settings)
3. Edit an existing newsletter post. Observe an error saying "You cannot use this resource" when you try to do any of the following: load the newsletter in the editor, update color options, send a test email or live email.
4. Check out this branch, refresh. Confirm that you're now able to edit all newsletter campaign options and send test and live emails.
5. Confirm that in WP admin, there's now a Newsletters > Ads menu item. Confirm that you can view, create, and edit newsletter ads.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
