### PR TITLE
Public newsletters – add bulk and quick edit option

### DIFF
--- a/includes/class-newspack-newsletters-bulk-actions.php
+++ b/includes/class-newspack-newsletters-bulk-actions.php
@@ -42,7 +42,7 @@ class Newspack_Newsletters_Bulk_Actions {
 	 * @return array Updated bulk actions. 
 	 */
 	public static function register_bulk_actions( $bulk_actions ) {
-		$bulk_actions['newsletters_public']     = __( 'Make newsletters page public', 'newspack-newsletters' );
+		$bulk_actions['newsletters_public']     = __( 'Make newsletter pages public', 'newspack-newsletters' );
 		$bulk_actions['newsletters_non_public'] = __( 'Make newsletter pages non-public', 'newspack-newsletters' );
 		return $bulk_actions;
 	}
@@ -84,7 +84,7 @@ class Newspack_Newsletters_Bulk_Actions {
 			$count = (int) $_REQUEST['newsletters_public_count'];
 			printf(
 				/* translators: %d updated posts count */
-				'<div id="message" class="updated notice is-dismissable"><p>' . esc_html( _n( '%d newsletter now have public page available.', '%d newsletters now have public page available.', $count, 'newspack-newsletters' ) ) . '</p></div>',
+				'<div id="message" class="updated notice is-dismissable"><p>' . esc_html( _n( '%d newsletter now has public page available.', '%d newsletters now have public page available.', $count, 'newspack-newsletters' ) ) . '</p></div>',
 				esc_attr( number_format_i18n( $count ) )
 			);
 		}

--- a/includes/class-newspack-newsletters-bulk-actions.php
+++ b/includes/class-newspack-newsletters-bulk-actions.php
@@ -1,0 +1,102 @@
+<?php
+/**
+ * Newspack Newsletters Bulk Actions
+ *
+ * @package Newspack
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Newspack Newsletters Bulk Actions Class.
+ */
+class Newspack_Newsletters_Bulk_Actions {
+	/**
+	 * Set up hooks.
+	 */
+	public static function init() {
+		add_filter( 'removable_query_args', [ __CLASS__, 'register_removable_args' ] );
+		add_filter( 'bulk_actions-edit-newspack_nl_cpt', [ __CLASS__, 'register_bulk_actions' ] );
+		add_filter( 'handle_bulk_actions-edit-newspack_nl_cpt', [ __CLASS__, 'bulk_action_handler' ], 10, 3 );
+		add_action( 'admin_notices', [ __CLASS__, 'admin_notices' ] );
+	}
+
+	/**
+	 * Register removable query args.
+	 * 
+	 * @param array $removable_query_args Removable query args.
+	 * 
+	 * @return array Updated removable query args.
+	 */
+	public static function register_removable_args( $removable_query_args ) {
+		$removable_query_args[] = 'newsletters_public_count';
+		$removable_query_args[] = 'newsletters_non_public_count';
+		return $removable_query_args;
+	}
+
+	/**
+	 * Register bulk action fields in bulk action dropdown.
+	 * 
+	 * @param array $bulk_actions Bulk actions.
+	 * 
+	 * @return array Updated bulk actions. 
+	 */
+	public static function register_bulk_actions( $bulk_actions ) {
+		$bulk_actions['newsletters_public']     = __( 'Make newsletters page public', 'newspack-newsletters' );
+		$bulk_actions['newsletters_non_public'] = __( 'Make newsletters page non-public', 'newspack-newsletters' );
+		return $bulk_actions;
+	}
+
+	/**
+	 * Bulk action handler.
+	 * 
+	 * @param string $redirect_to Redirect URL.
+	 * @param string $action_name Action name.
+	 * @param array  $post_ids    Post IDs.
+	 */
+	public static function bulk_action_handler( $redirect_to, $action_name, $post_ids ) {
+		$redirect_to = remove_query_arg( array( 'newsletters_public_count', 'newsletters_non_public_count' ), $redirect_to );
+		switch ( $action_name ) {
+			case 'newsletters_public':
+				foreach ( $post_ids as $post_id ) {
+					update_post_meta( $post_id, 'is_public', true );
+				}
+				$redirect_to = add_query_arg( 'newsletters_public_count', count( $post_ids ), $redirect_to );
+				break;
+			case 'newsletters_non_public':
+				foreach ( $post_ids as $post_id ) {
+					update_post_meta( $post_id, 'is_public', false );
+				}
+				$redirect_to = add_query_arg( 'newsletters_non_public_count', count( $post_ids ), $redirect_to );
+				break;
+		}
+		return $redirect_to;
+	}
+
+	/**
+	 * Admin notice on bulk action update result.
+	 */
+	public static function admin_notices() {
+		if ( isset( $_REQUEST['newsletters_public_count'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			$count = (int) $_REQUEST['newsletters_public_count']; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			printf(
+				/* translators: %d updated posts count */
+				'<div id="message" class="updated notice is-dismissable"><p>' . esc_html( _n( '%d newsletter now have public page available.', '%d newsletters now have public page available.', $count, 'newspack-newsletters' ) ) . '</p></div>',
+				esc_attr( number_format_i18n( $count ) )
+			);
+		}
+
+		if ( isset( $_REQUEST['newsletters_non_public_count'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			$count = (int) $_REQUEST['newsletters_non_public_count']; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			printf( 
+				/* translators: %d updated posts count */
+				'<div id="message" class="updated notice is-dismissable"><p>' . esc_html( _n( '%d newsletter now have public page disabled.', '%d newsletters now have public page disabled.', $count, 'newspack-newsletters' ) ) . '</p></div>',
+				esc_attr( number_format_i18n( $count ) )
+			);
+		}
+	}
+}
+
+if ( is_admin() ) {
+	Newspack_Newsletters_Bulk_Actions::init();
+}

--- a/includes/class-newspack-newsletters-bulk-actions.php
+++ b/includes/class-newspack-newsletters-bulk-actions.php
@@ -93,7 +93,7 @@ class Newspack_Newsletters_Bulk_Actions {
 			$count = (int) $_REQUEST['newsletters_non_public_count'];
 			printf( 
 				/* translators: %d updated posts count */
-				'<div id="message" class="updated notice is-dismissable"><p>' . esc_html( _n( '%d newsletter now have public page disabled.', '%d newsletters now have public page disabled.', $count, 'newspack-newsletters' ) ) . '</p></div>',
+				'<div id="message" class="updated notice is-dismissable"><p>' . esc_html( _n( '%d newsletter now has public page disabled.', '%d newsletters now have public page disabled.', $count, 'newspack-newsletters' ) ) . '</p></div>',
 				esc_attr( number_format_i18n( $count ) )
 			);
 		}

--- a/includes/class-newspack-newsletters-bulk-actions.php
+++ b/includes/class-newspack-newsletters-bulk-actions.php
@@ -75,10 +75,13 @@ class Newspack_Newsletters_Bulk_Actions {
 
 	/**
 	 * Admin notice on bulk action update result.
+	 * 
+	 * phpcs:disable WordPress.Security.NonceVerification.Recommended
+	 * Bulk actions nonces are verified by the core, before the action handler and admin_notices.
 	 */
 	public static function admin_notices() {
-		if ( isset( $_REQUEST['newsletters_public_count'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
-			$count = (int) $_REQUEST['newsletters_public_count']; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		if ( isset( $_REQUEST['newsletters_public_count'] ) ) {
+			$count = (int) $_REQUEST['newsletters_public_count'];
 			printf(
 				/* translators: %d updated posts count */
 				'<div id="message" class="updated notice is-dismissable"><p>' . esc_html( _n( '%d newsletter now have public page available.', '%d newsletters now have public page available.', $count, 'newspack-newsletters' ) ) . '</p></div>',
@@ -86,8 +89,8 @@ class Newspack_Newsletters_Bulk_Actions {
 			);
 		}
 
-		if ( isset( $_REQUEST['newsletters_non_public_count'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
-			$count = (int) $_REQUEST['newsletters_non_public_count']; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		if ( isset( $_REQUEST['newsletters_non_public_count'] ) ) {
+			$count = (int) $_REQUEST['newsletters_non_public_count'];
 			printf( 
 				/* translators: %d updated posts count */
 				'<div id="message" class="updated notice is-dismissable"><p>' . esc_html( _n( '%d newsletter now have public page disabled.', '%d newsletters now have public page disabled.', $count, 'newspack-newsletters' ) ) . '</p></div>',
@@ -95,6 +98,7 @@ class Newspack_Newsletters_Bulk_Actions {
 			);
 		}
 	}
+	// phpcs:enable WordPress.Security.NonceVerification.Recommended
 }
 
 if ( is_admin() ) {

--- a/includes/class-newspack-newsletters-bulk-actions.php
+++ b/includes/class-newspack-newsletters-bulk-actions.php
@@ -43,7 +43,7 @@ class Newspack_Newsletters_Bulk_Actions {
 	 */
 	public static function register_bulk_actions( $bulk_actions ) {
 		$bulk_actions['newsletters_public']     = __( 'Make newsletters page public', 'newspack-newsletters' );
-		$bulk_actions['newsletters_non_public'] = __( 'Make newsletters page non-public', 'newspack-newsletters' );
+		$bulk_actions['newsletters_non_public'] = __( 'Make newsletter pages non-public', 'newspack-newsletters' );
 		return $bulk_actions;
 	}
 

--- a/includes/class-newspack-newsletters-quick-edit.php
+++ b/includes/class-newspack-newsletters-quick-edit.php
@@ -1,0 +1,97 @@
+<?php
+/**
+ * Newspack Newsletters Quick Edit
+ *
+ * @package Newspack
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Newspack Newsletters Quick Edit Class.
+ */
+class Newspack_Newsletters_Quick_Edit {
+	/**
+	 * Set up hooks.
+	 */
+	public static function init() {
+		add_action( 'admin_enqueue_scripts', [ __CLASS__, 'enqueue_scripts' ] );
+		add_action( 'quick_edit_custom_box', [ __CLASS__, 'quick_edit_box' ], 10, 2 );
+		add_action( 'save_post', [ __CLASS__, 'save' ], 10, 2 );
+	}
+  
+	/**
+	 * Enqueue Quick Edit scripts used to update inputs.
+	 */
+	public static function enqueue_scripts() {
+		$screen = get_current_screen();
+		if ( Newspack_Newsletters::NEWSPACK_NEWSLETTERS_CPT !== $screen->post_type ) {
+			return;
+		}
+		wp_enqueue_script(
+			'newspack-newsletters-quickEdit',
+			plugins_url( '../dist/quickEdit.js', __FILE__ ),
+			[ 'jquery', 'wp-api-fetch' ],
+			filemtime( NEWSPACK_NEWSLETTERS_PLUGIN_FILE . 'dist/quickEdit.js' ),
+			true
+		);
+	}
+
+	/**
+	 * Display "Make newsletter page public" checkbox field
+	 * 
+	 * @param string $column_name Coulumn name.
+	 * @param string $post_type   Post Type.
+	 */
+	public static function quick_edit_box( $column_name, $post_type ) {
+		if (
+			'public_page' !== $column_name ||
+			Newspack_Newsletters::NEWSPACK_NEWSLETTERS_CPT !== $post_type
+		) {
+			return;
+		}
+		?>
+		<fieldset class="inline-edit-col-right">
+			<div class="inline-edit-col">
+				<div class="inline-edit-group wp-clearfix">
+					<label class="alignleft">
+						<input type="checkbox" name="switch_public_page">
+						<span class="checkbox-title"><?php _e( 'Make newsletter page public?', 'newspack-newsletters' ); ?></span>
+					</label>
+				</div>
+			</div>
+			<?php wp_nonce_field( 'newspack_nl_quick_edit', 'newspack_nl_quick_edit_nonce' ); ?>
+		</fieldset>
+		<?php
+	}
+
+	/**
+	 * Save Quick Edit action values.
+	 * 
+	 * @param int     $post_id Post ID.
+	 * @param WP_Post $post    The post being saved.
+	 */
+	public static function save( $post_id, $post ) {
+		if ( ! current_user_can( 'edit_post', $post_id ) ) {
+			return;
+		}
+		if ( Newspack_Newsletters::NEWSPACK_NEWSLETTERS_CPT !== $post->post_type ) {
+			return;
+		}
+		if (
+			! isset( $_POST['newspack_nl_quick_edit_nonce'] ) ||
+			! wp_verify_nonce( sanitize_text_field( $_POST['newspack_nl_quick_edit_nonce'] ), 'newspack_nl_quick_edit' )
+		) {
+			return;
+		}
+		update_post_meta(
+			$post_id,
+			'is_public',
+			isset( $_POST['switch_public_page'] ) && sanitize_text_field( $_POST['switch_public_page'] )
+		);
+	}
+}
+
+if ( is_admin() ) {
+	Newspack_Newsletters_Quick_Edit::init();
+}

--- a/includes/class-newspack-newsletters-quick-edit.php
+++ b/includes/class-newspack-newsletters-quick-edit.php
@@ -17,7 +17,7 @@ class Newspack_Newsletters_Quick_Edit {
 	public static function init() {
 		add_action( 'admin_enqueue_scripts', [ __CLASS__, 'enqueue_scripts' ] );
 		add_action( 'quick_edit_custom_box', [ __CLASS__, 'quick_edit_box' ], 10, 2 );
-		add_action( 'save_post', [ __CLASS__, 'save' ], 10, 2 );
+		add_action( 'save_post_newspack_nl_cpt', [ __CLASS__, 'save' ] );
 	}
   
 	/**
@@ -68,14 +68,10 @@ class Newspack_Newsletters_Quick_Edit {
 	/**
 	 * Save Quick Edit action values.
 	 * 
-	 * @param int     $post_id Post ID.
-	 * @param WP_Post $post    The post being saved.
+	 * @param int $post_id Post ID.
 	 */
-	public static function save( $post_id, $post ) {
+	public static function save( $post_id ) {
 		if ( ! current_user_can( 'edit_post', $post_id ) ) {
-			return;
-		}
-		if ( Newspack_Newsletters::NEWSPACK_NEWSLETTERS_CPT !== $post->post_type ) {
 			return;
 		}
 		if (

--- a/includes/class-newspack-newsletters.php
+++ b/includes/class-newspack-newsletters.php
@@ -73,6 +73,8 @@ final class Newspack_Newsletters {
 		add_filter( 'display_post_states', [ __CLASS__, 'display_post_states' ], 10, 2 );
 		add_action( 'pre_get_posts', [ __CLASS__, 'maybe_display_public_archive_posts' ] );
 		add_action( 'template_redirect', [ __CLASS__, 'maybe_display_public_post' ] );
+		add_filter( 'manage_' . self::NEWSPACK_NEWSLETTERS_CPT . '_posts_columns', [ __CLASS__, 'add_public_page_column' ] );
+		add_action( 'manage_' . self::NEWSPACK_NEWSLETTERS_CPT . '_posts_custom_column', [ __CLASS__, 'public_page_column_content' ], 10, 2 );
 		add_filter( 'post_row_actions', [ __CLASS__, 'display_view_or_preview_link_in_admin' ] );
 		add_filter( 'newspack_newsletters_assess_has_disabled_popups', [ __CLASS__, 'disable_campaigns_for_newsletters' ], 11 );
 		add_filter( 'jetpack_relatedposts_filter_options', [ __CLASS__, 'disable_jetpack_related_posts' ] );
@@ -645,6 +647,35 @@ final class Newspack_Newsletters {
 			nocache_headers();
 			include get_query_template( '404' );
 			die();
+		}
+	}
+
+	/**
+	 * Add "Public page" admin column
+	 * 
+	 * @param array $columns Newsletters columns.
+	 * 
+	 * @return array
+	 */
+	public static function add_public_page_column( $columns ) {
+		return array_merge( $columns, [ 'public_page' => __( 'Public page', 'newspack-newsletters' ) ] );
+	}
+
+	/**
+	 * Add "Public page" admin column content
+	 * Displays wether the newsletter post has a public page or not
+	 * 
+	 * @param string $column_name Column name.
+	 * @param int    $post_id     Post ID.
+	 */
+	public static function public_page_column_content( $column_name, $post_id ) {
+		if ( 'public_page' === $column_name ) {
+			$is_public = get_post_meta( $post_id, 'is_public', true );
+			echo empty( $is_public ) ? esc_html__( 'No', 'newspack-newsletters' ) : esc_html__( 'Yes', 'newspack-newsletters' );
+			// Inline data for javascript use.
+			?>
+			<div class="is_public hidden"><?php echo esc_html( $is_public ); ?></div>
+			<?php
 		}
 	}
 

--- a/includes/class-newspack-newsletters.php
+++ b/includes/class-newspack-newsletters.php
@@ -671,10 +671,10 @@ final class Newspack_Newsletters {
 	public static function public_page_column_content( $column_name, $post_id ) {
 		if ( 'public_page' === $column_name ) {
 			$is_public = get_post_meta( $post_id, 'is_public', true );
-			echo empty( $is_public ) ? esc_html__( 'No', 'newspack-newsletters' ) : esc_html__( 'Yes', 'newspack-newsletters' );
-			// Inline data for javascript use.
 			?>
-			<div class="is_public hidden"><?php echo esc_html( $is_public ); ?></div>
+			<span class="inline_data is_public" data-is_public="<?php echo esc_html( $is_public ); ?>">
+				<?php echo empty( $is_public ) ? esc_html__( 'No', 'newspack-newsletters' ) : esc_html__( 'Yes', 'newspack-newsletters' ); ?>
+			</span>
 			<?php
 		}
 	}

--- a/includes/class-newspack-newsletters.php
+++ b/includes/class-newspack-newsletters.php
@@ -561,10 +561,6 @@ final class Newspack_Newsletters {
 				/* translators:  Absolute time stamp of sent/published date */
 				$post_states[ $post_status->name ] = sprintf( __( 'Sent %1$s', 'newspack-newsletters' ), get_the_time( get_option( 'date_format' ), $post ) );
 			}
-
-			if ( $is_public ) {
-				$post_states[ $post_status->name ] .= __( ' | Published as a post', 'newspack-newsletters' );
-			}
 		}
 
 		return $post_states;

--- a/newspack-newsletters.php
+++ b/newspack-newsletters.php
@@ -35,4 +35,6 @@ require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/class-newspack-newsle
 require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/class-newspack-newsletters-settings.php';
 require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/class-newspack-newsletters-renderer.php';
 require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/class-newspack-newsletters-ads.php';
+require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/class-newspack-newsletters-bulk-actions.php';
+require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/class-newspack-newsletters-quick-edit.php';
 require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/class-newspack-newsletters.php';

--- a/src/quick-edit/index.js
+++ b/src/quick-edit/index.js
@@ -14,7 +14,7 @@ if ( 'undefined' !== typeof inlineEditPost ) {
 		}
 
 		if ( id > 0 ) {
-			if ( jQuery( `tr#post-${ id } .is_public` ).text() ) {
+			if ( jQuery( `tr#post-${ id } .inline_data.is_public` ).data( 'is_public' ) ) {
 				jQuery( `tr#edit-${ id } :input[name="switch_public_page"]` ).prop( 'checked', true );
 			}
 		}

--- a/src/quick-edit/index.js
+++ b/src/quick-edit/index.js
@@ -1,0 +1,22 @@
+const jQuery = window && window.jQuery;
+
+if ( 'undefined' !== typeof inlineEditPost ) {
+	// eslint-disable-next-line no-undef
+	const wp_inline_edit_function = inlineEditPost.edit;
+
+	// eslint-disable-next-line no-undef
+	inlineEditPost.edit = function( post_id ) {
+		wp_inline_edit_function.apply( this, arguments );
+
+		let id = 0;
+		if ( typeof post_id === 'object' ) {
+			id = parseInt( this.getId( post_id ) );
+		}
+
+		if ( id > 0 ) {
+			if ( jQuery( `tr#post-${ id } .is_public` ).text() ) {
+				jQuery( `tr#edit-${ id } :input[name="switch_public_page"]` ).prop( 'checked', true );
+			}
+		}
+	};
+}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -16,6 +16,7 @@ const editor = path.join( __dirname, 'src', 'editor' );
 const admin = path.join( __dirname, 'src', 'admin' );
 const adsEditor = path.join( __dirname, 'src', 'ads-admin', 'editor' );
 const branding = path.join( __dirname, 'src', 'branding' );
+const quickEdit = path.join( __dirname, 'src', 'quick-edit' );
 const blocks = path.join( __dirname, 'src', 'editor', 'blocks' );
 
 const webpackConfig = getBaseWebpackConfig(
@@ -26,6 +27,7 @@ const webpackConfig = getBaseWebpackConfig(
 			admin,
 			adsEditor,
 			branding,
+			quickEdit,
 			blocks,
 		},
 		'output-path': path.join( __dirname, 'dist' ),


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Thir PR implements **bulk action** and **quick edit** options for modifying the public page option for a newsletter.

Closes #325.

### How to test the changes in this Pull Request:

#### Bulk Edit

1. Visit Newsletters list dashboard
2. Select multiple newsletters for bulk edit
3. Select "Make newsletters page public" from Bulk actions and apply

https://user-images.githubusercontent.com/820752/124185083-d9d9af80-da90-11eb-9cf2-cc7a5fa4f4f9.mov

#### Quick Edit

1. Visit Newsletters list dashboard
2. Click `Quick Edit` option on a newsletter
3. Click on `Make newsletter page public?` checkbox
4. Click on Update

https://user-images.githubusercontent.com/820752/124185131-f1189d00-da90-11eb-869f-4b3e2a8b7648.mov

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
