### PR TITLE
Persist user defined test emails as user meta

### DIFF
--- a/includes/class-newspack-newsletters-editor.php
+++ b/includes/class-newspack-newsletters-editor.php
@@ -295,9 +295,11 @@ final class Newspack_Newsletters_Editor {
 	 * @return array List of user defined emails.
 	 */
 	public static function get_current_user_test_emails() {
-		$emails = get_user_meta( get_current_user_id(), 'newspack_nl_test_emails', true );
+		$user_id = get_current_user_id();
+		$emails  = get_user_meta( $user_id, 'newspack_nl_test_emails', true );
 		if ( ! is_array( $emails ) ) {
-			return array();
+			$user_info = get_userdata( $user_id );
+			return array( $user_info->user_email );
 		}
 		return $emails;
 	}

--- a/includes/class-newspack-newsletters-editor.php
+++ b/includes/class-newspack-newsletters-editor.php
@@ -176,6 +176,7 @@ final class Newspack_Newsletters_Editor {
 				'service_provider'               => Newspack_Newsletters::service_provider(),
 				'email_html_meta'                => Newspack_Newsletters::EMAIL_HTML_META,
 				'newsletter_cpt'                 => Newspack_Newsletters::NEWSPACK_NEWSLETTERS_CPT,
+				'user_test_emails'               => self::get_current_user_test_emails(),
 			]
 		);
 	}
@@ -286,6 +287,19 @@ final class Newspack_Newsletters_Editor {
 	public static function remove_wc_memberships_excerpt_limit() {
 		$excerpt = get_the_excerpt( get_the_id() );
 		return $excerpt;
+	}
+
+	/**
+	 * Get current user test emails
+	 * 
+	 * @return array List of user defined emails.
+	 */
+	public static function get_current_user_test_emails() {
+		$emails = get_user_meta( get_current_user_id(), 'newspack_nl_test_emails', true );
+		if ( ! is_array( $emails ) ) {
+			return array();
+		}
+		return $emails;
 	}
 
 	/**

--- a/includes/service-providers/campaign_monitor/class-newspack-newsletters-campaign-monitor-controller.php
+++ b/includes/service-providers/campaign_monitor/class-newspack-newsletters-campaign-monitor-controller.php
@@ -97,6 +97,7 @@ class Newspack_Newsletters_Campaign_Monitor_Controller extends Newspack_Newslett
 		foreach ( $emails as &$email ) {
 			$email = sanitize_email( trim( $email ) );
 		}
+		$this->update_user_test_emails( $emails );
 		$response = $this->service_provider->test(
 			$request['id'],
 			$emails

--- a/includes/service-providers/class-newspack-newsletters-service-provider-controller.php
+++ b/includes/service-providers/class-newspack-newsletters-service-provider-controller.php
@@ -42,6 +42,11 @@ abstract class Newspack_Newsletters_Service_Provider_Controller extends \WP_REST
 	 * @return bool Whether the value has been updated or not
 	 */
 	public function update_user_test_emails( $emails ) {
+		$user_id   = get_current_user_id();
+		$user_info = get_userdata( $user_id );
+		if ( 1 === count( $emails ) && $user_info->user_email === $emails[0] ) {
+			return false;
+		}
 		return (bool) update_user_meta( get_current_user_id(), 'newspack_nl_test_emails', $emails );
 	}
 }

--- a/includes/service-providers/class-newspack-newsletters-service-provider-controller.php
+++ b/includes/service-providers/class-newspack-newsletters-service-provider-controller.php
@@ -47,6 +47,6 @@ abstract class Newspack_Newsletters_Service_Provider_Controller extends \WP_REST
 		if ( 1 === count( $emails ) && $user_info->user_email === $emails[0] ) {
 			return false;
 		}
-		return (bool) update_user_meta( get_current_user_id(), 'newspack_nl_test_emails', $emails );
+		return (bool) update_user_meta( $user_id, 'newspack_nl_test_emails', $emails );
 	}
 }

--- a/includes/service-providers/class-newspack-newsletters-service-provider-controller.php
+++ b/includes/service-providers/class-newspack-newsletters-service-provider-controller.php
@@ -34,4 +34,14 @@ abstract class Newspack_Newsletters_Service_Provider_Controller extends \WP_REST
 	public function register_routes() {
 		// Currently empty. Add endpoints common to all the ESP Service Providers.
 	}
+
+	/**
+	 * Update user's default email addresses for test email
+	 * 
+	 * @param array $emails Email addresses.
+	 * @return bool Whether the value has been updated or not
+	 */
+	public function update_user_test_emails( $emails ) {
+		return (bool) update_user_meta( get_current_user_id(), 'newspack_nl_test_emails', $emails );
+	}
 }

--- a/includes/service-providers/constant_contact/class-newspack-newsletters-constant-contact-controller.php
+++ b/includes/service-providers/constant_contact/class-newspack-newsletters-constant-contact-controller.php
@@ -144,6 +144,7 @@ class Newspack_Newsletters_Constant_Contact_Controller extends Newspack_Newslett
 		foreach ( $emails as &$email ) {
 			$email = sanitize_email( trim( $email ) );
 		}
+		$this->update_user_test_emails( $emails );
 		$response = $this->service_provider->test(
 			$request['id'],
 			$emails

--- a/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp-controller.php
+++ b/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp-controller.php
@@ -149,6 +149,7 @@ class Newspack_Newsletters_Mailchimp_Controller extends Newspack_Newsletters_Ser
 		foreach ( $emails as &$email ) {
 			$email = sanitize_email( trim( $email ) );
 		}
+		$this->update_user_test_emails( $emails );
 		$response = $this->service_provider->test(
 			$request['id'],
 			$emails

--- a/src/newsletter-editor/index.js
+++ b/src/newsletter-editor/index.js
@@ -28,6 +28,10 @@ const NewsletterEdit = ( { layoutId } ) => {
 			window.newspack_newsletters_data.is_service_provider_configured !== '1'
 	);
 
+	const [ testEmail, setTestEmail ] = useState(
+		window?.newspack_newsletters_data?.user_test_emails?.join( ',' ) || ''
+	);
+
 	const isDisplayingInitModal = shouldDisplaySettings || -1 === layoutId;
 
 	return isDisplayingInitModal ? (
@@ -54,7 +58,7 @@ const NewsletterEdit = ( { layoutId } ) => {
 				name="newsletters-testing-panel"
 				title={ __( 'Testing', 'newspack-newsletters' ) }
 			>
-				<Testing />
+				<Testing testEmail={ testEmail } onChangeEmail={ setTestEmail } />
 			</PluginDocumentSettingPanel>
 			<PluginDocumentSettingPanel
 				name="newsletters-layout-panel"

--- a/src/newsletter-editor/testing/index.js
+++ b/src/newsletter-editor/testing/index.js
@@ -28,7 +28,7 @@ export default compose( [
 	} ),
 ] )( ( { apiFetchWithErrorHandling, inFlight, postId, savePost, setInFlightForAsync } ) => {
 	const [ testEmail, setTestEmail ] = useState(
-		window?.newspack_newsletters_data?.user_test_emails?.join( ',' )
+		window?.newspack_newsletters_data?.user_test_emails?.join( ',' ) || ''
 	);
 
 	const sendTestEmail = async () => {

--- a/src/newsletter-editor/testing/index.js
+++ b/src/newsletter-editor/testing/index.js
@@ -4,7 +4,7 @@
 import { __ } from '@wordpress/i18n';
 import { withSelect, withDispatch } from '@wordpress/data';
 import { compose } from '@wordpress/compose';
-import { Fragment, useState } from '@wordpress/element';
+import { Fragment } from '@wordpress/element';
 import { Button, Spinner, TextControl } from '@wordpress/components';
 import { hasValidEmail } from '../utils';
 
@@ -26,48 +26,48 @@ export default compose( [
 			savePost,
 		};
 	} ),
-] )( ( { apiFetchWithErrorHandling, inFlight, postId, savePost, setInFlightForAsync } ) => {
-	const [ testEmail, setTestEmail ] = useState(
-		window?.newspack_newsletters_data?.user_test_emails?.join( ',' ) || ''
-	);
+] )(
+	( { apiFetchWithErrorHandling, inFlight, postId, savePost, setInFlightForAsync, ...props } ) => {
+		const { testEmail, onChangeEmail } = props;
 
-	const sendTestEmail = async () => {
-		const serviceProvider =
-			window &&
-			window.newspack_newsletters_data &&
-			window.newspack_newsletters_data.service_provider;
-		setInFlightForAsync();
-		await savePost();
-		const params = {
-			path: `/newspack-newsletters/v1/${ serviceProvider }/${ postId }/test`,
-			data: {
-				test_email: testEmail,
-			},
-			method: 'POST',
+		const sendTestEmail = async () => {
+			const serviceProvider =
+				window &&
+				window.newspack_newsletters_data &&
+				window.newspack_newsletters_data.service_provider;
+			setInFlightForAsync();
+			await savePost();
+			const params = {
+				path: `/newspack-newsletters/v1/${ serviceProvider }/${ postId }/test`,
+				data: {
+					test_email: testEmail,
+				},
+				method: 'POST',
+			};
+			apiFetchWithErrorHandling( params );
 		};
-		apiFetchWithErrorHandling( params );
-	};
-	return (
-		<Fragment>
-			<TextControl
-				label={ __( 'Send a test to', 'newspack-newsletters' ) }
-				value={ testEmail }
-				type="email"
-				onChange={ setTestEmail }
-				help={ __( 'Use commas to separate multiple emails.', 'newspack-newsletters' ) }
-			/>
-			<div className="newspack-newsletters__testing-controls">
-				<Button
-					isPrimary
-					onClick={ sendTestEmail }
-					disabled={ inFlight || ! hasValidEmail( testEmail ) }
-				>
-					{ inFlight
-						? __( 'Sending Test Email...', 'newspack-newsletters' )
-						: __( 'Send a Test Email', 'newspack-newsletters' ) }
-				</Button>
-				{ inFlight && <Spinner /> }
-			</div>
-		</Fragment>
-	);
-} );
+		return (
+			<Fragment>
+				<TextControl
+					label={ __( 'Send a test to', 'newspack-newsletters' ) }
+					value={ testEmail }
+					type="email"
+					onChange={ onChangeEmail }
+					help={ __( 'Use commas to separate multiple emails.', 'newspack-newsletters' ) }
+				/>
+				<div className="newspack-newsletters__testing-controls">
+					<Button
+						isPrimary
+						onClick={ sendTestEmail }
+						disabled={ inFlight || ! hasValidEmail( testEmail ) }
+					>
+						{ inFlight
+							? __( 'Sending Test Email...', 'newspack-newsletters' )
+							: __( 'Send a Test Email', 'newspack-newsletters' ) }
+					</Button>
+					{ inFlight && <Spinner /> }
+				</div>
+			</Fragment>
+		);
+	}
+);

--- a/src/newsletter-editor/testing/index.js
+++ b/src/newsletter-editor/testing/index.js
@@ -27,7 +27,10 @@ export default compose( [
 		};
 	} ),
 ] )( ( { apiFetchWithErrorHandling, inFlight, postId, savePost, setInFlightForAsync } ) => {
-	const [ testEmail, setTestEmail ] = useState( '' );
+	const [ testEmail, setTestEmail ] = useState(
+		window?.newspack_newsletters_data?.user_test_emails?.join( ',' )
+	);
+
 	const sendTestEmail = async () => {
 		const serviceProvider =
 			window &&

--- a/src/newsletter-editor/testing/index.js
+++ b/src/newsletter-editor/testing/index.js
@@ -27,9 +27,15 @@ export default compose( [
 		};
 	} ),
 ] )(
-	( { apiFetchWithErrorHandling, inFlight, postId, savePost, setInFlightForAsync, ...props } ) => {
-		const { testEmail, onChangeEmail } = props;
-
+	( {
+		apiFetchWithErrorHandling,
+		inFlight,
+		postId,
+		savePost,
+		setInFlightForAsync,
+		testEmail,
+		onChangeEmail,
+	} ) => {
 		const sendTestEmail = async () => {
 			const serviceProvider =
 				window &&


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Populate the field for email testing with the address(es) previously set by the user. If no email has been previously set, populates the field with the user email address.

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes #156.

### How to test the changes in this Pull Request:

1. Write a newsletter
2. Send a test to a custom email address (or multiple comma-separated addresses)
3. Refresh the page or create a new newsletter and see that the emails have persisted

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
