### PR TITLE
Fix: remove non-existent enqueued styles

### DIFF
--- a/includes/class-newspack-newsletters-editor.php
+++ b/includes/class-newspack-newsletters-editor.php
@@ -128,14 +128,6 @@ final class Newspack_Newsletters_Editor {
 				filemtime( NEWSPACK_NEWSLETTERS_PLUGIN_FILE . 'dist/adsEditor.js' ),
 				true
 			);
-			wp_register_style(
-				'newspack-newsletters-ads-page',
-				plugins_url( '../dist/adsEditor.css', __FILE__ ),
-				[],
-				filemtime( NEWSPACK_NEWSLETTERS_PLUGIN_FILE . 'dist/adsEditor.css' )
-			);
-			wp_style_add_data( 'newspack-newsletters-ads-page', 'rtl', 'replace' );
-			wp_enqueue_style( 'newspack-newsletters-ads-page' );
 		}
 
 		// If it's a reusable block, register this plugin's blocks.


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Removes enqueued styles that does not exist since a3ce0cd0beeebff778af217988d05b6410e095bd.
<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
