### PR TITLE
Add "manual" provider for email markup copy

### DIFF
--- a/includes/class-newspack-newsletters-settings.php
+++ b/includes/class-newspack-newsletters-settings.php
@@ -36,6 +36,10 @@ class Newspack_Newsletters_Settings {
 						'value' => '',
 					),
 					array(
+						'name'  => __( 'Manual', 'newspack-newsletters' ),
+						'value' => 'manual',
+					),
+					array(
 						'name'  => __( 'Mailchimp', 'newspack-newsletters' ),
 						'value' => 'mailchimp',
 					),

--- a/includes/class-newspack-newsletters.php
+++ b/includes/class-newspack-newsletters.php
@@ -118,6 +118,22 @@ final class Newspack_Newsletters {
 	public static function register_meta() {
 		\register_meta(
 			'post',
+			'without_provider',
+			[
+				'object_subtype' => self::NEWSPACK_NEWSLETTERS_CPT,
+				'show_in_rest'   => [
+					'schema' => [
+						'context' => [ 'edit' ],
+					],
+				],
+				'type'           => 'boolean',
+				'single'         => true,
+				'auth_callback'  => '__return_true',
+			]
+		);
+
+		\register_meta(
+			'post',
 			'mc_campaign_id',
 			[
 				'object_subtype' => self::NEWSPACK_NEWSLETTERS_CPT,
@@ -447,6 +463,12 @@ final class Newspack_Newsletters {
 	public static function save( $post_id, $post, $update ) {
 		if ( ! $update ) {
 			update_post_meta( $post_id, 'template_id', -1 );
+
+			// Set "without provider" post meta if using manual.
+			$provider = self::service_provider();
+			if ( 'manual' === $provider ) {
+				update_post_meta( $post_id, 'without_provider', true );
+			}
 		}
 	}
 
@@ -941,6 +963,10 @@ final class Newspack_Newsletters {
 		}
 
 		if ( self::$provider && self::$provider->has_api_credentials() ) {
+			$response['status'] = true;
+		}
+
+		if ( 'manual' === $service_provider ) {
 			$response['status'] = true;
 		}
 

--- a/includes/class-newspack-newsletters.php
+++ b/includes/class-newspack-newsletters.php
@@ -118,22 +118,6 @@ final class Newspack_Newsletters {
 	public static function register_meta() {
 		\register_meta(
 			'post',
-			'without_provider',
-			[
-				'object_subtype' => self::NEWSPACK_NEWSLETTERS_CPT,
-				'show_in_rest'   => [
-					'schema' => [
-						'context' => [ 'edit' ],
-					],
-				],
-				'type'           => 'boolean',
-				'single'         => true,
-				'auth_callback'  => '__return_true',
-			]
-		);
-
-		\register_meta(
-			'post',
 			'mc_campaign_id',
 			[
 				'object_subtype' => self::NEWSPACK_NEWSLETTERS_CPT,
@@ -463,12 +447,6 @@ final class Newspack_Newsletters {
 	public static function save( $post_id, $post, $update ) {
 		if ( ! $update ) {
 			update_post_meta( $post_id, 'template_id', -1 );
-
-			// Set "without provider" post meta if using manual.
-			$provider = self::service_provider();
-			if ( 'manual' === $provider ) {
-				update_post_meta( $post_id, 'without_provider', true );
-			}
 		}
 	}
 
@@ -964,11 +942,10 @@ final class Newspack_Newsletters {
 			$response['credentials'] = self::$provider->api_credentials();
 		}
 
-		if ( self::$provider && self::$provider->has_api_credentials() ) {
-			$response['status'] = true;
-		}
-
-		if ( 'manual' === $service_provider ) {
+		if (
+			'manual' === $service_provider ||
+			( self::$provider && self::$provider->has_api_credentials() )
+		) {
 			$response['status'] = true;
 		}
 

--- a/includes/class-newspack-newsletters.php
+++ b/includes/class-newspack-newsletters.php
@@ -926,16 +926,18 @@ final class Newspack_Newsletters {
 		}
 
 		// Service Provider credentials.
-		if ( empty( $credentials ) ) {
-			$wp_error->add(
-				'newspack_newsletters_invalid_keys',
-				__( 'Please input credentials.', 'newspack-newsletters' )
-			);
-		} else {
-			$status = self::$provider->set_api_credentials( $credentials );
-			if ( is_wp_error( $status ) ) {
-				foreach ( $status->errors as $code => $message ) {
-					$wp_error->add( $code, implode( ' ', $message ) );
+		if ( 'manual' !== $service_provider ) {
+			if ( empty( $credentials ) ) {
+				$wp_error->add(
+					'newspack_newsletters_invalid_keys',
+					__( 'Please input credentials.', 'newspack-newsletters' )
+				);
+			} else {
+				$status = self::$provider->set_api_credentials( $credentials );
+				if ( is_wp_error( $status ) ) {
+					foreach ( $status->errors as $code => $message ) {
+						$wp_error->add( $code, implode( ' ', $message ) );
+					}
 				}
 			}
 		}

--- a/src/components/copy-html/index.js
+++ b/src/components/copy-html/index.js
@@ -1,0 +1,39 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { withSelect } from '@wordpress/data';
+import { compose } from '@wordpress/compose';
+import { useState } from '@wordpress/element';
+import { TextareaControl, ClipboardButton } from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
+import './style.scss';
+
+export default compose( [
+	withSelect( select => {
+		const { getCurrentPostAttribute } = select( 'core/editor' );
+		return {
+			meta: getCurrentPostAttribute( 'meta' ),
+		};
+	} ),
+] )( ( { meta } ) => {
+	const { newspack_email_html: html } = meta;
+	const [ hasCopied, setHasCopied ] = useState( false );
+	return (
+		<div className="newspack-newsletters__copy_html">
+			<TextareaControl disabled value={ html } rows="10" />
+			<ClipboardButton
+				text={ html }
+				onCopy={ () => setHasCopied( true ) }
+				onFinishCopy={ () => setHasCopied( false ) }
+			>
+				{ hasCopied
+					? __( 'Copied!', 'newspack-newsletters' )
+					: __( 'Copy to clipboard', 'newspack-newsletters' ) }
+			</ClipboardButton>
+		</div>
+	);
+} );

--- a/src/components/copy-html/style.scss
+++ b/src/components/copy-html/style.scss
@@ -1,0 +1,9 @@
+.newspack-newsletters__copy_html {
+	margin-bottom: 1em;
+	display: flex;
+	flex-direction: column;
+	align-items: flex-end;
+	.components-base-control {
+		width: 100%;
+	}
+}

--- a/src/components/init-modal/screens/api-keys/index.js
+++ b/src/components/init-modal/screens/api-keys/index.js
@@ -74,7 +74,7 @@ export default ( { onSetupStatus } ) => {
 
 	const { service_provider: serviceProvider = '', credentials = {} } = settings;
 
-	const canSubmit = values( credentials ).join( '' ).length;
+	const canSubmit = 'manual' === serviceProvider || values( credentials ).join( '' ).length;
 
 	const classes = classnames(
 		'newspack-newsletters-modal__content',
@@ -109,6 +109,7 @@ export default ( { onSetupStatus } ) => {
 								disabled: true,
 								label: __( 'Select service provider', 'newspack-newsletters' ),
 							},
+							{ value: 'manual', label: __( 'Manual', 'newspack-newsletters' ) },
 							{ value: 'mailchimp', label: __( 'Mailchimp', 'newspack-newsletters' ) },
 							{
 								value: 'constant_contact',

--- a/src/components/send-button/index.js
+++ b/src/components/send-button/index.js
@@ -21,7 +21,7 @@ import './style.scss';
 import { NEWSLETTER_AD_CPT_SLUG, NEWSLETTER_CPT_SLUG } from '../../utils/consts';
 import { isAdActive } from '../../ads-admin/utils';
 
-const { renderPreSendInfo } = getServiceProvider();
+const { renderPreSendInfo, renderPostUpdateInfo } = getServiceProvider();
 
 export default compose( [
 	withDispatch( dispatch => {
@@ -65,14 +65,19 @@ export default compose( [
 		meta,
 		isPublished,
 	} ) => {
-		const { newsletterData = {}, newsletterValidationErrors = [], is_public } = meta;
+		const {
+			without_provider: withoutProvider,
+			newsletterData = {},
+			newsletterValidationErrors = [],
+			is_public,
+		} = meta;
 
 		const isButtonEnabled =
 			( isPublishable || isEditedPostBeingScheduled ) &&
 			isSaveable &&
 			! isPublished &&
 			! isSaving &&
-			newsletterData.campaign &&
+			( newsletterData.campaign || withoutProvider ) &&
 			0 === newsletterValidationErrors.length;
 		let label;
 		if ( isPublished ) {
@@ -91,6 +96,15 @@ export default compose( [
 			label = is_public
 				? __( 'Send and Publish', 'newspack-newsletters' )
 				: __( 'Send', 'newspack-newsletters' );
+		}
+
+		let updateLabel;
+		if ( isSaving ) {
+			updateLabel = __( 'Updating...', 'newspack-newsletters' );
+		} else if ( withoutProvider ) {
+			updateLabel = __( 'Update and copy HTML', 'newspack-newsletters' );
+		} else {
+			updateLabel = __( 'Update', 'newspack-newsletters' );
 		}
 
 		let publishStatus;
@@ -136,17 +150,39 @@ export default compose( [
 		// For sent newsletters, display the generic button text.
 		if ( isPublished ) {
 			return (
-				<Button
-					className="editor-post-publish-button"
-					isBusy={ isSaving }
-					isPrimary
-					disabled={ isSaving }
-					onClick={ savePost }
-				>
-					{ isSaving
-						? __( 'Updating...', 'newspack-newsletters' )
-						: __( 'Update', 'newspack-newsletters' ) }
-				</Button>
+				<Fragment>
+					<Button
+						className="editor-post-publish-button"
+						isBusy={ isSaving }
+						isPrimary
+						disabled={ isSaving }
+						onClick={ async () => {
+							await savePost();
+							if ( renderPostUpdateInfo ) setModalVisible( true );
+						} }
+					>
+						{ updateLabel }
+					</Button>
+					{ modalVisible && renderPostUpdateInfo && (
+						<Modal
+							className="newspack-newsletters__modal"
+							title={ __( 'Newsletter HTML', 'newspack-newsletters' ) }
+							onRequestClose={ () => setModalVisible( false ) }
+						>
+							{ adsWarning ? (
+								<Notice isDismissible={ false }>
+									{ adsWarning }{' '}
+									<a
+										href={ `/wp-admin/edit.php?post_type=${ NEWSLETTER_CPT_SLUG }&page=newspack-newsletters-ads-admin` }
+									>
+										{ __( 'Manage ads', 'newspack-newsletters' ) }
+									</a>
+								</Notice>
+							) : null }
+							{ renderPostUpdateInfo( newsletterData ) }
+						</Modal>
+					) }
+				</Fragment>
 			);
 		}
 
@@ -194,19 +230,23 @@ export default compose( [
 								</ul>
 							</Notice>
 						) : null }
-						<Button
-							isPrimary
-							disabled={ newsletterValidationErrors.length > 0 }
-							onClick={ () => {
-								triggerCampaignSend();
-								setModalVisible( false );
-							} }
-						>
-							{ __( 'Send', 'newspack-newsletters' ) }
-						</Button>
-						<Button isSecondary onClick={ () => setModalVisible( false ) }>
-							{ __( 'Cancel', 'newspack-newsletters' ) }
-						</Button>
+						<div className="modal-buttons">
+							<Button isSecondary onClick={ () => setModalVisible( false ) }>
+								{ __( 'Cancel', 'newspack-newsletters' ) }
+							</Button>
+							<Button
+								isPrimary
+								disabled={ newsletterValidationErrors.length > 0 }
+								onClick={ () => {
+									triggerCampaignSend();
+									setModalVisible( false );
+								} }
+							>
+								{ withoutProvider
+									? __( 'Mark as sent', 'newspack-newsletters' )
+									: __( 'Send', 'newspack-newsletters' ) }
+							</Button>
+						</div>
 					</Modal>
 				) }
 			</Fragment>

--- a/src/components/send-button/index.js
+++ b/src/components/send-button/index.js
@@ -117,6 +117,15 @@ export default compose( [
 			publishStatus = 'publish';
 		}
 
+		let modalSubmitLabel;
+		if ( 'manual' === serviceProviderName ) {
+			modalSubmitLabel = is_public
+				? __( 'Mark as sent and publish', 'newspack-newsletters' )
+				: __( 'Mark as sent', 'newspack-newsletters' );
+		} else {
+			modalSubmitLabel = __( 'Send', 'newspack-newsletters' );
+		}
+
 		const [ adsWarning, setAdsWarning ] = useState();
 		useEffect(() => {
 			apiFetch( {
@@ -241,9 +250,7 @@ export default compose( [
 									setModalVisible( false );
 								} }
 							>
-								{ 'manual' === serviceProviderName
-									? __( 'Mark as sent', 'newspack-newsletters' )
-									: __( 'Send', 'newspack-newsletters' ) }
+								{ modalSubmitLabel }
 							</Button>
 						</div>
 					</Modal>

--- a/src/components/send-button/index.js
+++ b/src/components/send-button/index.js
@@ -21,8 +21,6 @@ import './style.scss';
 import { NEWSLETTER_AD_CPT_SLUG, NEWSLETTER_CPT_SLUG } from '../../utils/consts';
 import { isAdActive } from '../../ads-admin/utils';
 
-const { renderPreSendInfo, renderPostUpdateInfo } = getServiceProvider();
-
 export default compose( [
 	withDispatch( dispatch => {
 		const { editPost, savePost } = dispatch( 'core/editor' );
@@ -65,19 +63,20 @@ export default compose( [
 		meta,
 		isPublished,
 	} ) => {
+		const { newsletterData = {}, newsletterValidationErrors = [], is_public } = meta;
+
 		const {
-			without_provider: withoutProvider,
-			newsletterData = {},
-			newsletterValidationErrors = [],
-			is_public,
-		} = meta;
+			name: serviceProviderName,
+			renderPreSendInfo,
+			renderPostUpdateInfo,
+		} = getServiceProvider();
 
 		const isButtonEnabled =
 			( isPublishable || isEditedPostBeingScheduled ) &&
 			isSaveable &&
 			! isPublished &&
 			! isSaving &&
-			( newsletterData.campaign || withoutProvider ) &&
+			( newsletterData.campaign || 'manual' === serviceProviderName ) &&
 			0 === newsletterValidationErrors.length;
 		let label;
 		if ( isPublished ) {
@@ -101,7 +100,7 @@ export default compose( [
 		let updateLabel;
 		if ( isSaving ) {
 			updateLabel = __( 'Updating...', 'newspack-newsletters' );
-		} else if ( withoutProvider ) {
+		} else if ( 'manual' === serviceProviderName ) {
 			updateLabel = __( 'Update and copy HTML', 'newspack-newsletters' );
 		} else {
 			updateLabel = __( 'Update', 'newspack-newsletters' );
@@ -242,7 +241,7 @@ export default compose( [
 									setModalVisible( false );
 								} }
 							>
-								{ withoutProvider
+								{ 'manual' === serviceProviderName
 									? __( 'Mark as sent', 'newspack-newsletters' )
 									: __( 'Send', 'newspack-newsletters' ) }
 							</Button>

--- a/src/components/send-button/style.scss
+++ b/src/components/send-button/style.scss
@@ -6,4 +6,12 @@
 			margin-left: 1.3em;
 		}
 	}
+	.modal-buttons {
+		display: flex;
+		justify-content: flex-end;
+		margin-top: 1.3em;
+		.components-button {
+			margin-left: 0.7rem;
+		}
+	}
 }

--- a/src/newsletter-editor/editor/index.js
+++ b/src/newsletter-editor/editor/index.js
@@ -177,8 +177,13 @@ const Editor = compose( [
 	// Fetch data from service provider.
 	useEffect(() => {
 		if ( ! props.isCleanNewPost && ! props.isPublishingOrSavingPost ) {
+			// Exit if provider does not support fetching data.
+			if ( ! getFetchDataConfig ) {
+				return;
+			}
 			const params = getFetchDataConfig( { postId: props.postId } );
-			if ( 0 === params.path.indexOf( '/newspack-newsletters/v1/example/' ) ) {
+			// Exit if data config is example or does not provide path
+			if ( ! params?.path || 0 === params.path.indexOf( '/newspack-newsletters/v1/example/' ) ) {
 				return;
 			}
 			props.apiFetchWithErrorHandling( params ).then( result => {

--- a/src/newsletter-editor/index.js
+++ b/src/newsletter-editor/index.js
@@ -12,6 +12,7 @@ import { registerPlugin } from '@wordpress/plugins';
  * Internal dependencies
  */
 import InitModal from '../components/init-modal';
+import { getServiceProvider } from '../service-providers';
 import Layout from './layout/';
 import Sidebar from './sidebar/';
 import Testing from './testing/';
@@ -21,7 +22,7 @@ import registerEditorPlugin from './editor/';
 
 registerEditorPlugin();
 
-const NewsletterEdit = ( { layoutId, withoutProvider } ) => {
+const NewsletterEdit = ( { layoutId } ) => {
 	const [ shouldDisplaySettings, setShouldDisplaySettings ] = useState(
 		window?.newspack_newsletters_data?.is_service_provider_configured !== '1'
 	);
@@ -29,6 +30,8 @@ const NewsletterEdit = ( { layoutId, withoutProvider } ) => {
 	const [ testEmail, setTestEmail ] = useState(
 		window?.newspack_newsletters_data?.user_test_emails?.join( ',' ) || ''
 	);
+
+	const { name: serviceProviderName } = getServiceProvider();
 
 	const isDisplayingInitModal = shouldDisplaySettings || -1 === layoutId;
 
@@ -52,7 +55,7 @@ const NewsletterEdit = ( { layoutId, withoutProvider } ) => {
 			>
 				<Styling />
 			</PluginDocumentSettingPanel>
-			{ ! withoutProvider && (
+			{ 'manual' !== serviceProviderName && (
 				<PluginDocumentSettingPanel
 					name="newsletters-testing-panel"
 					title={ __( 'Testing', 'newspack-newsletters' ) }
@@ -76,7 +79,7 @@ const NewsletterEditWithSelect = compose( [
 	withSelect( select => {
 		const { getEditedPostAttribute } = select( 'core/editor' );
 		const meta = getEditedPostAttribute( 'meta' );
-		return { layoutId: meta.template_id, withoutProvider: meta.without_provider };
+		return { layoutId: meta.template_id };
 	} ),
 ] )( NewsletterEdit );
 

--- a/src/newsletter-editor/index.js
+++ b/src/newsletter-editor/index.js
@@ -21,11 +21,9 @@ import registerEditorPlugin from './editor/';
 
 registerEditorPlugin();
 
-const NewsletterEdit = ( { layoutId } ) => {
+const NewsletterEdit = ( { layoutId, withoutProvider } ) => {
 	const [ shouldDisplaySettings, setShouldDisplaySettings ] = useState(
-		window &&
-			window.newspack_newsletters_data &&
-			window.newspack_newsletters_data.is_service_provider_configured !== '1'
+		window?.newspack_newsletters_data?.is_service_provider_configured !== '1'
 	);
 
 	const [ testEmail, setTestEmail ] = useState(
@@ -54,12 +52,14 @@ const NewsletterEdit = ( { layoutId } ) => {
 			>
 				<Styling />
 			</PluginDocumentSettingPanel>
-			<PluginDocumentSettingPanel
-				name="newsletters-testing-panel"
-				title={ __( 'Testing', 'newspack-newsletters' ) }
-			>
-				<Testing testEmail={ testEmail } onChangeEmail={ setTestEmail } />
-			</PluginDocumentSettingPanel>
+			{ ! withoutProvider && (
+				<PluginDocumentSettingPanel
+					name="newsletters-testing-panel"
+					title={ __( 'Testing', 'newspack-newsletters' ) }
+				>
+					<Testing testEmail={ testEmail } onChangeEmail={ setTestEmail } />
+				</PluginDocumentSettingPanel>
+			) }
 			<PluginDocumentSettingPanel
 				name="newsletters-layout-panel"
 				title={ __( 'Layout', 'newspack-newsletters' ) }
@@ -76,7 +76,7 @@ const NewsletterEditWithSelect = compose( [
 	withSelect( select => {
 		const { getEditedPostAttribute } = select( 'core/editor' );
 		const meta = getEditedPostAttribute( 'meta' );
-		return { layoutId: meta.template_id };
+		return { layoutId: meta.template_id, withoutProvider: meta.without_provider };
 	} ),
 ] )( NewsletterEdit );
 

--- a/src/newsletter-editor/sidebar/index.js
+++ b/src/newsletter-editor/sidebar/index.js
@@ -89,14 +89,17 @@ const Sidebar = ( {
 					{ __( 'Update Sender', 'newspack-newsletters' ) }
 				</Button>
 			) }
-			<TextareaControl
-				label={ __( 'Preview text', 'newspack-newsletters' ) }
-				className="newspack-newsletters__name-textcontrol newspack-newsletters__name-textcontrol--separated"
-				value={ previewText }
-				disabled={ inFlight }
-				onChange={ value => editPost( { meta: { preview_text: value } } ) }
-			/>
 		</Fragment>
+	);
+
+	const renderPreviewText = () => (
+		<TextareaControl
+			label={ __( 'Preview text', 'newspack-newsletters' ) }
+			className="newspack-newsletters__name-textcontrol newspack-newsletters__name-textcontrol--separated"
+			value={ previewText }
+			disabled={ inFlight }
+			onChange={ value => editPost( { meta: { preview_text: value } } ) }
+		/>
 	);
 
 	const { ProviderSidebar } = getServiceProvider();
@@ -109,6 +112,7 @@ const Sidebar = ( {
 				apiFetch={ apiFetch }
 				renderSubject={ renderSubject }
 				renderFrom={ renderFrom }
+				renderPreviewText={ renderPreviewText }
 				updateMeta={ meta => editPost( { meta } ) }
 			/>
 			<ToggleControl

--- a/src/service-providers/constant_contact/ProviderSidebar.js
+++ b/src/service-providers/constant_contact/ProviderSidebar.js
@@ -8,6 +8,7 @@ import { BaseControl, CheckboxControl, Spinner, Notice } from '@wordpress/compon
 const ProviderSidebar = ( {
 	renderSubject,
 	renderFrom,
+	renderPreviewText,
 	inFlight,
 	newsletterData,
 	apiFetch,
@@ -81,6 +82,7 @@ const ProviderSidebar = ( {
 				) ) }
 			</BaseControl>
 			{ renderFrom( { handleSenderUpdate: setSender } ) }
+			{ renderPreviewText() }
 		</Fragment>
 	);
 };

--- a/src/service-providers/example/index.js
+++ b/src/service-providers/example/index.js
@@ -59,6 +59,10 @@ const ProviderSidebar = ( {
 	 * the data can be sent to the backend.
 	 */
 	renderFrom,
+	/**
+	 * Function that renders preview text input
+	 */
+	renderPreviewText,
 } ) => {
 	const handleSenderUpdate = ( { senderName, senderEmail } ) =>
 		apiFetch( {
@@ -74,6 +78,7 @@ const ProviderSidebar = ( {
 		<Fragment>
 			{ renderSubject() }
 			{ renderFrom( { handleSenderUpdate } ) }
+			{ renderPreviewText() }
 		</Fragment>
 	);
 };

--- a/src/service-providers/index.js
+++ b/src/service-providers/index.js
@@ -1,10 +1,12 @@
 import example from './example';
+import manual from './manual';
 import mailchimp from './mailchimp';
 import constant_contact from './constant_contact';
 import campaign_monitor from './campaign_monitor';
 
 const SERVICE_PROVIDERS = {
 	example,
+	manual,
 	mailchimp,
 	constant_contact,
 	campaign_monitor,

--- a/src/service-providers/index.js
+++ b/src/service-providers/index.js
@@ -15,5 +15,8 @@ const SERVICE_PROVIDERS = {
 export const getServiceProvider = () => {
 	const serviceProvider =
 		window && window.newspack_newsletters_data && window.newspack_newsletters_data.service_provider;
-	return SERVICE_PROVIDERS[ serviceProvider || 'example' ];
+	return {
+		name: serviceProvider,
+		...SERVICE_PROVIDERS[ serviceProvider || 'example' ],
+	};
 };

--- a/src/service-providers/mailchimp/ProviderSidebar.js
+++ b/src/service-providers/mailchimp/ProviderSidebar.js
@@ -82,6 +82,7 @@ const SegmentsSelection = ( {
 const ProviderSidebar = ( {
 	renderSubject,
 	renderFrom,
+	renderPreviewText,
 	inFlight,
 	newsletterData,
 	apiFetch,
@@ -189,6 +190,7 @@ const ProviderSidebar = ( {
 			/>
 
 			{ renderFrom( { handleSenderUpdate: setSender } ) }
+			{ renderPreviewText() }
 		</Fragment>
 	);
 };

--- a/src/service-providers/manual/index.js
+++ b/src/service-providers/manual/index.js
@@ -1,0 +1,77 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { Fragment } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import CopyHTML from '../../components/copy-html';
+
+/**
+ * Validation utility.
+ *
+ * @param  {Object} object data fetched using getFetchDataConfig
+ * @return {string[]} Array of validation messages. If empty, newsletter is valid.
+ */
+const validateNewsletter = ( { status } ) => {
+	const messages = [];
+	if ( 'sent' === status || 'sending' === status ) {
+		messages.push( __( 'Newsletter has already been sent.', 'newspack-newsletters' ) );
+	}
+
+	return messages;
+};
+
+/**
+ * Component to be rendered in the sidebar panel.
+ * Has full control over the panel contents rendering,
+ * so that it's possible to render e.g. a loader while
+ * the data is not yet available.
+ *
+ * @param {Object} props props
+ */
+const ProviderSidebar = ( { renderSubject, renderPreviewText } ) => {
+	return (
+		<Fragment>
+			{ renderSubject() }
+			{ renderPreviewText() }
+		</Fragment>
+	);
+};
+
+const renderPreSendInfo = () => {
+	return (
+		<Fragment>
+			<p>
+				{ __(
+					'Copy the HTML code below to manually publish your newsletter with your provider.',
+					'newspack-newsletters'
+				) }
+			</p>
+			<CopyHTML />
+		</Fragment>
+	);
+};
+
+const renderPostUpdateInfo = () => {
+	return (
+		<Fragment>
+			<p>
+				{ __(
+					'Copy the HTML code below to manually publish your newsletter with your provider.',
+					'newspack-newsletters'
+				) }
+			</p>
+			<CopyHTML />
+		</Fragment>
+	);
+};
+
+export default {
+	validateNewsletter,
+	ProviderSidebar,
+	renderPreSendInfo,
+	renderPostUpdateInfo,
+};

--- a/src/service-providers/manual/index.js
+++ b/src/service-providers/manual/index.js
@@ -12,16 +12,11 @@ import CopyHTML from '../../components/copy-html';
 /**
  * Validation utility.
  *
- * @param  {Object} object data fetched using getFetchDataConfig
  * @return {string[]} Array of validation messages. If empty, newsletter is valid.
  */
-const validateNewsletter = ( { status } ) => {
-	const messages = [];
-	if ( 'sent' === status || 'sending' === status ) {
-		messages.push( __( 'Newsletter has already been sent.', 'newspack-newsletters' ) );
-	}
-
-	return messages;
+const validateNewsletter = () => {
+	// Return empty array as there is no validation.
+	return [];
 };
 
 /**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Implements "manual" provider to accommodate features from #470.

Although the issue mentions a "generic" provider approach, this PR interprets the required features as a manual approach, as it does not consist in new provider in its concept nor in our [ESP service interface](https://github.com/Automattic/newspack-newsletters/blob/master/includes/service-providers/interface-newspack-newsletters-esp-service.php). The manual option is available as a provider option for the user, which is interpreted in the editor to implement the necessary features.

The implemented features/changes in the editor are:
 - Isolate the "preview text" input into `renderPreviewText` so it can be available outside of a provider sender context.
 - Added HTML markup copy to clipboard in pre-send info modal.
 - Added support for post-update modal (which  `manual` implements to provide the updated HTML)
 - Removed "test email" when the provider is set to "Manual".

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes #470.
Closes #368 (see 2d70899d3fa4de6c7716cb9d7289e3e0c469a869 commit message).

### How to test the changes in this Pull Request:

1. Run `npm ci && npm run build`
2. Modify your provider settings to "Manual" (make sure to clear Mailchimp API Key, as it enforces the provider to Mailchimp due to legacy reasons)
3. Create a new Newsletter and select a layout
4. Click on **Send**
5. Observe the new modal with the "Copy to clipboard" option
6. Click on Mark as sent (which sets the newsletter to `publish`)

After the newsletter is marked as sent, you can still make changes and obtain the updated HTML by clicking on `Update and copy HTML` button.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
