### PR TITLE
fix(wp-5.8): ensure string for displayTransform

### DIFF
--- a/src/editor/blocks/posts-inserter/query-controls.js
+++ b/src/editor/blocks/posts-inserter/query-controls.js
@@ -218,7 +218,7 @@ const QueryControlsSettings = ( { attributes, setAttributes } ) => {
 					suggestions={ encodePosts( foundPosts ) }
 					displayTransform={ string => {
 						const [ id, title ] = decodePost( string );
-						return title || id;
+						return title || id || '';
 					} }
 					onInputChange={ debounce( handleSpecificPostsInput, 400 ) }
 				/>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

While selecting individual posts in the Posts Inserter block, the block would encounter a JS error and break, as identified in #493.

I identified the issue occurring only on 5.8. While searching for posts, the `FormTokenField` would eventually process an empty string, which was not properly handled by `decodePost`.

I was not able to identify the reason why an empty string is sent to `displayTransform`, but it does not seem to persist in the selected options or suggestions list.

This PR ensures that `displayTransform` always returns a string.

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes #493.

### How to test the changes in this Pull Request:

1. Update to 5.8 RC3 with this plugin's master branch to identify the error
2. Make sure your installation have multiple posts to be inserted
3. Create newlestter with Posts Inserter block
4. Select "Display specific posts" and attempt to select multiple posts
5. Observe the error message as displayed in #493.

Switch to this PR branch for the fix:
1. Run `npm run build`
2. Refresh your newsletter editor page
3. Select multiple posts on your Posts Inserter block.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
