### PR TITLE
Fix: sync instead of erroring for missing campaign id

### DIFF
--- a/includes/service-providers/constant_contact/class-newspack-newsletters-constant-contact.php
+++ b/includes/service-providers/constant_contact/class-newspack-newsletters-constant-contact.php
@@ -469,7 +469,7 @@ final class Newspack_Newsletters_Constant_Contact extends \Newspack_Newsletters_
 	public function retrieve_campaign_id( $post_id ) {
 		$cc_campaign_id = get_post_meta( $post_id, 'cc_campaign_id', true );
 		if ( ! $cc_campaign_id ) {
-			throw new Exception( __( 'Constant Contact campaign ID not found.', 'newspack-newsletters' ) );
+			$this->sync();
 		}
 		return $cc_campaign_id;
 	}

--- a/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp.php
+++ b/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp.php
@@ -148,10 +148,7 @@ final class Newspack_Newsletters_Mailchimp extends \Newspack_Newsletters_Service
 		try {
 			$mc_campaign_id = get_post_meta( $post_id, 'mc_campaign_id', true );
 			if ( ! $mc_campaign_id ) {
-				return new WP_Error(
-					'newspack_newsletters_mailchimp_error',
-					__( 'No Mailchimp campaign ID found for this Newsletter', 'newspack-newsletter' )
-				);
+				$this->sync();
 			}
 			$mc                  = new Mailchimp( $this->api_key() );
 			$campaign            = $this->validate(


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Execute `sync()` method instead of return error when `retrieve()` method is unable to identify an existing campaign id.

Warning: Although the change in Constant Contact provider follows the same logic as for Mailchimp, I was not able to test it due to #503.

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes #499.

### How to test the changes in this Pull Request:

1. In `master` branch, create a newsletter draft using the Manual provider
2. Change your provider to Mailchimp with valid API keys
3. Edit the created draft and see the "no campaign ID" error.
4. Switch to this PR branch, repeat steps and see that no error is displayed and the newsletter is synchronized with the ESP.

Steps should also be executed using Constant Contact instead of Mailchimp.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
