### PR TITLE
fix: ensure post object for syncs

### DIFF
--- a/includes/service-providers/constant_contact/class-newspack-newsletters-constant-contact.php
+++ b/includes/service-providers/constant_contact/class-newspack-newsletters-constant-contact.php
@@ -469,7 +469,7 @@ final class Newspack_Newsletters_Constant_Contact extends \Newspack_Newsletters_
 	public function retrieve_campaign_id( $post_id ) {
 		$cc_campaign_id = get_post_meta( $post_id, 'cc_campaign_id', true );
 		if ( ! $cc_campaign_id ) {
-			$this->sync();
+			$this->sync( get_post( $post_id ) );
 		}
 		return $cc_campaign_id;
 	}

--- a/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp.php
+++ b/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp.php
@@ -148,7 +148,7 @@ final class Newspack_Newsletters_Mailchimp extends \Newspack_Newsletters_Service
 		try {
 			$mc_campaign_id = get_post_meta( $post_id, 'mc_campaign_id', true );
 			if ( ! $mc_campaign_id ) {
-				$this->sync();
+				$this->sync( get_post( $post_id ) );
 			}
 			$mc                  = new Mailchimp( $this->api_key() );
 			$campaign            = $this->validate(


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes a sync error when syncing after changing service providers to a new ESP.

### How to test the changes in this Pull Request:

1. Install and activate the [v1.29.2-alpha.1](https://github.com/Automattic/newspack-newsletters/releases/tag/v1.29.2-alpha.1) built asset on a fresh site.
2. Go to **Newsletters > Settings** and set the provider to "manual".
3. Create a new newsletter draft and save.
4. Go back to Settings and set the provider to Mailchimp with a valid Mailchimp API key.
5. Edit the newsletter draft. Observe a fatal error:

```
[19-Jul-2021 21:45:39 UTC] PHP Fatal error:  Uncaught ArgumentCountError: Too few arguments to function Newspack_Newsletters_Mailchimp::sync(), 0 passed in /srv/users/user44cb75cc/apps/user44cb75cc/public/wp-content/plugins/newspack-newsletters/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp.php on line 151 and exactly 1 expected in /srv/users/user44cb75cc/apps/user44cb75cc/public/wp-content/plugins/newspack-newsletters/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp.php:338
```

6. Build this branch, install on your test site, refresh the draft. Confirm that the error no longer occurs and that the draft syncs successfully with Mailchimp.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
