### PR TITLE
Fix: refactor constant contact provider

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,15 +4,16 @@
   "type": "wordpress-plugin",
   "require": {
     "drewm/mailchimp-api": "^2.5",
-    "constantcontact/constantcontact": "2.1.*",
-    "campaignmonitor/createsend-php": "^6.1"
+    "campaignmonitor/createsend-php": "^6.1",
+    "guzzlehttp/guzzle": "^7.0"
   },
   "require-dev": {
     "automattic/vipwpcs": "^2.0",
     "wp-coding-standards/wpcs": "^2.2",
     "phpcompatibility/phpcompatibility-wp": "^2.1",
     "brainmaestro/composer-git-hooks": "^2.8",
-    "dealerdirect/phpcodesniffer-composer-installer": "^0.7.0"
+    "dealerdirect/phpcodesniffer-composer-installer": "^0.7.0",
+    "automattic/jetpack-autoloader": "^2"
   },
   "license": "GPL-2.0-or-later",
   "scripts": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "0484cfb9a7ac16c65725a60b924252db",
+    "content-hash": "7456dce38b29ca34d253ae9b1e8fff00",
     "packages": [
         {
             "name": "campaignmonitor/createsend-php",
@@ -64,56 +64,11 @@
                 "campaign",
                 "monitor"
             ],
+            "support": {
+                "issues": "https://github.com/campaignmonitor/createsend-php/issues",
+                "source": "https://github.com/campaignmonitor/createsend-php/tree/master"
+            },
             "time": "2020-05-06T02:33:22+00:00"
-        },
-        {
-            "name": "constantcontact/constantcontact",
-            "version": "2.1.4",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/constantcontact/php-sdk.git",
-                "reference": "4546700862f7832aa3d18e02cf77bf5d3c2ab277"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/constantcontact/php-sdk/zipball/4546700862f7832aa3d18e02cf77bf5d3c2ab277",
-                "reference": "4546700862f7832aa3d18e02cf77bf5d3c2ab277",
-                "shasum": ""
-            },
-            "require": {
-                "ext-curl": "*",
-                "guzzlehttp/guzzle": "^5.1.0",
-                "php": ">=5.4.0"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "4.4.1"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-0": {
-                    "Ctct": "src"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Constant Contact Web Services",
-                    "email": "webservices@constantcontact.com",
-                    "homepage": "http://developer.constantcontact.com"
-                }
-            ],
-            "description": "Constant Contact PHP SDK for v2",
-            "homepage": "http://developer.constantcontact.com",
-            "keywords": [
-                "constant contact",
-                "constantcontact",
-                "ctct",
-                "email marketing"
-            ],
-            "time": "2016-02-17T14:19:57+00:00"
         },
         {
             "name": "drewm/mailchimp-api",
@@ -157,188 +112,57 @@
             ],
             "description": "Super-simple, minimum abstraction MailChimp API v3 wrapper",
             "homepage": "https://github.com/drewm/mailchimp-api",
+            "support": {
+                "issues": "https://github.com/drewm/mailchimp-api/issues",
+                "source": "https://github.com/drewm/mailchimp-api/tree/master"
+            },
             "time": "2019-08-06T09:24:58+00:00"
         },
         {
             "name": "guzzlehttp/guzzle",
-            "version": "5.3.4",
+            "version": "7.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/guzzle.git",
-                "reference": "b87eda7a7162f95574032da17e9323c9899cb6b2"
+                "reference": "7008573787b430c1c1f650e3722d9bba59967628"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/b87eda7a7162f95574032da17e9323c9899cb6b2",
-                "reference": "b87eda7a7162f95574032da17e9323c9899cb6b2",
+                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/7008573787b430c1c1f650e3722d9bba59967628",
+                "reference": "7008573787b430c1c1f650e3722d9bba59967628",
                 "shasum": ""
             },
             "require": {
-                "guzzlehttp/ringphp": "^1.1",
-                "php": ">=5.4.0",
-                "react/promise": "^2.2"
+                "ext-json": "*",
+                "guzzlehttp/promises": "^1.4",
+                "guzzlehttp/psr7": "^1.7 || ^2.0",
+                "php": "^7.2.5 || ^8.0",
+                "psr/http-client": "^1.0"
+            },
+            "provide": {
+                "psr/http-client-implementation": "1.0"
             },
             "require-dev": {
+                "bamarni/composer-bin-plugin": "^1.4.1",
                 "ext-curl": "*",
-                "phpunit/phpunit": "^4.0"
+                "php-http/client-integration-tests": "^3.0",
+                "phpunit/phpunit": "^8.5.5 || ^9.3.5",
+                "psr/log": "^1.1"
+            },
+            "suggest": {
+                "ext-curl": "Required for CURL handler support",
+                "ext-intl": "Required for Internationalized Domain Name (IDN) support",
+                "psr/log": "Required for using the Log middleware"
             },
             "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "7.3-dev"
+                }
+            },
             "autoload": {
                 "psr-4": {
                     "GuzzleHttp\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Michael Dowling",
-                    "email": "mtdowling@gmail.com",
-                    "homepage": "https://github.com/mtdowling"
-                }
-            ],
-            "description": "Guzzle is a PHP HTTP client library and framework for building RESTful web service clients",
-            "homepage": "http://guzzlephp.org/",
-            "keywords": [
-                "client",
-                "curl",
-                "framework",
-                "http",
-                "http client",
-                "rest",
-                "web service"
-            ],
-            "time": "2019-10-30T09:32:00+00:00"
-        },
-        {
-            "name": "guzzlehttp/ringphp",
-            "version": "1.1.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/guzzle/RingPHP.git",
-                "reference": "5e2a174052995663dd68e6b5ad838afd47dd615b"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/RingPHP/zipball/5e2a174052995663dd68e6b5ad838afd47dd615b",
-                "reference": "5e2a174052995663dd68e6b5ad838afd47dd615b",
-                "shasum": ""
-            },
-            "require": {
-                "guzzlehttp/streams": "~3.0",
-                "php": ">=5.4.0",
-                "react/promise": "~2.0"
-            },
-            "require-dev": {
-                "ext-curl": "*",
-                "phpunit/phpunit": "~4.0"
-            },
-            "suggest": {
-                "ext-curl": "Guzzle will use specific adapters if cURL is present"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.1-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "GuzzleHttp\\Ring\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Michael Dowling",
-                    "email": "mtdowling@gmail.com",
-                    "homepage": "https://github.com/mtdowling"
-                }
-            ],
-            "description": "Provides a simple API and specification that abstracts away the details of HTTP into a single PHP function.",
-            "abandoned": true,
-            "time": "2018-07-31T13:22:33+00:00"
-        },
-        {
-            "name": "guzzlehttp/streams",
-            "version": "3.0.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/guzzle/streams.git",
-                "reference": "47aaa48e27dae43d39fc1cea0ccf0d84ac1a2ba5"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/streams/zipball/47aaa48e27dae43d39fc1cea0ccf0d84ac1a2ba5",
-                "reference": "47aaa48e27dae43d39fc1cea0ccf0d84ac1a2ba5",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.4.0"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "~4.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "3.0-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "GuzzleHttp\\Stream\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Michael Dowling",
-                    "email": "mtdowling@gmail.com",
-                    "homepage": "https://github.com/mtdowling"
-                }
-            ],
-            "description": "Provides a simple abstraction over streams of data",
-            "homepage": "http://guzzlephp.org/",
-            "keywords": [
-                "Guzzle",
-                "stream"
-            ],
-            "abandoned": true,
-            "time": "2014-10-12T19:18:40+00:00"
-        },
-        {
-            "name": "react/promise",
-            "version": "v2.8.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/reactphp/promise.git",
-                "reference": "f3cff96a19736714524ca0dd1d4130de73dbbbc4"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/reactphp/promise/zipball/f3cff96a19736714524ca0dd1d4130de73dbbbc4",
-                "reference": "f3cff96a19736714524ca0dd1d4130de73dbbbc4",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.4.0"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^7.0 || ^6.5 || ^5.7 || ^4.8.36"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "React\\Promise\\": "src/"
                 },
                 "files": [
                     "src/functions_include.php"
@@ -350,46 +174,472 @@
             ],
             "authors": [
                 {
-                    "name": "Jan Sorgalla",
-                    "email": "jsorgalla@gmail.com"
+                    "name": "Michael Dowling",
+                    "email": "mtdowling@gmail.com",
+                    "homepage": "https://github.com/mtdowling"
+                },
+                {
+                    "name": "Márk Sági-Kazár",
+                    "email": "mark.sagikazar@gmail.com",
+                    "homepage": "https://sagikazarmark.hu"
                 }
             ],
-            "description": "A lightweight implementation of CommonJS Promises/A for PHP",
+            "description": "Guzzle is a PHP HTTP client library",
+            "homepage": "http://guzzlephp.org/",
             "keywords": [
-                "promise",
-                "promises"
+                "client",
+                "curl",
+                "framework",
+                "http",
+                "http client",
+                "psr-18",
+                "psr-7",
+                "rest",
+                "web service"
             ],
-            "time": "2020-05-12T15:16:56+00:00"
+            "support": {
+                "issues": "https://github.com/guzzle/guzzle/issues",
+                "source": "https://github.com/guzzle/guzzle/tree/7.3.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/GrahamCampbell",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/Nyholm",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/alexeyshockov",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/gmponos",
+                    "type": "github"
+                }
+            ],
+            "time": "2021-03-23T11:33:13+00:00"
+        },
+        {
+            "name": "guzzlehttp/promises",
+            "version": "1.4.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/guzzle/promises.git",
+                "reference": "8e7d04f1f6450fef59366c399cfad4b9383aa30d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/guzzle/promises/zipball/8e7d04f1f6450fef59366c399cfad4b9383aa30d",
+                "reference": "8e7d04f1f6450fef59366c399cfad4b9383aa30d",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.5"
+            },
+            "require-dev": {
+                "symfony/phpunit-bridge": "^4.4 || ^5.1"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.4-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "GuzzleHttp\\Promise\\": "src/"
+                },
+                "files": [
+                    "src/functions_include.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Michael Dowling",
+                    "email": "mtdowling@gmail.com",
+                    "homepage": "https://github.com/mtdowling"
+                }
+            ],
+            "description": "Guzzle promises library",
+            "keywords": [
+                "promise"
+            ],
+            "support": {
+                "issues": "https://github.com/guzzle/promises/issues",
+                "source": "https://github.com/guzzle/promises/tree/1.4.1"
+            },
+            "time": "2021-03-07T09:25:29+00:00"
+        },
+        {
+            "name": "guzzlehttp/psr7",
+            "version": "2.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/guzzle/psr7.git",
+                "reference": "1dc8d9cba3897165e16d12bb13d813afb1eb3fe7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/guzzle/psr7/zipball/1dc8d9cba3897165e16d12bb13d813afb1eb3fe7",
+                "reference": "1dc8d9cba3897165e16d12bb13d813afb1eb3fe7",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2.5 || ^8.0",
+                "psr/http-factory": "^1.0",
+                "psr/http-message": "^1.0",
+                "ralouphie/getallheaders": "^3.0"
+            },
+            "provide": {
+                "psr/http-factory-implementation": "1.0",
+                "psr/http-message-implementation": "1.0"
+            },
+            "require-dev": {
+                "bamarni/composer-bin-plugin": "^1.4.1",
+                "http-interop/http-factory-tests": "^0.9",
+                "phpunit/phpunit": "^8.5.8 || ^9.3.10"
+            },
+            "suggest": {
+                "laminas/laminas-httphandlerrunner": "Emit PSR-7 responses"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "GuzzleHttp\\Psr7\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Michael Dowling",
+                    "email": "mtdowling@gmail.com",
+                    "homepage": "https://github.com/mtdowling"
+                },
+                {
+                    "name": "Tobias Schultze",
+                    "homepage": "https://github.com/Tobion"
+                },
+                {
+                    "name": "Márk Sági-Kazár",
+                    "email": "mark.sagikazar@gmail.com",
+                    "homepage": "https://sagikazarmark.hu"
+                }
+            ],
+            "description": "PSR-7 message implementation that also provides common utility methods",
+            "keywords": [
+                "http",
+                "message",
+                "psr-7",
+                "request",
+                "response",
+                "stream",
+                "uri",
+                "url"
+            ],
+            "support": {
+                "issues": "https://github.com/guzzle/psr7/issues",
+                "source": "https://github.com/guzzle/psr7/tree/2.0.0"
+            },
+            "time": "2021-06-30T20:03:07+00:00"
+        },
+        {
+            "name": "psr/http-client",
+            "version": "1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/http-client.git",
+                "reference": "2dfb5f6c5eff0e91e20e913f8c5452ed95b86621"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/http-client/zipball/2dfb5f6c5eff0e91e20e913f8c5452ed95b86621",
+                "reference": "2dfb5f6c5eff0e91e20e913f8c5452ed95b86621",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.0 || ^8.0",
+                "psr/http-message": "^1.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Http\\Client\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "http://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for HTTP clients",
+            "homepage": "https://github.com/php-fig/http-client",
+            "keywords": [
+                "http",
+                "http-client",
+                "psr",
+                "psr-18"
+            ],
+            "support": {
+                "source": "https://github.com/php-fig/http-client/tree/master"
+            },
+            "time": "2020-06-29T06:28:15+00:00"
+        },
+        {
+            "name": "psr/http-factory",
+            "version": "1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/http-factory.git",
+                "reference": "12ac7fcd07e5b077433f5f2bee95b3a771bf61be"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/http-factory/zipball/12ac7fcd07e5b077433f5f2bee95b3a771bf61be",
+                "reference": "12ac7fcd07e5b077433f5f2bee95b3a771bf61be",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.0.0",
+                "psr/http-message": "^1.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Http\\Message\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "http://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interfaces for PSR-7 HTTP message factories",
+            "keywords": [
+                "factory",
+                "http",
+                "message",
+                "psr",
+                "psr-17",
+                "psr-7",
+                "request",
+                "response"
+            ],
+            "support": {
+                "source": "https://github.com/php-fig/http-factory/tree/master"
+            },
+            "time": "2019-04-30T12:38:16+00:00"
+        },
+        {
+            "name": "psr/http-message",
+            "version": "1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/http-message.git",
+                "reference": "f6561bf28d520154e4b0ec72be95418abe6d9363"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/http-message/zipball/f6561bf28d520154e4b0ec72be95418abe6d9363",
+                "reference": "f6561bf28d520154e4b0ec72be95418abe6d9363",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Http\\Message\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "http://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for HTTP messages",
+            "homepage": "https://github.com/php-fig/http-message",
+            "keywords": [
+                "http",
+                "http-message",
+                "psr",
+                "psr-7",
+                "request",
+                "response"
+            ],
+            "support": {
+                "source": "https://github.com/php-fig/http-message/tree/master"
+            },
+            "time": "2016-08-06T14:39:51+00:00"
+        },
+        {
+            "name": "ralouphie/getallheaders",
+            "version": "3.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/ralouphie/getallheaders.git",
+                "reference": "120b605dfeb996808c31b6477290a714d356e822"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/ralouphie/getallheaders/zipball/120b605dfeb996808c31b6477290a714d356e822",
+                "reference": "120b605dfeb996808c31b6477290a714d356e822",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.6"
+            },
+            "require-dev": {
+                "php-coveralls/php-coveralls": "^2.1",
+                "phpunit/phpunit": "^5 || ^6.5"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/getallheaders.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Ralph Khattar",
+                    "email": "ralph.khattar@gmail.com"
+                }
+            ],
+            "description": "A polyfill for getallheaders.",
+            "support": {
+                "issues": "https://github.com/ralouphie/getallheaders/issues",
+                "source": "https://github.com/ralouphie/getallheaders/tree/develop"
+            },
+            "time": "2019-03-08T08:55:37+00:00"
         }
     ],
     "packages-dev": [
         {
-            "name": "automattic/vipwpcs",
-            "version": "2.2.0",
+            "name": "automattic/jetpack-autoloader",
+            "version": "v2.10.3",
             "source": {
                 "type": "git",
-                "url": "https://github.com/Automattic/VIP-Coding-Standards.git",
-                "reference": "4d0612461232b313d06321f1501c3989bd6aecf9"
+                "url": "https://github.com/Automattic/jetpack-autoloader.git",
+                "reference": "aab966d6f2c8fd6669d6f5b1378d8ced5fd665b4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Automattic/VIP-Coding-Standards/zipball/4d0612461232b313d06321f1501c3989bd6aecf9",
-                "reference": "4d0612461232b313d06321f1501c3989bd6aecf9",
+                "url": "https://api.github.com/repos/Automattic/jetpack-autoloader/zipball/aab966d6f2c8fd6669d6f5b1378d8ced5fd665b4",
+                "reference": "aab966d6f2c8fd6669d6f5b1378d8ced5fd665b4",
                 "shasum": ""
             },
             "require": {
+                "composer-plugin-api": "^1.1 || ^2.0"
+            },
+            "require-dev": {
+                "automattic/jetpack-changelogger": "^1.2",
+                "yoast/phpunit-polyfills": "0.2.0"
+            },
+            "type": "composer-plugin",
+            "extra": {
+                "autotagger": true,
+                "class": "Automattic\\Jetpack\\Autoloader\\CustomAutoloaderPlugin",
+                "mirror-repo": "Automattic/jetpack-autoloader",
+                "changelogger": {
+                    "link-template": "https://github.com/Automattic/jetpack-autoloader/compare/v${old}...v${new}"
+                },
+                "branch-alias": {
+                    "dev-master": "2.10.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/AutoloadGenerator.php"
+                ],
+                "psr-4": {
+                    "Automattic\\Jetpack\\Autoloader\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "description": "Creates a custom autoloader for a plugin or theme.",
+            "support": {
+                "source": "https://github.com/Automattic/jetpack-autoloader/tree/v2.10.3"
+            },
+            "time": "2021-05-25T16:35:16+00:00"
+        },
+        {
+            "name": "automattic/vipwpcs",
+            "version": "2.3.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Automattic/VIP-Coding-Standards.git",
+                "reference": "efacebef421334d54b99afa92fb8fa645336a8a7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Automattic/VIP-Coding-Standards/zipball/efacebef421334d54b99afa92fb8fa645336a8a7",
+                "reference": "efacebef421334d54b99afa92fb8fa645336a8a7",
+                "shasum": ""
+            },
+            "require": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.4.1 || ^0.5 || ^0.6.2 || ^0.7",
                 "php": ">=5.4",
                 "sirbrillig/phpcs-variable-analysis": "^2.8.3",
                 "squizlabs/php_codesniffer": "^3.5.5",
                 "wp-coding-standards/wpcs": "^2.3"
             },
             "require-dev": {
-                "dealerdirect/phpcodesniffer-composer-installer": "^0.7",
+                "php-parallel-lint/php-console-highlighter": "^0.5",
+                "php-parallel-lint/php-parallel-lint": "^1.0",
                 "phpcompatibility/php-compatibility": "^9",
+                "phpcsstandards/phpcsdevtools": "^1.0",
                 "phpunit/phpunit": "^4 || ^5 || ^6 || ^7"
-            },
-            "suggest": {
-                "dealerdirect/phpcodesniffer-composer-installer": "^0.7 || This Composer plugin will manage the PHPCS 'installed_paths' automatically."
             },
             "type": "phpcodesniffer-standard",
             "notification-url": "https://packagist.org/downloads/",
@@ -408,20 +658,25 @@
                 "standards",
                 "wordpress"
             ],
-            "time": "2020-09-07T10:45:45+00:00"
+            "support": {
+                "issues": "https://github.com/Automattic/VIP-Coding-Standards/issues",
+                "source": "https://github.com/Automattic/VIP-Coding-Standards",
+                "wiki": "https://github.com/Automattic/VIP-Coding-Standards/wiki"
+            },
+            "time": "2021-04-28T16:41:50+00:00"
         },
         {
             "name": "brainmaestro/composer-git-hooks",
-            "version": "v2.8.3",
+            "version": "v2.8.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/BrainMaestro/composer-git-hooks.git",
-                "reference": "97888dd34e900931117747cd34a42fdfcf271142"
+                "reference": "ffed8803690ac12214082120eee3441b00aa390e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/BrainMaestro/composer-git-hooks/zipball/97888dd34e900931117747cd34a42fdfcf271142",
-                "reference": "97888dd34e900931117747cd34a42fdfcf271142",
+                "url": "https://api.github.com/repos/BrainMaestro/composer-git-hooks/zipball/ffed8803690ac12214082120eee3441b00aa390e",
+                "reference": "ffed8803690ac12214082120eee3441b00aa390e",
                 "shasum": ""
             },
             "require": {
@@ -477,26 +732,30 @@
                 "composer",
                 "git"
             ],
-            "time": "2019-12-09T09:49:20+00:00"
+            "support": {
+                "issues": "https://github.com/BrainMaestro/composer-git-hooks/issues",
+                "source": "https://github.com/BrainMaestro/composer-git-hooks/tree/v2.8.5"
+            },
+            "time": "2021-02-08T15:59:11+00:00"
         },
         {
             "name": "dealerdirect/phpcodesniffer-composer-installer",
-            "version": "v0.7.0",
+            "version": "v0.7.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Dealerdirect/phpcodesniffer-composer-installer.git",
-                "reference": "e8d808670b8f882188368faaf1144448c169c0b7"
+                "reference": "fe390591e0241955f22eb9ba327d137e501c771c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Dealerdirect/phpcodesniffer-composer-installer/zipball/e8d808670b8f882188368faaf1144448c169c0b7",
-                "reference": "e8d808670b8f882188368faaf1144448c169c0b7",
+                "url": "https://api.github.com/repos/Dealerdirect/phpcodesniffer-composer-installer/zipball/fe390591e0241955f22eb9ba327d137e501c771c",
+                "reference": "fe390591e0241955f22eb9ba327d137e501c771c",
                 "shasum": ""
             },
             "require": {
                 "composer-plugin-api": "^1.0 || ^2.0",
                 "php": ">=5.3",
-                "squizlabs/php_codesniffer": "^2 || ^3 || 4.0.x-dev"
+                "squizlabs/php_codesniffer": "^2.0 || ^3.0 || ^4.0"
             },
             "require-dev": {
                 "composer/composer": "*",
@@ -543,7 +802,11 @@
                 "stylecheck",
                 "tests"
             ],
-            "time": "2020-06-25T14:57:39+00:00"
+            "support": {
+                "issues": "https://github.com/dealerdirect/phpcodesniffer-composer-installer/issues",
+                "source": "https://github.com/dealerdirect/phpcodesniffer-composer-installer"
+            },
+            "time": "2020-12-07T18:04:37+00:00"
         },
         {
             "name": "phpcompatibility/php-compatibility",
@@ -601,32 +864,36 @@
                 "phpcs",
                 "standards"
             ],
+            "support": {
+                "issues": "https://github.com/PHPCompatibility/PHPCompatibility/issues",
+                "source": "https://github.com/PHPCompatibility/PHPCompatibility"
+            },
             "time": "2019-12-27T09:44:58+00:00"
         },
         {
             "name": "phpcompatibility/phpcompatibility-paragonie",
-            "version": "1.3.0",
+            "version": "1.3.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCompatibility/PHPCompatibilityParagonie.git",
-                "reference": "b862bc32f7e860d0b164b199bd995e690b4b191c"
+                "reference": "ddabec839cc003651f2ce695c938686d1086cf43"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibilityParagonie/zipball/b862bc32f7e860d0b164b199bd995e690b4b191c",
-                "reference": "b862bc32f7e860d0b164b199bd995e690b4b191c",
+                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibilityParagonie/zipball/ddabec839cc003651f2ce695c938686d1086cf43",
+                "reference": "ddabec839cc003651f2ce695c938686d1086cf43",
                 "shasum": ""
             },
             "require": {
                 "phpcompatibility/php-compatibility": "^9.0"
             },
             "require-dev": {
-                "dealerdirect/phpcodesniffer-composer-installer": "^0.5",
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.7",
                 "paragonie/random_compat": "dev-master",
                 "paragonie/sodium_compat": "dev-master"
             },
             "suggest": {
-                "dealerdirect/phpcodesniffer-composer-installer": "^0.5 || This Composer plugin will sort out the PHP_CodeSniffer 'installed_paths' automatically.",
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.7 || This Composer plugin will sort out the PHP_CodeSniffer 'installed_paths' automatically.",
                 "roave/security-advisories": "dev-master || Helps prevent installing dependencies with known security issues."
             },
             "type": "phpcodesniffer-standard",
@@ -653,20 +920,24 @@
                 "polyfill",
                 "standards"
             ],
-            "time": "2019-11-04T15:17:54+00:00"
+            "support": {
+                "issues": "https://github.com/PHPCompatibility/PHPCompatibilityParagonie/issues",
+                "source": "https://github.com/PHPCompatibility/PHPCompatibilityParagonie"
+            },
+            "time": "2021-02-15T10:24:51+00:00"
         },
         {
             "name": "phpcompatibility/phpcompatibility-wp",
-            "version": "2.1.0",
+            "version": "2.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCompatibility/PHPCompatibilityWP.git",
-                "reference": "41bef18ba688af638b7310666db28e1ea9158b2f"
+                "reference": "b7dc0cd7a8f767ccac5e7637550ea1c50a67b09e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibilityWP/zipball/41bef18ba688af638b7310666db28e1ea9158b2f",
-                "reference": "41bef18ba688af638b7310666db28e1ea9158b2f",
+                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibilityWP/zipball/b7dc0cd7a8f767ccac5e7637550ea1c50a67b09e",
+                "reference": "b7dc0cd7a8f767ccac5e7637550ea1c50a67b09e",
                 "shasum": ""
             },
             "require": {
@@ -674,10 +945,10 @@
                 "phpcompatibility/phpcompatibility-paragonie": "^1.0"
             },
             "require-dev": {
-                "dealerdirect/phpcodesniffer-composer-installer": "^0.5"
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.7"
             },
             "suggest": {
-                "dealerdirect/phpcodesniffer-composer-installer": "^0.5 || This Composer plugin will sort out the PHP_CodeSniffer 'installed_paths' automatically.",
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.7 || This Composer plugin will sort out the PHP_CodeSniffer 'installed_paths' automatically.",
                 "roave/security-advisories": "dev-master || Helps prevent installing dependencies with known security issues."
             },
             "type": "phpcodesniffer-standard",
@@ -703,31 +974,30 @@
                 "standards",
                 "wordpress"
             ],
-            "time": "2019-08-28T14:22:28+00:00"
+            "support": {
+                "issues": "https://github.com/PHPCompatibility/PHPCompatibilityWP/issues",
+                "source": "https://github.com/PHPCompatibility/PHPCompatibilityWP"
+            },
+            "time": "2021-02-15T12:58:46+00:00"
         },
         {
             "name": "psr/container",
-            "version": "1.0.0",
+            "version": "1.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-fig/container.git",
-                "reference": "b7ce3b176482dbbc1245ebf52b181af44c2cf55f"
+                "reference": "8622567409010282b7aeebe4bb841fe98b58dcaf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/container/zipball/b7ce3b176482dbbc1245ebf52b181af44c2cf55f",
-                "reference": "b7ce3b176482dbbc1245ebf52b181af44c2cf55f",
+                "url": "https://api.github.com/repos/php-fig/container/zipball/8622567409010282b7aeebe4bb841fe98b58dcaf",
+                "reference": "8622567409010282b7aeebe4bb841fe98b58dcaf",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.0"
+                "php": ">=7.2.0"
             },
             "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.0.x-dev"
-                }
-            },
             "autoload": {
                 "psr-4": {
                     "Psr\\Container\\": "src/"
@@ -740,7 +1010,7 @@
             "authors": [
                 {
                     "name": "PHP-FIG",
-                    "homepage": "http://www.php-fig.org/"
+                    "homepage": "https://www.php-fig.org/"
                 }
             ],
             "description": "Common Container Interface (PHP FIG PSR-11)",
@@ -752,28 +1022,32 @@
                 "container-interop",
                 "psr"
             ],
-            "time": "2017-02-14T16:28:37+00:00"
+            "support": {
+                "issues": "https://github.com/php-fig/container/issues",
+                "source": "https://github.com/php-fig/container/tree/1.1.1"
+            },
+            "time": "2021-03-05T17:36:06+00:00"
         },
         {
             "name": "sirbrillig/phpcs-variable-analysis",
-            "version": "v2.9.0",
+            "version": "v2.11.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sirbrillig/phpcs-variable-analysis.git",
-                "reference": "ff54d4ec7f2bd152d526fdabfeff639aa9b8be01"
+                "reference": "3fad28475bfbdbf8aa5c440f8a8f89824983d85e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sirbrillig/phpcs-variable-analysis/zipball/ff54d4ec7f2bd152d526fdabfeff639aa9b8be01",
-                "reference": "ff54d4ec7f2bd152d526fdabfeff639aa9b8be01",
+                "url": "https://api.github.com/repos/sirbrillig/phpcs-variable-analysis/zipball/3fad28475bfbdbf8aa5c440f8a8f89824983d85e",
+                "reference": "3fad28475bfbdbf8aa5c440f8a8f89824983d85e",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.4.0",
-                "squizlabs/php_codesniffer": "^3.1"
+                "squizlabs/php_codesniffer": "^3.5"
             },
             "require-dev": {
-                "dealerdirect/phpcodesniffer-composer-installer": "^0.4.4 || ^0.5 || ^0.6",
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.7.0",
                 "limedeck/phpunit-detailed-printer": "^3.1 || ^4.0 || ^5.0",
                 "phpstan/phpstan": "^0.11.8",
                 "phpunit/phpunit": "^5.0 || ^6.5 || ^7.0 || ^8.0",
@@ -800,20 +1074,25 @@
                 }
             ],
             "description": "A PHPCS sniff to detect problems with variables.",
-            "time": "2020-10-07T23:32:29+00:00"
+            "support": {
+                "issues": "https://github.com/sirbrillig/phpcs-variable-analysis/issues",
+                "source": "https://github.com/sirbrillig/phpcs-variable-analysis",
+                "wiki": "https://github.com/sirbrillig/phpcs-variable-analysis/wiki"
+            },
+            "time": "2021-07-06T23:45:17+00:00"
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "3.5.8",
+            "version": "3.6.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
-                "reference": "9d583721a7157ee997f235f327de038e7ea6dac4"
+                "reference": "ffced0d2c8fa8e6cdc4d695a743271fab6c38625"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/9d583721a7157ee997f235f327de038e7ea6dac4",
-                "reference": "9d583721a7157ee997f235f327de038e7ea6dac4",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/ffced0d2c8fa8e6cdc4d695a743271fab6c38625",
+                "reference": "ffced0d2c8fa8e6cdc4d695a743271fab6c38625",
                 "shasum": ""
             },
             "require": {
@@ -851,24 +1130,30 @@
                 "phpcs",
                 "standards"
             ],
-            "time": "2020-10-23T02:01:07+00:00"
+            "support": {
+                "issues": "https://github.com/squizlabs/PHP_CodeSniffer/issues",
+                "source": "https://github.com/squizlabs/PHP_CodeSniffer",
+                "wiki": "https://github.com/squizlabs/PHP_CodeSniffer/wiki"
+            },
+            "time": "2021-04-09T00:54:41+00:00"
         },
         {
             "name": "symfony/console",
-            "version": "v5.1.8",
+            "version": "v5.3.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "e0b2c29c0fa6a69089209bbe8fcff4df2a313d0e"
+                "reference": "649730483885ff2ca99ca0560ef0e5f6b03f2ac1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/e0b2c29c0fa6a69089209bbe8fcff4df2a313d0e",
-                "reference": "e0b2c29c0fa6a69089209bbe8fcff4df2a313d0e",
+                "url": "https://api.github.com/repos/symfony/console/zipball/649730483885ff2ca99ca0560ef0e5f6b03f2ac1",
+                "reference": "649730483885ff2ca99ca0560ef0e5f6b03f2ac1",
                 "shasum": ""
             },
             "require": {
                 "php": ">=7.2.5",
+                "symfony/deprecation-contracts": "^2.1",
                 "symfony/polyfill-mbstring": "~1.0",
                 "symfony/polyfill-php73": "^1.8",
                 "symfony/polyfill-php80": "^1.15",
@@ -923,22 +1208,112 @@
                     "homepage": "https://symfony.com/contributors"
                 }
             ],
-            "description": "Symfony Console Component",
+            "description": "Eases the creation of beautiful and testable command line interfaces",
             "homepage": "https://symfony.com",
-            "time": "2020-10-24T12:01:57+00:00"
+            "keywords": [
+                "cli",
+                "command line",
+                "console",
+                "terminal"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/console/tree/v5.3.2"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2021-06-12T09:42:48+00:00"
         },
         {
-            "name": "symfony/polyfill-ctype",
-            "version": "v1.20.0",
+            "name": "symfony/deprecation-contracts",
+            "version": "v2.4.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/polyfill-ctype.git",
-                "reference": "f4ba089a5b6366e453971d3aad5fe8e897b37f41"
+                "url": "https://github.com/symfony/deprecation-contracts.git",
+                "reference": "5f38c8804a9e97d23e0c8d63341088cd8a22d627"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/f4ba089a5b6366e453971d3aad5fe8e897b37f41",
-                "reference": "f4ba089a5b6366e453971d3aad5fe8e897b37f41",
+                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/5f38c8804a9e97d23e0c8d63341088cd8a22d627",
+                "reference": "5f38c8804a9e97d23e0c8d63341088cd8a22d627",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "2.4-dev"
+                },
+                "thanks": {
+                    "name": "symfony/contracts",
+                    "url": "https://github.com/symfony/contracts"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "function.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "A generic function and convention to trigger deprecation notices",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/deprecation-contracts/tree/v2.4.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2021-03-23T23:28:01+00:00"
+        },
+        {
+            "name": "symfony/polyfill-ctype",
+            "version": "v1.23.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-ctype.git",
+                "reference": "46cd95797e9df938fdd2b03693b5fca5e64b01ce"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/46cd95797e9df938fdd2b03693b5fca5e64b01ce",
+                "reference": "46cd95797e9df938fdd2b03693b5fca5e64b01ce",
                 "shasum": ""
             },
             "require": {
@@ -950,7 +1325,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "1.20-dev"
+                    "dev-main": "1.23-dev"
                 },
                 "thanks": {
                     "name": "symfony/polyfill",
@@ -987,20 +1362,37 @@
                 "polyfill",
                 "portable"
             ],
-            "time": "2020-10-23T14:02:19+00:00"
+            "support": {
+                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.23.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2021-02-19T12:13:01+00:00"
         },
         {
             "name": "symfony/polyfill-intl-grapheme",
-            "version": "v1.20.0",
+            "version": "v1.23.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-intl-grapheme.git",
-                "reference": "c7cf3f858ec7d70b89559d6e6eb1f7c2517d479c"
+                "reference": "24b72c6baa32c746a4d0840147c9715e42bb68ab"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-intl-grapheme/zipball/c7cf3f858ec7d70b89559d6e6eb1f7c2517d479c",
-                "reference": "c7cf3f858ec7d70b89559d6e6eb1f7c2517d479c",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-grapheme/zipball/24b72c6baa32c746a4d0840147c9715e42bb68ab",
+                "reference": "24b72c6baa32c746a4d0840147c9715e42bb68ab",
                 "shasum": ""
             },
             "require": {
@@ -1012,7 +1404,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "1.20-dev"
+                    "dev-main": "1.23-dev"
                 },
                 "thanks": {
                     "name": "symfony/polyfill",
@@ -1051,20 +1443,37 @@
                 "portable",
                 "shim"
             ],
-            "time": "2020-10-23T14:02:19+00:00"
+            "support": {
+                "source": "https://github.com/symfony/polyfill-intl-grapheme/tree/v1.23.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2021-05-27T09:17:38+00:00"
         },
         {
             "name": "symfony/polyfill-intl-normalizer",
-            "version": "v1.20.0",
+            "version": "v1.23.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-intl-normalizer.git",
-                "reference": "727d1096295d807c309fb01a851577302394c897"
+                "reference": "8590a5f561694770bdcd3f9b5c69dde6945028e8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-intl-normalizer/zipball/727d1096295d807c309fb01a851577302394c897",
-                "reference": "727d1096295d807c309fb01a851577302394c897",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-normalizer/zipball/8590a5f561694770bdcd3f9b5c69dde6945028e8",
+                "reference": "8590a5f561694770bdcd3f9b5c69dde6945028e8",
                 "shasum": ""
             },
             "require": {
@@ -1076,7 +1485,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "1.20-dev"
+                    "dev-main": "1.23-dev"
                 },
                 "thanks": {
                     "name": "symfony/polyfill",
@@ -1118,20 +1527,37 @@
                 "portable",
                 "shim"
             ],
-            "time": "2020-10-23T14:02:19+00:00"
+            "support": {
+                "source": "https://github.com/symfony/polyfill-intl-normalizer/tree/v1.23.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2021-02-19T12:13:01+00:00"
         },
         {
             "name": "symfony/polyfill-mbstring",
-            "version": "v1.20.0",
+            "version": "v1.23.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-mbstring.git",
-                "reference": "39d483bdf39be819deabf04ec872eb0b2410b531"
+                "reference": "2df51500adbaebdc4c38dea4c89a2e131c45c8a1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/39d483bdf39be819deabf04ec872eb0b2410b531",
-                "reference": "39d483bdf39be819deabf04ec872eb0b2410b531",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/2df51500adbaebdc4c38dea4c89a2e131c45c8a1",
+                "reference": "2df51500adbaebdc4c38dea4c89a2e131c45c8a1",
                 "shasum": ""
             },
             "require": {
@@ -1143,7 +1569,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "1.20-dev"
+                    "dev-main": "1.23-dev"
                 },
                 "thanks": {
                     "name": "symfony/polyfill",
@@ -1181,20 +1607,37 @@
                 "portable",
                 "shim"
             ],
-            "time": "2020-10-23T14:02:19+00:00"
+            "support": {
+                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.23.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2021-05-27T09:27:20+00:00"
         },
         {
             "name": "symfony/polyfill-php73",
-            "version": "v1.20.0",
+            "version": "v1.23.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php73.git",
-                "reference": "8ff431c517be11c78c48a39a66d37431e26a6bed"
+                "reference": "fba8933c384d6476ab14fb7b8526e5287ca7e010"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php73/zipball/8ff431c517be11c78c48a39a66d37431e26a6bed",
-                "reference": "8ff431c517be11c78c48a39a66d37431e26a6bed",
+                "url": "https://api.github.com/repos/symfony/polyfill-php73/zipball/fba8933c384d6476ab14fb7b8526e5287ca7e010",
+                "reference": "fba8933c384d6476ab14fb7b8526e5287ca7e010",
                 "shasum": ""
             },
             "require": {
@@ -1203,7 +1646,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "1.20-dev"
+                    "dev-main": "1.23-dev"
                 },
                 "thanks": {
                     "name": "symfony/polyfill",
@@ -1243,20 +1686,37 @@
                 "portable",
                 "shim"
             ],
-            "time": "2020-10-23T14:02:19+00:00"
+            "support": {
+                "source": "https://github.com/symfony/polyfill-php73/tree/v1.23.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2021-02-19T12:13:01+00:00"
         },
         {
             "name": "symfony/polyfill-php80",
-            "version": "v1.20.0",
+            "version": "v1.23.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php80.git",
-                "reference": "e70aa8b064c5b72d3df2abd5ab1e90464ad009de"
+                "reference": "eca0bf41ed421bed1b57c4958bab16aa86b757d0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php80/zipball/e70aa8b064c5b72d3df2abd5ab1e90464ad009de",
-                "reference": "e70aa8b064c5b72d3df2abd5ab1e90464ad009de",
+                "url": "https://api.github.com/repos/symfony/polyfill-php80/zipball/eca0bf41ed421bed1b57c4958bab16aa86b757d0",
+                "reference": "eca0bf41ed421bed1b57c4958bab16aa86b757d0",
                 "shasum": ""
             },
             "require": {
@@ -1265,7 +1725,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "1.20-dev"
+                    "dev-main": "1.23-dev"
                 },
                 "thanks": {
                     "name": "symfony/polyfill",
@@ -1309,25 +1769,42 @@
                 "portable",
                 "shim"
             ],
-            "time": "2020-10-23T14:02:19+00:00"
+            "support": {
+                "source": "https://github.com/symfony/polyfill-php80/tree/v1.23.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2021-02-19T12:13:01+00:00"
         },
         {
             "name": "symfony/service-contracts",
-            "version": "v2.2.0",
+            "version": "v2.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/service-contracts.git",
-                "reference": "d15da7ba4957ffb8f1747218be9e1a121fd298a1"
+                "reference": "f040a30e04b57fbcc9c6cbcf4dbaa96bd318b9bb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/d15da7ba4957ffb8f1747218be9e1a121fd298a1",
-                "reference": "d15da7ba4957ffb8f1747218be9e1a121fd298a1",
+                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/f040a30e04b57fbcc9c6cbcf4dbaa96bd318b9bb",
+                "reference": "f040a30e04b57fbcc9c6cbcf4dbaa96bd318b9bb",
                 "shasum": ""
             },
             "require": {
                 "php": ">=7.2.5",
-                "psr/container": "^1.0"
+                "psr/container": "^1.1"
             },
             "suggest": {
                 "symfony/service-implementation": ""
@@ -1335,7 +1812,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.2-dev"
+                    "dev-main": "2.4-dev"
                 },
                 "thanks": {
                     "name": "symfony/contracts",
@@ -1371,20 +1848,37 @@
                 "interoperability",
                 "standards"
             ],
-            "time": "2020-09-07T11:33:47+00:00"
+            "support": {
+                "source": "https://github.com/symfony/service-contracts/tree/v2.4.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2021-04-01T10:43:52+00:00"
         },
         {
             "name": "symfony/string",
-            "version": "v5.1.8",
+            "version": "v5.3.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/string.git",
-                "reference": "a97573e960303db71be0dd8fda9be3bca5e0feea"
+                "reference": "bd53358e3eccec6a670b5f33ab680d8dbe1d4ae1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/string/zipball/a97573e960303db71be0dd8fda9be3bca5e0feea",
-                "reference": "a97573e960303db71be0dd8fda9be3bca5e0feea",
+                "url": "https://api.github.com/repos/symfony/string/zipball/bd53358e3eccec6a670b5f33ab680d8dbe1d4ae1",
+                "reference": "bd53358e3eccec6a670b5f33ab680d8dbe1d4ae1",
                 "shasum": ""
             },
             "require": {
@@ -1427,7 +1921,7 @@
                     "homepage": "https://symfony.com/contributors"
                 }
             ],
-            "description": "Symfony String component",
+            "description": "Provides an object-oriented API to strings and deals with bytes, UTF-8 code points and grapheme clusters in a unified way",
             "homepage": "https://symfony.com",
             "keywords": [
                 "grapheme",
@@ -1437,7 +1931,24 @@
                 "utf-8",
                 "utf8"
             ],
-            "time": "2020-10-24T12:01:57+00:00"
+            "support": {
+                "source": "https://github.com/symfony/string/tree/v5.3.3"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2021-06-27T11:44:38+00:00"
         },
         {
             "name": "wp-coding-standards/wpcs",
@@ -1483,6 +1994,11 @@
                 "standards",
                 "wordpress"
             ],
+            "support": {
+                "issues": "https://github.com/WordPress/WordPress-Coding-Standards/issues",
+                "source": "https://github.com/WordPress/WordPress-Coding-Standards",
+                "wiki": "https://github.com/WordPress/WordPress-Coding-Standards/wiki"
+            },
             "time": "2020-05-13T23:57:56+00:00"
         }
     ],
@@ -1492,5 +2008,6 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": [],
-    "platform-dev": []
+    "platform-dev": [],
+    "plugin-api-version": "2.1.0"
 }

--- a/includes/class-newspack-newsletters-settings.php
+++ b/includes/class-newspack-newsletters-settings.php
@@ -67,8 +67,8 @@ class Newspack_Newsletters_Settings {
 				'provider'    => 'constant_contact',
 			),
 			array(
-				'description' => __( 'Constant Contact API Access token', 'newspack-newsletters' ),
-				'key'         => 'newspack_newsletters_constant_contact_api_access_token',
+				'description' => __( 'Constant Contact API Secret', 'newspack-newsletters' ),
+				'key'         => 'newspack_newsletters_constant_contact_api_secret',
 				'type'        => 'text',
 				'provider'    => 'constant_contact',
 			),

--- a/includes/class-newspack-newsletters.php
+++ b/includes/class-newspack-newsletters.php
@@ -182,11 +182,7 @@ final class Newspack_Newsletters {
 			'cc_campaign_id',
 			[
 				'object_subtype' => self::NEWSPACK_NEWSLETTERS_CPT,
-				'show_in_rest'   => [
-					'schema' => [
-						'context' => [ 'edit' ],
-					],
-				],
+				'show_in_rest'   => false,
 				'type'           => 'string',
 				'single'         => true,
 				'auth_callback'  => '__return_true',

--- a/includes/service-providers/constant_contact/class-newspack-newsletters-constant-contact-controller.php
+++ b/includes/service-providers/constant_contact/class-newspack-newsletters-constant-contact-controller.php
@@ -32,10 +32,10 @@ class Newspack_Newsletters_Constant_Contact_Controller extends Newspack_Newslett
 
 		\register_rest_route(
 			$this->service_provider::BASE_NAMESPACE . $this->service_provider->service,
-			'verify_connection',
+			'verify_token',
 			[
 				'methods'             => \WP_REST_Server::READABLE,
-				'callback'            => [ $this, 'verify_connection' ],
+				'callback'            => [ $this, 'verify_token' ],
 				'permission_callback' => [ $this->service_provider, 'api_authoring_permissions_check' ],
 			]
 		);
@@ -136,8 +136,8 @@ class Newspack_Newsletters_Constant_Contact_Controller extends Newspack_Newslett
 	 * 
 	 * @return WP_REST_Response|mixed API response or error.
 	 */
-	public function verify_connection() {
-		$response = $this->service_provider->verify_connection();
+	public function verify_token() {
+		$response = $this->service_provider->verify_token();
 		return \rest_ensure_response( $response );
 	}
 

--- a/includes/service-providers/constant_contact/class-newspack-newsletters-constant-contact-controller.php
+++ b/includes/service-providers/constant_contact/class-newspack-newsletters-constant-contact-controller.php
@@ -32,6 +32,15 @@ class Newspack_Newsletters_Constant_Contact_Controller extends Newspack_Newslett
 
 		\register_rest_route(
 			$this->service_provider::BASE_NAMESPACE . $this->service_provider->service,
+			'verify_connection',
+			[
+				'methods'             => \WP_REST_Server::READABLE,
+				'callback'            => [ $this, 'verify_connection' ],
+				'permission_callback' => [ $this->service_provider, 'api_authoring_permissions_check' ],
+			]
+		);
+		\register_rest_route(
+			$this->service_provider::BASE_NAMESPACE . $this->service_provider->service,
 			'(?P<id>[\a-z]+)',
 			[
 				'methods'             => \WP_REST_Server::READABLE,
@@ -120,6 +129,16 @@ class Newspack_Newsletters_Constant_Contact_Controller extends Newspack_Newslett
 				],
 			]
 		);
+	}
+
+	/**
+	 * Verify connection
+	 * 
+	 * @return WP_REST_Response|mixed API response or error.
+	 */
+	public function verify_connection() {
+		$response = $this->service_provider->verify_connection();
+		return \rest_ensure_response( $response );
 	}
 
 	/**

--- a/includes/service-providers/constant_contact/class-newspack-newsletters-constant-contact-sdk.php
+++ b/includes/service-providers/constant_contact/class-newspack-newsletters-constant-contact-sdk.php
@@ -87,7 +87,7 @@ final class Newspack_Newsletters_Constant_Contact_SDK {
 			return json_decode( $response->getBody() );
 		} catch ( RequestException $e ) {
 			$body = json_decode( $e->getResponse()->getBody()->getContents() );
-			if ( isset( $body[0] ) && isset( $body[0]->error_message ) ) {
+			if ( is_array( $body ) && isset( $body[0] ) && isset( $body[0]->error_message ) ) {
 				$message = $body[0]->error_message;
 			} elseif ( isset( $body->error_message ) ) {
 				$message = $body->error_message;

--- a/includes/service-providers/constant_contact/class-newspack-newsletters-constant-contact-sdk.php
+++ b/includes/service-providers/constant_contact/class-newspack-newsletters-constant-contact-sdk.php
@@ -71,8 +71,9 @@ final class Newspack_Newsletters_Constant_Contact_SDK {
 	 * @param string $path    Request path.
 	 * @param array  $options Request options to apply. See \GuzzleHttp\RequestOptions.
 	 *
+	 * @return object Request result.
+	 *
 	 * @throws Exception Error message.
-	 * @return mixed
 	 */
 	private function request( $method, $path, $options = [] ) {
 		$config = [
@@ -231,7 +232,7 @@ final class Newspack_Newsletters_Constant_Contact_SDK {
 	/**
 	 * Get Account info
 	 *
-	 * @return mixed
+	 * @return object Account info.
 	 */
 	public function get_account_info() {
 		return $this->request(
@@ -244,7 +245,7 @@ final class Newspack_Newsletters_Constant_Contact_SDK {
 	/**
 	 * Get account email addresses
 	 *
-	 * @return mixed
+	 * @return object Email addresses.
 	 */
 	public function get_email_addresses() {
 		return $this->request( 'GET', 'account/emails' );
@@ -254,7 +255,7 @@ final class Newspack_Newsletters_Constant_Contact_SDK {
 	/**
 	 * Get Contact Lists
 	 *
-	 * @return mixed
+	 * @return object Contact lists.
 	 */
 	public function get_contact_lists() {
 		return $this->request(
@@ -294,7 +295,8 @@ final class Newspack_Newsletters_Constant_Contact_SDK {
 	 * Get campaign data from v2 or v3 API
 	 *
 	 * @param string $campaign_id Campaign id.
-	 * @return mixed
+	 *
+	 * @return object Campaign data.
 	 */
 	public function get_campaign( $campaign_id ) {
 		$campaign           = $this->request( 'GET', 'emails/' . $this->parse_campaign_id( $campaign_id ) );
@@ -314,10 +316,10 @@ final class Newspack_Newsletters_Constant_Contact_SDK {
 
 	/**
 	 * Get campaign activity.
-	 * 
+	 *
 	 * @param string $campaign_activity_id Campaign Activity ID.
-	 * 
-	 * @return mixed
+	 *
+	 * @return object Campaign activity data.
 	 */
 	public function get_campaign_activity( $campaign_activity_id ) {
 		return $this->request( 'GET', 'emails/activities/' . $campaign_activity_id );
@@ -329,7 +331,7 @@ final class Newspack_Newsletters_Constant_Contact_SDK {
 	 * @param string $campaign_id Campaign ID.
 	 * @param string $name        Campaign name.
 	 *
-	 * @return mixed
+	 * @return object Updated campaign data.
 	 */
 	public function update_campaign_name( $campaign_id, $name ) {
 		$campaign = $this->request(
@@ -346,7 +348,7 @@ final class Newspack_Newsletters_Constant_Contact_SDK {
 	 * @param string $campaign_activity_id Campaign Activity ID.
 	 * @param string $data                 Campaign Activity Data.
 	 *
-	 * @return mixed
+	 * @return object Updated campaign activity data.
 	 */
 	public function update_campaign_activity( $campaign_activity_id, $data ) {
 		return $this->request(
@@ -361,7 +363,7 @@ final class Newspack_Newsletters_Constant_Contact_SDK {
 	 *
 	 * @param array $data Campaign data.
 	 *
-	 * @return mixed
+	 * @return object Created campaign data.
 	 */
 	public function create_campaign( $data ) {
 		$campaign = $this->request(
@@ -376,11 +378,9 @@ final class Newspack_Newsletters_Constant_Contact_SDK {
 	 * Delete campaign
 	 *
 	 * @param string $campaign_id Campaign ID.
-	 *
-	 * @return mixed
 	 */
 	public function delete_campaign( $campaign_id ) {
-		return $this->request( 'DELETE', 'emails/' . $this->parse_campaign_id( $campaign_id ) );
+		$this->request( 'DELETE', 'emails/' . $this->parse_campaign_id( $campaign_id ) );
 	}
 
 	/**
@@ -388,11 +388,9 @@ final class Newspack_Newsletters_Constant_Contact_SDK {
 	 *
 	 * @param string   $campaign_activity_id Campaign Activity ID.
 	 * @param string[] $emails               Email addresses.
-	 *
-	 * @return mixed
 	 */
 	public function test_campaign( $campaign_activity_id, $emails ) {
-		return $this->request(
+		$this->request(
 			'POST',
 			'emails/activities/' . $campaign_activity_id . '/tests',
 			[ 'body' => wp_json_encode( [ 'email_addresses' => $emails ] ) ]
@@ -404,11 +402,9 @@ final class Newspack_Newsletters_Constant_Contact_SDK {
 	 *
 	 * @param string $campaign_activity_id Campaign Activity ID.
 	 * @param string $date                 ISO-8601 Formatted date or '0' for immediately.
-	 *
-	 * @return mixed
 	 */
 	public function create_schedule( $campaign_activity_id, $date = '0' ) {
-		return $this->request(
+		$this->request(
 			'POST',
 			'emails/activities/' . $campaign_activity_id . '/schedules',
 			[ 'body' => wp_json_encode( [ 'scheduled_date' => $date ] ) ]

--- a/includes/service-providers/constant_contact/class-newspack-newsletters-constant-contact-sdk.php
+++ b/includes/service-providers/constant_contact/class-newspack-newsletters-constant-contact-sdk.php
@@ -170,10 +170,12 @@ final class Newspack_Newsletters_Constant_Contact_SDK {
 	}
 
 	/**
-	 * Refresh access token.
+	 * Get access token.
 	 *
 	 * @param string $redirect_uri Redirect URI.
 	 * @param string $code         Authorization code.
+	 *
+	 * @return object Token data.
 	 *
 	 * @throws Exception Error message.
 	 */
@@ -204,6 +206,8 @@ final class Newspack_Newsletters_Constant_Contact_SDK {
 	 * Refresh access token.
 	 *
 	 * @param string $refresh_token Refresh token.
+	 *
+	 * @return object Token data.
 	 *
 	 * @throws Exception Error message.
 	 */

--- a/includes/service-providers/constant_contact/class-newspack-newsletters-constant-contact-sdk.php
+++ b/includes/service-providers/constant_contact/class-newspack-newsletters-constant-contact-sdk.php
@@ -1,0 +1,418 @@
+<?php
+/**
+ * Constant Contact Simple SDK
+ *
+ * @package Newspack
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+use GuzzleHttp\Client;
+use GuzzleHttp\Exception\RequestException;
+
+/**
+ * Constant Contact Simple SDK for v3 API.
+ */
+final class Newspack_Newsletters_Constant_Contact_SDK {
+
+	/**
+	 * Base URI for API requests.
+	 *
+	 * @var string
+	 */
+	private $base_uri = 'https://api.cc.email/v3/';
+
+	/**
+	 * Base URI for Token requests.
+	 *
+	 * @var string
+	 */
+	private $token_base_uri = 'https://idfed.constantcontact.com/as/token.oauth2';
+
+	/**
+	 * Scope for API requests.
+	 *
+	 * @var string[]
+	 */
+	private $scope = [ 'account_read', 'contact_data', 'campaign_data' ];
+
+	/**
+	 * API Key
+	 *
+	 * @var string
+	 */
+	private $api_key;
+
+	/**
+	 * API Secret
+	 *
+	 * @var string
+	 */
+	private $api_secret;
+
+	/**
+	 * Access token
+	 *
+	 * @var string
+	 */
+	private $access_token;
+
+	/**
+	 * Client for making API requests.
+	 *
+	 * @var Client
+	 */
+	private $client;
+
+	/**
+	 * Perform API requests.
+	 *
+	 * @param string $method  Request method.
+	 * @param string $path    Request path.
+	 * @param array  $options Request options to apply. See \GuzzleHttp\RequestOptions.
+	 *
+	 * @throws Exception Error message.
+	 * @return mixed
+	 */
+	private function request( $method, $path, $options = [] ) {
+		$config = [
+			'headers' => [
+				'Content-Type'  => 'application/json',
+				'Accept'        => 'application/json',
+				'Authorization' => $this->access_token ? 'Bearer ' . $this->access_token : '',
+			],
+		];
+		try {
+			$response = $this->client->request( $method, $path, $config + $options );
+			return json_decode( $response->getBody() );
+		} catch ( RequestException $e ) {
+			$body = json_decode( $e->getResponse()->getBody()->getContents() );
+			if ( isset( $body[0] ) && isset( $body[0]->error_message ) ) {
+				$message = $body[0]->error_message;
+			} elseif ( isset( $body->error_message ) ) {
+				$message = $body->error_message;
+			} else {
+				$message = $e->getMessage();
+			}
+			throw new Exception( 'Constant Contact: ' . $message );
+		}
+	}
+
+	/**
+	 * Class constructor.
+	 *
+	 * @param string $api_key      Api Key.
+	 * @param string $api_secret   Api Secret.
+	 * @param string $access_token Access token.
+	 *
+	 * @throws Exception Error message.
+	 */
+	public function __construct( $api_key, $api_secret, $access_token = '' ) {
+		if ( ! $api_key ) {
+			throw new Exception( 'API key is required.' );
+		}
+		if ( ! $api_secret ) {
+			throw new Exception( 'API secret is required.' );
+		}
+		$this->api_key    = $api_key;
+		$this->api_secret = $api_secret;
+
+		if ( $access_token ) {
+			$this->access_token = $access_token;
+		}
+
+		$this->client = new Client( [ 'base_uri' => $this->base_uri ] );
+	}
+
+	/**
+	 * Get authorization code url
+	 *
+	 * @param string $redirect_uri Redirect URI.
+	 *
+	 * @return string
+	 */
+	public function get_auth_code_url( $redirect_uri = '' ) {
+		return $this->base_uri . 'idfed?client_id=' . $this->api_key . '&scope=' . implode( '+', $this->scope ) . '&response_type=code&redirect_uri=' . urlencode( $redirect_uri );
+	}
+
+	/**
+	 * Set access token
+	 *
+	 * @param string $access_token Access token.
+	 */
+	public function set_access_token( $access_token ) {
+		$this->access_token = $access_token;
+	}
+
+	/**
+	 * Validate access token
+	 *
+	 * @param string $access_token Access token.
+	 *
+	 * @return bool Wether the token is valid or not.
+	 */
+	public function validate_token( $access_token = '' ) {
+		$access_token = $access_token ? $access_token : $this->access_token;
+		if ( ! $access_token ) {
+			return false;
+		}
+		try {
+			$response = $this->request(
+				'POST',
+				'token_info',
+				[ 'body' => wp_json_encode( [ 'token' => $access_token ] ) ]
+			);
+			return [] === array_diff( $this->scope, $response->scopes );
+		} catch ( Exception $e ) {
+			return false;
+		}
+	}
+
+	/**
+	 * Refresh access token.
+	 *
+	 * @param string $redirect_uri Redirect URI.
+	 * @param string $code         Authorization code.
+	 *
+	 * @throws Exception Error message.
+	 */
+	public function get_access_token( $redirect_uri, $code ) {
+		$credentials = base64_encode( $this->api_key . ':' . $this->api_secret );
+
+		$options = [
+			'query'   => [
+				'code'         => $code,
+				'grant_type'   => 'authorization_code',
+				'redirect_uri' => $redirect_uri,
+			],
+			'headers' => [
+				'Content-Type'  => 'application/json',
+				'Accept'        => 'application/json',
+				'Authorization' => 'Basic ' . $credentials,
+			],
+		];
+		try {
+			$response = $this->client->post( $this->token_base_uri, $options );
+			return json_decode( $response->getBody() );
+		} catch ( RequestException $e ) {
+			throw new Exception( $e->getMessage() );
+		}
+	}
+
+	/**
+	 * Refresh access token.
+	 *
+	 * @param string $refresh_token Refresh token.
+	 *
+	 * @throws Exception Error message.
+	 */
+	public function refresh_token( $refresh_token ) {
+		$credentials = base64_encode( $this->api_key . ':' . $this->api_secret );
+
+		$options = [
+			'query'   => [
+				'refresh_token' => $refresh_token,
+				'grant_type'    => 'refresh_token',
+			],
+			'headers' => [
+				'Content-Type'  => 'application/json',
+				'Accept'        => 'application/json',
+				'Authorization' => 'Basic ' . $credentials,
+			],
+		];
+		try {
+			$response = $this->client->post( $this->token_base_uri, $options );
+			return json_decode( $response->getBody() );
+		} catch ( RequestException $e ) {
+			throw new Exception( $e->getMessage() );
+		}
+	}
+
+	/**
+	 * Get Account info
+	 *
+	 * @return mixed
+	 */
+	public function get_account_info() {
+		return $this->request(
+			'GET',
+			'account/summary',
+			[ 'query' => [ 'extra_fields' => 'physical_address' ] ]
+		);
+	}
+
+	/**
+	 * Get account email addresses
+	 *
+	 * @return mixed
+	 */
+	public function get_email_addresses() {
+		return $this->request( 'GET', 'account/emails' );
+	}
+	
+	
+	/**
+	 * Get Contact Lists
+	 *
+	 * @return mixed
+	 */
+	public function get_contact_lists() {
+		return $this->request(
+			'GET',
+			'contact_lists',
+			[ 'query' => [ 'include_count' => 'true' ] ]
+		)->lists;
+	}
+
+	/**
+	 * Get v3 campaign UUID if matches v2 format.
+	 *
+	 * @param string $campaign_id Campaign ID.
+	 *
+	 * @return string Campaign ID.
+	 */
+	private function parse_campaign_id( $campaign_id ) {
+		if (
+			! preg_match(
+				'/^[0-9a-f]{8}-[0-9a-f]{4}-[0-5][0-9a-f]{3}-[089ab][0-9a-f]{3}-[0-9a-f]{12}$/i',
+				$campaign_id
+			)
+		) {
+			$ids_res = $this->request(
+				'GET',
+				'emails/campaign_id_xrefs',
+				[ 'query' => [ 'v2_email_campaign_ids' => $campaign_id ] ]
+			);
+			if ( $ids_res->xrefs && $ids_res->xrefs[0] && $ids_res->xrefs[0]->campaign_id ) {
+				$campaign_id = $ids_res->xrefs[0]->campaign_id;
+			}
+		}
+		return $campaign_id;
+	}
+
+	/**
+	 * Get campaign data from v2 or v3 API
+	 *
+	 * @param string $campaign_id Campaign id.
+	 * @return mixed
+	 */
+	public function get_campaign( $campaign_id ) {
+		$campaign           = $this->request( 'GET', 'emails/' . $this->parse_campaign_id( $campaign_id ) );
+		$activities         = array_values(
+			array_filter(
+				$campaign->campaign_activities,
+				function( $activity ) {
+					return 'primary_email' === $activity->role;
+				}
+			)
+		);
+		$activity_id        = $activities[0]->campaign_activity_id;
+		$campaign->activity = $this->get_campaign_activity( $activity_id );
+
+		return $campaign;
+	}
+
+	/**
+	 * Get campaign activity.
+	 * 
+	 * @param string $campaign_activity_id Campaign Activity ID.
+	 * 
+	 * @return mixed
+	 */
+	public function get_campaign_activity( $campaign_activity_id ) {
+		return $this->request( 'GET', 'emails/activities/' . $campaign_activity_id );
+	}
+
+	/**
+	 * Update campaign name.
+	 *
+	 * @param string $campaign_id Campaign ID.
+	 * @param string $name        Campaign name.
+	 *
+	 * @return mixed
+	 */
+	public function update_campaign_name( $campaign_id, $name ) {
+		$campaign = $this->request(
+			'PATCH',
+			'emails/' . $this->parse_campaign_id( $campaign_id ),
+			[ 'body' => wp_json_encode( [ 'name' => $name ] ) ]
+		);
+		return $this->get_campaign( $campaign->campaign_id );
+	}
+
+	/**
+	 * Update campaign activity.
+	 *
+	 * @param string $campaign_activity_id Campaign Activity ID.
+	 * @param string $data                 Campaign Activity Data.
+	 *
+	 * @return mixed
+	 */
+	public function update_campaign_activity( $campaign_activity_id, $data ) {
+		return $this->request(
+			'PUT',
+			'emails/activities/' . $campaign_activity_id,
+			[ 'body' => wp_json_encode( $data ) ]
+		);
+	}
+
+	/**
+	 * Create campaign
+	 *
+	 * @param array $data Campaign data.
+	 *
+	 * @return mixed
+	 */
+	public function create_campaign( $data ) {
+		$campaign = $this->request(
+			'POST',
+			'emails',
+			[ 'body' => wp_json_encode( $data ) ]
+		);
+		return $this->get_campaign( $campaign->campaign_id );
+	}
+
+	/**
+	 * Delete campaign
+	 *
+	 * @param string $campaign_id Campaign ID.
+	 *
+	 * @return mixed
+	 */
+	public function delete_campaign( $campaign_id ) {
+		return $this->request( 'DELETE', 'emails/' . $this->parse_campaign_id( $campaign_id ) );
+	}
+
+	/**
+	 * Test send email
+	 *
+	 * @param string   $campaign_activity_id Campaign Activity ID.
+	 * @param string[] $emails               Email addresses.
+	 *
+	 * @return mixed
+	 */
+	public function test_campaign( $campaign_activity_id, $emails ) {
+		return $this->request(
+			'POST',
+			'emails/activities/' . $campaign_activity_id . '/tests',
+			[ 'body' => wp_json_encode( [ 'email_addresses' => $emails ] ) ]
+		);
+	}
+
+	/**
+	 * Create campaign schedule
+	 *
+	 * @param string $campaign_activity_id Campaign Activity ID.
+	 * @param string $date                 ISO-8601 Formatted date or '0' for immediately.
+	 *
+	 * @return mixed
+	 */
+	public function create_schedule( $campaign_activity_id, $date = '0' ) {
+		return $this->request(
+			'POST',
+			'emails/activities/' . $campaign_activity_id . '/schedules',
+			[ 'body' => wp_json_encode( [ 'scheduled_date' => $date ] ) ]
+		);
+	}
+
+}

--- a/includes/service-providers/constant_contact/class-newspack-newsletters-constant-contact.php
+++ b/includes/service-providers/constant_contact/class-newspack-newsletters-constant-contact.php
@@ -7,12 +7,6 @@
 
 defined( 'ABSPATH' ) || exit;
 
-use Ctct\Components\EmailMarketing\Campaign;
-use Ctct\Components\EmailMarketing\Schedule;
-use Ctct\Components\EmailMarketing\TestSend;
-use Ctct\ConstantContact;
-use Ctct\Exceptions\CtctException;
-
 /**
  * Main Newspack Newsletters Class for Constant Contact ESP.
  */
@@ -25,8 +19,9 @@ final class Newspack_Newsletters_Constant_Contact extends \Newspack_Newsletters_
 		$this->service    = 'constant_contact';
 		$this->controller = new Newspack_Newsletters_Constant_Contact_Controller( $this );
 
+		add_action( 'admin_init', [ $this, 'oauth_callback' ] );
 		add_action( 'save_post_' . Newspack_Newsletters::NEWSPACK_NEWSLETTERS_CPT, [ $this, 'save' ], 10, 3 );
-		add_action( 'transition_post_status_' . Newspack_Newsletters::NEWSPACK_NEWSLETTERS_CPT, [ $this, 'send' ], 10, 3 );
+		add_action( 'transition_post_status', [ $this, 'send' ], 10, 3 );
 		add_action( 'wp_trash_post', [ $this, 'trash' ], 10, 1 );
 
 		parent::__construct( $this );
@@ -39,8 +34,10 @@ final class Newspack_Newsletters_Constant_Contact extends \Newspack_Newsletters_
 	 */
 	public function api_credentials() {
 		return [
-			'api_key'      => get_option( 'newspack_newsletters_constant_contact_api_key', '' ),
-			'access_token' => get_option( 'newspack_newsletters_constant_contact_api_access_token', '' ),
+			'api_key'       => get_option( 'newspack_newsletters_constant_contact_api_key', '' ),
+			'api_secret'    => get_option( 'newspack_newsletters_constant_contact_api_secret', '' ),
+			'access_token'  => get_option( 'newspack_newsletters_constant_contact_api_access_token', '' ),
+			'refresh_token' => get_option( 'newspack_newsletters_constant_contact_api_refresh_token', '' ),
 		];
 	}
 
@@ -50,7 +47,116 @@ final class Newspack_Newsletters_Constant_Contact extends \Newspack_Newsletters_
 	 * @return Boolean Result.
 	 */
 	public function has_api_credentials() {
-		return ! empty( $this->api_key() ) && ! empty( $this->access_token() );
+		return ! empty( $this->api_key() ) && ! empty( $this->api_secret() );
+	}
+
+	/**
+	 * Verify service provider connection.
+	 * 
+	 * @param boolean $refresh Whether to attempt connection refresh.
+	 * 
+	 * @return array
+	 */
+	public function verify_connection( $refresh = true ) {
+		$credentials  = $this->api_credentials();
+		$redirect_uri = $this->get_oauth_redirect_uri();
+		$cc           = new Newspack_Newsletters_Constant_Contact_SDK( $credentials['api_key'], $credentials['api_secret'] );
+
+		if ( ! empty( $credentials['access_token'] ) ) {
+			$cc->set_access_token( $credentials['access_token'] );
+		}
+
+		$response = [
+			'error'    => null,
+			'valid'    => false,
+			'auth_url' => $cc->get_auth_code_url( $redirect_uri ),
+		];
+
+		try {
+			// If we have a valid access token, we're connected.
+			if ( ! empty( $credentials['access_token'] ) && $cc->validate_token() ) {
+				$response['valid'] = true;
+				return $response;
+			}
+			// If we have a refresh token, we can get a new access token.
+			if ( $refresh && ! empty( $credentials['refresh_token'] ) ) {
+				$token             = $cc->refresh_token( $credentials['refresh_token'] );
+				$response['valid'] = $this->set_access_token( $token->access_token, $token->refresh_token );
+				return $response;
+			}
+			return $response;
+		} catch ( Exception $e ) {
+			$response['error'] = $e->getMessage();
+			return $response;
+		}
+	}
+
+	/**
+	 * Check if is connected to service provider.
+	 * 
+	 * @return Boolean 
+	 */
+	public function has_valid_connection() {
+		return $this->verify_connection( false )['valid'];
+	}
+
+	/**
+	 * Get OAuth Redirect URI.
+	 *
+	 * @param string $nonce Optional nonce used for URI identity validation.
+	 * 
+	 * @return string OAuth Redirect URI.
+	 */
+	private function get_oauth_redirect_uri( $nonce = '' ) {
+		return add_query_arg(
+			'cc_oauth2callback',
+			empty( $nonce ) ? wp_create_nonce( 'newspack_newsletters_oauth_nonce' ) : $nonce,
+			admin_url( 'index.php' )
+		);
+	}
+
+	/**
+	 * Authorization code callback
+	 */
+	public function oauth_callback() {
+		if ( ! current_user_can( 'edit_others_posts' ) ) {
+			return;
+		}
+		if (
+			! isset( $_GET['cc_oauth2callback'] ) || 
+			! wp_verify_nonce( sanitize_text_field( $_GET['cc_oauth2callback'] ), 'newspack_newsletters_oauth_nonce' ) ||
+			! isset( $_GET['code'] )
+		) {
+			return;
+		}
+
+		$redirect_uri = $this->get_oauth_redirect_uri( sanitize_text_field( $_GET['cc_oauth2callback'] ) );
+		$code         = sanitize_text_field( $_GET['code'] );
+
+		$this->connect( $redirect_uri, $code );
+		?>
+		<script type="text/javascript">
+			if(window.opener && window.opener.verify) {
+				window.opener.verify();
+			}
+			window.close();
+		</script>
+		<?php
+		wp_die();
+	}
+
+	/**
+	 * Connect using authorization code.
+	 *
+	 * @param string $redirect_uri Redirect URI.
+	 * @param string $code         Authorization code.
+	 *
+	 * @return Boolean Whether we are connected.
+	 */
+	private function connect( $redirect_uri, $code ) {
+		$cc    = new Newspack_Newsletters_Constant_Contact_SDK( $this->api_key(), $this->api_secret() );
+		$token = $cc->get_access_token( $redirect_uri, $code );
+		return $this->set_access_token( $token->access_token, $token->refresh_token );
 	}
 
 	/**
@@ -59,8 +165,18 @@ final class Newspack_Newsletters_Constant_Contact extends \Newspack_Newsletters_
 	 * @return String Stored API key for the service provider.
 	 */
 	public function api_key() {
-		$credentials = self::api_credentials();
+		$credentials = $this->api_credentials();
 		return $credentials['api_key'];
+	}
+
+	/**
+	 * Get API secret for service provider.
+	 *
+	 * @return String Stored API secret for the service provider.
+	 */
+	public function api_secret() {
+		$credentials = $this->api_credentials();
+		return $credentials['api_secret'];
 	}
 
 	/**
@@ -69,7 +185,7 @@ final class Newspack_Newsletters_Constant_Contact extends \Newspack_Newsletters_
 	 * @return String Stored Access Token key for the service provider.
 	 */
 	public function access_token() {
-		$credentials = self::api_credentials();
+		$credentials = $this->api_credentials();
 		return $credentials['access_token'];
 	}
 
@@ -79,16 +195,47 @@ final class Newspack_Newsletters_Constant_Contact extends \Newspack_Newsletters_
 	 * @param object $credentials API credentials.
 	 */
 	public function set_api_credentials( $credentials ) {
-		if ( empty( $credentials['api_key'] ) || empty( $credentials['access_token'] ) ) {
+		if ( empty( $credentials['api_key'] ) || empty( $credentials['api_secret'] ) ) {
 			return new WP_Error(
 				'newspack_newsletters_invalid_keys',
-				__( 'Please input Constant Contact API key and access token.', 'newspack-newsletters' )
+				__( 'Please input Constant Contact API key and secret.', 'newspack-newsletters' )
 			);
 		} else {
-			$update_api_key      = update_option( 'newspack_newsletters_constant_contact_api_key', $credentials['api_key'] );
-			$update_access_token = update_option( 'newspack_newsletters_constant_contact_api_access_token', $credentials['access_token'] );
-			return $update_api_key && $update_access_token;
+			$update_api_key    = update_option( 'newspack_newsletters_constant_contact_api_key', $credentials['api_key'] );
+			$update_api_secret = update_option( 'newspack_newsletters_constant_contact_api_secret', $credentials['api_secret'] );
+			return $update_api_key && $update_api_secret;
 		}
+	}
+
+	/**
+	 * Set acccess and refresh tokens.
+	 *
+	 * @param string $access_token  Access token.
+	 * @param string $refresh_token Refresh token.
+	 *
+	 * @return Boolean Whether values were updated.
+	 *
+	 * @throws Exception Error message.
+	 */
+	private function set_access_token( $access_token = '', $refresh_token = '' ) {
+		if ( empty( $access_token ) || empty( $refresh_token ) ) {
+			throw new Exception(
+				__( 'Access and refresh tokens are required.', 'newspack-newsletter' )
+			);
+		}
+		$update_access_token  = update_option( 'newspack_newsletters_constant_contact_api_access_token', $access_token );
+		$update_refresh_token = update_option( 'newspack_newsletters_constant_contact_api_refresh_token', $refresh_token );
+		return $update_access_token && $update_refresh_token;
+	}
+
+	/**
+	 * Get campaign name.
+	 *
+	 * @param WP_Post $post Post object.
+	 * @return String Campaign name.
+	 */
+	private function get_campaign_name( $post ) {
+		return 'Newspack Newsletter #' . $post->ID;
 	}
 
 	/**
@@ -99,22 +246,27 @@ final class Newspack_Newsletters_Constant_Contact extends \Newspack_Newsletters_
 	 * @return object|WP_Error API API Response or error.
 	 */
 	public function list( $post_id, $list_id ) {
+		if ( ! $this->has_valid_connection() ) {
+			return new WP_Error(
+				'newspack_newsletters_constant_contact_error',
+				__( 'Unable to connect to Constant Contact API', 'newspack-newsletters' )
+			);
+		}
 		try {
 			$cc_campaign_id = $this->retrieve_campaign_id( $post_id );
-			$cc             = new ConstantContact( $this->api_key() );
+			$cc             = new Newspack_Newsletters_Constant_Contact_SDK( $this->api_key(), $this->api_secret(), $this->access_token() );
 
-			$campaign = $cc->emailMarketingService->getCampaign( $this->access_token(), $cc_campaign_id ); //phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+			$campaign = $cc->get_campaign( $cc_campaign_id );
+			$activity = $campaign->activity;
 
-			$campaign->addList( $list_id );
+			if ( ! in_array( $list_id, $activity->contact_list_ids, true ) ) {
+				$activity->contact_list_ids[] = $list_id;
+			}
 
-			$campaign_result = $cc->emailMarketingService->updateCampaign( $this->access_token(), $campaign ); //phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+			$cc->update_campaign_activity( $activity->campaign_activity_id, $activity );
 
-			$data           = $this->retrieve( $post_id );
-			$data['result'] = $campaign_result;
-			return \rest_ensure_response( $data );
+			return \rest_ensure_response( $this->retrieve( $post_id ) );
 
-		} catch ( CtctException $e ) {
-			return $this->manage_ctct_exception( $e );
 		} catch ( Exception $e ) {
 			return new WP_Error(
 				'newspack_newsletters_constant_contact_error',
@@ -131,27 +283,25 @@ final class Newspack_Newsletters_Constant_Contact extends \Newspack_Newsletters_
 	 * @return object|WP_Error API API Response or error.
 	 */
 	public function unset_list( $post_id, $list_id ) {
+		if ( ! $this->has_valid_connection() ) {
+			return new WP_Error(
+				'newspack_newsletters_constant_contact_error',
+				__( 'Unable to connect to Constant Contact API', 'newspack-newsletters' )
+			);
+		}
 		try {
 			$cc_campaign_id = $this->retrieve_campaign_id( $post_id );
-			$cc             = new ConstantContact( $this->api_key() );
+			$cc             = new Newspack_Newsletters_Constant_Contact_SDK( $this->api_key(), $this->api_secret(), $this->access_token() );
 
-			$campaign = $cc->emailMarketingService->getCampaign( $this->access_token(), $cc_campaign_id ); //phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+			$campaign = $cc->get_campaign( $cc_campaign_id );
+			$activity = $campaign->activity;
 
-			$campaign->sent_to_contact_lists = array_filter(
-				$campaign->sent_to_contact_lists,
-				function( $list ) use ( $list_id ) {
-					return $list->id !== $list_id;
-				}
-			);
+			$activity->contact_list_ids = array_diff( $activity->contact_list_ids, [ $list_id ] );
 
-			$campaign_result = $cc->emailMarketingService->updateCampaign( $this->access_token(), $campaign ); //phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+			$cc->update_campaign_activity( $activity->campaign_activity_id, $activity );
 
-			$data           = $this->retrieve( $post_id );
-			$data['result'] = $campaign_result;
-			return \rest_ensure_response( $data );
+			return \rest_ensure_response( $this->retrieve( $post_id ) );
 
-		} catch ( CtctException $e ) {
-			return $this->manage_ctct_exception( $e );
 		} catch ( Exception $e ) {
 			return new WP_Error(
 				'newspack_newsletters_constant_contact_error',
@@ -167,7 +317,7 @@ final class Newspack_Newsletters_Constant_Contact extends \Newspack_Newsletters_
 	 * @return object|WP_Error API Response or error.
 	 */
 	public function retrieve( $post_id ) {
-		if ( ! $this->has_api_credentials() ) {
+		if ( ! $this->has_api_credentials() || ! $this->has_valid_connection() ) {
 			return [];
 		}
 		$transient       = sprintf( 'newspack_newsletters_error_%s_%s', $post_id, get_current_user_id() );
@@ -180,12 +330,17 @@ final class Newspack_Newsletters_Constant_Contact extends \Newspack_Newsletters_
 			);
 		}
 		try {
-			$cc_campaign_id = $this->retrieve_campaign_id( $post_id );
-			$cc             = new ConstantContact( $this->api_key() );
+			$cc             = new Newspack_Newsletters_Constant_Contact_SDK( $this->api_key(), $this->api_secret(), $this->access_token() );
+			$cc_campaign_id = get_post_meta( $post_id, 'cc_campaign_id', true );
 
-			$campaign = $cc->emailMarketingService->getCampaign( $this->access_token(), $cc_campaign_id ); //phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+			if ( ! $cc_campaign_id ) {
+				$campaign       = $this->sync( get_post( $post_id ) );
+				$cc_campaign_id = $campaign->campaign_id;
+			} else {
+				$campaign = $cc->get_campaign( $cc_campaign_id );
+			}
 
-			$lists = $cc->listService->getLists( $this->access_token() ); //phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+			$lists = $cc->get_contact_lists();
 
 			return [
 				'lists'       => $lists,
@@ -193,8 +348,6 @@ final class Newspack_Newsletters_Constant_Contact extends \Newspack_Newsletters_
 				'campaign_id' => $cc_campaign_id,
 			];
 
-		} catch ( CtctException $e ) {
-			return $this->manage_ctct_exception( $e );
 		} catch ( Exception $e ) {
 			return new WP_Error(
 				'newspack_newsletters_constant_contact_error',
@@ -212,24 +365,34 @@ final class Newspack_Newsletters_Constant_Contact extends \Newspack_Newsletters_
 	 * @return object|WP_Error API Response or error.
 	 */
 	public function sender( $post_id, $from_name, $reply_to ) {
+		if ( ! $this->has_valid_connection() ) {
+			return new WP_Error(
+				'newspack_newsletters_constant_contact_error',
+				__( 'Unable to connect to Constant Contact API', 'newspack-newsletters' )
+			);
+		}
 		try {
+			$post           = get_post( $post_id );
 			$cc_campaign_id = $this->retrieve_campaign_id( $post_id );
-			$cc             = new ConstantContact( $this->api_key() );
+			$cc             = new Newspack_Newsletters_Constant_Contact_SDK( $this->api_key(), $this->api_secret(), $this->access_token() );
+			$renderer       = new Newspack_Newsletters_Renderer();
+			$content        = $renderer->retrieve_email_html( $post );
 
-			$campaign = $cc->emailMarketingService->getCampaign( $this->access_token(), $cc_campaign_id ); //phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+			$campaign = $cc->get_campaign( $cc_campaign_id );
 
-			$campaign->from_email     = $reply_to;
-			$campaign->reply_to_email = $reply_to;
-			$campaign->from_name      = $from_name;
+			$activity = [
+				'format_type'      => 5,
+				'email_content'    => $content,
+				'subject'          => $post->post_title,
+				'contact_list_ids' => $campaign->activity->contact_list_ids,
+				'from_name'        => $from_name,
+				'from_email'       => $reply_to,
+				'reply_to_email'   => $reply_to,
+			];
 
-			$campaign_result = $cc->emailMarketingService->updateCampaign( $this->access_token(), $campaign ); //phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+			$cc->update_campaign_activity( $campaign->activity->campaign_activity_id, $activity );
 
-			$data           = $this->retrieve( $post_id );
-			$data['result'] = $campaign_result;
-
-			return \rest_ensure_response( $data );
-		} catch ( CtctException $e ) {
-			return $this->manage_ctct_exception( $e );
+			return \rest_ensure_response( $this->retrieve( $post_id ) );
 		} catch ( Exception $e ) {
 			return new WP_Error(
 				'newspack_newsletters_constant_contact_error',
@@ -246,22 +409,20 @@ final class Newspack_Newsletters_Constant_Contact extends \Newspack_Newsletters_
 	 * @return object|WP_Error API Response or error.
 	 */
 	public function test( $post_id, $emails ) {
-		try {
-			$cc_campaign_id = $this->retrieve_campaign_id( $post_id );
-			$cc             = new ConstantContact( $this->api_key() );
-
-			$result = $cc->campaignScheduleService->sendTest( //phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
-				$this->access_token(),
-				$cc_campaign_id,
-				TestSend::create(
-					[
-						'format'          => 'HTML',
-						'email_addresses' => $emails,
-					]
-				)
+		if ( ! $this->has_valid_connection() ) {
+			return new WP_Error(
+				'newspack_newsletters_constant_contact_error',
+				__( 'Unable to connect to Constant Contact API', 'newspack-newsletters' )
 			);
+		}
+		try {
+			$cc = new Newspack_Newsletters_Constant_Contact_SDK( $this->api_key(), $this->api_secret(), $this->access_token() );
 
-			$data            = $this->retrieve( $post_id );
+			$data = $this->retrieve( $post_id );
+
+			$activity = $data['campaign']->activity;
+			$result   = $cc->test_campaign( $activity->campaign_activity_id, $emails );
+
 			$data['result']  = $result;
 			$data['message'] = sprintf(
 			// translators: Message after successful test email.
@@ -270,9 +431,6 @@ final class Newspack_Newsletters_Constant_Contact extends \Newspack_Newsletters_
 			);
 
 			return \rest_ensure_response( $data );
-
-		} catch ( CtctException $e ) {
-			return $this->manage_ctct_exception( $e );
 		} catch ( Exception $e ) {
 			return new WP_Error(
 				'newspack_newsletters_constant_contact_error',
@@ -291,27 +449,38 @@ final class Newspack_Newsletters_Constant_Contact extends \Newspack_Newsletters_
 	public function sync( $post ) {
 		$api_key = $this->api_key();
 		if ( ! $api_key ) {
-			return new WP_Error(
-				'newspack_newsletters_missing_api_key',
+			throw new Exception(
 				__( 'No Constant Contact API key available.', 'newspack-newsletters' )
 			);
 		}
+		if ( ! $this->has_valid_connection() ) {
+			throw new Exception(
+				__( 'Unable to connect to Constant Contact API', 'newspack-newsletters' )
+			);
+		}
 		try {
-			$cc             = new ConstantContact( $api_key );
+			$cc             = new Newspack_Newsletters_Constant_Contact_SDK( $this->api_key(), $this->api_secret(), $this->access_token() );
 			$cc_campaign_id = get_post_meta( $post->ID, 'cc_campaign_id', true );
 			$renderer       = new Newspack_Newsletters_Renderer();
 			$content        = $renderer->retrieve_email_html( $post );
 			if ( $cc_campaign_id ) {
-				$campaign = $cc->emailMarketingService->getCampaign( $this->access_token(), $cc_campaign_id ); //phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+				$campaign = $cc->get_campaign( $cc_campaign_id );
 
-				$campaign->subject       = $post->post_title;
-				$campaign->email_content = $content;
+				$activity = [
+					'format_type'      => 5,
+					'email_content'    => $content,
+					'subject'          => $post->post_title,
+					'contact_list_ids' => $campaign->activity->contact_list_ids,
+					'from_email'       => $campaign->activity->from_email,
+					'from_name'        => $campaign->activity->from_name,
+					'reply_to_email'   => $campaign->activity->reply_to_email,
+				];
 
-				$campaign_result = $cc->emailMarketingService->updateCampaign( $this->access_token(), $campaign ); //phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+				$cc->update_campaign_activity( $campaign->activity->campaign_activity_id, $activity );
 
+				$campaign_result = $cc->get_campaign( $cc_campaign_id );
 			} else {
-
-				$account_info = $cc->accountService->getAccountInfo( $this->access_token() ); //phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+				$account_info = $cc->get_account_info();
 
 				$initial_sender = __( 'Sender Name', 'newspack-newsletters' );
 				if ( $account_info->organization_name ) {
@@ -320,7 +489,13 @@ final class Newspack_Newsletters_Constant_Contact extends \Newspack_Newsletters_
 					$initial_sender = $account_info->first_name . ' ' . $account_info->last_name;
 				}
 
-				$verified_email_addresses = $cc->accountService->getVerifiedEmailAddresses( $this->access_token() ); //phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+				$email_addresses          = $cc->get_email_addresses();
+				$verified_email_addresses = array_filter(
+					$email_addresses,
+					function ( $email ) {
+						return 'CONFIRMED' === $email->confirm_status;
+					}
+				);
 
 				if ( empty( $verified_email_addresses ) ) {
 					throw new Exception( __( 'There are no verified email addresses in the Constant Contact account.', 'newspack-newsletters' ) );
@@ -328,30 +503,27 @@ final class Newspack_Newsletters_Constant_Contact extends \Newspack_Newsletters_
 
 				$initial_email_address = $verified_email_addresses[0]->email_address;
 
-				$campaign                       = new Campaign();
-				$campaign->name                 = __( 'Newspack Newsletters', 'newspack-newsletters' ) . ' ' . uniqid();
-				$campaign->subject              = $post->post_title;
-				$campaign->from_email           = $initial_email_address;
-				$campaign->reply_to_email       = $initial_email_address;
-				$campaign->from_name            = $initial_sender;
-				$campaign->email_content        = $content;
-				$campaign->text_content         = $content;
-				$campaign->email_content_format = 'HTML';
+				$auto_draft_html = '<html><body><p>Auto draft</p></body></html>';
 
-				$campaign_result = $cc->emailMarketingService->addCampaign( $this->access_token(), $campaign ); //phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+				$campaign = [
+					'name'                      => $this->get_campaign_name( $post ),
+					'email_campaign_activities' => [
+						[
+							'format_type'    => 5, // https://v3.developer.constantcontact.com/api_guide/email_campaigns_overview.html#collapse-format-types .
+							'subject'        => $post->post_title,
+							'from_email'     => $initial_email_address,
+							'reply_to_email' => $initial_email_address,
+							'from_name'      => $initial_sender,
+							'html_content'   => empty( $content ) ? $auto_draft_html : $content,
+						],
+					],
+				];
 
-				update_post_meta( $post->ID, 'cc_campaign_id', $campaign_result->id );
+				$campaign_result = $cc->create_campaign( $campaign );
 			}
+			update_post_meta( $post->ID, 'cc_campaign_id', $campaign_result->campaign_id );
+			return $campaign_result;
 
-			return [
-				'campaign_result' => $campaign_result,
-			];
-
-		} catch ( CtctException $e ) {
-			$wp_error  = $this->manage_ctct_exception( $e );
-			$transient = sprintf( 'newspack_newsletters_error_%s_%s', $post->ID, get_current_user_id() );
-			set_transient( $transient, implode( ' ', $wp_error->get_error_messages() ), 45 );
-			return $wp_error;
 		} catch ( Exception $e ) {
 			$transient = sprintf( 'newspack_newsletters_error_%s_%s', $post->ID, get_current_user_id() );
 			set_transient( $transient, $e->getMessage(), 45 );
@@ -390,19 +562,12 @@ final class Newspack_Newsletters_Constant_Contact extends \Newspack_Newsletters_
 		}
 
 		if ( ! Newspack_Newsletters::validate_newsletter_id( $post_id ) ) {
-			return new WP_Error(
-				'newspack_newsletters_incorrect_post_type',
-				__( 'Post is not a Newsletter.', 'newspack-newsletters' )
-			);
+			return;
 		}
 
 		if ( 'publish' === $new_status && 'publish' !== $old_status ) {
 			try {
 				$sync_result = $this->sync( $post );
-
-				if ( is_wp_error( $sync_result ) ) {
-					return $sync_result;
-				}
 
 				$cc_campaign_id = get_post_meta( $post_id, 'cc_campaign_id', true );
 				if ( ! $cc_campaign_id ) {
@@ -412,19 +577,21 @@ final class Newspack_Newsletters_Constant_Contact extends \Newspack_Newsletters_
 					);
 				}
 
-				$cc       = new ConstantContact( $this->api_key() );
-				$schedule = new Schedule();
+				$cc = new Newspack_Newsletters_Constant_Contact_SDK( $this->api_key(), $this->api_secret(), $this->access_token() );
 
-				$cc->campaignScheduleService->addSchedule( $this->access_token(), $cc_campaign_id, $schedule ); //phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
-			} catch ( CtctException $e ) {
-				$wp_error  = $this->manage_ctct_exception( $e );
-				$transient = sprintf( 'newspack_newsletters_error_%s_%s', $post->ID, get_current_user_id() );
-				set_transient( $transient, implode( ' ', $wp_error->get_error_messages() ), 45 );
-				return $wp_error;
+				$cc->create_schedule( $sync_result->activity->campaign_activity_id );
 			} catch ( Exception $e ) {
 				$transient = sprintf( 'newspack_newsletters_error_%s_%s', $post->ID, get_current_user_id() );
 				set_transient( $transient, $e->getMessage(), 45 );
-				return;
+				// Reset publish status.
+				wp_update_post(
+					[
+						'ID'          => $post_id,
+						'post_status' => 'draft',
+					],
+					true
+				);
+				wp_die( esc_html( $e->getMessage() ) );
 			}
 		}
 	}
@@ -448,10 +615,11 @@ final class Newspack_Newsletters_Constant_Contact extends \Newspack_Newsletters_
 			return;
 		}
 		try {
-			$cc       = new ConstantContact( $this->api_key() );
-			$campaign = $cc->emailMarketingService->getCampaign( $this->access_token(), $cc_campaign_id ); //phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
-			if ( $campaign && 'DRAFT' === $campaign->status ) {
-				$result = $cc->emailMarketingService->deleteCampaign( $this->access_token(), $cc_campaign_id ); //phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+			$cc = new Newspack_Newsletters_Constant_Contact_SDK( $this->api_key(), $this->api_secret(), $this->access_token() );
+
+			$campaign = $cc->get_campaign( $cc_campaign_id );
+			if ( $campaign && 'DRAFT' === $campaign->current_status ) {
+				$result = $cc->delete_campaign( $cc_campaign_id );
 				delete_post_meta( $post_id, 'cc_campaign_id', $cc_campaign_id );
 			}
 		} catch ( Exception $e ) {
@@ -469,28 +637,8 @@ final class Newspack_Newsletters_Constant_Contact extends \Newspack_Newsletters_
 	public function retrieve_campaign_id( $post_id ) {
 		$cc_campaign_id = get_post_meta( $post_id, 'cc_campaign_id', true );
 		if ( ! $cc_campaign_id ) {
-			$this->sync( get_post( $post_id ) );
+			throw new Exception( __( 'Constant Contact campaign ID not found.', 'newspack-newsletters' ) );
 		}
 		return $cc_campaign_id;
-	}
-
-	/**
-	 * Format and handle Constant Contact error messages.
-	 *
-	 * @param CtctException $e Error.
-	 */
-	public function manage_ctct_exception( $e ) {
-		return new WP_Error(
-			'newspack_newsletters_constant_contact_error',
-			implode(
-				' ',
-				array_map(
-					function( $error ) {
-						return $error->error_message;
-					},
-					$e->getErrors()
-				)
-			)
-		);
 	}
 }

--- a/includes/service-providers/constant_contact/class-newspack-newsletters-constant-contact.php
+++ b/includes/service-providers/constant_contact/class-newspack-newsletters-constant-contact.php
@@ -526,11 +526,13 @@ final class Newspack_Newsletters_Constant_Contact extends \Newspack_Newsletters_
 				}
 
 				$email_addresses          = (array) $cc->get_email_addresses();
-				$verified_email_addresses = array_filter(
-					$email_addresses,
-					function ( $email ) {
-						return 'CONFIRMED' === $email->confirm_status;
-					}
+				$verified_email_addresses = array_values(
+					array_filter(
+						$email_addresses,
+						function ( $email ) {
+							return 'CONFIRMED' === $email->confirm_status;
+						}
+					)
 				);
 
 				if ( empty( $verified_email_addresses ) ) {

--- a/includes/service-providers/constant_contact/class-newspack-newsletters-constant-contact.php
+++ b/includes/service-providers/constant_contact/class-newspack-newsletters-constant-contact.php
@@ -483,12 +483,17 @@ final class Newspack_Newsletters_Constant_Contact extends \Newspack_Newsletters_
 			$renderer        = new Newspack_Newsletters_Renderer();
 			$content         = $renderer->retrieve_email_html( $post );
 			$auto_draft_html = '<html><body>[[trackingImage]]<p>Auto draft</p></body></html>';
+			$account_info    = $cc->get_account_info();
 
 			$activity_data = [
 				'format_type'  => 5, // https://v3.developer.constantcontact.com/api_guide/email_campaigns_overview.html#collapse-format-types .
 				'html_content' => empty( $content ) ? $auto_draft_html : $content,
 				'subject'      => $post->post_title,
 			];
+
+			if ( $account_info->physical_address ) {
+				$activity_data['physical_address_in_footer'] = $account_info->physical_address;
+			}
 
 			if ( $cc_campaign_id ) {
 				$campaign = $cc->get_campaign( $cc_campaign_id );
@@ -512,7 +517,6 @@ final class Newspack_Newsletters_Constant_Contact extends \Newspack_Newsletters_
 
 				$campaign_result = $cc->get_campaign( $cc_campaign_id );
 			} else {
-				$account_info = $cc->get_account_info();
 
 				$initial_sender = __( 'Sender Name', 'newspack-newsletters' );
 				if ( $account_info->organization_name ) {

--- a/newspack-newsletters.php
+++ b/newspack-newsletters.php
@@ -19,7 +19,7 @@ if ( ! defined( 'NEWSPACK_NEWSLETTERS_PLUGIN_FILE' ) ) {
 }
 
 // Include main plugin resources.
-require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/vendor/autoload.php';
+require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/vendor/autoload_packages.php';
 require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/service-providers/interface-newspack-newsletters-esp-service.php';
 require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/service-providers/interface-newspack-newsletters-wp-hookable.php';
 require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/service-providers/class-newspack-newsletters-service-provider.php';
@@ -28,6 +28,7 @@ require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/service-providers/mai
 require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp-controller.php';
 require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/service-providers/constant_contact/class-newspack-newsletters-constant-contact.php';
 require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/service-providers/constant_contact/class-newspack-newsletters-constant-contact-controller.php';
+require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/service-providers/constant_contact/class-newspack-newsletters-constant-contact-sdk.php';
 require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/service-providers/campaign_monitor/class-newspack-newsletters-campaign-monitor.php';
 require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/service-providers/campaign_monitor/class-newspack-newsletters-campaign-monitor-controller.php';
 require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/class-newspack-newsletters-editor.php';

--- a/src/components/init-modal/screens/api-keys/index.js
+++ b/src/components/init-modal/screens/api-keys/index.js
@@ -166,9 +166,9 @@ export default ( { onSetupStatus } ) => {
 								className={ errors.newspack_newsletters_invalid_keys && 'has-error' }
 							/>
 							<TextControl
-								label={ __( 'Constant Contact Access token', 'newspack-newsletters' ) }
-								value={ credentials.access_token }
-								onChange={ setCredentials( 'access_token' ) }
+								label={ __( 'Constant Contact API Secret', 'newspack-newsletters' ) }
+								value={ credentials.api_secret }
+								onChange={ setCredentials( 'api_secret' ) }
 								disabled={ inFlight }
 								onKeyDown={ handleKeyDown }
 								className={ errors.newspack_newsletters_invalid_keys && 'has-error' }

--- a/src/newsletter-editor/index.js
+++ b/src/newsletter-editor/index.js
@@ -2,9 +2,9 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { withSelect } from '@wordpress/data';
+import { withSelect, withDispatch } from '@wordpress/data';
 import { compose } from '@wordpress/compose';
-import { Fragment, useState } from '@wordpress/element';
+import { Fragment, useEffect, useState } from '@wordpress/element';
 import { PluginDocumentSettingPanel } from '@wordpress/edit-post';
 import { registerPlugin } from '@wordpress/plugins';
 
@@ -19,19 +19,49 @@ import Testing from './testing/';
 import { Styling, ApplyStyling } from './styling/';
 import { PublicSettings } from './public';
 import registerEditorPlugin from './editor/';
+import withApiHandler from '../components/with-api-handler';
 
 registerEditorPlugin();
 
-const NewsletterEdit = ( { layoutId } ) => {
+const NewsletterEdit = ( {
+	apiFetchWithErrorHandling,
+	setInFlightForAsync,
+	savePost,
+	layoutId,
+} ) => {
 	const [ shouldDisplaySettings, setShouldDisplaySettings ] = useState(
 		window?.newspack_newsletters_data?.is_service_provider_configured !== '1'
 	);
-
 	const [ testEmail, setTestEmail ] = useState(
 		window?.newspack_newsletters_data?.user_test_emails?.join( ',' ) || ''
 	);
+	const [ isConnected, setIsConnected ] = useState( null );
+	const [ oauthUrl, setOauthUrl ] = useState( null );
 
-	const { name: serviceProviderName } = getServiceProvider();
+	const { name: serviceProviderName, hasOauth } = getServiceProvider();
+
+	const verifyToken = () => {
+		const params = {
+			path: `/newspack-newsletters/v1/${ serviceProviderName }/verify_token`,
+			method: 'GET',
+		};
+		setInFlightForAsync();
+		apiFetchWithErrorHandling( params ).then( async response => {
+			if ( false === isConnected && true === response.valid ) {
+				savePost();
+			}
+			setOauthUrl( response.auth_url );
+			setIsConnected( response.valid );
+		} );
+	};
+
+	useEffect(() => {
+		if ( ! isConnected && hasOauth ) {
+			verifyToken();
+		} else {
+			setIsConnected( true );
+		}
+	}, [ serviceProviderName ]);
 
 	const isDisplayingInitModal = shouldDisplaySettings || -1 === layoutId;
 
@@ -46,8 +76,8 @@ const NewsletterEdit = ( { layoutId } ) => {
 				name="newsletters-settings-panel"
 				title={ __( 'Newsletter', 'newspack-newsletters' ) }
 			>
-				<Sidebar />
-				<PublicSettings />
+				<Sidebar isConnected={ isConnected } oauthUrl={ oauthUrl } onAuthorize={ verifyToken } />
+				{ isConnected && <PublicSettings /> }
 			</PluginDocumentSettingPanel>
 			<PluginDocumentSettingPanel
 				name="newsletters-styling-panel"
@@ -60,7 +90,11 @@ const NewsletterEdit = ( { layoutId } ) => {
 					name="newsletters-testing-panel"
 					title={ __( 'Testing', 'newspack-newsletters' ) }
 				>
-					<Testing testEmail={ testEmail } onChangeEmail={ setTestEmail } />
+					<Testing
+						testEmail={ testEmail }
+						onChangeEmail={ setTestEmail }
+						disabled={ ! isConnected }
+					/>
 				</PluginDocumentSettingPanel>
 			) }
 			<PluginDocumentSettingPanel
@@ -76,10 +110,17 @@ const NewsletterEdit = ( { layoutId } ) => {
 };
 
 const NewsletterEditWithSelect = compose( [
+	withApiHandler(),
 	withSelect( select => {
 		const { getEditedPostAttribute } = select( 'core/editor' );
 		const meta = getEditedPostAttribute( 'meta' );
 		return { layoutId: meta.template_id };
+	} ),
+	withDispatch( dispatch => {
+		const { savePost } = dispatch( 'core/editor' );
+		return {
+			savePost,
+		};
 	} ),
 ] )( NewsletterEdit );
 

--- a/src/newsletter-editor/sidebar/index.js
+++ b/src/newsletter-editor/sidebar/index.js
@@ -11,6 +11,7 @@ import { Button, TextControl, TextareaControl, ToggleControl } from '@wordpress/
  * External dependencies
  */
 import classnames from 'classnames';
+import { once } from 'lodash';
 
 /**
  * Internal dependencies
@@ -21,6 +22,9 @@ import withApiHandler from '../../components/with-api-handler';
 import './style.scss';
 
 const Sidebar = ( {
+	isConnected,
+	oauthUrl,
+	onAuthorize,
 	inFlight,
 	errors,
 	editPost,
@@ -107,6 +111,30 @@ const Sidebar = ( {
 	);
 
 	const { ProviderSidebar } = getServiceProvider();
+
+	if ( false === isConnected ) {
+		return (
+			<Fragment>
+				<p>
+					{ __(
+						'You must authorize your account before publishing your newsletter.',
+						'newspack-newsletters'
+					) }
+				</p>
+				<Button
+					isPrimary
+					disabled={ inFlight }
+					onClick={ () => {
+						const authWindow = window.open( oauthUrl, 'esp_oauth', 'width=500,height=600' );
+						authWindow.opener = { verify: once( onAuthorize ) };
+					} }
+				>
+					{ __( 'Authorize', 'newspack-newsletter' ) }
+				</Button>
+			</Fragment>
+		);
+	}
+
 	return (
 		<Fragment>
 			<ProviderSidebar

--- a/src/newsletter-editor/sidebar/index.js
+++ b/src/newsletter-editor/sidebar/index.js
@@ -37,8 +37,12 @@ const Sidebar = ( {
 
 	const apiFetch = config =>
 		apiFetchWithErrorHandling( config ).then( result => {
-			editPost( getEditPostPayload( result ) );
-			setSenderDirty( false );
+			if ( typeof result === 'object' && result.campaign ) {
+				editPost( getEditPostPayload( result ) );
+				setSenderDirty( false );
+			} else {
+				return result;
+			}
 		} );
 
 	const renderSubject = () => (

--- a/src/newsletter-editor/testing/index.js
+++ b/src/newsletter-editor/testing/index.js
@@ -35,6 +35,7 @@ export default compose( [
 		setInFlightForAsync,
 		testEmail,
 		onChangeEmail,
+		disabled,
 	} ) => {
 		const sendTestEmail = async () => {
 			const serviceProvider =
@@ -65,7 +66,7 @@ export default compose( [
 					<Button
 						isPrimary
 						onClick={ sendTestEmail }
-						disabled={ inFlight || ! hasValidEmail( testEmail ) }
+						disabled={ disabled || inFlight || ! hasValidEmail( testEmail ) }
 					>
 						{ inFlight
 							? __( 'Sending Test Email...', 'newspack-newsletters' )

--- a/src/service-providers/constant_contact/ProviderSidebar.js
+++ b/src/service-providers/constant_contact/ProviderSidebar.js
@@ -1,11 +1,9 @@
-import { once } from 'lodash';
-
 /**
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { Fragment, useEffect, useState } from '@wordpress/element';
-import { BaseControl, CheckboxControl, Spinner, Notice, Button } from '@wordpress/components';
+import { Fragment, useEffect } from '@wordpress/element';
+import { BaseControl, CheckboxControl, Spinner, Notice } from '@wordpress/components';
 
 const ProviderSidebar = ( {
 	renderSubject,
@@ -17,27 +15,8 @@ const ProviderSidebar = ( {
 	postId,
 	updateMeta,
 } ) => {
-	const [ authURL, setAuthURL ] = useState( '' );
-	const [ validConnection, setValidConnection ] = useState( undefined );
-
 	const campaign = newsletterData.campaign;
 	const lists = newsletterData.lists || [];
-
-	const verifyConnection = () => {
-		if ( validConnection ) return;
-		setValidConnection( undefined );
-		apiFetch( {
-			path: '/newspack-newsletters/v1/constant_contact/verify_connection',
-			method: 'GET',
-		} )
-			.then( res => {
-				setAuthURL( res.auth_url );
-				setValidConnection( res.valid );
-			} )
-			.catch( () => {
-				setValidConnection( false );
-			} );
-	};
 
 	const setList = ( listId, value ) => {
 		const method = value ? 'PUT' : 'DELETE';
@@ -58,10 +37,6 @@ const ProviderSidebar = ( {
 		} );
 
 	useEffect(() => {
-		verifyConnection();
-	}, [ postId ]);
-
-	useEffect(() => {
 		if ( campaign ) {
 			updateMeta( {
 				senderName: campaign.activity.from_name,
@@ -69,37 +44,6 @@ const ProviderSidebar = ( {
 			} );
 		}
 	}, [ campaign ]);
-
-	if ( undefined === validConnection ) {
-		return (
-			<div className="newspack-newsletters__loading-data">
-				{ __( 'Checking Constant Contact connection status...', 'newspack-newsletters' ) }
-				<Spinner />
-			</div>
-		);
-	}
-
-	if ( ! validConnection ) {
-		return (
-			<Fragment>
-				<p>
-					{ __(
-						'You must connect with your Constant Contact account before publishing your newsletter.',
-						'newspack-newsletters'
-					) }
-				</p>
-				<Button
-					isPrimary
-					onClick={ () => {
-						const authWindow = window.open( authURL, 'ccOAuth', 'width=500,height=600' );
-						authWindow.opener = { verify: once( verifyConnection ) };
-					} }
-				>
-					{ __( 'Authenticate with Constant Contact', 'newspack-newsletter' ) }
-				</Button>
-			</Fragment>
-		);
-	}
 
 	if ( ! campaign ) {
 		return (

--- a/src/service-providers/constant_contact/index.js
+++ b/src/service-providers/constant_contact/index.js
@@ -11,10 +11,10 @@ import ProviderSidebar from './ProviderSidebar';
 const validateNewsletter = ( { campaign } ) => {
 	const messages = [];
 
-	if ( 'DRAFT' !== campaign.status ) {
+	if ( 'DRAFT' !== campaign.current_status ) {
 		messages.push( __( 'Newsletter has already been sent.', 'newspack-newsletters' ) );
 	}
-	if ( ! campaign.sent_to_contact_lists.length ) {
+	if ( ! campaign?.activity?.contact_list_ids?.length ) {
 		messages.push(
 			__(
 				'At least one Constant Contact list must be selected before publishing.',
@@ -33,24 +33,20 @@ const renderPreSendInfo = newsletterData => {
 	if ( ! newsletterData.campaign ) {
 		return null;
 	}
-	let subscriberCount = 0;
-	const listNames = [];
-	newsletterData.lists.forEach( ( { id, name, contact_count } ) => {
-		if (
-			newsletterData.campaign.sent_to_contact_lists.some(
-				( { id: usedListId } ) => usedListId === id
-			)
-		) {
-			listNames.push( name );
-			subscriberCount += contact_count;
-		}
-	} );
+	const campaignLists = newsletterData.lists.filter(
+		( { list_id } ) =>
+			newsletterData.campaign?.activity?.contact_list_ids?.indexOf( list_id ) !== -1
+	);
+	const subscriberCount = campaignLists.reduce(
+		( total, list ) => total + list.membership_count,
+		0
+	);
 
 	return (
 		<p>
 			{ __( "You're about to send a newsletter to:", 'newspack-newsletters' ) }
 			<br />
-			<strong>{ listNames.join( ', ' ) }</strong>
+			<strong>{ campaignLists.map( list => list.name ).join( ', ' ) }</strong>
 			<br />
 			<strong>
 				{ sprintf(

--- a/src/service-providers/constant_contact/index.js
+++ b/src/service-providers/constant_contact/index.js
@@ -8,10 +8,17 @@ import { __, sprintf, _n } from '@wordpress/i18n';
  */
 import ProviderSidebar from './ProviderSidebar';
 
+const hasOauth = true;
+
 const validateNewsletter = ( { campaign } ) => {
 	const messages = [];
 
-	if ( campaign && 'DRAFT' !== campaign.current_status ) {
+	// Exit early if campaign is not set
+	if ( ! campaign ) {
+		return [ __( 'Not connected to Constant Contact', 'newspack-newsletters' ) ];
+	}
+
+	if ( 'DRAFT' !== campaign.current_status ) {
 		messages.push( __( 'Newsletter has already been sent.', 'newspack-newsletters' ) );
 	}
 	if ( ! campaign?.activity?.contact_list_ids?.length ) {
@@ -59,6 +66,7 @@ const renderPreSendInfo = newsletterData => {
 };
 
 export default {
+	hasOauth,
 	validateNewsletter,
 	getFetchDataConfig,
 	ProviderSidebar,

--- a/src/service-providers/constant_contact/index.js
+++ b/src/service-providers/constant_contact/index.js
@@ -11,7 +11,7 @@ import ProviderSidebar from './ProviderSidebar';
 const validateNewsletter = ( { campaign } ) => {
 	const messages = [];
 
-	if ( 'DRAFT' !== campaign.current_status ) {
+	if ( campaign && 'DRAFT' !== campaign.current_status ) {
 		messages.push( __( 'Newsletter has already been sent.', 'newspack-newsletters' ) );
 	}
 	if ( ! campaign?.activity?.contact_list_ids?.length ) {

--- a/src/service-providers/example/index.js
+++ b/src/service-providers/example/index.js
@@ -5,6 +5,11 @@ import { __ } from '@wordpress/i18n';
 import { Fragment } from '@wordpress/element';
 
 /**
+ * @type {boolean} Whether the ESP requires OAuth authentication.
+ */
+const hasOauth = false;
+
+/**
  * Validation utility.
  *
  * @param  {Object} object data fetched using getFetchDataConfig
@@ -97,6 +102,7 @@ const renderPreSendInfo = ( newsletterData = {} ) => (
 );
 
 export default {
+	hasOauth,
 	validateNewsletter,
 	getFetchDataConfig,
 	ProviderSidebar,


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Implements our own [simplified SDK](https://github.com/Automattic/newspack-newsletters/blob/fix/refactor-constant-contact/includes/service-providers/constant_contact/class-newspack-newsletters-constant-contact-sdk.php) to handle the [maintained v3 API](https://v3.developer.constantcontact.com/api_guide/index.html) with OAuth integration.

Instead of storing a generated access token, the API credentials now store API's `key` and `secret`, used to manage access and refresh tokens. After the first configuration with the app's credentials, the editor sidebar is replaced with an Authorization button, which will prompt the OAuth flow, update the tokens seamlessly for the user and synchronize the post with the provider.

I struggled a little bit to implement the ability to synchronize the newsletter with the provider **after** the draft was created (either by the post being created with a different provider or before the tokens were available). I wasn't able to identify the root of this sync issue, but I identified that it was caused by the `cc_campaign_id` meta being available on the rest API. At some save cycle, the meta was being deleted and the post was desynced from the provider. Removing the meta from the API (see 2b1061b47fc63c37118105393709a26f7475142e) solved the issue. I figured it's not a problem, since we don't (and probably shouldn't) manage this data on the frontend.

#### Composer Autoloader update

To ensure that our Guzzle dependency does not conflict with an older version loaded from a different plugin, I'm using [this autoloader by Jetpack](https://github.com/Automattic/jetpack/tree/master/projects/packages/autoloader). According to its readme:

> This is a custom autoloader generator that uses a classmap to always load the latest version of a class.

Might be the case for further testing, but seems to work great here.

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes #503.
Closes #511.
Closes #512.

### How to test the changes in this Pull Request:

1. Register a [Constant Contact Application](https://app.constantcontact.com/pages/dma/portal/)
2. Copy the API key and the generated secret
3. Update your Redirect URI setting to include: `https://newspack.local/wp-admin/index.php?cc_oauth2callback=*`
3. Make sure you have a Constant Contact account with updated information (or the API might fail sending)
4. Check out this branch and run `composer install && npm run build`
5. Go to Newsletters settings and set the provider to Constant Contact with your API credentials
6. Create a new newsletter and select a layout
7. Observe the "Authorize" message and button
8. Click on Authorize, login to your account if necessary, and Allow the app
9. Observe that the sidebar has been updated to synchronize with the provider
10. When it finishes retrieving the data, test by updating the content, sending test emails, and sending the newsletter.

In case your Constant Contact account is under review or suspended, you'll receive the following error notice while trying to send a test email or publishing:

<img width="1703" alt="Captura de Tela 2021-07-27 às 11 33 31" src="https://user-images.githubusercontent.com/820752/127173146-29bbe2b8-5c78-42fe-9e4b-6f76952564bb.png">

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
