### PR TITLE
Fix: include format assets editor

### DIFF
--- a/includes/class-newspack-newsletters-editor.php
+++ b/includes/class-newspack-newsletters-editor.php
@@ -61,11 +61,17 @@ final class Newspack_Newsletters_Editor {
 			return;
 		}
 
+		$allowed_actions = [
+			__CLASS__ . '::enqueue_block_editor_assets',
+			'newspack_enqueue_scripts',
+			'wp_enqueue_editor_format_library_assets',
+		];
+
 		$enqueue_block_editor_assets_filters = $GLOBALS['wp_filter']['enqueue_block_editor_assets']->callbacks;
 		foreach ( $enqueue_block_editor_assets_filters as $index => $filter ) {
 			$action_handlers = array_keys( $filter );
 			foreach ( $action_handlers as $handler ) {
-				if ( __CLASS__ . '::enqueue_block_editor_assets' != $handler && 'newspack_enqueue_scripts' !== $handler ) {
+				if ( ! in_array( $handler, $allowed_actions, true ) ) {
 					remove_action( 'enqueue_block_editor_assets', $handler, $index );
 				}
 			}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Since the 5.8 upgrade, newsletters and newsletter ads editor does not display the toolbar for text formatting (bold, italic, etc...).

This PR includes the "formatting" asset as an allowed asset in the newsletter and newsletter ad editor.

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes #520.

### How to test the changes in this Pull Request:

1. In the master branch verify the missing toolbar (see #520 for reference).
2. Checkout this branch and verify that the toolbar is back.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
