### PR TITLE
feat: subtitle support for post inserter

### DIFF
--- a/src/editor/blocks/posts-inserter/block.json
+++ b/src/editor/blocks/posts-inserter/block.json
@@ -61,6 +61,10 @@
 			"type": "number",
 			"default": 25
 		},
+		"subHeadingFontSize": {
+			"type": "number",
+			"default": 18
+		},
 		"textColor": {
 			"type": "string",
 			"default": "#000"

--- a/src/editor/blocks/posts-inserter/block.json
+++ b/src/editor/blocks/posts-inserter/block.json
@@ -13,6 +13,10 @@
 			"type": "number",
 			"default": 3
 		},
+		"displayPostSubtitle": {
+			"type": "boolean",
+			"default": false
+		},
 		"displayPostExcerpt": {
 			"type": "boolean",
 			"default": true

--- a/src/editor/blocks/posts-inserter/index.js
+++ b/src/editor/blocks/posts-inserter/index.js
@@ -144,6 +144,11 @@ const PostsInserterBlock = ( {
 			<InspectorControls>
 				<PanelBody title={ __( 'Post content settings', 'newspack-newsletters' ) }>
 					<ToggleControl
+						label={ __( 'Post subtitle', 'newspack-newsletters' ) }
+						checked={ attributes.displayPostSubtitle }
+						onChange={ value => setAttributes( { displayPostSubtitle: value } ) }
+					/>
+					<ToggleControl
 						label={ __( 'Post excerpt', 'newspack-newsletters' ) }
 						checked={ attributes.displayPostExcerpt }
 						onChange={ value => setAttributes( { displayPostExcerpt: value } ) }

--- a/src/editor/blocks/posts-inserter/utils.js
+++ b/src/editor/blocks/posts-inserter/utils.js
@@ -45,10 +45,10 @@ const getDateBlockTemplate = ( post, { textFontSize, textColor } ) => {
 	];
 };
 
-const getSubtitleBlockTemplate = ( post, { textFontSize, textColor } ) => {
+const getSubtitleBlockTemplate = ( post, { subHeadingFontSize, textColor } ) => {
 	const subtitle = post?.meta?.newspack_post_subtitle || '';
-	const attributes = { content: subtitle.trim(), style: { color: { text: textColor } } };
-	return [ 'core/paragraph', assignFontSize( textFontSize, attributes ) ];
+	const attributes = { level: 4, content: subtitle.trim(), style: { color: { text: textColor } } };
+	return [ 'core/heading', assignFontSize( subHeadingFontSize, attributes ) ];
 };
 
 const getExcerptBlockTemplate = ( post, { excerptLength, textFontSize, textColor } ) => {
@@ -114,6 +114,9 @@ const getAuthorBlockTemplate = ( post, { textFontSize, textColor } ) => {
 const createBlockTemplatesForSinglePost = ( post, attributes ) => {
 	const postContentBlocks = [ getHeadingBlockTemplate( post, attributes ) ];
 
+	if ( attributes.displayPostSubtitle && post.meta?.newspack_post_subtitle ) {
+		postContentBlocks.push( getSubtitleBlockTemplate( post, attributes ) );
+	}
 	if ( attributes.displayAuthor ) {
 		const author = getAuthorBlockTemplate( post, attributes );
 
@@ -123,9 +126,6 @@ const createBlockTemplatesForSinglePost = ( post, attributes ) => {
 	}
 	if ( attributes.displayPostDate && post.date_gmt ) {
 		postContentBlocks.push( getDateBlockTemplate( post, attributes ) );
-	}
-	if ( attributes.displayPostSubtitle && post.meta?.newspack_post_subtitle ) {
-		postContentBlocks.push( getSubtitleBlockTemplate( post, attributes ) );
 	}
 	if ( attributes.displayPostExcerpt ) {
 		postContentBlocks.push( getExcerptBlockTemplate( post, attributes ) );

--- a/src/editor/blocks/posts-inserter/utils.js
+++ b/src/editor/blocks/posts-inserter/utils.js
@@ -45,6 +45,12 @@ const getDateBlockTemplate = ( post, { textFontSize, textColor } ) => {
 	];
 };
 
+const getSubtitleBlockTemplate = ( post, { textFontSize, textColor } ) => {
+	const subtitle = post?.meta?.newspack_post_subtitle || '';
+	const attributes = { content: subtitle.trim(), style: { color: { text: textColor } } };
+	return [ 'core/paragraph', assignFontSize( textFontSize, attributes ) ];
+};
+
 const getExcerptBlockTemplate = ( post, { excerptLength, textFontSize, textColor } ) => {
 	let excerpt = post.excerpt.rendered;
 	const excerptElement = document.createElement( 'div' );
@@ -117,6 +123,9 @@ const createBlockTemplatesForSinglePost = ( post, attributes ) => {
 	}
 	if ( attributes.displayPostDate && post.date_gmt ) {
 		postContentBlocks.push( getDateBlockTemplate( post, attributes ) );
+	}
+	if ( attributes.displayPostSubtitle && post.meta?.newspack_post_subtitle ) {
+		postContentBlocks.push( getSubtitleBlockTemplate( post, attributes ) );
 	}
 	if ( attributes.displayPostExcerpt ) {
 		postContentBlocks.push( getExcerptBlockTemplate( post, attributes ) );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Subtitle as a displayable post meta on post inserter.

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes #295.

### How to test the changes in this Pull Request:

1. Check out this branch and run `npm run build`
2. Create a new post with subtitle and another without
3. Create a newsletter with Post Inserter block
4. Make the Post Inserter block display 2 posts and enable **Post subtitle**
5. Observe the post subtitle being displayed accordingly without errors
6. Send a test email to confirm that its also displayed as expected

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
