### PR TITLE
fix: add campaign monitor to readme

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Requires at least: 5.3
 Tested up to: 5.8.0
 Requires PHP: 5.6
 Stable tag: trunk
-Tags: newsletters, Newspack, WordPress.com, Mailchimp, Constant Contact
+Tags: newsletters, Newspack, WordPress.com, Mailchimp, Constant Contact, Campaign Monitor
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -58,7 +58,7 @@ The [beach photograph](https://www.pexels.com/photo/wind-grass-beach-sea-7763/) 
 
 = What newsletter providers are supported? =
 
-Mailchimp and Constant Contact are currently supported.
+Mailchimp, Constant Contact and Campaign Monitor are currently supported.
 
 == Screenshots ==
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Update readme to include Campaign Monitor as ESP.