### PR TITLE
fix: renderer button styling

### DIFF
--- a/includes/class-newspack-newsletters-renderer.php
+++ b/includes/class-newspack-newsletters-renderer.php
@@ -135,6 +135,14 @@ final class Newspack_Newsletters_Renderer {
 			}
 		}
 
+		// Add !important to all colors.
+		if ( isset( $colors['color'] ) ) {
+			$colors['color'] .= ' !important';
+		}
+		if ( isset( $colors['background-color'] ) ) {
+			$colors['background-color'] .= ' !important';
+		}
+
 		return $colors;
 	}
 
@@ -364,7 +372,7 @@ final class Newspack_Newsletters_Renderer {
 					$anchor        = $xpath->query( '//a' )[0];
 					$attrs         = $button_block['attrs'];
 					$text          = $anchor->textContent; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
-					$border_radius = isset( $attrs['borderRadius'] ) ? $attrs['borderRadius'] : 5;
+					$border_radius = isset( $attrs['borderRadius'] ) ? $attrs['borderRadius'] : 999;
 					$is_outlined   = isset( $attrs['className'] ) && 'is-style-outline' == $attrs['className'];
 
 					$default_button_attrs = array(

--- a/tests/test-renderer.php
+++ b/tests/test-renderer.php
@@ -49,7 +49,7 @@ class Newsletters_Renderer_Test extends WP_UnitTestCase {
 					'innerHTML'   => $inner_html,
 				]
 			),
-			'<mj-section textColor="vivid-purple" color="#db18e6" background-color="#4aadd7" font-size="16px" padding="0"><mj-column padding="12px" width="100%"><mj-text padding="0" line-height="1.8" font-size="16px"  textColor="vivid-purple" color="#db18e6" container-background-color="#4aadd7">' . $inner_html . '</mj-text></mj-column></mj-section>',
+			'<mj-section textColor="vivid-purple" color="#db18e6 !important" background-color="#4aadd7 !important" font-size="16px" padding="0"><mj-column padding="12px" width="100%"><mj-text padding="0" line-height="1.8" font-size="16px"  textColor="vivid-purple" color="#db18e6 !important" container-background-color="#4aadd7 !important">' . $inner_html . '</mj-text></mj-column></mj-section>',
 			'Renders styled paragraph'
 		);
 	}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

As seen on #484, different mail clients apply CSS rules differently. While in Chrome the global `a { color: inherit !important; }` gets overwritten by the element rule `style="color:#FFFFFF;"`, it is not the case for Safari (and Mac's Mail client).

This PR ensures user-defined colors are rendered on any browser/mail client and changes the default button radius to the default value on the Newspack theme.

Closes #484.

### How to test the changes in this Pull Request:

1. Change your provider to Manual
2. On the master branch create a newsletter with 2 different buttons:
    1. with bright text and dark background
    2. with dark text and bright background
3. Click on send, copy and save the resulting HTML.
4. Open the HTML file in different browsers (Chrome, Firefox, Edge, and Safari) and observe the consistency issue.
5. Checkout this branch, save the newsletter to generate a new render, update the HTML file.
6. Observe that the buttons look the same on all browsers.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
