### PR TITLE
fix: add custom css to layouts

### DIFF
--- a/includes/class-newspack-newsletters-layouts.php
+++ b/includes/class-newspack-newsletters-layouts.php
@@ -99,6 +99,17 @@ final class Newspack_Newsletters_Layouts {
 				'auth_callback'  => '__return_true',
 			]
 		);
+		\register_meta(
+			'post',
+			'custom_css',
+			[
+				'object_subtype' => self::NEWSPACK_NEWSLETTERS_LAYOUT_CPT,
+				'show_in_rest'   => true,
+				'type'           => 'string',
+				'single'         => true,
+				'auth_callback'  => '__return_true',
+			]
+		);
 	}
 
 	/**

--- a/includes/class-newspack-newsletters.php
+++ b/includes/class-newspack-newsletters.php
@@ -873,6 +873,7 @@ final class Newspack_Newsletters {
 					'background_color' => get_post_meta( $post->ID, 'background_color', true ),
 					'font_body'        => get_post_meta( $post->ID, 'font_body', true ),
 					'font_header'      => get_post_meta( $post->ID, 'font_header', true ),
+					'custom_css'       => get_post_meta( $post->ID, 'custom_css', true ),
 				];
 				return $post;
 			},

--- a/src/components/newsletter-preview/index.js
+++ b/src/components/newsletter-preview/index.js
@@ -8,6 +8,7 @@ import { Fragment, useMemo } from '@wordpress/element';
  * Internal dependencies
  */
 import './style.scss';
+import { getScopedCss } from '../../newsletter-editor/styling';
 
 const NewsletterPreview = ( { meta = {}, ...props } ) => {
 	const ELEMENT_ID = useMemo( () => `preview-${ Math.round( Math.random() * 1000 ) }`, [] );
@@ -27,6 +28,12 @@ const NewsletterPreview = ( { meta = {}, ...props } ) => {
 #${ ELEMENT_ID } h1, #${ ELEMENT_ID } h2, #${ ELEMENT_ID } h3, #${ ELEMENT_ID } h4, #${ ELEMENT_ID } h5, #${ ELEMENT_ID } h6 {
   font-family: ${ meta.font_header };
 }`
+					: ' '
+			}${
+				meta.custom_css
+					? `
+${ getScopedCss( `#${ ELEMENT_ID }`, meta.custom_css ) }
+`
 					: ' '
 			}` }</style>
 			<div

--- a/src/newsletter-editor/layout/index.js
+++ b/src/newsletter-editor/layout/index.js
@@ -28,7 +28,7 @@ export default compose( [
 		const { getEditedPostAttribute, isEditedPostEmpty, getCurrentPostId } = select( 'core/editor' );
 		const { getBlocks } = select( 'core/block-editor' );
 		const meta = getEditedPostAttribute( 'meta' );
-		const { template_id: layoutId, background_color, font_body, font_header } = meta;
+		const { template_id: layoutId, background_color, font_body, font_header, custom_css } = meta;
 		return {
 			layoutId,
 			postTitle: getEditedPostAttribute( 'title' ),
@@ -39,6 +39,7 @@ export default compose( [
 				background_color,
 				font_body,
 				font_header,
+				custom_css,
 			},
 		};
 	} ),

--- a/src/newsletter-editor/styling/index.js
+++ b/src/newsletter-editor/styling/index.js
@@ -105,7 +105,7 @@ const doc = document.implementation.createHTMLDocument( 'Temp' );
  * @param {string} css The CSS to scope.
  * @return Scoped CSS string.
  */
-const getScopedCss = ( scope, css ) => {
+export const getScopedCss = ( scope, css ) => {
 	const style = doc.querySelector( 'style' ) || document.createElement( 'style' );
 
 	style.textContent = css;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Implements custom CSS to layouts.

Closes #538.

### How to test the changes in this Pull Request:

1. In the master branch, create a newsletter with custom CSS and save it as a new layout
2. Create a newsletter with the saved layout and observe that it didn't save the custom CSS
3. Switch to this branch, run `npm run build`, repeat steps, and observe the custom CSS being saved and applied

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
