### PR TITLE
feat(post inserter): add post content option

### DIFF
--- a/src/editor/blocks/posts-inserter/block.json
+++ b/src/editor/blocks/posts-inserter/block.json
@@ -17,6 +17,10 @@
 			"type": "boolean",
 			"default": false
 		},
+	  	"displayPostContent": {
+			"type": "boolean",
+			"default": false
+		},
 		"displayPostExcerpt": {
 			"type": "boolean",
 			"default": true

--- a/src/editor/blocks/posts-inserter/index.js
+++ b/src/editor/blocks/posts-inserter/index.js
@@ -149,9 +149,24 @@ const PostsInserterBlock = ( {
 						onChange={ value => setAttributes( { displayPostSubtitle: value } ) }
 					/>
 					<ToggleControl
+						label={ __( 'Post content', 'newspack-newsletters' ) }
+						checked={ attributes.displayPostContent }
+						onChange={ value =>
+							setAttributes( {
+								displayPostContent: value,
+								displayPostExcerpt: value ? false : attributes.displayPostExcerpt,
+							} )
+						}
+					/>
+					<ToggleControl
 						label={ __( 'Post excerpt', 'newspack-newsletters' ) }
 						checked={ attributes.displayPostExcerpt }
-						onChange={ value => setAttributes( { displayPostExcerpt: value } ) }
+						onChange={ value => {
+							setAttributes( {
+								displayPostContent: value ? false : attributes.displayPostContent,
+								displayPostExcerpt: value,
+							} );
+						} }
 					/>
 					{ attributes.displayPostExcerpt && (
 						<RangeControl

--- a/src/editor/blocks/posts-inserter/utils.js
+++ b/src/editor/blocks/posts-inserter/utils.js
@@ -51,6 +51,16 @@ const getSubtitleBlockTemplate = ( post, { subHeadingFontSize, textColor } ) => 
 	return [ 'core/heading', assignFontSize( subHeadingFontSize, attributes ) ];
 };
 
+const getContentBlockTemplate = ( post, { textFontSize, textColor } ) => {
+	let content = post.content.rendered;
+	const contentElement = document.createElement( 'div' );
+	contentElement.innerHTML = content;
+	content = contentElement.textContent || contentElement.innerText || '';
+
+	const attributes = { content: content.trim(), style: { color: { text: textColor } } };
+	return [ 'core/paragraph', assignFontSize( textFontSize, attributes ) ];
+};
+
 const getExcerptBlockTemplate = ( post, { excerptLength, textFontSize, textColor } ) => {
 	let excerpt = post.excerpt.rendered;
 	const excerptElement = document.createElement( 'div' );
@@ -126,6 +136,9 @@ const createBlockTemplatesForSinglePost = ( post, attributes ) => {
 	}
 	if ( attributes.displayPostDate && post.date_gmt ) {
 		postContentBlocks.push( getDateBlockTemplate( post, attributes ) );
+	}
+	if ( attributes.displayPostContent ) {
+		postContentBlocks.push( getContentBlockTemplate( post, attributes ) );
 	}
 	if ( attributes.displayPostExcerpt ) {
 		postContentBlocks.push( getExcerptBlockTemplate( post, attributes ) );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

add post content as an option for the post inserter, it will disable the post excerpt if selected and
vice versa, since it doesn't make sense to have both post excerpt and content in the same post

fix #478

### How to test the changes in this Pull Request:

1. Pull the branch of this PR.
2. On a new newsletter, add a post-inserter block.
3. Observe the new option to add the post content.
4. Check the post content checkbox and observe that the post excerpt is removed and the post content is added instead.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
