### PR TITLE
Prefix classes before generating autoload files

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
 		"post-update-cmd": [
 			"vendor/bin/cghooks update"
 		],
-		"post-autoload-dump": [
+		"pre-autoload-dump": [
 			"composer prefix-guzzle"
 		]
 	},


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

This PR fixes and issue @miguelpeixe noticed while building the releases: the namespaced Guzzle classes weren't getting included in the composer autoload. This is because `post-composer-autoload` runs after the autoload file is generated. Switching to `pre-composer-autoload` solves the issue.

### How to test the changes in this Pull Request:

1. Before checking out this PR, run `rm -r vendor; rm -r vendor_prefixed/*`, then run `composer install --no-dev --no-scripts && composer dump-autoload`, then run `cat vendor/composer/autoload_classmap.php`. You should not see the Guzzle classes in the classmap.
2.  Check out this PR, run all those above commands again. You should see the Guzzle classes in the classmap.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
