### PR TITLE
fix: unbind prefix command from composer dump event

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -75,7 +75,7 @@ jobs:
       - checkout_with_workspace
       - run:
           name: Install PHP dependencies
-          command: composer install --no-dev --no-scripts && composer dump-autoload
+          command: composer install --no-dev --no-scripts && composer prefix-guzzle && composer dump-autoload
       - run:
           name: Install rsync
           command: sudo apt install rsync

--- a/composer.json
+++ b/composer.json
@@ -32,9 +32,6 @@
 		],
 		"post-update-cmd": [
 			"vendor/bin/cghooks update"
-		],
-		"post-autoload-dump": [
-			"composer prefix-guzzle"
 		]
 	},
 	"extra": {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

After some investigation with @claudiulodro (see #552), this PR fixes the missing namespaced Guzzle from the autoload by running the custom prefix command outside of the autoload dump event.

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

### How to test the changes in this Pull Request:

1. Check out this PR, `run rm -r vendor; rm -r vendor_prefixed/*`, then run `composer install --no-dev --no-scripts && composer prefix-guzzle && composer dump-autoload`, then run `cat vendor/composer/autoload_classmap.php`. You should see the Guzzle classes in the classmap.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
