### PR TITLE
Refactor Mailchimp recipients and segmentation options

### DIFF
--- a/includes/class-newspack-newsletters-settings.php
+++ b/includes/class-newspack-newsletters-settings.php
@@ -101,13 +101,6 @@ class Newspack_Newsletters_Settings {
 			);
 		}
 
-		$settings_list[] = array(
-			'description' => __( 'Use Mailchimp Tags?', 'newspack-newsletters' ),
-			'key'         => 'newspack_newsletters_use_mailchimp_tags',
-			'type'        => 'checkbox',
-			'provider'    => 'mailchimp',
-		);
-
 		$settings_list = array_map(
 			function ( $item ) {
 				$default       = ! empty( $item['default'] ) ? $item['default'] : false;

--- a/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp-controller.php
+++ b/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp-controller.php
@@ -145,15 +145,12 @@ class Newspack_Newsletters_Mailchimp_Controller extends Newspack_Newsletters_Ser
 				'callback'            => [ $this, 'api_segments' ],
 				'permission_callback' => [ $this->service_provider, 'api_authoring_permissions_check' ],
 				'args'                => [
-					'id'          => [
+					'id'        => [
 						'sanitize_callback' => 'absint',
 						'validate_callback' => [ 'Newspack_Newsletters', 'validate_newsletter_id' ],
 					],
-					'interest_id' => [
+					'target_id' => [
 						'sanitize_callback' => 'esc_attr',
-					],
-					'tag_ids'     => [
-						'sanitize_callback' => 'wp_parse_list',
 					],
 				],
 			]
@@ -228,8 +225,7 @@ class Newspack_Newsletters_Mailchimp_Controller extends Newspack_Newsletters_Ser
 	public function api_segments( $request ) {
 		$response = $this->service_provider->audience_segments(
 			$request['id'],
-			$request['interest_id'],
-			$request['tag_ids']
+			$request['target_id']
 		);
 		return \rest_ensure_response( $response );
 	}

--- a/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp.php
+++ b/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp.php
@@ -546,12 +546,15 @@ final class Newspack_Newsletters_Mailchimp extends \Newspack_Newsletters_Service
 	 */
 	public function audience_segments( $post_id, $target_id ) {
 
+		$interest_id = false;
+		$segment_id  = false;
+
 		// Determine if we're dealing with an interest or a segment.
 		if ( false !== strpos( $target_id, ':' ) ) {
 			$exploded    = explode( ':', $target_id );
 			$field       = count( $exploded ) ? $exploded[0] : null;
 			$interest_id = count( $exploded ) > 1 ? $exploded[1] : null;
-		} else {
+		} elseif ( '' !== $target_id ) {
 			$segment_id = $target_id;
 		}
 

--- a/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp.php
+++ b/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp.php
@@ -170,10 +170,8 @@ final class Newspack_Newsletters_Mailchimp extends \Newspack_Newsletters_Service
 				}
 			}
 
-			$newspack_newsletters_use_mailchimp_tags = get_option( 'newspack_newsletters_use_mailchimp_tags', false );
-
 			$tags = [];
-			if ( $list_id && $newspack_newsletters_use_mailchimp_tags ) {
+			if ( $list_id ) {
 				$tags_response = $this->validate(
 					$mc->get( "lists/$list_id/segments?count=1000", [], 20 ),
 					__( 'Error retrieving Mailchimp tags.', 'newspack_newsletters' )

--- a/src/service-providers/mailchimp/ProviderSidebar.js
+++ b/src/service-providers/mailchimp/ProviderSidebar.js
@@ -58,7 +58,7 @@ const SegmentsSelection = ( {
 		<Fragment>
 			{ options.length ? (
 				<SelectControl
-					label={ __( 'Group, segment or tag', 'newspack-newsletters' ) }
+					label={ __( 'Group, segment, or tag', 'newspack-newsletters' ) }
 					value={ targetId }
 					options={ [
 						{

--- a/src/service-providers/mailchimp/ProviderSidebar.js
+++ b/src/service-providers/mailchimp/ProviderSidebar.js
@@ -3,75 +3,71 @@
  */
 import { __ } from '@wordpress/i18n';
 import { Fragment, useEffect, useState } from '@wordpress/element';
-import {
-	ExternalLink,
-	SelectControl,
-	Spinner,
-	Notice,
-	FormTokenField,
-} from '@wordpress/components';
+import { ExternalLink, SelectControl, Spinner, Notice } from '@wordpress/components';
 
 /**
  * Internal dependencies
  */
-import { getListInterestsSettings, getListTags, getTagNames, getTagIds } from './utils';
+import { getListInterestsSettings } from './utils';
 
 const SegmentsSelection = ( {
 	onUpdate,
 	inFlight,
-	chosenInterestId,
+	chosenTarget,
 	availableInterests,
-	chosenTags,
-	availableTags,
+	availableSegments,
 } ) => {
-	const [ segmentsData, setSegmentsData ] = useState( {
-		interest_id: chosenInterestId,
-		tag_ids: chosenTags,
-	} );
-	const updateSegmentsData = data => setSegmentsData( { ...segmentsData, ...data } );
-
-	// Update with real data after local (optimistic) update.
-	useEffect(() => {
-		setSegmentsData( {
-			interest_id: chosenInterestId,
-			tag_ids: chosenTags,
-		} );
-	}, [ chosenInterestId, chosenTags.join() ]);
+	const [ targetId, setTargetId ] = useState( chosenTarget || '' );
 
 	const [ isInitial, setIsInitial ] = useState( true );
 	useEffect(() => {
 		if ( ! isInitial ) {
-			onUpdate( segmentsData );
+			onUpdate( targetId );
 		}
 		setIsInitial( false );
-	}, [ segmentsData.interest_id, segmentsData.tag_ids.join() ]);
+	}, [ targetId ]);
+
+	let options = [];
+
+	if ( availableInterests.length > 0 ) {
+		options = options.concat( [
+			{
+				label: __( 'Group', 'newspack-newsletters' ),
+				value: 'groups',
+				disabled: true,
+			},
+			...availableInterests,
+		] );
+	}
+
+	if ( availableSegments.length > 0 ) {
+		options = options.concat( [
+			{
+				label: __( 'Segment or tag', 'newspack-newsletters' ),
+				value: 'segments',
+				disabled: true,
+			},
+			...availableSegments.map( segment => ( {
+				label: ` - ${ segment.name }`,
+				value: segment.id,
+			} ) ),
+		] );
+	}
 
 	return (
 		<Fragment>
-			{ availableInterests.length ? (
+			{ options.length ? (
 				<SelectControl
-					label={ __( 'Groups', 'newspack-newsletters' ) }
-					value={ segmentsData.interest_id }
+					label={ __( 'Group, segment or tag', 'newspack-newsletters' ) }
+					value={ targetId }
 					options={ [
 						{
-							label: __( '-- Select a group --', 'newspack-newsletters' ),
-							value: 'no_interests',
+							label: __( 'All subscribers in audience', 'newspack-newsletters' ),
+							value: '',
 						},
-						...availableInterests,
+						...options,
 					] }
-					onChange={ interest_id => updateSegmentsData( { interest_id } ) }
-					disabled={ inFlight }
-				/>
-			) : null }
-			{ availableTags.length ? (
-				<FormTokenField
-					className="newspack-newsletters__mailchimp-tags"
-					label={ __( 'Tags', 'newspack-newsletters' ) }
-					value={ getTagNames( segmentsData.tag_ids, availableTags ) }
-					suggestions={ availableTags.map( tag => tag.name ) }
-					onChange={ updatedTagsNames =>
-						updateSegmentsData( { tag_ids: getTagIds( updatedTagsNames, availableTags ) } )
-					}
+					onChange={ id => setTargetId( id ) }
 					disabled={ inFlight }
 				/>
 			) : null }
@@ -91,6 +87,7 @@ const ProviderSidebar = ( {
 } ) => {
 	const campaign = newsletterData.campaign;
 	const lists = newsletterData.lists?.lists || [];
+	const segments = newsletterData.segments || newsletterData.tags || []; // Keep .tags for backwards compatibility.
 
 	const setList = listId =>
 		apiFetch( {
@@ -98,12 +95,15 @@ const ProviderSidebar = ( {
 			method: 'POST',
 		} );
 
-	const updateSegments = updatedData =>
+	const updateSegments = target_id => {
 		apiFetch( {
 			path: `/newspack-newsletters/v1/mailchimp/${ postId }/segments`,
 			method: 'POST',
-			data: updatedData,
+			data: {
+				target_id,
+			},
 		} );
+	};
 
 	const setSender = ( { senderName, senderEmail } ) =>
 		apiFetch( {
@@ -147,15 +147,19 @@ const ProviderSidebar = ( {
 	const list = list_id && lists.find( ( { id } ) => list_id === id );
 	const { web_id: listWebId } = list || {};
 
+	const recipients = newsletterData.campaign?.recipients;
+
+	const chosenTarget =
+		recipients?.segment_opts?.saved_segment_id || recipients?.segment_opts?.conditions[ 0 ]?.value;
+
 	const interestSettings = getListInterestsSettings( newsletterData );
-	const chosenTags = getListTags( newsletterData );
 
 	return (
 		<Fragment>
 			{ renderSubject() }
 
 			<SelectControl
-				label={ __( 'To', 'newspack-newsletters' ) }
+				label={ __( 'Audience', 'newspack-newsletters' ) }
 				className="newspack-newsletters__to-selectcontrol"
 				value={ list_id }
 				options={ [
@@ -180,10 +184,9 @@ const ProviderSidebar = ( {
 			) }
 
 			<SegmentsSelection
-				chosenInterestId={ interestSettings.interestValue }
+				chosenTarget={ chosenTarget }
 				availableInterests={ interestSettings.options }
-				chosenTags={ chosenTags }
-				availableTags={ newsletterData.tags.filter( tag => tag.member_count > 0 ) }
+				availableSegments={ segments.filter( segment => segment.member_count > 0 ) }
 				apiFetch={ apiFetch }
 				inFlight={ inFlight }
 				onUpdate={ updateSegments }

--- a/src/service-providers/mailchimp/index.js
+++ b/src/service-providers/mailchimp/index.js
@@ -13,7 +13,6 @@ import { find } from 'lodash';
  * Internal dependencies
  */
 import ProviderSidebar from './ProviderSidebar';
-import './style.scss';
 
 const validateNewsletter = ( { campaign } ) => {
 	const { recipients, settings, status } = campaign || {};

--- a/src/service-providers/mailchimp/style.scss
+++ b/src/service-providers/mailchimp/style.scss
@@ -1,6 +1,0 @@
-.newspack-newsletters__mailchimp-tags {
-	margin-bottom: 1em;
-	+ .components-form-token-field__help {
-		display: none;
-	}
-}

--- a/src/service-providers/mailchimp/utils.js
+++ b/src/service-providers/mailchimp/utils.js
@@ -29,7 +29,7 @@ export const getListInterestsSettings = ( {
 	const options = interestCategories.categories.reduce( ( accumulator, item ) => {
 		const { title, interests, id } = item;
 		accumulator.push( {
-			label: title,
+			label: `- ${ title }`,
 			disabled: true,
 		} );
 		if ( interests && interests.interests && interests.interests.length ) {
@@ -41,7 +41,7 @@ export const getListInterestsSettings = ( {
 				);
 
 				accumulator.push( {
-					label: `- ${ interest.name } (${ subscriberCountInfo })`,
+					label: `-- ${ interest.name } (${ subscriberCountInfo })`,
 					value: `interests-${ id }:${ interest.id }`,
 					disabled: subscriberCount === 0,
 					rawInterest: interest,
@@ -56,21 +56,3 @@ export const getListInterestsSettings = ( {
 
 	return { options, interestValue, setInterest: find( options, [ 'value', interestValue ] ) };
 };
-
-export const getListTags = ( { campaign } ) => {
-	const conditions = get( campaign, 'recipients.segment_opts.conditions' );
-	if ( ! conditions ) {
-		return [];
-	}
-	return conditions.reduce( ( tagIds, condition ) => {
-		if ( condition.condition_type === 'StaticSegment' ) {
-			tagIds.push( condition.value );
-		}
-		return tagIds;
-	}, [] );
-};
-
-export const getTagIds = ( tagNames, allTags ) =>
-	tagNames.map( tagName => find( allTags, [ 'name', tagName ] ).id );
-export const getTagNames = ( tagIds, allTags ) =>
-	tagIds.map( id => find( allTags, [ 'id', id ] ).name );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PRs proposes a change on how we support segmentation with the Mailchimp provider. Currently, we have support for selecting a group and multiple tags. The tags implementation also included saved segments, although not supported due to the segmentation options for `saved` segments being different for `static` segments (tags).

The redesign fixes the segmentation support and proposes a simpler approach, similar to how Mailchimp's wizard works, in which you are able to select one of the available groups, tags, or segments. For what we generally propose in terms of form complexity, this approach avoids scenarios in which the user would select a group and different segments that don't match existing recipients.

It also removes the `Use Mailchimp tags` field. It looks like an unnecessary block for accessing segmentation options.

![image](https://user-images.githubusercontent.com/820752/130153357-62d1dbed-d8c0-4876-a18c-dc0ae84ed795.png)

![image](https://user-images.githubusercontent.com/820752/130153390-2cef42b3-6d17-4806-945d-cc2e971802d8.png)

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes #22.

### How to test the changes in this Pull Request:

1. Switch to this branch and run `npm run build`
2. Test selecting different segmentation options and publishing campaigns

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
