### PR TITLE
fix: prevent sender data overwrite on updates

### DIFF
--- a/src/newsletter-editor/sidebar/index.js
+++ b/src/newsletter-editor/sidebar/index.js
@@ -4,7 +4,7 @@
 import { __ } from '@wordpress/i18n';
 import { compose } from '@wordpress/compose';
 import { withSelect, withDispatch } from '@wordpress/data';
-import { useState, Fragment } from '@wordpress/element';
+import { Fragment } from '@wordpress/element';
 import { Button, TextControl, TextareaControl, ToggleControl } from '@wordpress/components';
 
 /**
@@ -37,13 +37,10 @@ const Sidebar = ( {
 	apiFetchWithErrorHandling,
 	postId,
 } ) => {
-	const [ senderDirty, setSenderDirty ] = useState( false );
-
 	const apiFetch = config =>
 		apiFetchWithErrorHandling( config ).then( result => {
 			if ( typeof result === 'object' && result.campaign ) {
 				editPost( getEditPostPayload( result ) );
-				setSenderDirty( false );
 			} else {
 				return result;
 			}
@@ -74,7 +71,6 @@ const Sidebar = ( {
 				disabled={ inFlight }
 				onChange={ value => {
 					editPost( { meta: { senderName: value } } );
-					setSenderDirty( true );
 				} }
 			/>
 			<TextControl
@@ -85,18 +81,15 @@ const Sidebar = ( {
 				disabled={ inFlight }
 				onChange={ value => {
 					editPost( { meta: { senderEmail: value } } );
-					setSenderDirty( true );
 				} }
 			/>
-			{ senderDirty && (
-				<Button
-					isLink
-					onClick={ () => handleSenderUpdate( { senderName, senderEmail } ) }
-					disabled={ inFlight || ( senderEmail.length ? ! hasValidEmail( senderEmail ) : false ) }
-				>
-					{ __( 'Update Sender', 'newspack-newsletters' ) }
-				</Button>
-			) }
+			<Button
+				isLink
+				onClick={ () => handleSenderUpdate( { senderName, senderEmail } ) }
+				disabled={ inFlight || ( senderEmail.length ? ! hasValidEmail( senderEmail ) : false ) }
+			>
+				{ __( 'Update Sender', 'newspack-newsletters' ) }
+			</Button>
 		</Fragment>
 	);
 
@@ -109,8 +102,6 @@ const Sidebar = ( {
 			onChange={ value => editPost( { meta: { preview_text: value } } ) }
 		/>
 	);
-
-	const { ProviderSidebar } = getServiceProvider();
 
 	if ( false === isConnected ) {
 		return (
@@ -135,6 +126,8 @@ const Sidebar = ( {
 		);
 	}
 
+	// eslint-disable-next-line @wordpress/no-unused-vars-before-return
+	const { ProviderSidebar } = getServiceProvider();
 	return (
 		<Fragment>
 			<ProviderSidebar

--- a/src/service-providers/mailchimp/ProviderSidebar.js
+++ b/src/service-providers/mailchimp/ProviderSidebar.js
@@ -117,9 +117,18 @@ const ProviderSidebar = ( {
 
 	useEffect(() => {
 		if ( campaign && campaign.settings ) {
+			const { from_name, reply_to } = campaign.settings;
 			updateMeta( {
-				senderName: campaign.settings.from_name,
-				senderEmail: campaign.settings.reply_to,
+				...( from_name
+					? {
+							senderName: from_name,
+					  }
+					: {} ),
+				...( reply_to
+					? {
+							senderEmail: reply_to,
+					  }
+					: {} ),
 			} );
 		}
 	}, [ campaign ]);


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes a bug.

### How to test the changes in this Pull Request:

1. On `master`, create a new newsletter using Mailchimp as the ESP
2. Input something into to "From" name and email, but don't click "Update Sender"
3. Update the newsletter - set or change the target group or save draft
4. Observe the "From" inputs are cleared
5. Switch to this branch and rebuild, observe the inputs are not cleared after an update 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->