### PR TITLE
fix: custom CSS selector

### DIFF
--- a/src/newsletter-editor/styling/index.js
+++ b/src/newsletter-editor/styling/index.js
@@ -112,9 +112,15 @@ export const getScopedCss = ( scope, css ) => {
 	doc.head.appendChild( style );
 
 	const rules = [ ...style.sheet.cssRules ];
-	const scopedRules = rules.map( rule => scope + ' ' + rule.cssText );
-
-	return scopedRules.join( '\n' );
+	return rules
+		.map( rule => {
+			rule.selectorText = rule.selectorText
+				.split( ',' )
+				.map( selector => `${ scope } ${ selector }` )
+				.join( ', ' );
+			return rule.cssText;
+		} )
+		.join( '\n' );
 };
 
 export const ApplyStyling = withSelect( customStylesSelector )(


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Modify `CSSStyleRule`'s [`selectorText`](https://developer.mozilla.org/en-US/docs/Web/API/CSSStyleRule/selectorText) instead of `cssText` to handle multiple selectors in the same rule, e.g.: `h1, h2 {}`.

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes #545.

### How to test the changes in this Pull Request:

1. In the master branch, create a Newsletter with `h1` and `h2` and apply the following custom CSS: `h1, h2 { color: #f00; }` 2. Observe that only the h1 is colored red
3. Switch to this branch, run `npm run build`, and observe the rule being applied to both headings

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
