### PR TITLE
fix: post inserter default styles

### DIFF
--- a/src/editor/blocks/posts-inserter/block.json
+++ b/src/editor/blocks/posts-inserter/block.json
@@ -54,24 +54,22 @@
 			"default": []
 		},
 		"textFontSize": {
-			"type": "number",
-			"default": 16
+			"type": "number"
 		},
 		"headingFontSize": {
-			"type": "number",
-			"default": 25
+			"type": "number"
 		},
 		"subHeadingFontSize": {
-			"type": "number",
-			"default": 18
+			"type": "number"
 		},
 		"textColor": {
-			"type": "string",
-			"default": "#000"
+			"type": "string"
 		},
 		"headingColor": {
-			"type": "string",
-			"default": "#000"
+			"type": "string"
+		},
+		"subHeadingColor": {
+			"type": "string"
 		},
 		"tags": {
 			"type": "array",

--- a/src/editor/blocks/posts-inserter/index.js
+++ b/src/editor/blocks/posts-inserter/index.js
@@ -190,11 +190,12 @@ const PostsInserterBlock = ( {
 					<FontSizePicker
 						fontSizes={ blockEditorSettings.fontSizes }
 						value={ attributes.textFontSize }
-						fallbackFontSize={ 16 }
-						onChange={ value => setAttributes( { textFontSize: isNaN( value ) ? null : value } ) }
+						onChange={ value => {
+							return setAttributes( { textFontSize: value } );
+						} }
 					/>
 					<ColorPicker
-						color={ attributes.textColor }
+						color={ attributes.textColor || '' }
 						onChangeComplete={ value => setAttributes( { textColor: value.hex } ) }
 						disableAlpha
 					/>
@@ -203,14 +204,23 @@ const PostsInserterBlock = ( {
 					<FontSizePicker
 						fontSizes={ blockEditorSettings.fontSizes }
 						value={ attributes.headingFontSize }
-						fallbackFontSize={ 25 }
-						onChange={ value =>
-							setAttributes( { headingFontSize: isNaN( value ) ? null : value } )
-						}
+						onChange={ value => setAttributes( { headingFontSize: value } ) }
 					/>
 					<ColorPicker
-						color={ attributes.headingColor }
+						color={ attributes.headingColor || '' }
 						onChangeComplete={ value => setAttributes( { headingColor: value.hex } ) }
+						disableAlpha
+					/>
+				</PanelBody>
+				<PanelBody title={ __( 'Subtitle style', 'newspack-newsletters' ) }>
+					<FontSizePicker
+						fontSizes={ blockEditorSettings.fontSizes }
+						value={ attributes.subHeadingFontSize }
+						onChange={ value => setAttributes( { subHeadingFontSize: value } ) }
+					/>
+					<ColorPicker
+						color={ attributes.subHeadingColor || '' }
+						onChangeComplete={ value => setAttributes( { subHeadingColor: value.hex } ) }
 						disableAlpha
 					/>
 				</PanelBody>

--- a/src/editor/blocks/posts-inserter/utils.js
+++ b/src/editor/blocks/posts-inserter/utils.js
@@ -17,10 +17,9 @@ import { POSTS_INSERTER_BLOCK_NAME } from './consts';
 
 const assignFontSize = ( fontSize, attributes ) => {
 	if ( typeof fontSize === 'number' ) {
-		attributes.style = { ...( attributes.style || {} ), typography: { fontSize } };
-	} else if ( typeof fontSize === 'string' ) {
-		attributes.fontSize = fontSize;
+		fontSize = fontSize + 'px';
 	}
+	attributes.style = { ...( attributes.style || {} ), typography: { fontSize } };
 	return attributes;
 };
 
@@ -45,9 +44,13 @@ const getDateBlockTemplate = ( post, { textFontSize, textColor } ) => {
 	];
 };
 
-const getSubtitleBlockTemplate = ( post, { subHeadingFontSize, textColor } ) => {
+const getSubtitleBlockTemplate = ( post, { subHeadingFontSize, subHeadingColor } ) => {
 	const subtitle = post?.meta?.newspack_post_subtitle || '';
-	const attributes = { level: 4, content: subtitle.trim(), style: { color: { text: textColor } } };
+	const attributes = {
+		level: 4,
+		content: subtitle.trim(),
+		style: { color: { text: subHeadingColor } },
+	};
 	return [ 'core/heading', assignFontSize( subHeadingFontSize, attributes ) ];
 };
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Fix the text and headings font-size update and set the default styles to empty so it follows the newsletter standard or the custom CSS.

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes #566.

### How to test the changes in this Pull Request:

#### Font size update fix

1. In the master branch, create a newsletter with the Posts Inserter block
2. Attempt to modify the font size of the text and observe it doesn't change
3. Switch to this branch, run `npm run build` observe that you are able to modify the font size

#### Default styles

1. Still in this branch, create a newsletter and paste the following custom CSS to it: `h3 { color: #f00; font-size: 30px; }`
2. Insert a Posts Inserter block and observe the posts titles reflect the custom CSS

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
