### PR TITLE
feat: add support for embed

### DIFF
--- a/includes/class-newspack-newsletters-editor.php
+++ b/includes/class-newspack-newsletters-editor.php
@@ -97,6 +97,7 @@ final class Newspack_Newsletters_Editor {
 			'core/block',
 			'core/group',
 			'core/paragraph',
+			'core/embed',
 			'core/heading',
 			'core/column',
 			'core/columns',

--- a/includes/class-newspack-newsletters-embed.php
+++ b/includes/class-newspack-newsletters-embed.php
@@ -1,0 +1,72 @@
+<?php
+/**
+ * Newspack Newsletter Embed
+ *
+ * @package Newspack
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Newspack Newsletters Embed Class.
+ */
+final class Newspack_Newsletters_Embed {
+	/**
+	 * Allowed HTML tags for rich embeds.
+	 *
+	 * @var array
+	 */
+	public static $allowed_html = array(
+		'a'          => array(
+			'href'  => array(),
+			'title' => array(),
+		),
+		'blockquote' => array(),
+		'br'         => array(),
+		'em'         => array(),
+		'strong'     => array(),
+	);
+	/**
+	 * The single instance of the class.
+	 *
+	 * @var Newspack_Newsletters_Embed
+	 */
+	protected static $instance = null;
+
+	/**
+	 * Main Newspack Newsletter Embed Instance.
+	 * Ensures only one instance of Newspack Embed Instance is loaded or can be loaded.
+	 *
+	 * @return Newspack Embed Instance - Main instance.
+	 */
+	public static function instance() {
+		if ( is_null( self::$instance ) ) {
+			self::$instance = new self();
+		}
+		return self::$instance;
+	}
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct() {
+		add_filter( 'rest_pre_echo_response', [ __CLASS__, 'add_sanitized_html' ], 10, 3 );
+	}
+
+	/**
+	 * Add sanitized HTML to oEmbed API response.
+	 *
+	 * @param object          $response Response data to send to the client.
+	 * @param WP_REST_Server  $server   Server instance.
+	 * @param WP_REST_Request $request  Request used to generate the response.
+	 * 
+	 * @return array Response data to send to the client.
+	 */
+	public static function add_sanitized_html( $response, $server, $request ) {
+		if ( '/oembed/1.0/proxy' === $request->get_route() && isset( $response->html ) ) {
+			$response->sanitized_html = wp_kses( $response->html, self::$allowed_html );
+		}
+		return $response;
+	}
+}
+Newspack_Newsletters_Embed::instance();

--- a/includes/class-newspack-newsletters-renderer.php
+++ b/includes/class-newspack-newsletters-renderer.php
@@ -586,7 +586,7 @@ final class Newspack_Newsletters_Renderer {
 				$oembed = _wp_oembed_get_object();
 				$data   = $oembed->get_data( $attrs['url'] );
 
-				if ( ! $data || ! empty( $data->type ) ) {
+				if ( ! $data || empty( $data->type ) ) {
 					break;
 				}
 

--- a/includes/class-newspack-newsletters-renderer.php
+++ b/includes/class-newspack-newsletters-renderer.php
@@ -593,6 +593,13 @@ final class Newspack_Newsletters_Renderer {
 					'font-family' => $font_family,
 				);
 
+				$caption_attrs = array(
+					'align'       => 'center',
+					'color'       => '#555d66',
+					'font-size'   => '13px',
+					'font-family' => $font_family,
+				);
+
 				$allowed_html = array(
 					'a'          => array(
 						'href'  => array(),
@@ -634,13 +641,7 @@ final class Newspack_Newsletters_Renderer {
 						);
 						$markup   .= '<mj-image ' . self::array_to_attributes( $img_attrs ) . ' />';
 						if ( ! empty( $caption ) ) {
-							$caption_attrs = array(
-								'align'       => 'center',
-								'color'       => '#555d66',
-								'font-size'   => '13px',
-								'font-family' => $font_family,
-							);
-							$markup       .= '<mj-text ' . self::array_to_attributes( $caption_attrs ) . '>' . esc_html( $caption ) . ' - ' . esc_html( $data->provider_name ) . '</mj-text>';
+							$markup .= '<mj-text ' . self::array_to_attributes( $caption_attrs ) . '>' . esc_html( $caption ) . ' - ' . esc_html( $data->provider_name ) . '</mj-text>';
 						}
 						break;
 					case 'video':
@@ -655,13 +656,7 @@ final class Newspack_Newsletters_Renderer {
 							$markup   .= '<mj-image ' . self::array_to_attributes( $img_attrs ) . ' />';
 						}
 						if ( ! empty( $caption ) ) {
-							$caption_attrs = array(
-								'align'       => 'center',
-								'color'       => '#555d66',
-								'font-size'   => '13px',
-								'font-family' => $font_family,
-							);
-							$markup       .= '<mj-text ' . self::array_to_attributes( $caption_attrs ) . '>' . esc_html( $caption ) . ' - ' . esc_html( $data->provider_name ) . '</mj-text>';
+							$markup .= '<mj-text ' . self::array_to_attributes( $caption_attrs ) . '>' . esc_html( $caption ) . ' - ' . esc_html( $data->provider_name ) . '</mj-text>';
 						}
 						break;
 					case 'rich':

--- a/includes/class-newspack-newsletters-renderer.php
+++ b/includes/class-newspack-newsletters-renderer.php
@@ -586,6 +586,10 @@ final class Newspack_Newsletters_Renderer {
 				$oembed = _wp_oembed_get_object();
 				$data   = $oembed->get_data( $attrs['url'] );
 
+				if ( ! $data || ! empty( $data->type ) ) {
+					break;
+				}
+
 				$text_attrs = array(
 					'padding'     => '0',
 					'line-height' => '1.8',

--- a/includes/class-newspack-newsletters-renderer.php
+++ b/includes/class-newspack-newsletters-renderer.php
@@ -604,17 +604,6 @@ final class Newspack_Newsletters_Renderer {
 					'font-family' => $font_family,
 				);
 
-				$allowed_html = array(
-					'a'          => array(
-						'href'  => array(),
-						'title' => array(),
-					),
-					'blockquote' => array(),
-					'br'         => array(),
-					'em'         => array(),
-					'strong'     => array(),
-				);
-
 				// Parse block caption.
 				$dom = new DomDocument();
 				@$dom->loadHTML( mb_convert_encoding( $inner_html, 'HTML-ENTITIES', 'UTF-8' ) ); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged
@@ -666,7 +655,7 @@ final class Newspack_Newsletters_Renderer {
 						}
 						break;
 					case 'rich':
-						$html = wp_kses( (string) $data->html, $allowed_html );
+						$html = wp_kses( (string) $data->html, Newspack_Newsletters_Embed::$allowed_html );
 						if ( ! empty( $html ) ) {
 							$markup .= '<mj-text ' . self::array_to_attributes( $text_attrs ) . '>' . $html . '</mj-text>';
 						} elseif ( ! empty( $caption ) ) {

--- a/includes/class-newspack-newsletters-renderer.php
+++ b/includes/class-newspack-newsletters-renderer.php
@@ -668,7 +668,7 @@ final class Newspack_Newsletters_Renderer {
 						if ( ! empty( $html ) ) {
 							$markup .= '<mj-text ' . self::array_to_attributes( $text_attrs ) . '>' . $html . '</mj-text>';
 						} elseif ( ! empty( $caption ) ) {
-							$markup .= '<mj-text ' . self::array_to_attributes( $text_attrs ) . '><a href="' . esc_url( $attrs['url'] ) . '">' . esc_html( $data->provider_name ) . ' - ' . esc_html( $caption ) . '</a></mj-text>';
+							$markup .= '<mj-text ' . self::array_to_attributes( $text_attrs ) . '><a href="' . esc_url( $attrs['url'] ) . '">' . esc_html( $caption ) . '</a></mj-text>';
 						}
 						break;
 					case 'link':

--- a/includes/class-newspack-newsletters-renderer.php
+++ b/includes/class-newspack-newsletters-renderer.php
@@ -665,8 +665,9 @@ final class Newspack_Newsletters_Renderer {
 						}
 						break;
 					case 'rich':
-						if ( ! empty( $data->html ) && is_string( $data->html ) ) {
-							$markup .= '<mj-text ' . self::array_to_attributes( $text_attrs ) . '>' . wp_kses( $data->html, $allowed_html ) . '</mj-text>';
+						$html = wp_kses( $data->html ?? '', $allowed_html );
+						if ( ! empty( $html ) && is_string( $html ) ) {
+							$markup .= '<mj-text ' . self::array_to_attributes( $text_attrs ) . '>' . $html . '</mj-text>';
 						} elseif ( ! empty( $caption ) ) {
 							$markup .= '<mj-text ' . self::array_to_attributes( $text_attrs ) . '><a href="' . esc_url( $attrs['url'] ) . '">' . esc_html( $data->provider_name ) . ' - ' . esc_html( $caption ) . '</a></mj-text>';
 						}

--- a/includes/class-newspack-newsletters-renderer.php
+++ b/includes/class-newspack-newsletters-renderer.php
@@ -661,6 +661,8 @@ final class Newspack_Newsletters_Renderer {
 							if ( ! empty( $caption ) ) {
 								$markup .= '<mj-text ' . self::array_to_attributes( $caption_attrs ) . '>' . esc_html( $caption ) . ' - ' . esc_html( $data->provider_name ) . '</mj-text>';
 							}
+						} elseif ( ! empty( $caption ) ) {
+							$markup .= '<mj-text ' . self::array_to_attributes( $text_attrs ) . '><a href="' . esc_url( $attrs['url'] ) . '">' . esc_html( $caption ) . '</a></mj-text>';
 						}
 						break;
 					case 'rich':

--- a/includes/class-newspack-newsletters-renderer.php
+++ b/includes/class-newspack-newsletters-renderer.php
@@ -649,7 +649,7 @@ final class Newspack_Newsletters_Renderer {
 						}
 						break;
 					case 'video':
-						if ( $data->thumbnail_url ) {
+						if ( ! empty( $data->thumbnail_url ) ) {
 							$img_attrs = array(
 								'padding' => '0',
 								'src'     => $data->thumbnail_url,
@@ -658,9 +658,9 @@ final class Newspack_Newsletters_Renderer {
 								'href'    => $attrs['url'],
 							);
 							$markup   .= '<mj-image ' . self::array_to_attributes( $img_attrs ) . ' />';
-						}
-						if ( ! empty( $caption ) ) {
-							$markup .= '<mj-text ' . self::array_to_attributes( $caption_attrs ) . '>' . esc_html( $caption ) . ' - ' . esc_html( $data->provider_name ) . '</mj-text>';
+							if ( ! empty( $caption ) ) {
+								$markup .= '<mj-text ' . self::array_to_attributes( $caption_attrs ) . '>' . esc_html( $caption ) . ' - ' . esc_html( $data->provider_name ) . '</mj-text>';
+							}
 						}
 						break;
 					case 'rich':

--- a/includes/class-newspack-newsletters-renderer.php
+++ b/includes/class-newspack-newsletters-renderer.php
@@ -630,9 +630,18 @@ final class Newspack_Newsletters_Renderer {
 							'alt'    => $caption,
 							'width'  => $data->width,
 							'height' => $data->height,
-							'href'   => $data->url,
+							'href'   => $attrs['url'],
 						);
 						$markup   .= '<mj-image ' . self::array_to_attributes( $img_attrs ) . ' />';
+						if ( ! empty( $caption ) ) {
+							$caption_attrs = array(
+								'align'       => 'center',
+								'color'       => '#555d66',
+								'font-size'   => '13px',
+								'font-family' => $font_family,
+							);
+							$markup       .= '<mj-text ' . self::array_to_attributes( $caption_attrs ) . '>' . esc_html( $caption ) . ' - ' . esc_html( $data->provider_name ) . '</mj-text>';
+						}
 						break;
 					case 'video':
 						if ( $data->thumbnail_url ) {

--- a/includes/class-newspack-newsletters-renderer.php
+++ b/includes/class-newspack-newsletters-renderer.php
@@ -664,8 +664,8 @@ final class Newspack_Newsletters_Renderer {
 						}
 						break;
 					case 'rich':
-						$html = wp_kses( $data->html ?? '', $allowed_html );
-						if ( ! empty( $html ) && is_string( $html ) ) {
+						$html = wp_kses( (string) $data->html, $allowed_html );
+						if ( ! empty( $html ) ) {
 							$markup .= '<mj-text ' . self::array_to_attributes( $text_attrs ) . '>' . $html . '</mj-text>';
 						} elseif ( ! empty( $caption ) ) {
 							$markup .= '<mj-text ' . self::array_to_attributes( $text_attrs ) . '><a href="' . esc_url( $attrs['url'] ) . '">' . esc_html( $data->provider_name ) . ' - ' . esc_html( $caption ) . '</a></mj-text>';

--- a/includes/email-template-mjml.css
+++ b/includes/email-template-mjml.css
@@ -40,14 +40,17 @@ ul, ol {
 }
 
 /* Quote */
+blockquote,
 .wp-block-quote {
 	border-left: 4px solid #000;
 	margin: 0;
 	padding-left: 20px;
 }
+blockquote,
 .wp-block-quote cite {
 	color: #767676;
 }
+blockquote,
 .wp-block-quote p {
 	padding-bottom: 12px;
 }

--- a/includes/email-template-mjml.css
+++ b/includes/email-template-mjml.css
@@ -46,11 +46,11 @@ blockquote,
 	margin: 0;
 	padding-left: 20px;
 }
-blockquote,
+blockquote cite,
 .wp-block-quote cite {
 	color: #767676;
 }
-blockquote,
+blockquote p,
 .wp-block-quote p {
 	padding-bottom: 12px;
 }

--- a/newspack-newsletters.php
+++ b/newspack-newsletters.php
@@ -38,4 +38,5 @@ require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/class-newspack-newsle
 require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/class-newspack-newsletters-ads.php';
 require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/class-newspack-newsletters-bulk-actions.php';
 require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/class-newspack-newsletters-quick-edit.php';
+require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/class-newspack-newsletters-embed.php';
 require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/class-newspack-newsletters.php';

--- a/src/editor/blocks/embed/index.js
+++ b/src/editor/blocks/embed/index.js
@@ -9,7 +9,7 @@ import classnames from 'classnames';
 import { __ } from '@wordpress/i18n';
 import { Fragment, useState } from '@wordpress/element';
 import { select } from '@wordpress/data';
-import { ToolbarButton, ToolbarGroup } from '@wordpress/components';
+import { ToolbarButton, ToolbarGroup, Placeholder } from '@wordpress/components';
 import { BlockControls, useBlockProps, RichText } from '@wordpress/block-editor';
 import { createBlock } from '@wordpress/blocks';
 import { globe } from '@wordpress/icons';
@@ -46,6 +46,15 @@ const EmbedPreview = props => {
 				embedContent = <div dangerouslySetInnerHTML={ { __html: props.sanitized_html } } />;
 			}
 			break;
+	}
+	if ( ! embedContent && ! caption ) {
+		return (
+			<Placeholder>
+				<p className="components-placeholder__error">
+					{ __( 'No suitable content found to display in email format.', 'newspack-newsletters' ) }
+				</p>
+			</Placeholder>
+		);
 	}
 	return (
 		<figure className={ classnames( props.className, 'wp-block-embed' ) }>

--- a/src/editor/blocks/embed/index.js
+++ b/src/editor/blocks/embed/index.js
@@ -1,0 +1,125 @@
+/**
+ * External dependencies
+ */
+import classnames from 'classnames';
+
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { Fragment, useState } from '@wordpress/element';
+import { select } from '@wordpress/data';
+import { ToolbarButton, ToolbarGroup } from '@wordpress/components';
+import { BlockControls, useBlockProps, RichText } from '@wordpress/block-editor';
+import { createBlock } from '@wordpress/blocks';
+import { globe } from '@wordpress/icons';
+
+/**
+ * Internal dependencies
+ */
+import './style.scss';
+
+const EmbedPreview = props => {
+	const caption = props.caption || props.title;
+	let embedContent;
+	switch ( props.type ) {
+		case 'photo':
+			if ( props.url ) {
+				const style = {
+					width: props.width,
+					height: props.height,
+				};
+				embedContent = <img src={ props.url } alt={ caption } style={ style } />;
+			}
+			break;
+		case 'video':
+			if ( props.thumbnail_url ) {
+				const style = {
+					width: props.thumbnail_width,
+					height: props.thumbnail_height,
+				};
+				embedContent = <img src={ props.thumbnail_url } alt={ props.title } style={ style } />;
+			}
+			break;
+		case 'rich':
+			if ( props.sanitized_html ) {
+				embedContent = <div dangerouslySetInnerHTML={ { __html: props.sanitized_html } } />;
+			}
+			break;
+	}
+	return (
+		<figure className={ classnames( props.className, 'wp-block-embed' ) }>
+			<div className="wp-block-embed__newsletters-wrapper">{ embedContent }</div>
+			{ ! RichText.isEmpty( caption ) && (
+				<RichText
+					tagName={ embedContent ? 'figcaption' : 'a' }
+					placeholder={ __( 'Add caption' ) }
+					value={ caption }
+					onChange={ props.onCaptionChange }
+					allowedFormats={ [ 'core/bold', 'core/italic', 'core/text-color' ] }
+					inlineToolbar
+					__unstableOnSplitAtEnd={ () =>
+						props.insertBlocksAfter( createBlock( 'core/paragraph' ) )
+					}
+				/>
+			) }
+		</figure>
+	);
+};
+
+export default () => {
+	wp.hooks.addFilter(
+		'editor.BlockEdit',
+		'newspack-newsletters/embed-block-edit-editor',
+		BlockEdit => {
+			return props => {
+				if ( props.name !== 'core/embed' ) return <BlockEdit { ...props } />;
+				const { getEmbedPreview } = select( 'core' );
+				const embedPreview = getEmbedPreview( props.attributes.url );
+				if ( ! embedPreview ) return <BlockEdit { ...props } />;
+				const [ isViewingEmail, setIsViewingEmail ] = useState( true );
+				const blockProps = useBlockProps();
+				return (
+					<Fragment>
+						<BlockControls>
+							<ToolbarGroup>
+								<ToolbarButton
+									icon="email"
+									label={ __( 'Preview email format', 'newspack-newsletters' ) }
+									isActive={ isViewingEmail }
+									onClick={ () => {
+										setIsViewingEmail( true );
+									} }
+								/>
+								<ToolbarButton
+									icon={ globe }
+									label={ __( 'Preview web format', 'newspack-newsletters' ) }
+									isActive={ ! isViewingEmail }
+									onClick={ () => {
+										setIsViewingEmail( false );
+									} }
+								/>
+							</ToolbarGroup>
+						</BlockControls>
+						{ isViewingEmail ? (
+							<div { ...blockProps }>
+								<EmbedPreview
+									{ ...embedPreview }
+									caption={ props.caption }
+									onCaptionChange={ value => {
+										props.setAttributes( { caption: value } );
+									} }
+									insertBlocksAfter={ props.insertBlocksAfter }
+									isSelected={ props.isSelected }
+									className={ props.className }
+								/>
+							</div>
+						) : (
+							<BlockEdit { ...props } />
+						) }
+					</Fragment>
+				);
+			};
+		}
+	);
+};

--- a/src/editor/blocks/embed/index.js
+++ b/src/editor/blocks/embed/index.js
@@ -78,6 +78,22 @@ const EmbedPreview = props => {
 
 export default () => {
 	wp.hooks.addFilter(
+		'blocks.registerBlockType',
+		'newspack-newsletters/embed-block/disable-align',
+		( settings, name ) => {
+			if ( name === 'core/embed' ) {
+				settings = {
+					...settings,
+					supports: {
+						...settings.supports,
+						align: false,
+					},
+				};
+			}
+			return settings;
+		}
+	);
+	wp.hooks.addFilter(
 		'editor.BlockEdit',
 		'newspack-newsletters/embed-block-edit-editor',
 		BlockEdit => {

--- a/src/editor/blocks/embed/style.scss
+++ b/src/editor/blocks/embed/style.scss
@@ -1,0 +1,17 @@
+.wp-block-embed__newsletters-wrapper {
+	img {
+		margin: 0 auto;
+		display: block;
+	}
+	blockquote {
+		border-left: 4px solid #000;
+		margin: 0;
+		padding-left: 20px;
+		cite {
+			color: #767676;
+		}
+		p {
+			padding-bottom: 12px;
+		}
+	}
+}

--- a/src/editor/index.js
+++ b/src/editor/index.js
@@ -12,6 +12,7 @@ import { registerPlugin } from '@wordpress/plugins';
 import './style.scss';
 import registerPostsInserterBlock from './blocks/posts-inserter';
 import registerShareBlock from './blocks/share';
+import registerEmbedBlockEdit from './blocks/embed';
 import { addBlocksValidationFilter } from './blocks-validation/blocks-filters';
 import { NestedColumnsDetection } from './blocks-validation/nesting-detection';
 import '../newsletter-editor';
@@ -19,6 +20,8 @@ import '../newsletter-editor';
 addBlocksValidationFilter();
 registerPostsInserterBlock();
 registerShareBlock();
+
+registerEmbedBlockEdit();
 
 /* Unregister core block styles that are unsupported in emails */
 domReady( () => {

--- a/tests/test-renderer.php
+++ b/tests/test-renderer.php
@@ -72,7 +72,58 @@ class Newsletters_Renderer_Test extends WP_UnitTestCase {
 				]
 			),
 			'<mj-section url="https://www.youtube.com/watch?v=aIRgcb3cQ1Q" padding="0"><mj-column padding="12px" width="100%"><mj-image padding="0" src="https://i.ytimg.com/vi/aIRgcb3cQ1Q/hqdefault.jpg" width="480px" height="360px" href="https://www.youtube.com/watch?v=aIRgcb3cQ1Q" /><mj-text align="center" color="#555d66" font-size="13px" >How to use the Newspack Newsletter plugin - YouTube</mj-text></mj-column></mj-section>',
-			'Renders image with caption from video embed block'
+			'Renders image from video embed block with title as caption'
+		);
+
+		// Image with custom caption.
+		$inner_html = '<figure><div>https://flickr.com/photos/thomashawk/9274246246</div><figcaption>Automattic</figcaption></figure>';
+		$this->assertEquals(
+			Newspack_Newsletters_Renderer::render_mjml_component(
+				[
+					'blockName'   => 'core/embed',
+					'attrs'       => [
+						'url' => 'https://flickr.com/photos/thomashawk/9274246246',
+					],
+					'innerBlocks' => [],
+					'innerHTML'   => $inner_html,
+				]
+			),
+			'<mj-section url="https://flickr.com/photos/thomashawk/9274246246" padding="0"><mj-column padding="12px" width="100%"><mj-image src="https://live.staticflickr.com/7357/9274246246_201d71cf9a.jpg" alt="Automattic" width="500" height="333" href="https://flickr.com/photos/thomashawk/9274246246" /><mj-text align="center" color="#555d66" font-size="13px" >Automattic - Flickr</mj-text></mj-column></mj-section>',
+			'Renders image with inline figcaption as caption'
+		);
+
+		// Rich embed as HTML.
+		$inner_html = '<figure><div>https://twitter.com/automattic/status/1395447061336711181</div></figure>';
+		$this->assertEquals(
+			Newspack_Newsletters_Renderer::render_mjml_component(
+				[
+					'blockName'   => 'core/embed',
+					'attrs'       => [
+						'url' => 'https://twitter.com/automattic/status/1395447061336711181',
+					],
+					'innerBlocks' => [],
+					'innerHTML'   => $inner_html,
+				]
+			),
+			"<mj-section url=\"https://twitter.com/automattic/status/1395447061336711181\" padding=\"0\"><mj-column padding=\"12px\" width=\"100%\"><mj-text padding=\"0\" line-height=\"1.8\" font-size=\"16px\" ><blockquote>We&#039;re Hiring! We are continuing to grow and have some exciting open positions available, including in Engineering, Product, Marketing, Business Development, HR, Customer Support, and more. Work with us, from anywhere. <a href=\"https://t.co/EZST4WBsy2\">https://t.co/EZST4WBsy2</a> <a href=\"https://t.co/z8bKfCgn14\">pic.twitter.com/z8bKfCgn14</a>&mdash; Automattic (@automattic) <a href=\"https://twitter.com/automattic/status/1395447061336711181?ref_src=twsrc%5Etfw\">May 20, 2021</a></blockquote>\n\n</mj-text></mj-column></mj-section>",
+			'Renders tweet as HTML'
+		);
+
+		// Rich embed as link.
+		$inner_html = '<figure><div>https://www.amazon.com/Learning-PHP-MySQL-JavaScript-Javascript/dp/1491978910</div></figure>';
+		$this->assertEquals(
+			Newspack_Newsletters_Renderer::render_mjml_component(
+				[
+					'blockName'   => 'core/embed',
+					'attrs'       => [
+						'url' => 'https://www.amazon.com/Learning-PHP-MySQL-JavaScript-Javascript/dp/1491978910',
+					],
+					'innerBlocks' => [],
+					'innerHTML'   => $inner_html,
+				]
+			),
+			'<mj-section url="https://www.amazon.com/Learning-PHP-MySQL-JavaScript-Javascript/dp/1491978910" padding="0"><mj-column padding="12px" width="100%"><mj-text padding="0" line-height="1.8" font-size="16px" ><a href="https://www.amazon.com/Learning-PHP-MySQL-JavaScript-Javascript/dp/1491978910">Learning PHP, MySQL &amp; JavaScript: With jQuery, CSS &amp; HTML5 (Learning PHP, MYSQL, Javascript, CSS &amp; HTML5)</a></mj-text></mj-column></mj-section>',
+			'Renders invalid rich HTML as link'
 		);
 	}
 

--- a/tests/test-renderer.php
+++ b/tests/test-renderer.php
@@ -55,6 +55,28 @@ class Newsletters_Renderer_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test embed blocks rendering.
+	 */
+	public function test_render_embed_blocks() {
+		// Video embed.
+		$inner_html = '<figure><div>https://www.youtube.com/watch?v=aIRgcb3cQ1Q</div></figure>';
+		$this->assertEquals(
+			Newspack_Newsletters_Renderer::render_mjml_component(
+				[
+					'blockName'   => 'core/embed',
+					'attrs'       => [
+						'url' => 'https://www.youtube.com/watch?v=aIRgcb3cQ1Q',
+					],
+					'innerBlocks' => [],
+					'innerHTML'   => $inner_html,
+				]
+			),
+			'<mj-section url="https://www.youtube.com/watch?v=aIRgcb3cQ1Q" padding="0"><mj-column padding="12px" width="100%"><mj-image padding="0" src="https://i.ytimg.com/vi/aIRgcb3cQ1Q/hqdefault.jpg" width="480px" height="360px" href="https://www.youtube.com/watch?v=aIRgcb3cQ1Q" /><mj-text align="center" color="#555d66" font-size="13px" >How to use the Newspack Newsletter plugin - YouTube</mj-text></mj-column></mj-section>',
+			'Renders image with caption from video embed block'
+		);
+	}
+
+	/**
 	 * Test other rendering-related function.
 	 */
 	public function test_aux_functions() {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Add support for the embed block. There are 4 types of embeddable content, as [specified on oEmbed](https://oembed.com/). For each available type we'll have the following behavior:

#### Video

Displays thumbnail with caption, which is the video title by default or the inline caption manually inserted. If no thumbnail is provided by the service, attempts to create a link with the title or caption.

#### Image

Displays image with caption, which is the image title by default or the inline caption manually inserted.

#### Rich

Validates HTML content, allowing `blockquote`, `p`, `a`, `br`, `em` and `strong`. If no valid HTML is returned after filtering, a link is generated with the resource title.

Examples are:

 - Twitter: returns a `blockquote`, which renders nicely
 - Amazon: returns an `iframe`, which becomes a link with the resource title

#### Link

Displays text with a link. The text is the resource title by default, or the inline caption manually inserted. I was not able to find a valid oembed provider that uses link as type but should work without problems.

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes #386.

### How to test the changes in this Pull Request:

1. In this branch, create a new newsletter
2. Create several embed blocks with content from different services:
   1. YouTube
   2. Vimeo
   3. VideoPress
   3. Twitter
   4. Amazon
   5. Flickr
   6. Reddit
3. Send a test email and make sure the content is displayed as described above for each embed type

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
