### PR TITLE
fix: list info in pre-send modal

### DIFF
--- a/src/service-providers/mailchimp/index.js
+++ b/src/service-providers/mailchimp/index.js
@@ -51,7 +51,7 @@ const renderPreSendInfo = newsletterData => {
 	}
 	let listData;
 	if ( newsletterData.campaign && newsletterData.lists ) {
-		const lists = newsletterData.lists?.lists || [];
+		const lists = newsletterData.lists || [];
 		const list = find( lists, [ 'id', newsletterData.campaign.recipients.list_id ] );
 		if ( list ) {
 			listData = {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Like 3d095c560228f83a582e5ac630f84c68dca309ac, fixes Mailchimp lists handling after #546 broke it

### How to test the changes in this Pull Request:

1. On `master`, with Mailchimp as ESP, initiate sending a campaign 
2. Observe the pre-send modal does not contain list information
3. Switch to this branch, rebuild 
4. Observe the pre-send modal contains information about the target list

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->