### PR TITLE
feat(editor): allow other post types to be treated as email

### DIFF
--- a/includes/class-newspack-newsletters-renderer.php
+++ b/includes/class-newspack-newsletters-renderer.php
@@ -771,7 +771,8 @@ final class Newspack_Newsletters_Renderer {
 		$total_length = self::get_total_newsletter_character_length( $valid_blocks );
 
 		// Gather ads.
-		if ( $include_ads && ! get_post_meta( $post->ID, 'diable_ads', true ) ) {
+		$is_newsletter = Newspack_Newsletters::NEWSPACK_NEWSLETTERS_CPT === get_post_type( $post->ID );
+		if ( $include_ads && $is_newsletter && ! get_post_meta( $post->ID, 'diable_ads', true ) ) {
 			$ads_query = new WP_Query(
 				array(
 					'post_type'      => Newspack_Newsletters_Ads::NEWSPACK_NEWSLETTERS_ADS_CPT,

--- a/includes/class-newspack-newsletters.php
+++ b/includes/class-newspack-newsletters.php
@@ -313,21 +313,6 @@ final class Newspack_Newsletters {
 				'auth_callback'  => '__return_true',
 			]
 		);
-		\register_meta(
-			'post',
-			self::EMAIL_HTML_META,
-			[
-				'object_subtype' => self::NEWSPACK_NEWSLETTERS_CPT,
-				'show_in_rest'   => [
-					'schema' => [
-						'context' => [ 'edit' ],
-					],
-				],
-				'type'           => 'string',
-				'single'         => true,
-				'auth_callback'  => '__return_true',
-			]
-		);
 	}
 
 	/**
@@ -688,9 +673,8 @@ final class Newspack_Newsletters {
 				'callback'            => [ __CLASS__, 'api_get_mjml' ],
 				'permission_callback' => [ __CLASS__, 'api_authoring_permissions_check' ],
 				'args'                => [
-					'id'      => [
+					'post_id' => [
 						'required'          => true,
-						'validate_callback' => [ __CLASS__, 'validate_newsletter_id' ],
 						'sanitize_callback' => 'absint',
 					],
 					'content' => [
@@ -721,7 +705,7 @@ final class Newspack_Newsletters {
 	 * @param WP_REST_Request $request API request object.
 	 */
 	public static function api_get_mjml( $request ) {
-		$post = get_post( $request['id'] );
+		$post = get_post( $request['post_id'] );
 		if ( ! empty( $request['title'] ) ) {
 			$post->post_title = $request['title'];
 		}

--- a/src/editor/api/index.js
+++ b/src/editor/api/index.js
@@ -1,0 +1,82 @@
+/**
+ * External dependencies
+ */
+import { pick, omit, includes } from 'lodash';
+import mjml2html from 'mjml-browser';
+
+/**
+ * WordPress dependencies
+ */
+import apiFetch from '@wordpress/api-fetch';
+import { dispatch as globalDispatch, select as globalSelect } from '@wordpress/data';
+import { __ } from '@wordpress/i18n';
+
+const POST_META_WHITELIST = [
+	'is_public',
+	'preview_text',
+	'diable_ads',
+	'font_body',
+	'font_header',
+	'background_color',
+	'custom_css',
+];
+
+/**
+ * Use a middleware to hijack the post update request.
+ * When a post is about to be updated, first the email-compliant HTML has
+ * to be produced. To do that, MJML (more at mjml.io) is used.
+ */
+apiFetch.use( async ( options, next ) => {
+	const { method, data = {} } = options;
+	if ( data.content && data.id && ( method === 'POST' || method === 'PUT' ) ) {
+		const emailHTMLMetaName = window.newspack_email_editor_data.email_html_meta;
+		const mjmlHandlingPostTypes = window.newspack_email_editor_data.mjml_handling_post_types;
+		const editorSelector = globalSelect( 'core/editor' );
+		const postType = editorSelector.getCurrentPostType();
+		if ( ! includes( mjmlHandlingPostTypes, postType ) ) {
+			return next( options );
+		}
+
+		// Strip the meta which will be updated explicitly from post update payload.
+		options.data.meta = omit( options.data.meta, [ ...POST_META_WHITELIST, emailHTMLMetaName ] );
+
+		// First, save post meta. It is not saved when saving a draft, so
+		// it's saved here in order for the backend to have access to these.
+		const postMeta = editorSelector.getEditedPostAttribute( 'meta' );
+		await apiFetch( {
+			data: { meta: pick( postMeta, POST_META_WHITELIST ) },
+			method: 'POST',
+			path: `/wp/v2/${ postType }/${ data.id }`,
+		} );
+
+		// Then, send the content over to the server to convert the post content
+		// into MJML markup.
+		return apiFetch( {
+			path: `/newspack-newsletters/v1/post-mjml`,
+			method: 'POST',
+			data: {
+				post_id: data.id,
+				title: data.title,
+				content: data.content,
+			},
+		} )
+			.then( ( { mjml } ) => {
+				// Once received MJML markup, convert it to email-compliant HTML
+				// and save as post meta for later retrieval.
+				const { html } = mjml2html( mjml );
+				return apiFetch( {
+					data: { meta: { [ emailHTMLMetaName ]: html } },
+					method: 'POST',
+					path: `/wp/v2/${ postType }/${ data.id }`,
+				} );
+			} )
+			.then( () => next( options ) ) // Proceed with the post update request.
+			.catch( error => {
+				// In case of an error, display notice and proceed with the post update request.
+				const { createErrorNotice } = globalDispatch( 'core/notices' );
+				createErrorNotice( error.message || __( 'Something went wrong', 'newspack-newsletters' ) );
+				return next( options );
+			} );
+	}
+	return next( options );
+} );

--- a/src/editor/index.js
+++ b/src/editor/index.js
@@ -16,7 +16,7 @@ import registerEmbedBlockEdit from './blocks/embed';
 import registerMergeTagsFilters from './blocks/mailchimp-merge-tags';
 import { addBlocksValidationFilter } from './blocks-validation/blocks-filters';
 import { NestedColumnsDetection } from './blocks-validation/nesting-detection';
-import '../newsletter-editor';
+import './api';
 
 addBlocksValidationFilter();
 registerPostsInserterBlock();

--- a/src/newsletter-editor/editor/index.js
+++ b/src/newsletter-editor/editor/index.js
@@ -1,97 +1,15 @@
 /**
  * External dependencies
  */
-import { pick, omit, get, isEmpty } from 'lodash';
-import mjml2html from 'mjml-browser';
+import { get, isEmpty } from 'lodash';
 
 /**
  * WordPress dependencies
  */
 import { compose } from '@wordpress/compose';
-import {
-	withDispatch,
-	dispatch as globalDispatch,
-	withSelect,
-	select as globalSelect,
-} from '@wordpress/data';
+import { withDispatch, withSelect } from '@wordpress/data';
 import { createPortal, useEffect, useState } from '@wordpress/element';
 import { registerPlugin } from '@wordpress/plugins';
-import { __ } from '@wordpress/i18n';
-import apiFetch from '@wordpress/api-fetch';
-
-/**
- * Internal dependencies
- */
-import { NEWSLETTER_CPT_SLUG } from '../../utils/consts';
-
-const POST_META_WHITELIST = [
-	'is_public',
-	'preview_text',
-	'diable_ads',
-	'font_body',
-	'font_header',
-	'background_color',
-	'custom_css',
-];
-
-/**
- * Use a middleware to hijack the post update request.
- * When a post is about to be updated, first the email-compliant HTML has
- * to be produced. To do that, MJML (more at mjml.io) is used.
- */
-apiFetch.use( async ( options, next ) => {
-	const { method, path = '', data = {} } = options;
-	if (
-		path.indexOf( window.newspack_newsletters_data.newsletter_cpt ) > 0 &&
-		data.content &&
-		data.id &&
-		( method === 'POST' || method === 'PUT' )
-	) {
-		const emailHTMLMetaName = window.newspack_newsletters_data.email_html_meta;
-
-		// Strip the meta which will be updated explicitly from post update payload.
-		options.data.meta = omit( options.data.meta, [ ...POST_META_WHITELIST, emailHTMLMetaName ] );
-
-		// First, save post meta. It is not saved when saving a draft, so
-		// it's saved here in order for the backend to have access to these.
-		const postMeta = globalSelect( 'core/editor' ).getEditedPostAttribute( 'meta' );
-		await apiFetch( {
-			data: { meta: pick( postMeta, POST_META_WHITELIST ) },
-			method: 'POST',
-			path: `/wp/v2/${ NEWSLETTER_CPT_SLUG }/${ data.id }`,
-		} );
-
-		// Then, send the content over to the server to convert the post content
-		// into MJML markup.
-		return apiFetch( {
-			path: `/newspack-newsletters/v1/post-mjml`,
-			method: 'POST',
-			data: {
-				id: data.id,
-				title: data.title,
-				content: data.content,
-			},
-		} )
-			.then( ( { mjml } ) => {
-				// Once received MJML markup, convert it to email-compliant HTML
-				// and save as post meta for later retrieval.
-				const { html } = mjml2html( mjml );
-				return apiFetch( {
-					data: { meta: { [ emailHTMLMetaName ]: html } },
-					method: 'POST',
-					path: `/wp/v2/${ NEWSLETTER_CPT_SLUG }/${ data.id }`,
-				} );
-			} )
-			.then( () => next( options ) ) // Proceed with the post update request.
-			.catch( error => {
-				// In case of an error, display notice and proceed with the post update request.
-				const { createErrorNotice } = globalDispatch( 'core/notices' );
-				createErrorNotice( error.message || __( 'Something went wrong', 'newspack-newsletters' ) );
-				return next( options );
-			} );
-	}
-	return next( options );
-} );
 
 /**
  * Internal dependencies

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -18,6 +18,7 @@ const adsEditor = path.join( __dirname, 'src', 'ads-admin', 'editor' );
 const branding = path.join( __dirname, 'src', 'branding' );
 const quickEdit = path.join( __dirname, 'src', 'quick-edit' );
 const blocks = path.join( __dirname, 'src', 'editor', 'blocks' );
+const newsletterEditor = path.join( __dirname, 'src', 'newsletter-editor' );
 
 const webpackConfig = getBaseWebpackConfig(
 	{ WP: true },
@@ -29,6 +30,7 @@ const webpackConfig = getBaseWebpackConfig(
 			branding,
 			quickEdit,
 			blocks,
+			newsletterEditor,
 		},
 		'output-path': path.join( __dirname, 'dist' ),
 	}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Mostly a refactor to allow post types other than defined in this plugin to use the HTML email "version" of Gutenberg editor. When a post type is added from another plugin, it will use the stripped-down version of the editor, and then on saving, the email-compliant HTML will be saved as post meta. 

### How to test the changes in this Pull Request:

Ensure newsletter editing and regular post editing works as expected.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->