### PR TITLE
fix: handle empty button blocks

### DIFF
--- a/includes/class-newspack-newsletters-renderer.php
+++ b/includes/class-newspack-newsletters-renderer.php
@@ -305,7 +305,8 @@ final class Newspack_Newsletters_Renderer {
 			case 'core/image':
 				// Parse block content.
 				$dom = new DomDocument();
-				@$dom->loadHTML( mb_convert_encoding( $inner_html, 'HTML-ENTITIES', 'UTF-8' ) ); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged
+				libxml_use_internal_errors( true );
+				$dom->loadHTML( mb_convert_encoding( $inner_html, 'HTML-ENTITIES', get_bloginfo( 'charset' ) ) );
 				$xpath      = new DOMXpath( $dom );
 				$img        = $xpath->query( '//img' )[0];
 				$img_src    = $img->getAttribute( 'src' );
@@ -370,15 +371,25 @@ final class Newspack_Newsletters_Renderer {
 			 */
 			case 'core/buttons':
 				foreach ( $inner_blocks as $button_block ) {
+
+					if ( empty( $button_block['innerHTML'] ) ) {
+						break;
+					}
+
 					// Parse block content.
 					$dom = new DomDocument();
-					@$dom->loadHTML( mb_convert_encoding( $button_block['innerHTML'], 'HTML-ENTITIES', 'UTF-8' ) ); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged
+					libxml_use_internal_errors( true );
+					$dom->loadHTML( mb_convert_encoding( $button_block['innerHTML'], 'HTML-ENTITIES', get_bloginfo( 'charset' ) ) );
 					$xpath         = new DOMXpath( $dom );
 					$anchor        = $xpath->query( '//a' )[0];
 					$attrs         = $button_block['attrs'];
 					$text          = $anchor->textContent; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
 					$border_radius = isset( $attrs['borderRadius'] ) ? $attrs['borderRadius'] : 999;
 					$is_outlined   = isset( $attrs['className'] ) && 'is-style-outline' == $attrs['className'];
+
+					if ( ! $anchor ) {
+						break;
+					}
 
 					$default_button_attrs = array(
 						'padding'       => '0',
@@ -611,7 +622,8 @@ final class Newspack_Newsletters_Renderer {
 
 				// Parse block caption.
 				$dom = new DomDocument();
-				@$dom->loadHTML( mb_convert_encoding( $inner_html, 'HTML-ENTITIES', 'UTF-8' ) ); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged
+				libxml_use_internal_errors( true );
+				$dom->loadHTML( mb_convert_encoding( $inner_html, 'HTML-ENTITIES', get_bloginfo( 'charset' ) ) );
 				$xpath      = new DOMXpath( $dom );
 				$figcaption = $xpath->query( '//figcaption/text()' )[0];
 				// phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Buttons blocks are not rendered with HTML until you write text to it. The renderer should verify if the block contains the proper HTML before parsing its contents.

### How to test the changes in this Pull Request:

1. In the master branch, start a new newsletter
2. Create a new Buttons block and do not write anything in it
3. Attempt to save the draft and observe the fatal error
4. Switch this branch, repeat the steps and observe you are able to save the draft
5. Send a newsletter with an empty Buttons block and observe it is not rendered on the email (as it should not).

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
