### PR TITLE
fix: allow social-link inner block

### DIFF
--- a/includes/class-newspack-newsletters-editor.php
+++ b/includes/class-newspack-newsletters-editor.php
@@ -150,6 +150,7 @@ final class Newspack_Newsletters_Editor {
 			'core/list',
 			'core/quote',
 			'core/social-links',
+			'core/social-link',
 			'newspack-newsletters/posts-inserter',
 			'newspack-newsletters/share',
 		);


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

The `core/social-links` block requires an unlisted inner block called `core/social-link` that must be allowed for the block to function properly.

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes #595.

### How to test the changes in this Pull Request:

1. On the master branch, edit a newsletter and attempt to create Social Links
2. Observe that the appender element is not visible and you are not able to add links
3. Check out this branch, refresh the page and observe the block is now working as expected

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
