### PR TITLE
fix: enable prompts on public newsletters

### DIFF
--- a/includes/class-newspack-newsletters.php
+++ b/includes/class-newspack-newsletters.php
@@ -77,7 +77,6 @@ final class Newspack_Newsletters {
 		add_filter( 'manage_' . self::NEWSPACK_NEWSLETTERS_CPT . '_posts_columns', [ __CLASS__, 'add_public_page_column' ] );
 		add_action( 'manage_' . self::NEWSPACK_NEWSLETTERS_CPT . '_posts_custom_column', [ __CLASS__, 'public_page_column_content' ], 10, 2 );
 		add_filter( 'post_row_actions', [ __CLASS__, 'display_view_or_preview_link_in_admin' ] );
-		add_filter( 'newspack_newsletters_assess_has_disabled_popups', [ __CLASS__, 'disable_campaigns_for_newsletters' ], 11 );
 		add_filter( 'jetpack_relatedposts_filter_options', [ __CLASS__, 'disable_jetpack_related_posts' ] );
 		add_action( 'save_post_' . self::NEWSPACK_NEWSLETTERS_CPT, [ __CLASS__, 'save' ], 10, 3 );
 		add_action( 'admin_enqueue_scripts', [ __CLASS__, 'branding_scripts' ] );
@@ -588,20 +587,6 @@ final class Newspack_Newsletters {
 		}
 
 		return $actions;
-	}
-
-	/**
-	 * Disable Newspack Campaigns on Newsletter posts.
-	 *
-	 * @param array $disabled Disabled status to filter.
-	 * @return array|boolean Unfiltered disabled status, or true to disable.
-	 */
-	public static function disable_campaigns_for_newsletters( $disabled ) {
-		if ( self::NEWSPACK_NEWSLETTERS_CPT === get_post_type() ) {
-			return true;
-		}
-
-		return $disabled;
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

When public newsletters were set up in #272, it went without discussion that [prompts should be disabled](https://github.com/Automattic/newspack-newsletters/pull/272/files#diff-26ef8f37f3b226177500e67a7c2d6256651e7aecc380b008bd4c744c65495865R422-R434) on these posts. Now that prompts can be targeted by post type (https://github.com/Automattic/newspack-popups/pull/607), it makes sense to remove this restriction and allow prompts to be displayed on public newsletter posts.

### How to test the changes in this Pull Request:

1. Switch `newspack-popups` to `fix/custom-post-types` branch (unless https://github.com/Automattic/newspack-popups/pull/645 is already merged)
1. Create and publish a prompt and a public newsletter
2. Set the prompt to display on Newsletter CPTs via sidebar's "Post Types" panel
2. Observe the prompt is displayed on the public newsletter post

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->