### PR TITLE
fix: merge color palette values

### DIFF
--- a/includes/class-newspack-newsletters.php
+++ b/includes/class-newspack-newsletters.php
@@ -696,14 +696,14 @@ final class Newspack_Newsletters {
 	 * @param WP_REST_Request $request API request object.
 	 */
 	public static function api_set_color_palette( $request ) {
-		try {
-			$color_palette = json_decode( (string) get_option( 'newspack_newsletters_color_palette', '{}' ) ?? '{}', true );
-		} catch ( \Exception $e ) {
-			$color_palette = [];
-		}
 		update_option(
 			'newspack_newsletters_color_palette',
-			wp_json_encode( array_merge( $color_palette ?? [], json_decode( $request->get_body(), true ) ) )
+			wp_json_encode(
+				array_merge(
+					json_decode( (string) get_option( 'newspack_newsletters_color_palette', '{}' ), true ) ?? [],
+					json_decode( $request->get_body(), true )
+				)
+			)
 		);
 		return \rest_ensure_response( [] );
 	}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

The color palette that applies the appropriate RGB code according to its label (primary, secondary, etc) lives only on the editor. To remedy the situation, we push from the editor to the database the map of colors so it can be rendered into email HTML later.

The editor is actually sending 2 requests and the order of its execution is not expected to be consistent. One of the requests contains a map of common colors (cyan, pale-pink, etc) and the other contains site defined colors (primary, etc). One replaces the other on the database and by the time the newsletter is rendered, it may or may not have the primary color available to apply to buttons and other elements.

This PR merges the map of colors instead of replacing on each request.

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes #484.

### How to test the changes in this Pull Request:

1. On the master branch, create a new newsletter with DevTools open
2. Observe on the Network tab 2 requests being sent to the `color-palette` endpoint
3. Check your `wp_options` table for the value of `newspack_newsletters_color_palette` and observe only one of the lists being stored
4. Check out this branch, repeat steps, and observe all of the colors are stored

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
