### PR TITLE
chore: fix circleci build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ commands:
 jobs:
   build:
     docker:
-      - image: circleci/php:7.4-node-browsers
+      - image: cimg/php:7.4-browsers
     steps:
       - checkout_with_workspace
       - run:
@@ -24,7 +24,7 @@ jobs:
   # Linting
   lint:
     docker:
-      - image: circleci/php:7.4-node-browsers
+      - image: cimg/php:7.4-browsers
     steps:
       - checkout_with_workspace
       - run:
@@ -41,7 +41,7 @@ jobs:
 
   test-php:
     docker:
-      - image: circleci/php:7.4
+      - image: cimg/php:7.4
       - image: circleci/mysql:5.6
     environment:
       - WP_TESTS_DIR: '/tmp/wordpress-tests-lib'
@@ -70,7 +70,7 @@ jobs:
 
   release_github:
     docker:
-      - image: circleci/php:7.4-node-browsers
+      - image: cimg/php:7.4-browsers
     steps:
       - checkout_with_workspace
       - run:
@@ -90,7 +90,7 @@ jobs:
 
   release_wporg:
     docker:
-      - image: circleci/php:7.4-node-browsers
+      - image: cimg/php:7.4-browsers
     steps:
       - checkout_with_workspace
       - run:
@@ -101,7 +101,7 @@ jobs:
 
   post_release:
     docker:
-      - image: circleci/php:7.4-node-browsers
+      - image: cimg/php:7.4-browsers
     steps:
       - checkout_with_workspace
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,9 +56,7 @@ jobs:
       - run:
           name: Install Dependencies
           command: |
-            sudo apt-get update && sudo apt-get install subversion
-            sudo -E docker-php-ext-install mysqli
-            sudo apt-get update && sudo apt-get install default-mysql-client
+            sudo apt-get update && sudo apt-get install -y subversion default-mysql-client
       - run:
           name: Run Tests
           command: |


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

As seen on https://github.com/Automattic/newspack-ads/pull/214 and ab2f8926765ff6216bf87ef7be15ddad9159d7c2, this PR changes the circle ci tasks PHP images from `circleci` to `cimg`.

### How to test the changes in this Pull Request:

CI tasks must pass.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
