### PR TITLE
feat: add newsletter post type to supported post types in Campaigns

### DIFF
--- a/includes/class-newspack-newsletters.php
+++ b/includes/class-newspack-newsletters.php
@@ -85,6 +85,7 @@ final class Newspack_Newsletters {
 		add_filter( 'newspack_theme_featured_image_post_types', [ __CLASS__, 'support_featured_image_options' ] );
 		add_filter( 'gform_force_hooks_js_output', [ __CLASS__, 'suppress_gravityforms_js_on_newsletters' ] );
 		add_filter( 'render_block', [ __CLASS__, 'remove_email_only_block' ], 10, 2 );
+		add_filter( 'newspack_campaigns_default_supported_post_types', [ __CLASS__, 'add_campaigns_support' ] );
 		self::set_service_provider( self::service_provider() );
 
 		$needs_nag = is_admin() && ! self::is_service_provider_configured() && ! get_option( 'newspack_newsletters_activation_nag_viewed', false );
@@ -1192,6 +1193,17 @@ final class Newspack_Newsletters {
 				);
 			}
 		}
+	}
+
+	/**
+	 * If using the Newspack Campaigns plugin, add newsletters to the default list of supported post types.
+	 *
+	 * @param string[] $post_types Array of post types supported by Newspack Campaigns.
+	 *
+	 * @return string[] Filtered array of post types.
+	 */
+	public static function add_campaigns_support( $post_types ) {
+		return array_merge( $post_types, [ self::NEWSPACK_NEWSLETTERS_CPT ] );
 	}
 }
 Newspack_Newsletters::instance();


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Adds support for the newsletter post type to Newspack Campaigns. Requires the new filter applied in https://github.com/Automattic/newspack-popups/pull/726 to work.

h/t @kariae for helping me debug.

This doesn't necessarily fix a bug, but it does address some behavior that might be unexpected. Public newsletters are displayed in archives, alongside regular posts if they share the same categories, tags, or authors. Newspack Campaigns prompts can be set to display in post archives, but if the archive contains any post type other than `post` and `page`, those extra post types aren't used for determining whether to display the archive prompt. Adding support for newsletters to Campaigns by default seems a reasonable default behavior—editors can now _opt out_ of showing specific prompts on singular newsletters or archives that contain newsletters, instead of having to _opt in_ to showing specific prompts in these cases.

### How to test the changes in this Pull Request:

1. Publish a newsletter and assign it a category so that it shows up as the first post in that category's archive page.
2. In Newspack Campaigns, publish an archive prompt that should display after 1 post in category archives. Don't edit the Post Types options (but do observe that it shows newsletters, but it's not selected by default).
3. On `master`, observe that the prompt is not displayed on the category archive (because the first post shown is a newsletter, not a post).
4. Check out this branch, confirm that the archive prompt and any new prompt now have newsletters selected under Post Types by default.
5. Confirm that the category archive now shows the prompt after the first post.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
