### PR TITLE
Move styling settings to its own sidebar

### DIFF
--- a/src/newsletter-editor/index.js
+++ b/src/newsletter-editor/index.js
@@ -5,8 +5,13 @@ import { __ } from '@wordpress/i18n';
 import { withSelect, withDispatch } from '@wordpress/data';
 import { compose } from '@wordpress/compose';
 import { Fragment, useEffect, useState } from '@wordpress/element';
-import { PluginDocumentSettingPanel } from '@wordpress/edit-post';
+import {
+	PluginDocumentSettingPanel,
+	PluginSidebar,
+	PluginSidebarMoreMenuItem,
+} from '@wordpress/edit-post';
 import { registerPlugin } from '@wordpress/plugins';
+import { styles } from '@wordpress/icons';
 
 /**
  * Internal dependencies
@@ -65,6 +70,9 @@ const NewsletterEdit = ( {
 
 	const isDisplayingInitModal = shouldDisplaySettings || -1 === layoutId;
 
+	const stylingId = 'newspack-newsletters-styling';
+	const stylingTitle = __( 'Newsletter Styles', 'newspack-newsletters' );
+
 	return isDisplayingInitModal ? (
 		<InitModal
 			shouldDisplaySettings={ shouldDisplaySettings }
@@ -72,18 +80,19 @@ const NewsletterEdit = ( {
 		/>
 	) : (
 		<Fragment>
+			<PluginSidebar name={ stylingId } icon={ styles } title={ stylingTitle }>
+				<Styling />
+			</PluginSidebar>
+			<PluginSidebarMoreMenuItem target={ stylingId } icon={ styles }>
+				{ stylingTitle }
+			</PluginSidebarMoreMenuItem>
+
 			<PluginDocumentSettingPanel
 				name="newsletters-settings-panel"
 				title={ __( 'Newsletter', 'newspack-newsletters' ) }
 			>
 				<Sidebar isConnected={ isConnected } oauthUrl={ oauthUrl } onAuthorize={ verifyToken } />
 				{ isConnected && <PublicSettings /> }
-			</PluginDocumentSettingPanel>
-			<PluginDocumentSettingPanel
-				name="newsletters-styling-panel"
-				title={ __( 'Styling', 'newspack-newsletters' ) }
-			>
-				<Styling />
 			</PluginDocumentSettingPanel>
 			{ 'manual' !== serviceProviderName && (
 				<PluginDocumentSettingPanel

--- a/src/newsletter-editor/styling/index.js
+++ b/src/newsletter-editor/styling/index.js
@@ -2,10 +2,10 @@
  * WordPress dependencies
  */
 import { compose, useInstanceId } from '@wordpress/compose';
-import { ColorPicker, BaseControl } from '@wordpress/components';
+import { ColorPicker, BaseControl, Panel, PanelBody, PanelRow } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { withDispatch, withSelect } from '@wordpress/data';
-import { Fragment, useEffect } from '@wordpress/element';
+import { useEffect } from '@wordpress/element';
 import SelectControlWithOptGroup from '../../components/select-control-with-optgroup/';
 
 /**
@@ -173,49 +173,71 @@ export const Styling = compose( [
 	const id = `inspector-select-control-${ instanceId }`;
 
 	return (
-		<Fragment>
-			<SelectControlWithOptGroup
-				label={ __( 'Headings font', 'newspack-newsletters' ) }
-				value={ fontHeader }
-				optgroups={ fontOptgroups }
-				onChange={ value => updateStyleValue( 'font_header', value ) }
-			/>
-			<SelectControlWithOptGroup
-				label={ __( 'Body font', 'newspack-newsletters' ) }
-				value={ fontBody }
-				optgroups={ fontOptgroups }
-				onChange={ value => updateStyleValue( 'font_body', value ) }
-			/>
-			<BaseControl label={ __( 'Background color', 'newspack-newsletters' ) } id={ id }>
-				<ColorPicker
-					id={ id }
-					color={ backgroundColor }
-					onChangeComplete={ value => updateStyleValue( 'background_color', value.hex ) }
-					disableAlpha
-				/>
-			</BaseControl>
-			<BaseControl
-				id={ `inspector-custom-css-control-${ instanceId }` }
-				label={ __( 'Custom CSS', 'newspack-newsletters' ) }
-				help={ __(
-					'This is an advanced feature and may result in unpredictable behavior. Custom CSS will be appended to default styles in sent emails only.',
-					'newspack-newsletters'
-				) }
+		<Panel>
+			<PanelBody
+				name="newsletters-typography-panel"
+				title={ __( 'Typography', 'newspack-newsletters' ) }
 			>
-				<CodeMirror
-					className="components-textarea-control__input"
-					value={ customCss }
-					height={ 250 }
-					onChange={ instance => editPost( { meta: { custom_css: instance.getValue() } } ) }
-					options={ {
-						gutters: [ 'CodeMirror-lint-markers' ],
-						height: 'auto',
-						indentWithTabs: true,
-						mode: 'css',
-						lint: true,
-					} }
-				/>
-			</BaseControl>
-		</Fragment>
+				<PanelRow>
+					<SelectControlWithOptGroup
+						label={ __( 'Headings font', 'newspack-newsletters' ) }
+						value={ fontHeader }
+						optgroups={ fontOptgroups }
+						onChange={ value => updateStyleValue( 'font_header', value ) }
+					/>
+				</PanelRow>
+				<PanelRow>
+					<SelectControlWithOptGroup
+						label={ __( 'Body font', 'newspack-newsletters' ) }
+						value={ fontBody }
+						optgroups={ fontOptgroups }
+						onChange={ value => updateStyleValue( 'font_body', value ) }
+					/>
+				</PanelRow>
+			</PanelBody>
+			<PanelBody name="newsletters-color-panel" title={ __( 'Color', 'newspack-newsletters' ) }>
+				<PanelRow className="newspack-newsletters__color-panel">
+					<BaseControl label={ __( 'Background color', 'newspack-newsletters' ) } id={ id }>
+						<ColorPicker
+							id={ id }
+							color={ backgroundColor }
+							onChangeComplete={ value => updateStyleValue( 'background_color', value.hex ) }
+							disableAlpha
+						/>
+					</BaseControl>
+				</PanelRow>
+			</PanelBody>
+			<PanelBody
+				name="newsletters-css-panel"
+				title={ __( 'Custom CSS', 'newspack-newsletters' ) }
+				initialOpen={ false }
+			>
+				<PanelRow className="newspack-newsletters__css-panel">
+					<BaseControl
+						id={ `inspector-custom-css-control-${ instanceId }` }
+						label={ __( 'Custom CSS', 'newspack-newsletters' ) }
+						help={ __(
+							'This is an advanced feature and may result in unpredictable behavior. Custom CSS will be appended to default styles in sent emails only.',
+							'newspack-newsletters'
+						) }
+						hideLabelFromVision
+					>
+						<CodeMirror
+							className="components-textarea-control__input"
+							value={ customCss }
+							height={ 250 }
+							onChange={ instance => editPost( { meta: { custom_css: instance.getValue() } } ) }
+							options={ {
+								gutters: [ 'CodeMirror-lint-markers' ],
+								height: 'auto',
+								indentWithTabs: true,
+								mode: 'css',
+								lint: true,
+							} }
+						/>
+					</BaseControl>
+				</PanelRow>
+			</PanelBody>
+		</Panel>
 	);
 } );

--- a/src/newsletter-editor/styling/style.scss
+++ b/src/newsletter-editor/styling/style.scss
@@ -1,5 +1,36 @@
 @import '~@wordpress/base-styles/colors';
 
-.CodeMirror {
-	border: 1px solid $gray-700;
+.newspack-newsletters {
+	&__color-panel {
+		> .components-base-control {
+			max-width: 100%;
+			min-width: 100%;
+		}
+
+		.components-color-picker__inputs-wrapper {
+			min-width: 100%;
+		}
+
+		.components-color-picker__body {
+			padding-left: 0;
+			padding-right: 0;
+		}
+
+		label {
+			margin-right: 0;
+			max-width: 100%;
+		}
+	}
+
+	&__css-panel {
+		.CodeMirror {
+			border: 1px solid $gray-700;
+		}
+	}
+}
+
+.interface-complementary-area {
+	& > &-header {
+		border-top: 0;
+	}
 }

--- a/src/newsletter-editor/styling/style.scss
+++ b/src/newsletter-editor/styling/style.scss
@@ -33,4 +33,8 @@
 	& > &-header {
 		border-top: 0;
 	}
+
+	&__pin-unpin-item {
+		display: none !important;
+	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Instead of having the styles hidden in all the different sidebar settings, I moved the styling to its own sidebar, kind of similar to "Global Styles".

![localhost_10003_wp-admin_post php_post=100 action=edit](https://user-images.githubusercontent.com/177929/145822941-c1fd3396-5501-484d-92c1-e8202cc5e2c9.png)

### How to test the changes in this Pull Request:

1. Create/Edit a Newsletter
2. Notice the Styling panel somewhere in the sidebar
3. Switch to this branch and refresh the editor
4. Now the styles are behind the `styles` icon at the top
5. Check if the settings are still working

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
