### PR TITLE
Update vertical rhythm and various blocks to match sent email

### DIFF
--- a/includes/class-newspack-newsletters-renderer.php
+++ b/includes/class-newspack-newsletters-renderer.php
@@ -278,7 +278,7 @@ final class Newspack_Newsletters_Renderer {
 				$text_attrs = array_merge(
 					array(
 						'padding'     => '0',
-						'line-height' => '1.8',
+						'line-height' => '1.5',
 						'font-size'   => '16px',
 						'font-family' => $font_family,
 					),
@@ -356,6 +356,7 @@ final class Newspack_Newsletters_Renderer {
 					$caption_attrs = array(
 						'align'       => 'center',
 						'color'       => '#555d66',
+						'line-height' => '1.56',
 						'font-size'   => '13px',
 						'font-family' => $font_family,
 					);
@@ -394,10 +395,10 @@ final class Newspack_Newsletters_Renderer {
 					$default_button_attrs = array(
 						'padding'       => '0',
 						'inner-padding' => '12px 24px',
-						'line-height'   => '1.8',
+						'line-height'   => '1.5',
 						'href'          => $anchor->getAttribute( 'href' ),
 						'border-radius' => $border_radius . 'px',
-						'font-size'     => '18px',
+						'font-size'     => '16px',
 						'font-family'   => $font_family,
 						'font-weight'   => 'bold',
 						// Default color - will be replaced by get_colors if there are colors set.
@@ -431,10 +432,8 @@ final class Newspack_Newsletters_Renderer {
 				$divider_attrs      = array_merge(
 					array(
 						'padding'      => '0',
-						'border-width' => $is_style_default ? '2px' : '1px',
-						'width'        => $is_style_default ? '100px' : '100%',
-						// Default color - will be replaced by get_colors if there are colors set.
-						'border-color' => '#8f98a1',
+						'border-width' => '1px',
+						'width'        => $is_style_default ? '128px' : '100%',
 					),
 					self::get_colors( $attrs )
 				);
@@ -482,11 +481,11 @@ final class Newspack_Newsletters_Renderer {
 				);
 
 				$social_wrapper_attrs = array(
-					'icon-size'     => '22px',
+					'icon-size'     => '24px',
 					'mode'          => 'horizontal',
 					'padding'       => '0',
 					'border-radius' => '999px',
-					'icon-padding'  => '8px',
+					'icon-padding'  => '7px',
 				);
 				if ( isset( $attrs['align'] ) ) {
 					$social_wrapper_attrs['align'] = $attrs['align'];
@@ -608,7 +607,7 @@ final class Newspack_Newsletters_Renderer {
 
 				$text_attrs = array(
 					'padding'     => '0',
-					'line-height' => '1.8',
+					'line-height' => '1.5',
 					'font-size'   => '16px',
 					'font-family' => $font_family,
 				);
@@ -616,6 +615,7 @@ final class Newspack_Newsletters_Renderer {
 				$caption_attrs = array(
 					'align'       => 'center',
 					'color'       => '#555d66',
+					'line-height' => '1.56',
 					'font-size'   => '13px',
 					'font-family' => $font_family,
 				);

--- a/includes/email-template-mjml.css
+++ b/includes/email-template-mjml.css
@@ -24,13 +24,39 @@ a:focus {
 }
 
 /* Heading */
-h1 { font-size: 2.44em; line-height: 1.4; }
-h2 { font-size: 1.95em; line-height: 1.4; }
-h3 { font-size: 1.56em; line-height: 1.4; }
-h4 { font-size: 1.25em; line-height: 1.5; }
-h5 { font-size: 1em; line-height: 1.8; }
-h6 { font-size: 0.8em; line-height: 1.8; }
-h1, h2, h3, h4, h5, h6 { margin-top: 0; margin-bottom: 0; }
+h1, h2, h3, h4, h5, h6 {
+	margin-top: 0;
+	margin-bottom: 0;
+}
+
+h1 {
+	font-size: 2.44em;
+	line-height: 1.24;
+}
+
+h2 {
+	font-size: 1.95em;
+	line-height: 1.36;
+}
+
+h3 {
+	font-size: 1.56em;
+	line-height: 1.44;
+}
+
+h4 {
+	font-size: 1.25em;
+	line-height: 1.6;
+}
+
+h5 {
+	font-size: 1em;
+}
+
+h6 {
+	font-size: 0.8em;
+	line-height: 1.56;
+}
 
 /* List */
 ul, ol {

--- a/includes/email-template-mjml.css
+++ b/includes/email-template-mjml.css
@@ -51,6 +51,7 @@ h4 {
 
 h5 {
 	font-size: 1em;
+	line-height: 1.5em;
 }
 
 h6 {

--- a/src/editor/style.scss
+++ b/src/editor/style.scss
@@ -15,8 +15,12 @@
 			padding-right: 0;
 		}
 
-		*:not( code ) {
-			font-family: var( --body-font );
+		* {
+			line-height: 1.5;
+
+			&:not( code ) {
+				font-family: var( --body-font );
+			}
 		}
 
 		.newspack-posts-inserter__header span,
@@ -33,6 +37,36 @@
 		h5,
 		h6 {
 			font-family: var( --header-font );
+			line-height: 1.5;
+		}
+
+		h1 {
+			font-size: 2.44em;
+			line-height: 1.24;
+		}
+
+		h2 {
+			font-size: 1.95em;
+			line-height: 1.36;
+		}
+
+		h3 {
+			font-size: 1.56em;
+			line-height: 1.44;
+		}
+
+		h4 {
+			font-size: 1.25em;
+			line-height: 1.6;
+		}
+
+		h5 {
+			font-size: 1em;
+		}
+
+		h6 {
+			font-size: 0.8em;
+			line-height: 1.56;
 		}
 
 		a {
@@ -76,10 +110,16 @@
 		}
 
 		.wp-block-buttons {
+			font-weight: bold;
 			text-align: center;
 
 			.block-list-appender {
 				margin: 0;
+			}
+
+			.wp-block-button__link {
+				font-size: 1em;
+				padding: 0.75em 1.5em;
 			}
 		}
 
@@ -167,9 +207,18 @@
 				}
 			}
 
-			&[data-type='core/separator'] {
+			&[data-type='core/separator'],
+			.wp-block-separator {
+				background: none !important;
+				border-bottom: 1px solid;
+				opacity: 1;
 				padding-bottom: 12px;
 				padding-top: 12px;
+
+				&:not( .is-style-wide ):not( .is-style-dots ) {
+					border-bottom-width: 1px;
+					width: 128px;
+				}
 
 				hr {
 					margin-bottom: 0;

--- a/tests/test-renderer.php
+++ b/tests/test-renderer.php
@@ -71,7 +71,7 @@ class Newsletters_Renderer_Test extends WP_UnitTestCase {
 					'innerHTML'   => $inner_html,
 				]
 			),
-			'<mj-section url="https://www.youtube.com/watch?v=aIRgcb3cQ1Q" padding="0"><mj-column padding="12px" width="100%"><mj-image padding="0" src="https://i.ytimg.com/vi/aIRgcb3cQ1Q/hqdefault.jpg" width="480px" height="360px" href="https://www.youtube.com/watch?v=aIRgcb3cQ1Q" /><mj-text align="center" color="#555d66" font-size="13px" >How to use the Newspack Newsletter plugin - YouTube</mj-text></mj-column></mj-section>',
+			'<mj-section url="https://www.youtube.com/watch?v=aIRgcb3cQ1Q" padding="0"><mj-column padding="12px" width="100%"><mj-image padding="0" src="https://i.ytimg.com/vi/aIRgcb3cQ1Q/hqdefault.jpg" width="480px" height="360px" href="https://www.youtube.com/watch?v=aIRgcb3cQ1Q" /><mj-text align="center" color="#555d66" line-height="1.56" font-size="13px" >How to use the Newspack Newsletter plugin - YouTube</mj-text></mj-column></mj-section>',
 			'Renders image from video embed block with title as caption'
 		);
 
@@ -88,7 +88,7 @@ class Newsletters_Renderer_Test extends WP_UnitTestCase {
 					'innerHTML'   => $inner_html,
 				]
 			),
-			'<mj-section url="https://flickr.com/photos/thomashawk/9274246246" padding="0"><mj-column padding="12px" width="100%"><mj-image src="https://live.staticflickr.com/7357/9274246246_201d71cf9a.jpg" alt="Automattic" width="500" height="333" href="https://flickr.com/photos/thomashawk/9274246246" /><mj-text align="center" color="#555d66" font-size="13px" >Automattic - Flickr</mj-text></mj-column></mj-section>',
+			'<mj-section url="https://flickr.com/photos/thomashawk/9274246246" padding="0"><mj-column padding="12px" width="100%"><mj-image src="https://live.staticflickr.com/7357/9274246246_201d71cf9a.jpg" alt="Automattic" width="500" height="333" href="https://flickr.com/photos/thomashawk/9274246246" /><mj-text align="center" color="#555d66" line-height="1.56" font-size="13px" >Automattic - Flickr</mj-text></mj-column></mj-section>',
 			'Renders image with inline figcaption as caption'
 		);
 

--- a/tests/test-renderer.php
+++ b/tests/test-renderer.php
@@ -28,7 +28,7 @@ class Newsletters_Renderer_Test extends WP_UnitTestCase {
 					'innerHTML'   => $inner_html,
 				]
 			),
-			'<mj-section padding="0"><mj-column padding="12px" width="100%"><mj-text padding="0" line-height="1.8" font-size="16px" >' . $inner_html . '</mj-text></mj-column></mj-section>',
+			'<mj-section padding="0"><mj-column padding="12px" width="100%"><mj-text padding="0" line-height="1.5" font-size="16px" >' . $inner_html . '</mj-text></mj-column></mj-section>',
 			'Renders default paragraph'
 		);
 
@@ -49,7 +49,7 @@ class Newsletters_Renderer_Test extends WP_UnitTestCase {
 					'innerHTML'   => $inner_html,
 				]
 			),
-			'<mj-section textColor="vivid-purple" color="#db18e6 !important" background-color="#4aadd7 !important" font-size="16px" padding="0"><mj-column padding="12px" width="100%"><mj-text padding="0" line-height="1.8" font-size="16px"  textColor="vivid-purple" color="#db18e6 !important" container-background-color="#4aadd7 !important">' . $inner_html . '</mj-text></mj-column></mj-section>',
+			'<mj-section textColor="vivid-purple" color="#db18e6 !important" background-color="#4aadd7 !important" font-size="16px" padding="0"><mj-column padding="12px" width="100%"><mj-text padding="0" line-height="1.5" font-size="16px"  textColor="vivid-purple" color="#db18e6 !important" container-background-color="#4aadd7 !important">' . $inner_html . '</mj-text></mj-column></mj-section>',
 			'Renders styled paragraph'
 		);
 	}
@@ -105,7 +105,7 @@ class Newsletters_Renderer_Test extends WP_UnitTestCase {
 					'innerHTML'   => $inner_html,
 				]
 			),
-			"<mj-section url=\"https://twitter.com/automattic/status/1395447061336711181\" padding=\"0\"><mj-column padding=\"12px\" width=\"100%\"><mj-text padding=\"0\" line-height=\"1.8\" font-size=\"16px\" ><blockquote>We&#039;re Hiring! We are continuing to grow and have some exciting open positions available, including in Engineering, Product, Marketing, Business Development, HR, Customer Support, and more. Work with us, from anywhere. <a href=\"https://t.co/EZST4WBsy2\">https://t.co/EZST4WBsy2</a> <a href=\"https://t.co/z8bKfCgn14\">pic.twitter.com/z8bKfCgn14</a>&mdash; Automattic (@automattic) <a href=\"https://twitter.com/automattic/status/1395447061336711181?ref_src=twsrc%5Etfw\">May 20, 2021</a></blockquote>\n\n</mj-text></mj-column></mj-section>",
+			"<mj-section url=\"https://twitter.com/automattic/status/1395447061336711181\" padding=\"0\"><mj-column padding=\"12px\" width=\"100%\"><mj-text padding=\"0\" line-height=\"1.5\" font-size=\"16px\" ><blockquote>We&#039;re Hiring! We are continuing to grow and have some exciting open positions available, including in Engineering, Product, Marketing, Business Development, HR, Customer Support, and more. Work with us, from anywhere. <a href=\"https://t.co/EZST4WBsy2\">https://t.co/EZST4WBsy2</a> <a href=\"https://t.co/z8bKfCgn14\">pic.twitter.com/z8bKfCgn14</a>&mdash; Automattic (@automattic) <a href=\"https://twitter.com/automattic/status/1395447061336711181?ref_src=twsrc%5Etfw\">May 20, 2021</a></blockquote>\n\n</mj-text></mj-column></mj-section>",
 			'Renders tweet as HTML'
 		);
 
@@ -122,7 +122,7 @@ class Newsletters_Renderer_Test extends WP_UnitTestCase {
 					'innerHTML'   => $inner_html,
 				]
 			),
-			'<mj-section url="https://www.amazon.com/Learning-PHP-MySQL-JavaScript-Javascript/dp/1491978910" padding="0"><mj-column padding="12px" width="100%"><mj-text padding="0" line-height="1.8" font-size="16px" ><a href="https://www.amazon.com/Learning-PHP-MySQL-JavaScript-Javascript/dp/1491978910">Learning PHP, MySQL &amp; JavaScript: With jQuery, CSS &amp; HTML5 (Learning PHP, MYSQL, Javascript, CSS &amp; HTML5)</a></mj-text></mj-column></mj-section>',
+			'<mj-section url="https://www.amazon.com/Learning-PHP-MySQL-JavaScript-Javascript/dp/1491978910" padding="0"><mj-column padding="12px" width="100%"><mj-text padding="0" line-height="1.5" font-size="16px" ><a href="https://www.amazon.com/Learning-PHP-MySQL-JavaScript-Javascript/dp/1491978910">Learning PHP, MySQL &amp; JavaScript: With jQuery, CSS &amp; HTML5 (Learning PHP, MYSQL, Javascript, CSS &amp; HTML5)</a></mj-text></mj-column></mj-section>',
 			'Renders invalid rich HTML as link'
 		);
 	}
@@ -165,7 +165,7 @@ class Newsletters_Renderer_Test extends WP_UnitTestCase {
 			Newspack_Newsletters_Renderer::post_to_mjml_components(
 				get_post( $newsletter_post )
 			),
-			"<mj-wrapper ref=\"$reusable_block_post_id\"><mj-section padding=\"0\"><mj-column padding=\"12px\" width=\"100%\"><mj-text padding=\"0\" line-height=\"1.8\" font-size=\"16px\" >\n<p>Hello</p>\n</mj-text></mj-column></mj-section></mj-wrapper>",
+			"<mj-wrapper ref=\"$reusable_block_post_id\"><mj-section padding=\"0\"><mj-column padding=\"12px\" width=\"100%\"><mj-text padding=\"0\" line-height=\"1.5\" font-size=\"16px\" >\n<p>Hello</p>\n</mj-text></mj-column></mj-section></mj-wrapper>",
 			'Renders the reusable block into valid markup'
 		);
 	}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

* Small tweak to the vertical rhythm to follow an 8px baseline.
* Simplify separator block to only a thin 1px line irregardless of the block style
* Update button font-weight and padding

### How to test the changes in this Pull Request:

1. Create a newsletter and send yourself a preview
2. Compare the editor with the email you've just received
3. Switch to this branch and refresh the editor
4. Send yourself another preview
5. Check the email against the editor

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
