### PR TITLE
fix: editor script data

### DIFF
--- a/includes/class-newspack-newsletters-editor.php
+++ b/includes/class-newspack-newsletters-editor.php
@@ -205,6 +205,15 @@ final class Newspack_Newsletters_Editor {
 		}
 
 		if ( self::is_editing_newsletter() ) {
+			wp_localize_script(
+				'newspack-newsletters-editor',
+				'newspack_newsletters_data',
+				[
+					'is_service_provider_configured' => Newspack_Newsletters::is_service_provider_configured(),
+					'service_provider'               => Newspack_Newsletters::service_provider(),
+					'user_test_emails'               => self::get_current_user_test_emails(),
+				]
+			);
 			wp_register_style(
 				'newspack-newsletters-newsletter-editor',
 				plugins_url( '../dist/newsletterEditor.css', __FILE__ ),
@@ -219,15 +228,6 @@ final class Newspack_Newsletters_Editor {
 				[],
 				filemtime( NEWSPACK_NEWSLETTERS_PLUGIN_FILE . 'dist/newsletterEditor.js' ),
 				true
-			);
-			wp_localize_script(
-				'newspack-newsletters-newsletter-editor',
-				'newspack_newsletters_data',
-				[
-					'is_service_provider_configured' => Newspack_Newsletters::is_service_provider_configured(),
-					'service_provider'               => Newspack_Newsletters::service_provider(),
-					'user_test_emails'               => self::get_current_user_test_emails(),
-				]
 			);
 		}
 

--- a/src/service-providers/index.js
+++ b/src/service-providers/index.js
@@ -13,8 +13,7 @@ const SERVICE_PROVIDERS = {
 };
 
 export const getServiceProvider = () => {
-	const serviceProvider =
-		window && window.newspack_newsletters_data && window.newspack_newsletters_data.service_provider;
+	const serviceProvider = window?.newspack_newsletters_data?.service_provider;
 	return {
 		name: serviceProvider,
 		...SERVICE_PROVIDERS[ serviceProvider || 'example' ],


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

The localized data should be printed before the `newspack-newsletters-editor`, and not `newspack-newsletters-newsletter-editor`. The current implementation does not allow the service provider to be detected for the Mailchimp merge tags custom filters.

### How to test the changes in this Pull Request:

1. On the master branch using the Mailchimp as service provider, edit a newsletter
2. Start a new paragraph block and observe the `*|` autocompleter is not available
3. Check out this branch, run `npm run build` and refresh the editor
4. Confirm the `*|` autocompleter is now working for paragraph blocks

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
