### PR TITLE
fix: append layout preview css to iframe head

### DIFF
--- a/src/components/init-modal/screens/layout-picker/SingleLayoutPreview.js
+++ b/src/components/init-modal/screens/layout-picker/SingleLayoutPreview.js
@@ -76,7 +76,12 @@ const SingleLayoutPreview = ( {
 				aria-label={ title }
 			>
 				{ '' === content ? null : (
-					<NewsletterPreview meta={ meta } blocks={ blockPreviewBlocks } viewportWidth={ 600 } />
+					<NewsletterPreview
+						layoutId={ ID }
+						meta={ meta }
+						blocks={ blockPreviewBlocks }
+						viewportWidth={ 600 }
+					/>
 				) }
 			</div>
 			{ isEditable ? (

--- a/src/components/init-modal/screens/layout-picker/index.js
+++ b/src/components/init-modal/screens/layout-picker/index.js
@@ -64,7 +64,9 @@ const LayoutPicker = ( {
 	const [ selectedLayoutId, setSelectedLayoutId ] = useState( null );
 	const layoutPreviewProps = useMemo( () => {
 		const layout = selectedLayoutId && find( layouts, { ID: selectedLayoutId } );
-		return layout ? { blocks: parse( layout.post_content ), meta: layout.meta } : null;
+		return layout
+			? { layoutId: selectedLayoutId, blocks: parse( layout.post_content ), meta: layout.meta }
+			: null;
 	}, [ selectedLayoutId, layouts.length ] );
 
 	const canRenderPreview = layoutPreviewProps && layoutPreviewProps.blocks.length > 0;

--- a/src/components/init-modal/style.scss
+++ b/src/components/init-modal/style.scss
@@ -277,7 +277,7 @@
 		border-top: none;
 		display: none;
 		justify-content: center;
-		overflow-y: scroll;
+		overflow: hidden;
 		position: relative;
 
 		@media only screen and ( min-width: 600px ) {

--- a/src/components/newsletter-preview/index.js
+++ b/src/components/newsletter-preview/index.js
@@ -1,9 +1,8 @@
 /**
  * WordPress dependencies
  */
-import { useRefEffect } from '@wordpress/compose';
 import { BlockPreview } from '@wordpress/block-editor';
-import { Fragment, useMemo, useState } from '@wordpress/element';
+import { Fragment, useEffect, useRef, useState } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -11,57 +10,62 @@ import { Fragment, useMemo, useState } from '@wordpress/element';
 import './style.scss';
 import { getScopedCss } from '../../newsletter-editor/styling';
 
-const NewsletterPreview = ( { meta = {}, ...props } ) => {
-	const ELEMENT_ID = useMemo( () => `preview-${ Math.round( Math.random() * 1000 ) }`, [] );
-
+const NewsletterPreview = ( { layoutId = null, meta = {}, ...props } ) => {
+	const [ elementId, setElementId ] = useState( '' );
 	const [ css, setCss ] = useState( '' );
 
-	const useInlineStyles = useRefEffect(
-		node => {
-			const cssRules = [];
-			if ( meta.font_body ) {
-				cssRules.push( `*:not( code ) { font-family: ${ meta.font_body }; }` );
-			}
-			if ( meta.font_header ) {
-				cssRules.push( `h1, h2, h3, h4, h5, h6 { font-family: ${ meta.font_header }; }` );
-			}
-			if ( meta.custom_css ) {
-				cssRules.push( meta.custom_css );
-			}
-			if ( ! cssRules.length ) {
-				return;
-			}
-			const inlineCss = getScopedCss( `#${ ELEMENT_ID }`, cssRules.join( '\n' ) );
-			setCss( inlineCss );
-			const style = document.createElement( 'style' );
-			const appendStyle = () => {
-				const iframe = node.querySelector( 'iframe[title="Editor canvas"]' );
-				if ( iframe ) {
-					iframe.addEventListener( 'load', () => {
-						style.textContent = inlineCss;
-						iframe.contentDocument.body.id = ELEMENT_ID;
+	// Generate inline layout styles for the preview.
+	useEffect( () => {
+		const _elementId = `preview-${ Math.round( Math.random() * 1000 ) }`;
+		setElementId( _elementId );
+		const cssRules = [];
+		if ( meta.font_body ) {
+			cssRules.push( `*:not( code ) { font-family: ${ meta.font_body }; }` );
+		}
+		if ( meta.font_header ) {
+			cssRules.push( `h1, h2, h3, h4, h5, h6 { font-family: ${ meta.font_header }; }` );
+		}
+		if ( meta.custom_css ) {
+			cssRules.push( meta.custom_css );
+		}
+		setCss( cssRules.length ? getScopedCss( `#${ _elementId }`, cssRules.join( '\n' ) ) : '' );
+	}, [ layoutId ].concat( Object.values( meta ) ) );
+
+	// Apply the styles to the iframe editor.
+	const useInlineStyles = () => {
+		const ref = useRef();
+		useEffect( () => {
+			const node = ref.current;
+			const iframe = node.querySelector( 'iframe[title="Editor canvas"]' );
+			if ( iframe ) {
+				const appendStyle = () => {
+					const style = document.createElement( 'style' );
+					style.id = `newspack-newsletters__layout-preview-${ layoutId }`;
+					style.textContent = css;
+					if ( iframe.contentDocument?.body ) {
+						iframe.contentDocument.body.id = elementId;
 						iframe.contentDocument.head.appendChild( style );
-						observer.disconnect();
-					} );
-				}
-			};
-			const observer = new MutationObserver( appendStyle );
-			observer.observe( node, { childList: true } );
-			return () => {
-				observer.disconnect();
-			};
-		},
-		[ meta ]
-	);
+					}
+				};
+				appendStyle();
+				// Handle Firefox iframe.
+				iframe.addEventListener( 'load', appendStyle );
+				return () => {
+					iframe.removeEventListener( 'load', appendStyle );
+				};
+			}
+		}, [ layoutId, css ] );
+		return ref;
+	};
 
 	return (
 		<Fragment>
-			<style id="newspack-newsletters__layout-css" data-previewid={ ELEMENT_ID }>
+			<style id="newspack-newsletters__layout-css" data-previewid={ elementId }>
 				{ css }
 			</style>
 			<div
-				ref={ useInlineStyles }
-				id={ ELEMENT_ID }
+				ref={ useInlineStyles() }
+				id={ elementId }
 				className="newspack-newsletters__layout-preview"
 				style={ {
 					backgroundColor: meta.background_color,

--- a/src/components/newsletter-preview/index.js
+++ b/src/components/newsletter-preview/index.js
@@ -1,8 +1,9 @@
 /**
  * WordPress dependencies
  */
+import { useRefEffect } from '@wordpress/compose';
 import { BlockPreview } from '@wordpress/block-editor';
-import { Fragment, useMemo } from '@wordpress/element';
+import { Fragment, useMemo, useState } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -13,30 +14,53 @@ import { getScopedCss } from '../../newsletter-editor/styling';
 const NewsletterPreview = ( { meta = {}, ...props } ) => {
 	const ELEMENT_ID = useMemo( () => `preview-${ Math.round( Math.random() * 1000 ) }`, [] );
 
+	const [ css, setCss ] = useState( '' );
+
+	const useInlineStyles = useRefEffect(
+		node => {
+			const cssRules = [];
+			if ( meta.font_body ) {
+				cssRules.push( `*:not( code ) { font-family: ${ meta.font_body }; }` );
+			}
+			if ( meta.font_header ) {
+				cssRules.push( `h1, h2, h3, h4, h5, h6 { font-family: ${ meta.font_header }; }` );
+			}
+			if ( meta.custom_css ) {
+				cssRules.push( meta.custom_css );
+			}
+			if ( ! cssRules.length ) {
+				return;
+			}
+			const inlineCss = getScopedCss( `#${ ELEMENT_ID }`, cssRules.join( '\n' ) );
+			setCss( inlineCss );
+			const style = document.createElement( 'style' );
+			const appendStyle = () => {
+				const iframe = node.querySelector( 'iframe[title="Editor canvas"]' );
+				if ( iframe ) {
+					iframe.addEventListener( 'load', () => {
+						style.textContent = inlineCss;
+						iframe.contentDocument.body.id = ELEMENT_ID;
+						iframe.contentDocument.head.appendChild( style );
+						observer.disconnect();
+					} );
+				}
+			};
+			const observer = new MutationObserver( appendStyle );
+			observer.observe( node, { childList: true } );
+			return () => {
+				observer.disconnect();
+			};
+		},
+		[ meta ]
+	);
+
 	return (
 		<Fragment>
-			<style>{ `${
-				meta.font_body
-					? `
-#${ ELEMENT_ID } *:not( code ) {
-  font-family: ${ meta.font_body };
-}`
-					: ' '
-			}${
-				meta.font_header
-					? `
-#${ ELEMENT_ID } h1, #${ ELEMENT_ID } h2, #${ ELEMENT_ID } h3, #${ ELEMENT_ID } h4, #${ ELEMENT_ID } h5, #${ ELEMENT_ID } h6 {
-  font-family: ${ meta.font_header };
-}`
-					: ' '
-			}${
-				meta.custom_css
-					? `
-${ getScopedCss( `#${ ELEMENT_ID }`, meta.custom_css ) }
-`
-					: ' '
-			}` }</style>
+			<style id="newspack-newsletters__layout-css" data-previewid={ ELEMENT_ID }>
+				{ css }
+			</style>
 			<div
+				ref={ useInlineStyles }
 				id={ ELEMENT_ID }
 				className="newspack-newsletters__layout-preview"
 				style={ {

--- a/src/components/newsletter-preview/style.scss
+++ b/src/components/newsletter-preview/style.scss
@@ -5,6 +5,10 @@
 	width: 100%;
 }
 
+.newspack-newsletters-modal__preview .newspack-newsletters__layout-preview {
+	overflow: auto;
+}
+
 .block-editor-block-preview__content-iframe
 	.editor-styles-wrapper
 	.block-editor-block-list__layout.is-root-container {

--- a/src/editor/blocks/posts-inserter/index.js
+++ b/src/editor/blocks/posts-inserter/index.js
@@ -21,6 +21,7 @@ import {
 } from '@wordpress/components';
 import { InnerBlocks, InspectorControls, BlockControls } from '@wordpress/block-editor';
 import { Fragment, useEffect, useMemo, useState } from '@wordpress/element';
+import { useCustomFontsInIframe } from '../../../newsletter-editor/styling';
 
 /**
  * Internal dependencies
@@ -230,7 +231,13 @@ const PostsInserterBlock = ( {
 					{ Icon }
 					<span>{ __( 'Posts Inserter', 'newspack-newsletters' ) }</span>
 				</div>
-				<PostsPreview isReady={ isReady } blocks={ templateBlocks } viewportWidth={ 600 } />
+				<PostsPreview
+					// eslint-disable-next-line react-hooks/rules-of-hooks
+					ref={ useCustomFontsInIframe() }
+					isReady={ isReady }
+					blocks={ templateBlocks }
+					viewportWidth={ 600 }
+				/>
 				<div className="newspack-posts-inserter__footer">
 					<Button isPrimary onClick={ () => setAttributes( { areBlocksInserted: true } ) }>
 						{ __( 'Insert posts', 'newspack-newsletters' ) }

--- a/src/editor/blocks/posts-inserter/posts-preview.js
+++ b/src/editor/blocks/posts-inserter/posts-preview.js
@@ -28,6 +28,7 @@ const PostsPreview = ( { isReady, blocks, viewportWidth }, ref ) => {
 			observer.disconnect();
 		};
 	}, [] );
+
 	// Append layout style if viewing layout preview.
 	const useLayoutStyle = useRefEffect( node => {
 		const style = document.getElementById( 'newspack-newsletters__layout-css' );
@@ -50,6 +51,7 @@ const PostsPreview = ( { isReady, blocks, viewportWidth }, ref ) => {
 			observer.disconnect();
 		};
 	}, [] );
+
 	return (
 		<div
 			className="newspack-posts-inserter__preview"

--- a/src/newsletter-editor/layout/index.js
+++ b/src/newsletter-editor/layout/index.js
@@ -161,6 +161,7 @@ export default compose( [
 						<div className="newspack-newsletters-layouts__item">
 							<div className="newspack-newsletters-layouts__item-preview">
 								<NewsletterPreview
+									layoutId={ layoutId }
 									meta={ usedLayout.meta }
 									blocks={ setPreventDeduplicationForPostsInserter( blockPreview ) }
 									viewportWidth={ 600 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR implements the required hooks to apply a newsletter layout custom CSS to the Post Inserter block previews. It fixes the display for layout preview and newsletter editing.

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes #687 

### How to test the changes in this Pull Request:

1. Make sure you have WordPress 5.9 RC 2 installed
2. While on the master branch, create a newsletter layout with custom fonts and a Posts Inserter block
3. Click to create a new newsletter, choose the created layout and observe the Posts Inserter block does not apply the selected fonts
4. Check out this branch, run `npm run build` and refresh the page
5. Observe the fonts are now applied
6. Select the layout to enter the newsletter editor and observe the fonts are also applied
7. Repeat the steps above in WordPress 5.8 to make sure there are no regressions

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
