### PR TITLE
fix(post-inserter): preview ref hook on top level component

### DIFF
--- a/src/editor/blocks/posts-inserter/index.js
+++ b/src/editor/blocks/posts-inserter/index.js
@@ -21,7 +21,6 @@ import {
 } from '@wordpress/components';
 import { InnerBlocks, InspectorControls, BlockControls } from '@wordpress/block-editor';
 import { Fragment, useEffect, useMemo, useState } from '@wordpress/element';
-import { useCustomFontsInIframe } from '../../../newsletter-editor/styling';
 
 /**
  * Internal dependencies
@@ -231,13 +230,7 @@ const PostsInserterBlock = ( {
 					{ Icon }
 					<span>{ __( 'Posts Inserter', 'newspack-newsletters' ) }</span>
 				</div>
-				<PostsPreview
-					// eslint-disable-next-line react-hooks/rules-of-hooks
-					ref={ useCustomFontsInIframe() }
-					isReady={ isReady }
-					blocks={ templateBlocks }
-					viewportWidth={ 600 }
-				/>
+				<PostsPreview isReady={ isReady } blocks={ templateBlocks } viewportWidth={ 600 } />
 				<div className="newspack-posts-inserter__footer">
 					<Button isPrimary onClick={ () => setAttributes( { areBlocksInserted: true } ) }>
 						{ __( 'Insert posts', 'newspack-newsletters' ) }

--- a/src/editor/blocks/posts-inserter/posts-preview.js
+++ b/src/editor/blocks/posts-inserter/posts-preview.js
@@ -5,6 +5,7 @@ import { useMergeRefs, useRefEffect } from '@wordpress/compose';
 import { BlockPreview } from '@wordpress/block-editor';
 import { Spinner } from '@wordpress/components';
 import { forwardRef } from '@wordpress/element';
+import { useCustomFontsInIframe } from '../../../newsletter-editor/styling';
 
 /**
  * Posts Preview component.
@@ -63,7 +64,7 @@ const PostsPreview = ( { isReady, blocks, viewportWidth }, ref ) => {
 	return (
 		<div
 			className="newspack-posts-inserter__preview"
-			ref={ useMergeRefs( [ ref, useIframeBorderFix, useLayoutStyle ] ) }
+			ref={ useMergeRefs( [ ref, useIframeBorderFix, useLayoutStyle, useCustomFontsInIframe() ] ) }
 		>
 			{ isReady ? <BlockPreview blocks={ blocks } viewportWidth={ viewportWidth } /> : <Spinner /> }
 		</div>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Fix the rule of hooks infringement by placing the `useCustomFontsInIframe` hook in the top-level component `PostsPreview`.

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

### How to test the changes in this Pull Request:

Make sure you are able to create the Post Inserter block and click on "Insert Posts" in instances using WordPress 5.8 and 5.9 RC2.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
