### PR TITLE
fix: php warning when converting non-string attributes to mjml

### DIFF
--- a/includes/class-newspack-newsletters-renderer.php
+++ b/includes/class-newspack-newsletters-renderer.php
@@ -57,7 +57,10 @@ final class Newspack_Newsletters_Renderer {
 			' ',
 			array_map(
 				function( $key ) use ( $attributes ) {
-					if ( isset( $attributes[ $key ] ) ) {
+					if (
+						isset( $attributes[ $key ] ) &&
+						( is_string( $attributes[ $key ] ) || is_numeric( $attributes[ $key ] ) ) // Don't convert values that can't be expressed as a string.
+					) {
 						return $key . '="' . $attributes[ $key ] . '"';
 					} else {
 						return '';


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes a PHP warning triggered by the new "Layout" attribute in WP 5.9, that results from MJML trying to convert an array attribute value to a string.

### How to test the changes in this Pull Request:

1. Test on a site running WP 5.9.
2. On `master`, create a new newsletter and add a block with the Layout attribute (such as Buttons or Social Icons—both are part of the default newsletter layouts, so you can easily test with one of those).
3. Save the newsletter and observe a PHP error on save:

```
PHP Notice:  Array to string conversion in /Users/dkoo/Local Sites/newspack/app/public/wp-content/plugins/newspack-newsletters/includes/class-newspack-newsletters-renderer.php on line 61
```

4. Check out this branch and save again. Confirm that the warning no longer appears and that the `newspack_email_html` meta value is saved with MJML markup of the content.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
