### PR TITLE
Update init modal design

### DIFF
--- a/src/components/init-modal/index.js
+++ b/src/components/init-modal/index.js
@@ -25,8 +25,8 @@ export default ( { shouldDisplaySettings, onSetupStatus } ) => {
 			shouldCloseOnEsc={ false }
 			title={
 				shouldDisplaySettings
-					? __( 'Configure plugin', 'newspack-newsletters' )
-					: __( 'Select a layout for your newsletter', 'newspack-newsletters' )
+					? __( 'Configure Plugin', 'newspack-newsletters' )
+					: __( 'Add New Newsletter', 'newspack-newsletters' )
 			}
 		>
 			{ shouldDisplaySettings ? <APIKeys onSetupStatus={ onSetupStatus } /> : <LayoutPicker /> }

--- a/src/components/init-modal/screens/api-keys/index.js
+++ b/src/components/init-modal/screens/api-keys/index.js
@@ -109,19 +109,18 @@ export default ( { onSetupStatus } ) => {
 								disabled: true,
 								label: __( 'Select service provider', 'newspack-newsletters' ),
 							},
-							{ value: 'manual', label: __( 'Manual', 'newspack-newsletters' ) },
-							{ value: 'mailchimp', label: __( 'Mailchimp', 'newspack-newsletters' ) },
+							{ value: 'mailchimp', label: 'Mailchimp' },
 							{
 								value: 'constant_contact',
-								label: __( 'Constant Contact', 'newspack-newsletters' ),
+								label: 'Constant Contact',
 							},
 							{
 								value: 'campaign_monitor',
-								label: __( 'Campaign Monitor', 'newspack-newsletters' ),
+								label: 'Campaign Monitor',
 							},
+							{ value: 'manual', label: __( 'Manual / Other', 'newspack-newsletters' ) },
 						] }
 					/>
-					<hr />
 					{ 'mailchimp' === serviceProvider && (
 						<Fragment>
 							<h4>{ __( 'Enter your Mailchimp API key', 'newspack-newsletters' ) }</h4>
@@ -138,15 +137,10 @@ export default ( { onSetupStatus } ) => {
 							) }
 
 							<p>
-								<ExternalLink href="https://us1.admin.mailchimp.com/account/api/">
-									{ __( 'Generate Mailchimp API key', 'newspack-newsletters' ) }
-								</ExternalLink>
-								<span className="separator"> | </span>
-								<ExternalLink href="https://mailchimp.com/help/about-api-keys/">
-									{ __( 'About Mailchimp API keys', 'newspack-newsletters' ) }
+								<ExternalLink href="https://mailchimp.com/help/about-api-keys/#Find_or_generate_your_API_key">
+									{ __( 'Find or generate your API key', 'newspack-newsletters' ) }
 								</ExternalLink>
 							</p>
-							<hr />
 						</Fragment>
 					) }
 					{ 'constant_contact' === serviceProvider && (
@@ -186,7 +180,6 @@ export default ( { onSetupStatus } ) => {
 									{ __( 'Get Constant Contact access token', 'newspack-newsletters' ) }
 								</ExternalLink>
 							</p>
-							<hr />
 						</Fragment>
 					) }
 					{ 'campaign_monitor' === serviceProvider && (
@@ -228,7 +221,7 @@ export default ( { onSetupStatus } ) => {
 			</div>
 			<div className="newspack-newsletters-modal__action-buttons">
 				<Button isPrimary onClick={ commitSettings } disabled={ inFlight || ! canSubmit }>
-					{ __( 'Save settings', 'newspack-newsletter' ) }
+					{ __( 'Save Settings', 'newspack-newsletter' ) }
 				</Button>
 			</div>
 		</Fragment>

--- a/src/components/init-modal/screens/layout-picker/SingleLayoutPreview.js
+++ b/src/components/init-modal/screens/layout-picker/SingleLayoutPreview.js
@@ -80,7 +80,7 @@ const SingleLayoutPreview = ( {
 						layoutId={ ID }
 						meta={ meta }
 						blocks={ blockPreviewBlocks }
-						viewportWidth={ 600 }
+						viewportWidth={ 848 }
 					/>
 				) }
 			</div>

--- a/src/components/init-modal/screens/layout-picker/index.js
+++ b/src/components/init-modal/screens/layout-picker/index.js
@@ -24,11 +24,11 @@ import SingleLayoutPreview from './SingleLayoutPreview';
 
 const LAYOUTS_TABS = [
 	{
-		title: __( 'Default layouts', 'newspack-newsletters' ),
+		title: __( 'Prebuilt Layouts', 'newspack-newsletters' ),
 		filter: layout => layout.post_author === undefined,
 	},
 	{
-		title: __( 'My layouts', 'newspack-newsletters' ),
+		title: __( 'Saved Layouts', 'newspack-newsletters' ),
 		filter: isUserDefinedLayout,
 		isEditable: true,
 	},
@@ -77,10 +77,7 @@ const LayoutPicker = ( {
 			<div className="newspack-newsletters-modal__content">
 				<div className="newspack-newsletters-modal__content__sidebar">
 					<p>
-						{ __(
-							'Pick a pre-defined layout or start with a blank newsletter.',
-							'newspack-newsletters'
-						) }
+						{ __( 'Choose a layout or start with a blank newsletter.', 'newspack-newsletters' ) }
 					</p>
 					<div className="newspack-newsletters-modal__content__layout-buttons">
 						{ LAYOUTS_TABS.map( ( { title }, i ) => (
@@ -106,9 +103,11 @@ const LayoutPicker = ( {
 						<Spinner />
 					) : (
 						<div
-							className={ classnames( {
-								'newspack-newsletters-layouts': displayedLayouts.length > 0,
-							} ) }
+							className={
+								displayedLayouts.length > 0
+									? 'newspack-newsletters-layouts'
+									: 'newspack-newsletters-layouts--empty'
+							}
 						>
 							{ displayedLayouts.length ? (
 								displayedLayouts.map( layout => (
@@ -122,12 +121,17 @@ const LayoutPicker = ( {
 									/>
 								) )
 							) : (
-								<span>
-									{ __(
-										'Turn any newsletter to a layout via the "Layout" sidebar menu in the editor.',
-										'newspack-newsletters'
-									) }
-								</span>
+								<>
+									<h3 className="newspack-newsletters-layouts--empty">
+										{ __( 'You don’t have any saved layouts yet.', 'newspack-newsletters' ) }
+									</h3>
+									<p>
+										{ __(
+											'Turn any newsletter to a layout via the "Layout" sidebar menu in the editor.',
+											'newspack-newsletters'
+										) }
+									</p>
+								</>
 							) }
 						</div>
 					) }

--- a/src/components/init-modal/screens/layout-picker/index.js
+++ b/src/components/init-modal/screens/layout-picker/index.js
@@ -8,7 +8,7 @@ import { find } from 'lodash';
  * WordPress dependencies
  */
 import { parse } from '@wordpress/blocks';
-import { Fragment, useMemo, useState, useEffect } from '@wordpress/element';
+import { Fragment, useState, useEffect } from '@wordpress/element';
 import { compose } from '@wordpress/compose';
 import { withSelect, withDispatch } from '@wordpress/data';
 import { Button, Spinner } from '@wordpress/components';
@@ -21,7 +21,6 @@ import { BLANK_LAYOUT_ID } from '../../../../utils/consts';
 import { isUserDefinedLayout } from '../../../../utils';
 import { useLayoutsState } from '../../../../utils/hooks';
 import SingleLayoutPreview from './SingleLayoutPreview';
-import NewsletterPreview from '../../../newsletter-preview';
 
 const LAYOUTS_TABS = [
 	{
@@ -62,22 +61,6 @@ const LayoutPicker = ( {
 	};
 
 	const [ selectedLayoutId, setSelectedLayoutId ] = useState( null );
-	const layoutPreviewProps = useMemo( () => {
-		const layout = selectedLayoutId && find( layouts, { ID: selectedLayoutId } );
-		return layout
-			? { layoutId: selectedLayoutId, blocks: parse( layout.post_content ), meta: layout.meta }
-			: null;
-	}, [ selectedLayoutId, layouts.length ] );
-
-	const canRenderPreview = layoutPreviewProps && layoutPreviewProps.blocks.length > 0;
-
-	const renderPreview = () =>
-		canRenderPreview ? (
-			<NewsletterPreview { ...layoutPreviewProps } viewportWidth={ 600 } />
-		) : (
-			<p>{ __( 'Select a layout to preview.', 'newspack-newsletters' ) }</p>
-		);
-
 	const [ activeTabIndex, setActiveTabIndex ] = useState( 0 );
 	const activeTab = LAYOUTS_TABS[ activeTabIndex ];
 	const displayedLayouts = layouts.filter( activeTab.filter );
@@ -92,20 +75,27 @@ const LayoutPicker = ( {
 	return (
 		<Fragment>
 			<div className="newspack-newsletters-modal__content">
-				<div className="newspack-newsletters-tabs newspack-newsletters-buttons-group">
-					{ LAYOUTS_TABS.map( ( { title }, i ) => (
-						<Button
-							key={ i }
-							disabled={ isFetchingLayouts }
-							className={ classnames( 'newspack-newsletters-tabs__button', {
-								'newspack-newsletters-tabs__button--is-active':
-									! isFetchingLayouts && i === activeTabIndex,
-							} ) }
-							onClick={ () => setActiveTabIndex( i ) }
-						>
-							{ title }
-						</Button>
-					) ) }
+				<div className="newspack-newsletters-modal__content__sidebar">
+					<p>
+						{ __(
+							'Pick a pre-defined layout or start with a blank newsletter.',
+							'newspack-newsletters'
+						) }
+					</p>
+					<div className="newspack-newsletters-modal__content__layout-buttons">
+						{ LAYOUTS_TABS.map( ( { title }, i ) => (
+							<Button
+								key={ i }
+								disabled={ isFetchingLayouts }
+								className={ {
+									'is-active': ! isFetchingLayouts && i === activeTabIndex,
+								} }
+								onClick={ () => setActiveTabIndex( i ) }
+							>
+								{ title }
+							</Button>
+						) ) }
+					</div>
 				</div>
 				<div
 					className={ classnames( 'newspack-newsletters-modal__layouts', {
@@ -142,19 +132,14 @@ const LayoutPicker = ( {
 						</div>
 					) }
 				</div>
-
-				<div className="newspack-newsletters-modal__preview">
-					{ ! isFetchingLayouts && renderPreview() }
-				</div>
 			</div>
 			<div className="newspack-newsletters-modal__action-buttons">
 				<Button isSecondary onClick={ () => insertLayout( BLANK_LAYOUT_ID ) }>
-					{ __( 'Start From Scratch', 'newspack-newsletters' ) }
+					{ __( 'Blank Newsletter', 'newspack-newsletters' ) }
 				</Button>
-				<span className="separator">{ __( 'or', 'newspack-newsletters' ) }</span>
 				<Button
 					isPrimary
-					disabled={ isFetchingLayouts || ! canRenderPreview }
+					disabled={ isFetchingLayouts || ! selectedLayoutId }
 					onClick={ () => insertLayout( selectedLayoutId ) }
 				>
 					{ __( 'Use Selected Layout', 'newspack-newsletters' ) }

--- a/src/components/init-modal/style.scss
+++ b/src/components/init-modal/style.scss
@@ -147,6 +147,7 @@
 			.components-button {
 				border-bottom-left-radius: 0;
 				border-bottom-right-radius: 0;
+				min-height: 40px;
 
 				@media only screen and ( min-width: 600px ) {
 					border-bottom-left-radius: 2px;
@@ -328,6 +329,18 @@
 			&__item-label {
 				padding: 4px 2px;
 				text-align: center;
+			}
+
+			&--empty {
+				> * {
+					&:first-child {
+						margin-top: 0;
+					}
+
+					&:last-child {
+						margin-bottom: 0;
+					}
+				}
 			}
 		}
 	}

--- a/src/components/init-modal/style.scss
+++ b/src/components/init-modal/style.scss
@@ -70,10 +70,13 @@
 
 		@media only screen and ( min-width: 600px ) {
 			display: grid;
-			grid-auto-rows: calc( 100% - 48px );
 			gap: 0;
-			grid-template-columns: 1fr 2fr;
+			grid-template-columns: 200px 1fr;
 			grid-template-rows: 1fr;
+		}
+
+		@media only screen and ( min-width: 783px ) {
+			grid-template-columns: 320px 1fr;
 		}
 
 		@media only screen and ( min-width: 783px ) {
@@ -88,6 +91,69 @@
 				top: 60px;
 			}
 		}
+
+		&__sidebar {
+			border-bottom: 1px solid $gray-300;
+			padding: 24px 24px 0;
+
+			@media only screen and ( min-width: 600px ) {
+				border-bottom: none;
+				border-right: 1px solid $gray-300;
+				padding-top: 24px;
+			}
+
+			p {
+				margin: 0;
+			}
+		}
+
+		&__layout-buttons {
+			display: grid;
+			grid-gap: 4px;
+			grid-template-columns: repeat( 2, 1fr );
+			padding: 24px 0 0;
+
+			@media only screen and ( min-width: 600px ) {
+				grid-template-columns: 1fr;
+				width: calc( 100% + 24px );
+			}
+
+			.is-active {
+				box-shadow: 0 0 0 1px $gray-300;
+				font-weight: 700;
+				position: relative;
+
+				&:not( :focus )::before {
+					background: white;
+					bottom: -1px;
+					content: '';
+					display: block;
+					height: 1px;
+					left: 0;
+					position: absolute;
+					right: 0;
+
+					@media only screen and ( min-width: 600px ) {
+						bottom: 0;
+						height: auto;
+						left: auto;
+						right: -1px;
+						top: 0;
+						width: 1px;
+					}
+				}
+			}
+
+			.components-button {
+				border-bottom-left-radius: 0;
+				border-bottom-right-radius: 0;
+
+				@media only screen and ( min-width: 600px ) {
+					border-bottom-left-radius: 2px;
+					border-top-right-radius: 0;
+				}
+			}
+		}
 	}
 
 	&__action-buttons {
@@ -100,9 +166,8 @@
 		top: 12px;
 		z-index: 11;
 
-		.separator {
-			margin-left: 6px;
-			margin-right: 6px;
+		.components-button + .components-button {
+			margin-left: 8px;
 		}
 	}
 
@@ -164,10 +229,9 @@
 	}
 
 	&__layouts {
-		grid-column-start: 1;
 		overflow-y: scroll;
 		max-height: 100%;
-		padding: 20px;
+		padding: 24px;
 
 		&--loading {
 			display: flex;
@@ -188,7 +252,7 @@
 			}
 
 			@media only screen and ( min-width: 783px ) {
-				grid-template-columns: repeat( 2, 1fr );
+				grid-template-columns: repeat( auto-fill, minmax( 300px, 1fr ) );
 			}
 
 			&__item {
@@ -222,6 +286,7 @@
 					height: 20px;
 					&.is-destructive {
 						color: $alert-red;
+						height: auto;
 					}
 				}
 			}
@@ -290,53 +355,6 @@
 				margin: 0 auto;
 				max-width: 600px;
 			}
-		}
-	}
-}
-
-// Buttons group
-.newspack-newsletters-buttons-group {
-	display: flex;
-	justify-content: space-around;
-	&--spaced {
-		margin-left: -5px;
-		margin-right: -5px;
-		button {
-			margin-left: 5px;
-			margin-right: 5px;
-			justify-content: center;
-		}
-	}
-	button {
-		flex: 1;
-	}
-}
-
-// Tabs
-.newspack-newsletters-tabs {
-	&__button {
-		font-weight: 500;
-		min-height: 48px;
-		padding: 3px 16px;
-		position: relative;
-		border-radius: 0;
-		&:focus:not( :disabled ) {
-			outline: none;
-			box-shadow: none;
-		}
-
-		&::after {
-			content: '';
-			position: absolute;
-			bottom: 0;
-			left: 0;
-			width: 100%;
-			height: 1px;
-			background-color: $gray-300;
-		}
-		&--is-active::after {
-			height: 4px;
-			background-color: var( --wp-admin-theme-color );
 		}
 	}
 }

--- a/src/newsletter-editor/editor/style.scss
+++ b/src/newsletter-editor/editor/style.scss
@@ -1,6 +1,7 @@
 .post-type-newspack_nl_cpt {
 	.editor-post-title {
 		&.newspack-newsletters-post-title-hidden {
+			font-size: 1em;
 			height: 0;
 			margin: -4rem 0 calc( -1 * var( --wp--style--block-gap ) );
 			opacity: 0;

--- a/src/newsletter-editor/editor/style.scss
+++ b/src/newsletter-editor/editor/style.scss
@@ -2,7 +2,9 @@
 	.editor-post-title {
 		&.newspack-newsletters-post-title-hidden {
 			height: 0;
+			margin: -4rem 0 calc( -1 * var( --wp--style--block-gap ) );
 			opacity: 0;
+			padding: 0;
 			pointer-events: none;
 		}
 	}

--- a/src/newsletter-editor/editor/style.scss
+++ b/src/newsletter-editor/editor/style.scss
@@ -17,4 +17,10 @@
 	.editor-post-switch-to-draft {
 		display: none;
 	}
+
+	.newspack-newsletters-buttons-group {
+		display: flex;
+		flex-wrap: wrap;
+		gap: 12px;
+	}
 }

--- a/src/newsletter-editor/layout/index.js
+++ b/src/newsletter-editor/layout/index.js
@@ -164,7 +164,7 @@ export default compose( [
 									layoutId={ layoutId }
 									meta={ usedLayout.meta }
 									blocks={ setPreventDeduplicationForPostsInserter( blockPreview ) }
-									viewportWidth={ 600 }
+									viewportWidth={ 848 }
 								/>
 							</div>
 							<div className="newspack-newsletters-layouts__item-label">

--- a/src/newsletter-editor/layout/index.js
+++ b/src/newsletter-editor/layout/index.js
@@ -173,31 +173,33 @@ export default compose( [
 						</div>
 					</div>
 				) }
-				<div className="newspack-newsletters-buttons-group newspack-newsletters-buttons-group--spaced">
+				<div className="newspack-newsletters-buttons-group">
 					<Button
-						isPrimary
+						variant="secondary"
 						disabled={ isEditedPostEmpty || isSavingLayout }
 						onClick={ () => setIsManageModalVisible( true ) }
 					>
-						{ __( 'Save new layout', 'newspack-newsletters' ) }
+						{ __( 'Save New Layout', 'newspack-newsletters' ) }
 					</Button>
 
 					{ isUsingCustomLayout && (
 						<Button
-							isSecondary
+							variant="tertiary"
 							disabled={ isPostContentSameAsLayout || isSavingLayout }
 							onClick={ handeLayoutUpdate }
 						>
-							{ __( 'Update layout', 'newspack-newsletters' ) }
+							{ __( 'Update Layout', 'newspack-newsletters' ) }
 						</Button>
 					) }
+
+					<Button
+						variant="secondary"
+						isDestructive
+						onClick={ () => setWarningModalVisible( true ) }
+					>
+						{ __( 'Reset Layout', 'newspack-newsletters' ) }
+					</Button>
 				</div>
-
-				<br />
-
-				<Button isSecondary isLink isDestructive onClick={ () => setWarningModalVisible( true ) }>
-					{ __( 'Reset newsletter layout', 'newspack-newsletters' ) }
-				</Button>
 
 				{ isManageModalVisible && (
 					<Modal

--- a/src/newsletter-editor/testing/index.js
+++ b/src/newsletter-editor/testing/index.js
@@ -64,7 +64,7 @@ export default compose( [
 				/>
 				<div className="newspack-newsletters__testing-controls">
 					<Button
-						isPrimary
+						variant="secondary"
 						onClick={ sendTestEmail }
 						disabled={ disabled || inFlight || ! hasValidEmail( testEmail ) }
 					>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR redesigns the `Modal` on init and removes the big preview area to focus on the layouts instead.

![my-layouts](https://user-images.githubusercontent.com/177929/151377399-d0cd0186-26b9-4770-8987-6248b06a7990.png)

### How to test the changes in this Pull Request:

1. Switch to this branch
2. Remove all the Newsletter settings so you can also see the 1st step
3. Create a new newsletter 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
