### PR TITLE
fix: use mailchimp as the default ESP

### DIFF
--- a/includes/class-newspack-newsletters-settings.php
+++ b/includes/class-newspack-newsletters-settings.php
@@ -54,6 +54,7 @@ class Newspack_Newsletters_Settings {
 				),
 				'type'        => 'select',
 				'onboarding'  => true,
+				'default'     => 'mailchimp',
 			),
 			array(
 				'description' => esc_html__( 'Mailchimp API Key', 'newspack-newsletters' ),


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes https://github.com/Automattic/newspack-plugin/issues/1487

### How to test the changes in this Pull Request:

1. Install plugin on a fresh site, visit Settings, observe "Mailchimp" is set as the Service Provider
2. Observe that https://github.com/Automattic/newspack-plugin/issues/1487 is resolved

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1201754873912049