### PR TITLE
Fix iframe styles for post inserter

### DIFF
--- a/src/components/init-modal/style.scss
+++ b/src/components/init-modal/style.scss
@@ -297,7 +297,7 @@
 				border: 1px solid $gray-300;
 				border-radius: 2px;
 				overflow: hidden;
-				padding: 0 0 calc( 100% - 2px );
+				padding: 0 0 75%;
 				position: relative;
 				width: 100%;
 

--- a/src/editor/blocks/posts-inserter/index.js
+++ b/src/editor/blocks/posts-inserter/index.js
@@ -247,7 +247,6 @@ const PostsInserterBlock = ( {
 							attributes.featuredImageAlignment === 'right' ) && (
 							<Toolbar>
 								<ToolbarDropdownMenu
-									label={ __( 'Image Size', 'newspack-newsletters' ) }
 									text={ __( 'Image Size', 'newspack-newsletters' ) }
 									icon={ null }
 								>
@@ -289,7 +288,18 @@ const PostsInserterBlock = ( {
 					<Icon icon={ pages } />
 					<span>{ __( 'Posts Inserter', 'newspack-newsletters' ) }</span>
 				</div>
-				<PostsPreview isReady={ isReady } blocks={ templateBlocks } viewportWidth={ 786 } />
+				<PostsPreview
+					isReady={ isReady }
+					blocks={ templateBlocks }
+					viewportWidth={
+						'top' === attributes.featuredImageAlignment || ! attributes.displayFeaturedImage
+							? 574
+							: 1148
+					}
+					className={
+						attributes.displayFeaturedImage ? 'image-' + attributes.featuredImageAlignment : null
+					}
+				/>
 				<div className="newspack-posts-inserter__footer">
 					<Button isPrimary onClick={ () => setAttributes( { areBlocksInserted: true } ) }>
 						{ __( 'Insert posts', 'newspack-newsletters' ) }

--- a/src/editor/blocks/posts-inserter/posts-preview.js
+++ b/src/editor/blocks/posts-inserter/posts-preview.js
@@ -8,9 +8,14 @@ import { forwardRef } from '@wordpress/element';
 import { useCustomFontsInIframe } from '../../../newsletter-editor/styling';
 
 /**
+ * External dependencies.
+ */
+import classnames from 'classnames';
+
+/**
  * Posts Preview component.
  */
-const PostsPreview = ( { isReady, blocks, viewportWidth }, ref ) => {
+const PostsPreview = ( { isReady, blocks, className, viewportWidth }, ref ) => {
 	// Iframe styles are not properly applied when nesting iframed editors.
 	// This fix ensures the iframe is properly styled.
 	const useIframeBorderFix = useRefEffect( node => {
@@ -63,7 +68,7 @@ const PostsPreview = ( { isReady, blocks, viewportWidth }, ref ) => {
 
 	return (
 		<div
-			className="newspack-posts-inserter__preview"
+			className={ classnames( 'newspack-posts-inserter__preview', className ) }
 			ref={ useMergeRefs( [ ref, useIframeBorderFix, useLayoutStyle, useCustomFontsInIframe() ] ) }
 		>
 			{ isReady ? <BlockPreview blocks={ blocks } viewportWidth={ viewportWidth } /> : <Spinner /> }

--- a/src/editor/blocks/posts-inserter/style.scss
+++ b/src/editor/blocks/posts-inserter/style.scss
@@ -1,7 +1,7 @@
 @import '~@wordpress/base-styles/colors';
 
 :root {
-	--newspack-post-inserter-width: 786px;
+	--newspack-post-inserter-width: 574px;
 }
 
 .newspack-posts-inserter {
@@ -12,6 +12,7 @@
 	&__header {
 		align-items: center;
 		background: white;
+		border-bottom: 1px solid $gray-900;
 		display: flex;
 		padding: 1em;
 		position: relative;
@@ -25,13 +26,12 @@
 
 	&__footer {
 		background: white;
+		border-top: 1px solid $gray-900;
 		padding: 1em;
 	}
 
 	&__preview {
 		align-items: center;
-		border: 0 solid $gray-900;
-		border-width: 1px 0;
 		display: flex;
 		justify-content: center;
 		min-height: 4rem;
@@ -50,17 +50,19 @@
 			&__content {
 				position: relative;
 
-				@media only screen and ( min-width: 624px ) {
-					margin-left: calc(
-						-1 * ( ( var( --newspack-post-inserter-width ) - var( --newspack-max-width ) ) / 2 +
-									12px )
-					);
-					transform: scale( 1 ) !important;
-					transform-origin: 0 50% 0;
-				}
-
 				.editor-styles-wrapper.wp-embed-responsive {
 					background: transparent;
+				}
+			}
+		}
+
+		&.image-left,
+		&.image-right {
+			.block-editor-block-preview__content {
+				@media only screen and ( min-width: 624px ) {
+					margin-left: calc( var( --newspack-post-inserter-width ) / -2 );
+					transform: scale( 1 ) !important;
+					transform-origin: 0 50% 0;
 				}
 			}
 		}

--- a/src/newsletter-editor/layout/style.scss
+++ b/src/newsletter-editor/layout/style.scss
@@ -16,7 +16,7 @@
 		border: 1px solid $gray-300;
 		border-radius: 2px;
 		overflow: hidden;
-		padding: 0 0 calc( 100% - 2px );
+		padding: 0 0 75%;
 		position: relative;
 		width: 100%;
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

This PR adds a bit more consistency with the Post Inserter iframe preview.

Fixes #695

### How to test the changes in this Pull Request:

1. Create a new newsletter
2. Add the post inserter block
3. Switch between the different featured image positions

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
