### PR TITLE
Remove wp-bundled block patterns

### DIFF
--- a/includes/class-newspack-newsletters-editor.php
+++ b/includes/class-newspack-newsletters-editor.php
@@ -52,6 +52,7 @@ final class Newspack_Newsletters_Editor {
 		add_action( 'rest_post_query', [ __CLASS__, 'maybe_filter_excerpt_length' ], 10, 2 );
 		add_action( 'rest_api_init', [ __CLASS__, 'add_newspack_author_info' ] );
 		add_filter( 'the_posts', [ __CLASS__, 'maybe_reset_excerpt_length' ] );
+		add_action( 'should_load_remote_block_patterns', [ __CLASS__, 'strip_block_patterns' ] );
 	}
 
 	/**
@@ -126,6 +127,18 @@ final class Newspack_Newsletters_Editor {
 		remove_editor_styles();
 		add_theme_support( 'editor-gradient-presets', array() );
 		add_theme_support( 'disable-custom-gradients' );
+		unregister_block_pattern( 'core/social-links-shared-background-color' );
+	}
+
+	/**
+	 * Remove Core's Remote Block patterns.
+	 */
+	public static function strip_block_patterns() {
+		if ( ! self::is_editing_email() ) {
+			return true;
+		}
+
+		return false;
 	}
 
 	/**

--- a/includes/class-newspack-newsletters-editor.php
+++ b/includes/class-newspack-newsletters-editor.php
@@ -52,7 +52,7 @@ final class Newspack_Newsletters_Editor {
 		add_action( 'rest_post_query', [ __CLASS__, 'maybe_filter_excerpt_length' ], 10, 2 );
 		add_action( 'rest_api_init', [ __CLASS__, 'add_newspack_author_info' ] );
 		add_filter( 'the_posts', [ __CLASS__, 'maybe_reset_excerpt_length' ] );
-		add_action( 'should_load_remote_block_patterns', [ __CLASS__, 'strip_block_patterns' ] );
+		add_filter( 'should_load_remote_block_patterns', [ __CLASS__, 'strip_block_patterns' ] );
 	}
 
 	/**
@@ -132,13 +132,17 @@ final class Newspack_Newsletters_Editor {
 
 	/**
 	 * Remove Core's Remote Block patterns.
+	 *
+	 * @param boolean $should_load_remote Whether to load remote block patterns.
+	 *
+	 * @return boolean Whether to load remote block patterns.
 	 */
-	public static function strip_block_patterns() {
-		if ( ! self::is_editing_email() ) {
-			return true;
+	public static function strip_block_patterns( $should_load_remote ) {
+		if ( self::is_editing_email() ) {
+			return false;
 		}
 
-		return false;
+		return $should_load_remote;
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR removes the Patterns shipped with WP.
They don't work well with Newsletters and we should avoid displaying stuff that can break the editor 🙂

For some reason I couldn't make `remove_theme_support( 'core-block-patterns' );` work (open to suggestion here!) so instead I'm making sure I'm not loading the [Pattern Directory](https://wordpress.org/patterns/) and I removed the extra block pattern that was still there (`'core/social-links-shared-background-color'`)

### How to test the changes in this Pull Request:

1. Switch to this branch
2. Create a newsletter and check the patterns (you shouldn't see any)
3. Create a new post/page/cpt-of-your-choice and check if the patterns are available (they should be!)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
