### PR TITLE
fix: remove duotone filters

### DIFF
--- a/src/editor/index.js
+++ b/src/editor/index.js
@@ -3,7 +3,7 @@
  */
 import { unregisterBlockStyle } from '@wordpress/blocks';
 import domReady from '@wordpress/dom-ready';
-import { addFilter } from '@wordpress/hooks';
+import { addFilter, removeFilter } from '@wordpress/hooks';
 import { registerPlugin } from '@wordpress/plugins';
 
 /**
@@ -33,6 +33,11 @@ domReady( () => {
 	unregisterBlockStyle( 'core/social-links', 'logos-only' );
 	unregisterBlockStyle( 'core/social-links', 'pill-shape' );
 } );
+
+/* Remove Duotone filters */
+removeFilter( 'blocks.registerBlockType', 'core/editor/duotone/add-attributes' );
+removeFilter( 'editor.BlockEdit', 'core/editor/duotone/with-editor-controls' );
+removeFilter( 'editor.BlockListBlock', 'core/editor/duotone/with-styles' );
 
 addFilter( 'blocks.registerBlockType', 'newspack-newsletters/core-blocks', ( settings, name ) => {
 	/* Remove left/right alignment options wherever possible */


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Removes duotone filters for every block on newsletters. They are not supported and shouldn't be displayed as an option.

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

### How to test the changes in this Pull Request:

1. Check out this branch and create a new newsletter with an image block
2. Confirm the duotone filter is not available on the block toolbar
3. Edit a regular post with an image block, confirm the duotone filter continues to work as expected

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
