### PR TITLE
Simplify visibility option

### DIFF
--- a/src/editor/blocks/visibility-attribute/index.js
+++ b/src/editor/blocks/visibility-attribute/index.js
@@ -11,9 +11,16 @@ import { Fragment } from '@wordpress/element';
 import { compose, createHigherOrderComponent } from '@wordpress/compose';
 import { withSelect } from '@wordpress/data';
 import { BlockControls, InspectorControls } from '@wordpress/block-editor';
-import { PanelBody, ToolbarGroup, SelectControl, ToolbarDropdownMenu } from '@wordpress/components';
-import { __, sprintf } from '@wordpress/i18n';
-import { Icon, warning, globe } from '@wordpress/icons';
+import {
+	MenuGroup,
+	MenuItem,
+	PanelBody,
+	SelectControl,
+	Toolbar,
+	ToolbarDropdownMenu,
+} from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { Icon, check, warning } from '@wordpress/icons';
 
 /**
  * Internal dependencies
@@ -26,17 +33,14 @@ const visibilityOptions = [
 	{
 		label: __( 'Email and Web', 'newspack-newsletters' ),
 		value: '',
-		icon: 'visibility',
 	},
 	{
 		label: __( 'Email only', 'newspack-newsletters' ),
 		value: 'email',
-		icon: 'email',
 	},
 	{
 		label: __( 'Web only', 'newspack-newsletters' ),
 		value: 'web',
-		icon: globe,
 	},
 ];
 
@@ -60,39 +64,47 @@ const withVisibilityControl = createHigherOrderComponent(
 		)( props => {
 			const { attributes, setAttributes } = props;
 			const value = attributes[ ATTRIBUTE_NAME ];
-			const currentIcon =
-				visibilityOptions.find( option => option.value === value )?.icon || 'visibility';
-			const menuLabel = value
-				? // Translators: visibility help message.
-				  sprintf( __( 'Currently visible only on "%s" version.', 'newspack-newsletters' ), value )
-				: __( 'Select a visibility option', 'newspack-newsletter' );
-			if ( ! props.is_public && ! value ) {
+			if ( ! props.is_public ) {
 				return <BlockEdit { ...props } />;
 			}
 			return (
 				<Fragment>
 					<BlockControls>
-						<ToolbarGroup>
+						<Toolbar>
 							<ToolbarDropdownMenu
-								icon={ currentIcon }
-								label={ menuLabel }
-								toggleProps={ {
-									className: classnames( { 'is-pressed': !! value } ),
-								} }
-								controls={ visibilityOptions.map( option => ( {
-									icon: option.icon,
-									title: option.label,
-									onClick: () => setAttributes( { [ ATTRIBUTE_NAME ]: option.value } ),
-								} ) ) }
-							/>
-						</ToolbarGroup>
+								label={ __( 'Visibility', 'newspack-newsletters' ) }
+								icon={ 'visibility' }
+							>
+								{ ( { onClose } ) => (
+									<MenuGroup>
+										{ visibilityOptions.map( entry => {
+											return (
+												<MenuItem
+													icon={
+														( value === entry.value || ( ! value && entry.value === '' ) ) && check
+													}
+													isSelected={ value === entry.value }
+													key={ entry.value }
+													onClick={ () => {
+														setAttributes( {
+															[ ATTRIBUTE_NAME ]: entry.value,
+														} );
+													} }
+													onClose={ onClose }
+													role="menuitemradio"
+												>
+													{ entry.label }
+												</MenuItem>
+											);
+										} ) }
+									</MenuGroup>
+								) }
+							</ToolbarDropdownMenu>
+						</Toolbar>
 					</BlockControls>
 					<BlockEdit { ...props } />
 					<InspectorControls>
-						<PanelBody
-							title={ __( 'Visibility options', 'newspack-newsletters' ) }
-							initialOpen={ true }
-						>
+						<PanelBody title={ __( 'Visibility', 'newspack-newsletters' ) }>
 							<SelectControl
 								label={ __( 'Where should this block be visible?', 'newspack-newsletters' ) }
 								value={ value }

--- a/src/editor/blocks/visibility-attribute/index.js
+++ b/src/editor/blocks/visibility-attribute/index.js
@@ -161,7 +161,6 @@ const withVisibilityNotice = createHigherOrderComponent(
 									>
 										{ __( 'Clear visibility attribute', 'newspack-newsletters' ) }
 									</button>
-									.
 								</>
 							) : (
 								<Fragment>

--- a/src/editor/blocks/visibility-attribute/index.js
+++ b/src/editor/blocks/visibility-attribute/index.js
@@ -149,10 +149,20 @@ const withVisibilityNotice = createHigherOrderComponent(
 					>
 						<span className="newsletters-block-visibility-label">
 							{ shouldBePublic ? (
-								__(
-									'Newsletter is not public, this block will not be visible.',
-									'newspack-newsletters'
-								)
+								<>
+									{ __(
+										'Newsletter is not public, this block will not be visible.',
+										'newspack-newsletters'
+									) }
+									<button
+										onClick={ () => {
+											props.setAttributes( { [ ATTRIBUTE_NAME ]: '' } );
+										} }
+									>
+										{ __( 'Clear visibility attribute', 'newspack-newsletters' ) }
+									</button>
+									.
+								</>
 							) : (
 								<Fragment>
 									{ value === 'web' &&

--- a/src/editor/blocks/visibility-attribute/index.js
+++ b/src/editor/blocks/visibility-attribute/index.js
@@ -20,7 +20,7 @@ import {
 	ToolbarDropdownMenu,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { Icon, check, warning } from '@wordpress/icons';
+import { check } from '@wordpress/icons';
 
 /**
  * Internal dependencies
@@ -148,7 +148,6 @@ const withVisibilityNotice = createHigherOrderComponent(
 						data-align={ props.attributes?.align || null }
 					>
 						<span className="newsletters-block-visibility-label">
-							<Icon icon={ warning } size={ 15 } />
 							{ shouldBePublic ? (
 								__(
 									'Newsletter is not public, this block will not be visible.',

--- a/src/editor/blocks/visibility-attribute/style.scss
+++ b/src/editor/blocks/visibility-attribute/style.scss
@@ -1,47 +1,62 @@
 @import '~@wordpress/base-styles/colors';
 
+:root {
+	/* stylelint-disable value-keyword-case */
+	--newspack-system-font: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen-Sans, Ubuntu,
+		Cantarell, 'Helvetica Neue', sans-serif;
+	/* stylelint-enable value-keyword-case */
+}
+
 .newspack-newsletters__editor-block.newsletters-block-visibility__web,
 .newspack-newsletters__editor-block.newsletters-block-visibility__email {
-	box-shadow: 0 0 0 2px $alert-yellow;
-	border-radius: 3px;
 	position: relative;
 	margin-top: 0;
 	margin-bottom: 0;
 	padding: 0 !important;
-	transition: border-radius 0.2s ease-in-out;
-	.newsletters-block-visibility-label {
-		z-index: 10;
-		display: flex;
-		align-items: center;
-		background: $alert-yellow;
-		color: #fff;
-		position: absolute;
-		top: 100%;
-		right: -2px;
-		height: 15px;
-		margin-top: -13px;
-		padding: 0 3px;
-		line-height: 1;
-		font-size: 10px;
-		border-radius: 3px 0 3px 0;
-		transition: border-radius 0.2s ease-in-out, margin 0.2s ease-in-out;
+
+	&::after {
+		border-radius: 1px;
+		bottom: 1px;
+		box-shadow: 0 0 0 var( --wp-admin-border-width-focus ) $alert-yellow;
+		content: '';
+		left: 1px;
 		pointer-events: none;
-		svg {
-			margin-right: 2px;
-			fill: #fff;
-		}
+		position: absolute;
+		right: 1px;
+		top: 1px;
+	}
+
+	.newsletters-block-visibility-label {
+		background: $alert-yellow;
+		border-radius: 1px;
+		color: $gray-900;
+		display: flex;
+		font-family: var( --newspack-system-font );
+		font-size: 10px;
+		height: 16px;
+		line-height: 1.6;
+		margin-top: -18px;
+		padding: 0 4px;
+		pointer-events: none;
+		position: absolute;
+		right: 2px;
+		top: 100%;
+		transition: margin 0.25s ease-in-out;
+		z-index: 10;
 	}
 	&.newsletters-block-selected {
-		border-radius: 3px 3px 0 3px;
 		> .newsletters-block-visibility-label {
-			margin-top: 0;
-			border-radius: 3px 0 3px 3px;
+			margin-top: 2px;
 		}
 	}
 	&.newsletters-block-error {
-		box-shadow: 0 0 0 2px $alert-red;
-		.newsletters-block-visibility-label {
+		&::after {
+			box-shadow: 0 0 0 var( --wp-admin-border-width-focus ) $alert-red;
+		}
+
+		> .newsletters-block-visibility-label {
 			background: $alert-red;
+			color: white;
 		}
 	}
 }

--- a/src/editor/blocks/visibility-attribute/style.scss
+++ b/src/editor/blocks/visibility-attribute/style.scss
@@ -43,6 +43,18 @@
 		top: 100%;
 		transition: margin 0.25s ease-in-out;
 		z-index: 10;
+		button {
+			font-family: var( --newspack-system-font );
+			display: inline-block;
+			margin-left: 5px;
+			padding: 0;
+			cursor: pointer;
+			background: transparent;
+			border: 0;
+			text-decoration: underline;
+			color: inherit;
+			pointer-events: all;
+		}
 	}
 	&.newsletters-block-selected {
 		> .newsletters-block-visibility-label {

--- a/src/editor/blocks/visibility-attribute/style.scss
+++ b/src/editor/blocks/visibility-attribute/style.scss
@@ -28,37 +28,42 @@
 
 	.newsletters-block-visibility-label {
 		background: $alert-yellow;
-		border-radius: 1px;
+		border-radius: 2px;
 		color: $gray-900;
 		display: flex;
 		font-family: var( --newspack-system-font );
 		font-size: 10px;
-		height: 16px;
 		line-height: 1.6;
-		margin-top: -18px;
-		padding: 0 4px;
+		margin-top: -23px;
+		padding: 2px 4px;
 		pointer-events: none;
 		position: absolute;
-		right: 2px;
+		right: 3px;
 		top: 100%;
 		transition: margin 0.25s ease-in-out;
 		z-index: 10;
 		button {
-			font-family: var( --newspack-system-font );
-			display: inline-block;
-			margin-left: 5px;
-			padding: 0;
-			cursor: pointer;
-			background: transparent;
 			border: 0;
-			text-decoration: underline;
+			background: transparent;
 			color: inherit;
+			cursor: pointer;
+			display: inline-block;
+			font-family: inherit;
+			font-size: inherit;
+			line-height: inherit;
+			margin-left: 0.25em;
+			padding: 0;
 			pointer-events: all;
+			text-decoration: underline;
+
+			&:focus {
+				outline: 1px solid;
+			}
 		}
 	}
 	&.newsletters-block-selected {
 		> .newsletters-block-visibility-label {
-			margin-top: 2px;
+			margin-top: 3px;
 		}
 	}
 	&.newsletters-block-error {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR simplifies the `ToolbarDropdownMenu` of the Visibility option.

* Remove the use of icons (except for the "check")
* Display the all the options if the Newsletter is public (default: "Email and Web")

### How to test the changes in this Pull Request:

1. Switch to this branch
2. Enable Newsletter Public
3. Play with visibility settings
4. Also check if you disable Newsletter Public, the settings stay

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
