### PR TITLE
feat: remove subject input (title) from the sidebar

### DIFF
--- a/includes/class-newspack-newsletters-editor.php
+++ b/includes/class-newspack-newsletters-editor.php
@@ -53,6 +53,7 @@ final class Newspack_Newsletters_Editor {
 		add_action( 'rest_api_init', [ __CLASS__, 'add_newspack_author_info' ] );
 		add_filter( 'the_posts', [ __CLASS__, 'maybe_reset_excerpt_length' ] );
 		add_filter( 'should_load_remote_block_patterns', [ __CLASS__, 'strip_block_patterns' ] );
+		add_filter( 'enter_title_here', [ __CLASS__, 'replace_editor_title' ] );
 	}
 
 	/**
@@ -143,6 +144,21 @@ final class Newspack_Newsletters_Editor {
 		}
 
 		return $should_load_remote;
+	}
+
+	/**
+	 * Replace the Title's placeholder.
+	 *
+	 * @param string $should_replace_title Whether to replace the placeholder text.
+	 *
+	 * @return string Whether to replace the placeholder text.
+	 */
+	public static function replace_editor_title( $should_replace_title ) {
+		if ( self::is_editing_email() ) {
+			return __( 'Subject', 'newspack-newsletters' );
+		}
+
+		return $should_replace_title;
 	}
 
 	/**

--- a/includes/class-newspack-newsletters-editor.php
+++ b/includes/class-newspack-newsletters-editor.php
@@ -53,7 +53,7 @@ final class Newspack_Newsletters_Editor {
 		add_action( 'rest_api_init', [ __CLASS__, 'add_newspack_author_info' ] );
 		add_filter( 'the_posts', [ __CLASS__, 'maybe_reset_excerpt_length' ] );
 		add_filter( 'should_load_remote_block_patterns', [ __CLASS__, 'strip_block_patterns' ] );
-		add_filter( 'enter_title_here', [ __CLASS__, 'replace_editor_title' ] );
+		add_filter( 'enter_title_here', [ __CLASS__, 'placeholder_editor_title' ] );
 	}
 
 	/**
@@ -147,18 +147,18 @@ final class Newspack_Newsletters_Editor {
 	}
 
 	/**
-	 * Replace the Title's placeholder.
+	 * Placeholder text for the editor title.
 	 *
-	 * @param string $should_replace_title Whether to replace the placeholder text.
+	 * @param string $title_placeholder Placeholder text for the title.
 	 *
-	 * @return string Whether to replace the placeholder text.
+	 * @return string Placeholder text for the title.
 	 */
-	public static function replace_editor_title( $should_replace_title ) {
+	public static function placeholder_editor_title( $title_placeholder ) {
 		if ( self::is_editing_email() ) {
 			return __( 'Subject', 'newspack-newsletters' );
 		}
 
-		return $should_replace_title;
+		return $title_placeholder;
 	}
 
 	/**

--- a/src/newsletter-editor/editor/index.js
+++ b/src/newsletter-editor/editor/index.js
@@ -133,16 +133,6 @@ const Editor = compose( [
 		}
 	}, [ props.status ] );
 
-	useEffect( () => {
-		// Hide post title if the newsletter is a not a public post.
-		const editorTitleEl = document.querySelector( '.editor-post-title' );
-		if ( editorTitleEl ) {
-			editorTitleEl.classList[ props.isPublic ? 'remove' : 'add' ](
-				'newspack-newsletters-post-title-hidden'
-			);
-		}
-	}, [ props.isPublic ] );
-
 	return createPortal( <SendButton />, publishEl );
 } );
 

--- a/src/newsletter-editor/editor/style.scss
+++ b/src/newsletter-editor/editor/style.scss
@@ -23,6 +23,7 @@
 				font-size: 13px;
 				font-weight: bold;
 				line-height: 1.5;
+				margin-bottom: 8px;
 				text-transform: uppercase;
 			}
 		}

--- a/src/newsletter-editor/editor/style.scss
+++ b/src/newsletter-editor/editor/style.scss
@@ -1,12 +1,30 @@
+@import '~@wordpress/base-styles/colors';
+
 .post-type-newspack_nl_cpt {
-	.editor-post-title {
-		&.newspack-newsletters-post-title-hidden {
+	.is-mode-visual {
+		.edit-post-visual-editor__post-title-wrapper {
+			margin-top: var( --wp--style--block-gap );
+		}
+
+		.editor-post-title {
+			background: white;
+			border-radius: 1px;
+			color: $gray-900;
+			font-family: sans-serif;
 			font-size: 1em;
-			height: 0;
-			margin: -4rem 0 calc( -1 * var( --wp--style--block-gap ) );
-			opacity: 0;
-			padding: 0;
-			pointer-events: none;
+			font-style: normal;
+			font-weight: normal;
+			line-height: 1.5;
+			position: relative;
+
+			&::before {
+				content: attr( aria-label );
+				display: block;
+				font-size: 13px;
+				font-weight: bold;
+				line-height: 1.5;
+				text-transform: uppercase;
+			}
 		}
 	}
 

--- a/src/newsletter-editor/sidebar/index.js
+++ b/src/newsletter-editor/sidebar/index.js
@@ -28,7 +28,6 @@ const Sidebar = ( {
 	inFlight,
 	errors,
 	editPost,
-	title,
 	disableAds,
 	senderName,
 	senderEmail,
@@ -45,22 +44,6 @@ const Sidebar = ( {
 				return result;
 			}
 		} );
-
-	const renderSubject = () => (
-		<>
-			<strong className="newspack-newsletters__label">
-				{ __( 'Subject', 'newspack-newsletters' ) }
-			</strong>
-			<TextControl
-				label={ __( 'Subject', 'newspack-newsletters' ) }
-				className="newspack-newsletters__subject-textcontrol"
-				value={ title }
-				disabled={ inFlight }
-				onChange={ value => editPost( { title: value } ) }
-				hideLabelFromVision
-			/>
-		</>
-	);
 
 	const senderEmailClasses = classnames(
 		'newspack-newsletters__email-textcontrol',
@@ -143,7 +126,6 @@ const Sidebar = ( {
 				newsletterData={ newsletterData }
 				inFlight={ inFlight }
 				apiFetch={ apiFetch }
-				renderSubject={ renderSubject }
 				renderFrom={ renderFrom }
 				renderPreviewText={ renderPreviewText }
 				updateMeta={ meta => editPost( { meta } ) }
@@ -170,7 +152,6 @@ export default compose( [
 		const { getEditedPostAttribute, getCurrentPostId } = select( 'core/editor' );
 		const meta = getEditedPostAttribute( 'meta' );
 		return {
-			title: getEditedPostAttribute( 'title' ),
 			postId: getCurrentPostId(),
 			senderEmail: meta.senderEmail || '',
 			senderName: meta.senderName || '',

--- a/src/service-providers/campaign_monitor/ProviderSidebar.js
+++ b/src/service-providers/campaign_monitor/ProviderSidebar.js
@@ -63,7 +63,6 @@ export const validateNewsletter = ( { from_email, from_name, list_id, segment_id
  *
  * @param {Object}   props                   Component props.
  * @param {number}   props.postId            ID of the edited newsletter post.
- * @param {Function} props.renderSubject     Function that renders email subject input.
  * @param {boolean}  props.inFlight          True if the component is in a loading state.
  * @param {Object}   props.cmData            Campaign Monitor data.
  * @param {Function} props.updateMetaValue   Dispatcher to update post meta.
@@ -73,7 +72,6 @@ export const validateNewsletter = ( { from_email, from_name, list_id, segment_id
  */
 const ProviderSidebarComponent = ( {
 	postId,
-	renderSubject,
 	inFlight,
 	cmData,
 	updateMetaValue,
@@ -137,8 +135,6 @@ const ProviderSidebarComponent = ( {
 
 	return (
 		<div className="newspack-newsletters__campaign-monitor-sidebar">
-			{ renderSubject() }
-			<hr />
 			<strong className="newspack-newsletters__label">
 				{ __( 'From', 'newspack-newsletters' ) }
 			</strong>

--- a/src/service-providers/constant_contact/ProviderSidebar.js
+++ b/src/service-providers/constant_contact/ProviderSidebar.js
@@ -6,7 +6,6 @@ import { Fragment, useEffect } from '@wordpress/element';
 import { BaseControl, CheckboxControl, Spinner, Notice } from '@wordpress/components';
 
 const ProviderSidebar = ( {
-	renderSubject,
 	renderFrom,
 	renderPreviewText,
 	inFlight,
@@ -65,7 +64,6 @@ const ProviderSidebar = ( {
 
 	return (
 		<Fragment>
-			{ renderSubject() }
 			{ renderPreviewText() }
 			<hr />
 			{ renderFrom( { handleSenderUpdate: setSender } ) }

--- a/src/service-providers/example/index.js
+++ b/src/service-providers/example/index.js
@@ -47,14 +47,13 @@ const getFetchDataConfig = ( { postId } ) => ( {
  * @param {Object}   props                   Component props.
  * @param {number}   props.postId            ID of the edited newsletter post.
  * @param {Function} props.apiFetch          Fetching handler. Receives config for @wordpress/api-fetch as argument.
- * @param {Function} props.renderSubject     Function that renders email subject input.
  * @param {Function} props.renderFrom        Function that renders from inputs - sender name and email.
  *                                           Has to receive an object with `handleSenderUpdate` function,
  *                                           which will receive a `{senderName, senderEmail}` object – so that
  *                                           the data can be sent to the backend.
  * @param {Function} props.renderPreviewText Function that renders preview text input
  */
-const ProviderSidebar = ( { postId, apiFetch, renderSubject, renderFrom, renderPreviewText } ) => {
+const ProviderSidebar = ( { postId, apiFetch, renderFrom, renderPreviewText } ) => {
 	const handleSenderUpdate = ( { senderName, senderEmail } ) =>
 		apiFetch( {
 			path: `/newspack-newsletters/v1/example/${ postId }/sender`,
@@ -67,7 +66,6 @@ const ProviderSidebar = ( { postId, apiFetch, renderSubject, renderFrom, renderP
 
 	return (
 		<Fragment>
-			{ renderSubject() }
 			{ renderPreviewText() }
 			<hr />
 			{ renderFrom( { handleSenderUpdate } ) }

--- a/src/service-providers/mailchimp/ProviderSidebar.js
+++ b/src/service-providers/mailchimp/ProviderSidebar.js
@@ -86,7 +86,6 @@ const SegmentsSelection = ( {
 };
 
 const ProviderSidebar = ( {
-	renderSubject,
 	renderFrom,
 	renderPreviewText,
 	inFlight,
@@ -181,7 +180,6 @@ const ProviderSidebar = ( {
 
 	return (
 		<Fragment>
-			{ renderSubject() }
 			{ renderPreviewText() }
 			<hr />
 			{ renderFrom( { handleSenderUpdate: setSender } ) }

--- a/src/service-providers/manual/index.js
+++ b/src/service-providers/manual/index.js
@@ -27,16 +27,10 @@ const validateNewsletter = () => {
  * the data is not yet available.
  *
  * @param {Object}   props                   Component props.
- * @param {Function} props.renderSubject     Function that renders email subject input.
  * @param {Function} props.renderPreviewText Function that renders preview text input
  */
-const ProviderSidebar = ( { renderSubject, renderPreviewText } ) => {
-	return (
-		<div className="newspack-newsletters__manual">
-			{ renderSubject() }
-			{ renderPreviewText() }
-		</div>
-	);
+const ProviderSidebar = ( { renderPreviewText } ) => {
+	return <div className="newspack-newsletters__manual">{ renderPreviewText() }</div>;
 };
 
 const renderPreSendInfo = () => {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Inspired by pcD9cT-I4-p2, this PR completely removes the "Subject" field from the sidebar and instead reintroduces the standard Post Title in the editor, just slightly restyled.

![newsletter-editor](https://user-images.githubusercontent.com/177929/153241238-dd57d47a-ee12-40fd-9943-7ac9a4f8a9f6.png)

### How to test the changes in this Pull Request:

1. Switch to this branch
2. Edit the subject
3. Send newsletter and check if subject is correct

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
