### PR TITLE
fix: php warning when unregistering a block pattern that isn't registered

### DIFF
--- a/includes/class-newspack-newsletters-editor.php
+++ b/includes/class-newspack-newsletters-editor.php
@@ -128,8 +128,8 @@ final class Newspack_Newsletters_Editor {
 		add_theme_support( 'editor-gradient-presets', array() );
 		add_theme_support( 'disable-custom-gradients' );
 
-		$block_type_registry = new \WP_Block_Type_Registry();
-		if ( $block_type_registry->is_registered( 'core/social-links-shared-background-color' ) ) {
+		$block_patterns_registry = new \WP_Block_Patterns_Registry();
+		if ( $block_patterns_registry->is_registered( 'core/social-links-shared-background-color' ) ) {
 			unregister_block_pattern( 'core/social-links-shared-background-color' );
 		}
 	}

--- a/includes/class-newspack-newsletters-editor.php
+++ b/includes/class-newspack-newsletters-editor.php
@@ -127,7 +127,11 @@ final class Newspack_Newsletters_Editor {
 		remove_editor_styles();
 		add_theme_support( 'editor-gradient-presets', array() );
 		add_theme_support( 'disable-custom-gradients' );
-		unregister_block_pattern( 'core/social-links-shared-background-color' );
+
+		$block_type_registry = new \WP_Block_Type_Registry();
+		if ( $block_type_registry->is_registered( 'core/social-links-shared-background-color' ) ) {
+			unregister_block_pattern( 'core/social-links-shared-background-color' );
+		}
 	}
 
 	/**

--- a/includes/class-newspack-newsletters-editor.php
+++ b/includes/class-newspack-newsletters-editor.php
@@ -128,7 +128,7 @@ final class Newspack_Newsletters_Editor {
 		add_theme_support( 'editor-gradient-presets', array() );
 		add_theme_support( 'disable-custom-gradients' );
 
-		$block_patterns_registry = new \WP_Block_Patterns_Registry();
+		$block_patterns_registry = \WP_Block_Patterns_Registry::get_instance();
 		if ( $block_patterns_registry->is_registered( 'core/social-links-shared-background-color' ) ) {
 			unregister_block_pattern( 'core/social-links-shared-background-color' );
 		}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

#731 unregisters a block pattern by name, but the `unregister_block_pattern` function doesn't gracefully handle an argument for a pattern that isn't already registered and will throw a PHP warning in that case. This change checks whether the block pattern is actually registered before attempting to unregister.

I'm not 100% sure under what conditions the block pattern is or isn't registered. It's just a warning, so it shouldn't cause any issues, but it might cause a lot of noise in debug logs.

### How to test the changes in this Pull Request:

1. On `master`, visit the Newsletters post list in WP admin.
2. Observe a PHP warning being thrown:

```
[10-Feb-2022 23:20:38 UTC] PHP Notice:  WP_Block_Patterns_Registry::unregister was called <strong>incorrectly</strong>. Pattern "core/social-links-shared-background-color" not found. Please see <a href="https://wordpress.org/support/article/debugging-in-wordpress/">Debugging in WordPress</a> for more information. (This message was added in version 5.5.0.) in /Users/dkoo/Local Sites/newspack/app/public/wp-includes/functions.php on line 5768
[10-Feb-2022 23:20:38 UTC] PHP Stack trace:
[10-Feb-2022 23:20:38 UTC] PHP   1. {main}() /Users/dkoo/Local Sites/newspack/app/public/wp-admin/edit.php:0
[10-Feb-2022 23:20:38 UTC] PHP   2. WP_Posts_List_Table->display() /Users/dkoo/Local Sites/newspack/app/public/wp-admin/edit.php:477
[10-Feb-2022 23:20:38 UTC] PHP   3. WP_Posts_List_Table->display_rows_or_placeholder() /Users/dkoo/Local Sites/newspack/app/public/wp-admin/includes/class-wp-list-table.php:1289
[10-Feb-2022 23:20:38 UTC] PHP   4. WP_Posts_List_Table->display_rows() /Users/dkoo/Local Sites/newspack/app/public/wp-admin/includes/class-wp-list-table.php:1362
[10-Feb-2022 23:20:38 UTC] PHP   5. WP_Posts_List_Table->_display_rows() /Users/dkoo/Local Sites/newspack/app/public/wp-admin/includes/class-wp-posts-list-table.php:772
[10-Feb-2022 23:20:38 UTC] PHP   6. WP_Posts_List_Table->single_row() /Users/dkoo/Local Sites/newspack/app/public/wp-admin/includes/class-wp-posts-list-table.php:795
[10-Feb-2022 23:20:38 UTC] PHP   7. setup_postdata() /Users/dkoo/Local Sites/newspack/app/public/wp-admin/includes/class-wp-posts-list-table.php:1366
[10-Feb-2022 23:20:38 UTC] PHP   8. WP_Query->setup_postdata() /Users/dkoo/Local Sites/newspack/app/public/wp-includes/query.php:1179
[10-Feb-2022 23:20:38 UTC] PHP   9. do_action_ref_array() /Users/dkoo/Local Sites/newspack/app/public/wp-includes/class-wp-query.php:4399
[10-Feb-2022 23:20:38 UTC] PHP  10. WP_Hook->do_action() /Users/dkoo/Local Sites/newspack/app/public/wp-includes/plugin.php:522
[10-Feb-2022 23:20:38 UTC] PHP  11. WP_Hook->apply_filters() /Users/dkoo/Local Sites/newspack/app/public/wp-includes/class-wp-hook.php:331
[10-Feb-2022 23:20:38 UTC] PHP  12. Newspack_Newsletters_Editor::strip_editor_modifications() /Users/dkoo/Local Sites/newspack/app/public/wp-includes/class-wp-hook.php:309
[10-Feb-2022 23:20:38 UTC] PHP  13. unregister_block_pattern() /Users/dkoo/Local Sites/newspack/app/public/wp-content/plugins/newspack-newsletters/includes/class-newspack-newsletters-editor.php:130
[10-Feb-2022 23:20:38 UTC] PHP  14. WP_Block_Patterns_Registry->unregister() /Users/dkoo/Local Sites/newspack/app/public/wp-includes/class-wp-block-patterns-registry.php:200
[10-Feb-2022 23:20:38 UTC] PHP  15. _doing_it_wrong() /Users/dkoo/Local Sites/newspack/app/public/wp-includes/class-wp-block-patterns-registry.php:109
[10-Feb-2022 23:20:38 UTC] PHP  16. trigger_error() /Users/dkoo/Local Sites/newspack/app/public/wp-includes/functions.php:5768
```

3. Check out this branch, refresh, and confirm the warning is no longer thrown.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
