### PR TITLE
fix: support for image caption inner html

### DIFF
--- a/includes/class-newspack-newsletters-renderer.php
+++ b/includes/class-newspack-newsletters-renderer.php
@@ -314,10 +314,9 @@ final class Newspack_Newsletters_Renderer {
 				$dom = new DomDocument();
 				libxml_use_internal_errors( true );
 				$dom->loadHTML( mb_convert_encoding( $inner_html, 'HTML-ENTITIES', get_bloginfo( 'charset' ) ) );
-				$xpath      = new DOMXpath( $dom );
-				$img        = $xpath->query( '//img' )[0];
+				$img        = $dom->getElementsByTagName( 'img' )->item( 0 );
 				$img_src    = $img->getAttribute( 'src' );
-				$figcaption = $xpath->query( '//figcaption/text()' )[0];
+				$figcaption = $dom->getElementsByTagName( 'figcaption' )->item( 0 );
 
 				$img_attrs = array(
 					'padding' => '0',
@@ -360,6 +359,11 @@ final class Newspack_Newsletters_Renderer {
 				$markup = '<mj-image ' . self::array_to_attributes( $img_attrs ) . ' />';
 
 				if ( $figcaption ) {
+					$caption_html  = '';
+					$caption_nodes = $figcaption->childNodes; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+					foreach ( $caption_nodes as $caption_node ) {
+						$caption_html .= $dom->saveHTML( $caption_node );
+					}
 					$caption_attrs = array(
 						'align'       => 'center',
 						'color'       => '#555d66',
@@ -367,8 +371,7 @@ final class Newspack_Newsletters_Renderer {
 						'font-size'   => '13px',
 						'font-family' => $font_family,
 					);
-					 // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
-					$markup .= '<mj-text ' . self::array_to_attributes( $caption_attrs ) . '>' . $figcaption->wholeText . '</mj-text>';
+					$markup       .= '<mj-text ' . self::array_to_attributes( $caption_attrs ) . '>' . wp_kses( $caption_html, Newspack_Newsletters_Embed::$allowed_html ) . '</mj-text>';
 				}
 
 				$block_mjml_markup = $markup;

--- a/includes/class-newspack-newsletters-renderer.php
+++ b/includes/class-newspack-newsletters-renderer.php
@@ -371,7 +371,17 @@ final class Newspack_Newsletters_Renderer {
 						'font-size'   => '13px',
 						'font-family' => $font_family,
 					);
-					$markup       .= '<mj-text ' . self::array_to_attributes( $caption_attrs ) . '>' . wp_kses( $caption_html, Newspack_Newsletters_Embed::$allowed_html ) . '</mj-text>';
+					$markup       .= '<mj-text ' . self::array_to_attributes( $caption_attrs ) . '>' . wp_kses(
+						$caption_html,
+						[
+							'a'      => [
+								'href'  => [],
+								'title' => [],
+							],
+							'em'     => [],
+							'strong' => [],
+						] 
+					) . '</mj-text>';
 				}
 
 				$block_mjml_markup = $markup;

--- a/includes/class-newspack-newsletters-renderer.php
+++ b/includes/class-newspack-newsletters-renderer.php
@@ -49,7 +49,7 @@ final class Newspack_Newsletters_Renderer {
 	/**
 	 * Inline tags that are allowed to be rendered in a text block.
 	 * 
-	 * @var bool|array[] Associative array of tag names to allowed attributes.
+	 * @var bool[]|array[] Associative array of tag names to allowed attributes.
 	 */
 	public static $allowed_inline_tags = [
 		's'      => true,

--- a/includes/class-newspack-newsletters-renderer.php
+++ b/includes/class-newspack-newsletters-renderer.php
@@ -47,6 +47,29 @@ final class Newspack_Newsletters_Renderer {
 	protected static $post_permalink = null;
 
 	/**
+	 * Inline tags that are allowed to be rendered in a text block.
+	 * 
+	 * @var bool|array[] Associative array of tag names to allowed attributes.
+	 */
+	public static $allowed_inline_tags = [
+		's'      => true,
+		'b'      => true,
+		'strong' => true,
+		'i'      => true,
+		'em'     => true,
+		'mark'   => true,
+		'u'      => true,
+		'small'  => true,
+		'sub'    => true,
+		'sup'    => true,
+		'a'      => [
+			'href'   => true,
+			'target' => true,
+			'rel'    => true,
+		],
+	];
+
+	/**
 	 * Convert a list to HTML attributes.
 	 *
 	 * @param array $attributes Array of attributes.
@@ -373,14 +396,7 @@ final class Newspack_Newsletters_Renderer {
 					);
 					$markup       .= '<mj-text ' . self::array_to_attributes( $caption_attrs ) . '>' . wp_kses(
 						$caption_html,
-						[
-							'a'      => [
-								'href'  => [],
-								'title' => [],
-							],
-							'em'     => [],
-							'strong' => [],
-						] 
+						self::$allowed_inline_tags
 					) . '</mj-text>';
 				}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Support image's `figcaption` to have the following inline tags:

- s      
- b      
- strong 
- i      
- em     
- mark   
- u      
- small  
- sub    
- sup    
- a

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes #744.

### How to test the changes in this Pull Request:

1. Create a new newsletter with an image block
2. Add a caption with link, bold and italic
3. On the master branch, confirm the sent newsletter (or rendered markup) breaks the caption text on the first inner tag occurrence
4. Check out this branch and confirm the markup now contains the allowed tags

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
