### PR TITLE
fix(mailchimp): check send status

### DIFF
--- a/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp.php
+++ b/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp.php
@@ -536,6 +536,16 @@ final class Newspack_Newsletters_Mailchimp extends \Newspack_Newsletters_Service
 
 		if ( 'publish' === $new_status && 'publish' !== $old_status ) {
 			try {
+				// Check if campaign has already been sent and if so, don't attempt to
+				// send again.
+				$campaign_data = $this->retrieve( $post_id );
+				if (
+					isset( $campaign_data['campaign']['status'] ) &&
+					in_array( $campaign_data['campaign']['status'], [ 'sent', 'sending' ], true )
+				) {
+					return;
+				}
+
 				$sync_result = $this->sync( $post );
 
 				if ( ! $sync_result || is_wp_error( $sync_result ) ) {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Verify the campaign status before attempting to send a Mailchimp newsletter.

Closes #620 

### How to test the changes in this Pull Request:

1. On the master branch, create and send a new newsletter
2. Use the quick edit feature to edit the newsletter status to `Draft`, than back to `Publish`
3. Observe the error than delete this newsletter
4. Switch to this branch, create and send another newsletter
5. Repeat the second step and observe you are able to switch the status without attempting to send or errors

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
