### PR TITLE
fix: color palette css rules

### DIFF
--- a/includes/class-newspack-newsletters-editor.php
+++ b/includes/class-newspack-newsletters-editor.php
@@ -114,7 +114,8 @@ final class Newspack_Newsletters_Editor {
 			}
 		}
 		if ( $container_selector ) {
-			$rules = array_map(
+			$container_selector = esc_html( $container_selector );
+			$rules              = array_map(
 				function( $rule ) use ( $container_selector ) {
 					return $container_selector . ' ' . $rule;
 				},

--- a/includes/class-newspack-newsletters-editor.php
+++ b/includes/class-newspack-newsletters-editor.php
@@ -108,8 +108,10 @@ final class Newspack_Newsletters_Editor {
 		$rules = [];
 		// Add `.has-{color-name}-color` rules for each palette color.
 		$color_palette = json_decode( get_option( 'newspack_newsletters_color_palette', false ), true );
-		foreach ( $color_palette as $color_name => $color_value ) {
-			$rules[] = '.has-' . esc_html( $color_name ) . '-color { color: ' . esc_html( $color_value ) . '; }';
+		if ( ! empty( $color_palette ) ) {
+			foreach ( $color_palette as $color_name => $color_value ) {
+				$rules[] = '.has-' . esc_html( $color_name ) . '-color { color: ' . esc_html( $color_value ) . '; }';
+			}
 		}
 		if ( $container_selector ) {
 			$rules = array_map(

--- a/includes/class-newspack-newsletters-editor.php
+++ b/includes/class-newspack-newsletters-editor.php
@@ -98,6 +98,31 @@ final class Newspack_Newsletters_Editor {
 	}
 
 	/**
+	 * Get CSS rules for color palette.
+	 *
+	 * @param string $container_selector Optional selector to prefix as a container to every rule.
+	 * 
+	 * @return string CSS rules.
+	 */
+	public static function get_color_palette_css( $container_selector = '' ) {
+		$rules = [];
+		// Add `.has-{color-name}-color` rules for each palette color.
+		$color_palette = json_decode( get_option( 'newspack_newsletters_color_palette', false ), true );
+		foreach ( $color_palette as $color_name => $color_value ) {
+			$rules[] = '.has-' . esc_html( $color_name ) . '-color { color: ' . esc_html( $color_value ) . '; }';
+		}
+		if ( $container_selector ) {
+			$rules = array_map(
+				function( $rule ) use ( $container_selector ) {
+					return $container_selector . ' ' . $rule;
+				},
+				$rules 
+			);
+		}
+		return implode( "\n", $rules );
+	}
+
+	/**
 	 * Remove all editor enqueued assets besides this plugins' and disable some editor features.
 	 * This is to prevent theme styles being loaded in the editor.
 	 */
@@ -241,6 +266,8 @@ final class Newspack_Newsletters_Editor {
 			);
 			wp_style_add_data( 'newspack-newsletters', 'rtl', 'replace' );
 			wp_enqueue_style( 'newspack-newsletters' );
+
+			wp_add_inline_style( 'newspack-newsletters', self::get_color_palette_css( '.editor-styles-wrapper' ) );
 
 			\wp_enqueue_script(
 				'newspack-newsletters-editor',

--- a/includes/class-newspack-newsletters-renderer.php
+++ b/includes/class-newspack-newsletters-renderer.php
@@ -57,7 +57,7 @@ final class Newspack_Newsletters_Renderer {
 		'strong' => true,
 		'i'      => true,
 		'em'     => true,
-		'mark'   => true,
+		'span'   => true,
 		'u'      => true,
 		'small'  => true,
 		'sub'    => true,
@@ -296,6 +296,22 @@ final class Newspack_Newsletters_Renderer {
 
 		$font_family = 'core/heading' === $block_name ? self::$font_header : self::$font_body;
 
+		// Parse inner HTML.
+		if ( ! empty( $inner_html ) ) {
+			$dom = new DomDocument();
+			libxml_use_internal_errors( true );
+			$dom->loadHTML( mb_convert_encoding( $inner_html, 'HTML-ENTITIES', get_bloginfo( 'charset' ) ), LIBXML_HTML_NOIMPLIED | LIBXML_HTML_NODEFDTD );
+			$parsed_inner_html = '';
+			$nodes             = $dom->childNodes; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+			foreach ( $nodes as $node ) {
+				$node_html = $dom->saveHTML( $node );
+				// Replace <mark /> with <span />.
+				$node_html          = preg_replace( '/<mark\s(.+?)>(.+?)<\/mark>/is', '<span $1>$2</span>', $node_html );
+				$parsed_inner_html .= $node_html;
+			}
+			$inner_html = $parsed_inner_html;
+		}
+
 		switch ( $block_name ) {
 			/**
 			 * Text-based blocks.
@@ -336,7 +352,7 @@ final class Newspack_Newsletters_Renderer {
 				// Parse block content.
 				$dom = new DomDocument();
 				libxml_use_internal_errors( true );
-				$dom->loadHTML( mb_convert_encoding( $inner_html, 'HTML-ENTITIES', get_bloginfo( 'charset' ) ) );
+				$dom->loadHTML( mb_convert_encoding( $inner_html, 'HTML-ENTITIES', get_bloginfo( 'charset' ) ), LIBXML_HTML_NOIMPLIED | LIBXML_HTML_NODEFDTD );
 				$img        = $dom->getElementsByTagName( 'img' )->item( 0 );
 				$img_src    = $img->getAttribute( 'src' );
 				$figcaption = $dom->getElementsByTagName( 'figcaption' )->item( 0 );

--- a/includes/class-newspack-newsletters-renderer.php
+++ b/includes/class-newspack-newsletters-renderer.php
@@ -296,20 +296,9 @@ final class Newspack_Newsletters_Renderer {
 
 		$font_family = 'core/heading' === $block_name ? self::$font_header : self::$font_body;
 
-		// Parse inner HTML.
 		if ( ! empty( $inner_html ) ) {
-			$dom = new DomDocument();
-			libxml_use_internal_errors( true );
-			$dom->loadHTML( mb_convert_encoding( $inner_html, 'HTML-ENTITIES', get_bloginfo( 'charset' ) ), LIBXML_HTML_NOIMPLIED | LIBXML_HTML_NODEFDTD );
-			$parsed_inner_html = '';
-			$nodes             = $dom->childNodes; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
-			foreach ( $nodes as $node ) {
-				$node_html = $dom->saveHTML( $node );
-				// Replace <mark /> with <span />.
-				$node_html          = preg_replace( '/<mark\s(.+?)>(.+?)<\/mark>/is', '<span $1>$2</span>', $node_html );
-				$parsed_inner_html .= $node_html;
-			}
-			$inner_html = $parsed_inner_html;
+			// Replace <mark /> with <span />.
+			$inner_html = preg_replace( '/<mark\s(.+?)>(.+?)<\/mark>/is', '<span $1>$2</span>', $inner_html );
 		}
 
 		switch ( $block_name ) {

--- a/includes/email-template.mjml.php
+++ b/includes/email-template.mjml.php
@@ -17,6 +17,7 @@
 			$css         = $default_css . "\n" . $custom_css;
 
 			echo esc_html( $css );
+			echo Newspack_Newsletters_Editor::get_color_palette_css();
 		?>
 		</mj-style>
 		<?php if ( isset( $preview_text ) ): ?>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

The email editor strips all default editor styles, this also removes the `.has-{color-name}-color` used by the "Highlight" (`<mark />`) attribute used for inline coloring of texts.

<img width="482" alt="image" src="https://user-images.githubusercontent.com/820752/156803575-53345eef-b7d7-4f73-a37a-27db33815175.png">


### How to test the changes in this Pull Request:

1. While on the master branch, create a new newsletter and apply "highlight" to a selected text
2. Observe the background color works as expected but not the text color (background color uses inline CSS rules)
3. Check out this branch, apply the highlight text color and observe the changes are applied
4. Send the newsletter with a highlighted text and confirm it is also highlighted on the sent email

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
