### PR TITLE
feat: minify and notify clipable email body

### DIFF
--- a/src/components/with-api-handler/index.js
+++ b/src/components/with-api-handler/index.js
@@ -13,6 +13,7 @@ const successNote = __( 'Campaign sent on ', 'newspack-newsletters' );
 const shouldRemoveNotice = notice => {
 	return (
 		notice.id !== SHARE_BLOCK_NOTICE_ID &&
+		notice.id !== 'newspack-newsletters-email-content-too-large' &&
 		'error' !== notice.status &&
 		( 'success' !== notice.status || -1 === notice.content.indexOf( successNote ) )
 	);

--- a/src/editor/api/index.js
+++ b/src/editor/api/index.js
@@ -63,7 +63,7 @@ apiFetch.use( async ( options, next ) => {
 			.then( ( { mjml } ) => {
 				// Once received MJML markup, convert it to email-compliant HTML
 				// and save as post meta for later retrieval.
-				const { html } = mjml2html( mjml );
+				const { html } = mjml2html( mjml, { keepComments: false, minify: true } );
 				return apiFetch( {
 					data: { meta: { [ emailHTMLMetaName ]: html } },
 					method: 'POST',

--- a/src/newsletter-editor/editor/index.js
+++ b/src/newsletter-editor/editor/index.js
@@ -6,6 +6,7 @@ import { get, isEmpty } from 'lodash';
 /**
  * WordPress dependencies
  */
+import { __ } from '@wordpress/i18n';
 import { compose } from '@wordpress/compose';
 import { withDispatch, withSelect } from '@wordpress/data';
 import { createPortal, useEffect, useState } from '@wordpress/element';
@@ -60,14 +61,22 @@ const Editor = compose( [
 			status,
 			sentDate,
 			isPublic: meta.is_public,
+			html: meta[ window.newspack_email_editor_data.email_html_meta ],
 		};
 	} ),
 	withDispatch( dispatch => {
 		const { lockPostAutosaving, lockPostSaving, unlockPostSaving, editPost } = dispatch(
 			'core/editor'
 		);
-		const { createNotice } = dispatch( 'core/notices' );
-		return { lockPostAutosaving, lockPostSaving, unlockPostSaving, editPost, createNotice };
+		const { createNotice, removeNotice } = dispatch( 'core/notices' );
+		return {
+			lockPostAutosaving,
+			lockPostSaving,
+			unlockPostSaving,
+			editPost,
+			createNotice,
+			removeNotice,
+		};
 	} ),
 ] )( props => {
 	const [ publishEl ] = useState( document.createElement( 'div' ) );
@@ -132,6 +141,23 @@ const Editor = compose( [
 			} );
 		}
 	}, [ props.status ] );
+
+	// Notify if email content is larger than ~100kb.
+	useEffect( () => {
+		const noticeId = 'newspack-newsletters-email-content-too-large';
+		const message = __(
+			'Email content is too large and may get clipped by email clients.',
+			'newspack-newsletters'
+		);
+		if ( props.html.length > 100000 ) {
+			props.createNotice( 'warning', message, {
+				id: noticeId,
+				isDismissible: false,
+			} );
+		} else {
+			props.removeNotice( noticeId );
+		}
+	}, [ props.html ] );
 
 	return createPortal( <SendButton />, publishEl );
 } );

--- a/src/newsletter-editor/editor/index.js
+++ b/src/newsletter-editor/editor/index.js
@@ -146,7 +146,7 @@ const Editor = compose( [
 	useEffect( () => {
 		const noticeId = 'newspack-newsletters-email-content-too-large';
 		const message = __(
-			'Email content is too large and may get clipped by email clients.',
+			'Email content is too long and may get clipped by email clients.',
 			'newspack-newsletters'
 		);
 		if ( props.html.length > 100000 ) {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

[Email content larger than 102kb gets clipped by Gmail](https://mailchimp.com/pt-br/help/gmail-is-clipping-my-email/). This PR implements a notice to let the user know their content may get clipped if we detect a resulting body larger than 100,000 bytes. This approximation is assuming that the ESP will add extra tags for tracking, footer, etc.

<img width="1197" alt="image" src="https://user-images.githubusercontent.com/820752/158435651-2135029e-82e9-497a-b408-519ac069c031.png">

It also implements the minifying options to MJML to reduce the chance of clipping. My local tests produced a reduction of 25% of an email with ~100k bytes.

### How to test the changes in this Pull Request:

1. Check out this PR and run `npm run build`
2. Send an email using multiple different blocks to make sure the markup is not altered by the minification
3. Add multiple text blocks in a newsletter draft until it reaches > 100k bytes
4. Save the draft and confirm you see the notice in the screenshot above

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
