### PR TITLE
fix: disable row group block variation

### DIFF
--- a/src/editor/index.js
+++ b/src/editor/index.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { unregisterBlockStyle } from '@wordpress/blocks';
+import { unregisterBlockStyle, unregisterBlockVariation } from '@wordpress/blocks';
 import domReady from '@wordpress/dom-ready';
 import { addFilter, removeFilter } from '@wordpress/hooks';
 import { registerPlugin } from '@wordpress/plugins';
@@ -27,11 +27,13 @@ registerEmbedBlockEdit();
 registerMergeTagsFilters();
 registerVisibilityFilters();
 
-/* Unregister core block styles that are unsupported in emails */
 domReady( () => {
+	/* Unregister core block styles that are unsupported in emails */
 	unregisterBlockStyle( 'core/separator', 'dots' );
 	unregisterBlockStyle( 'core/social-links', 'logos-only' );
 	unregisterBlockStyle( 'core/social-links', 'pill-shape' );
+	/* Unregister "row" group block variation */
+	unregisterBlockVariation( 'core/group', 'group-row' );
 } );
 
 /* Remove Duotone filters */


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

[As pointed out](https://github.com/Automattic/newspack-newsletters/pull/764#pullrequestreview-916140528) by @dkoo, the "Row" block, which is a Group block variation, is not supported by our renderer. Instead of a row, the result is a regular group.

This PR unregisters the block variation.

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

### How to test the changes in this Pull Request:

1. While on the master branch, send a newsletter using the "Row" block
2. Confirm the unexpected layout
3. Check out this branch and confirm you are no longer able to use the "Row" block
4.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
