### PR TITLE
fix(layouts): ensure selected layout is saved

### DIFF
--- a/src/components/init-modal/screens/layout-picker/index.js
+++ b/src/components/init-modal/screens/layout-picker/index.js
@@ -56,8 +56,7 @@ const LayoutPicker = ( {
 			template_id: layoutId,
 			...meta,
 		};
-		setNewsletterMeta( metaPayload );
-		setTimeout( savePost, 1 );
+		setNewsletterMeta( metaPayload ).then( savePost );
 	};
 
 	const [ selectedLayoutId, setSelectedLayoutId ] = useState( null );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

`savePost()` is intended to be called after the selection of the layout ID but instead it's assuming the `editPost()` action will be fulfilled after 1 ms, which is not good practice.

This PR updates the `savePost()` action to be executed as a callback to the `setNewsletterMeta()`.

### How to test the changes in this Pull Request:

Confirm layout selection and draft saving behaves as expected and the selected layout is saved (the layout picker is not displayed again after refreshing the editor).

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
