### PR TITLE
Fix height of block visibility when using floats

### DIFF
--- a/src/editor/blocks/visibility-attribute/style.scss
+++ b/src/editor/blocks/visibility-attribute/style.scss
@@ -17,7 +17,7 @@
 	position: relative;
 	transition: min-height 0.25s ease-in-out;
 
-	&::after {
+	&::before {
 		border-radius: 1px;
 		bottom: 1px;
 		box-shadow: 0 0 0 var( --wp-admin-border-width-focus ) $alert-yellow;
@@ -27,6 +27,12 @@
 		position: absolute;
 		right: 1px;
 		top: 1px;
+	}
+
+	&::after {
+		clear: both;
+		content: '';
+		display: table;
 	}
 
 	.newsletters-block-visibility-label {

--- a/src/editor/blocks/visibility-attribute/style.scss
+++ b/src/editor/blocks/visibility-attribute/style.scss
@@ -9,10 +9,13 @@
 
 .newspack-newsletters__editor-block.newsletters-block-visibility__web,
 .newspack-newsletters__editor-block.newsletters-block-visibility__email {
-	position: relative;
-	margin-top: 0;
+	height: auto;
 	margin-bottom: 0;
+	margin-top: 0;
+	min-height: calc( 1.5em + 22px );
 	padding: 0 !important;
+	position: relative;
+	transition: min-height 0.25s ease-in-out;
 
 	&::after {
 		border-radius: 1px;
@@ -41,7 +44,7 @@
 		right: 3px;
 		top: 100%;
 		transition: margin 0.25s ease-in-out;
-		z-index: 10;
+		z-index: 22;
 		button {
 			border: 0;
 			background: transparent;
@@ -62,6 +65,8 @@
 		}
 	}
 	&.newsletters-block-selected {
+		min-height: 1.5em;
+
 		> .newsletters-block-visibility-label {
 			margin-top: 3px;
 		}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

When setting the visibility to a block that has some sort of float/alignment, the outline will look broken

E.g.

![1 before](https://user-images.githubusercontent.com/177929/163435590-d4650adc-a2a9-4ba0-8adc-35df958364f1.png)

This PR clears the floating element and adjust the min-height so that the first line of a sentence is readable.

![2 after](https://user-images.githubusercontent.com/177929/163435738-c1ebf8dc-a87e-4eaf-8825-feceb8ab7d5a.png)

### How to test the changes in this Pull Request:

1. Add a right align text and set its visibility to something other than newsletter and web
2. Notice the outline above the text -- it should be wrapped around it
3. Switch to this branch
4. Refresh your editor

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
