### PR TITLE
fix: ensure layout update has ID

### DIFF
--- a/src/newsletter-editor/layout/index.js
+++ b/src/newsletter-editor/layout/index.js
@@ -108,6 +108,7 @@ export default compose( [
 			// The shape of this data is different than the API response for CPT
 			setUsedLayout( {
 				...updatedLayout,
+				ID: updatedLayout.id,
 				post_content: updatedLayout.content.raw,
 				post_title: updatedLayout.title.raw,
 				post_type: LAYOUT_CPT_SLUG,


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Ensures the `usedLayout` data contains the proper layout ID after a layout update.

Closes #794 

### How to test the changes in this Pull Request:

1. On the master branch, create a new layout based on a newsletter
2. Edit the newsletter and click to update the layout a couple of times
3. You may get a 404 error or a duplicate layout being created (I've experienced both and couldn't pinpoint why the different side-effects from an `undefined` ID)
4. If you don't get a 404 error on the console, create a new newsletter and confirm there are duplicate saved layouts
5. Check out this branch, repeat the step 2 and confirm there are no errors or duplicate layouts created
6. Create a new newsletter based on the saved layout and confirm the changes are saved


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
