### PR TITLE
refactor: sending newsletters on status changes

### DIFF
--- a/includes/class-newspack-newsletters.php
+++ b/includes/class-newspack-newsletters.php
@@ -96,7 +96,7 @@ final class Newspack_Newsletters {
 	}
 
 	/**
-	 * Register custom fields.
+	 * Set service provider.
 	 *
 	 * @param string $service_provider Service provider slug.
 	 */
@@ -210,6 +210,22 @@ final class Newspack_Newsletters {
 				'single'         => true,
 				'auth_callback'  => '__return_true',
 				'default'        => -1,
+			]
+		);
+		\register_meta(
+			'post',
+			'newsletter_sent',
+			[
+				'object_subtype' => self::NEWSPACK_NEWSLETTERS_CPT,
+				'show_in_rest'   => [
+					'schema' => [
+						'context' => [ 'edit' ],
+					],
+				],
+				'type'           => 'integer',
+				'single'         => true,
+				'auth_callback'  => '__return_true',
+				'default'        => 0,
 			]
 		);
 		\register_meta(
@@ -459,21 +475,20 @@ final class Newspack_Newsletters {
 		}
 
 		$post_status = get_post_status_object( $post->post_status );
-		$is_sent     = 'publish' === $post_status->name;
+		$sent        = self::is_newsletter_sent( $post->ID );
 		$is_public   = get_post_meta( $post->ID, 'is_public', true );
 
-		if ( $is_sent ) {
-			$sent_date = get_the_time( 'U', $post );
-			$time_diff = time() - $sent_date;
-			$sent_date = human_time_diff( $sent_date, time() );
+		if ( $sent ) {
+			$time_diff = time() - $sent;
 
 			// Show relative date if sent within the past 24 hours.
 			if ( $time_diff < 86400 ) {
+				$sent_from_now = human_time_diff( $sent, time() );
 				/* translators: Relative time stamp of sent/published date */
-				$post_states[ $post_status->name ] = sprintf( __( 'Sent %1$s ago', 'newspack-newsletters' ), $sent_date );
+				$post_states[ $post_status->name ] = sprintf( __( 'Sent %1$s ago', 'newspack-newsletters' ), $sent_from_now );
 			} else {
 				/* translators:  Absolute time stamp of sent/published date */
-				$post_states[ $post_status->name ] = sprintf( __( 'Sent %1$s', 'newspack-newsletters' ), get_the_time( get_option( 'date_format' ), $post ) );
+				$post_states[ $post_status->name ] = sprintf( __( 'Sent %1$s', 'newspack-newsletters' ), ( new DateTime( $sent ) )->format( get_option( 'date_format' ) ) );
 			}
 		}
 
@@ -1265,6 +1280,38 @@ final class Newspack_Newsletters {
 				);
 			}
 		}
+	}
+
+	/**
+	 * Mark newsletter as sent.
+	 *
+	 * @param int $post_id Post ID.
+	 * @param int $time    Optional timestamp to mark as sent. Default is now.
+	 */
+	public static function set_newsletter_sent( $post_id, $time = 0 ) {
+		update_post_meta( $post_id, 'newsletter_sent', 0 < $time ? $time : time() );
+	}
+
+	/**
+	 * Whether the newsletter has been marked as sent.
+	 *
+	 * @param int $post_id Post ID.
+	 *
+	 * @return false|int False if not sent, or timestamp of when it was sent.
+	 */
+	public static function is_newsletter_sent( $post_id ) {
+		$sent = get_post_meta( $post_id, 'newsletter_sent', true );
+		if ( 0 < $sent ) {
+			return $sent;
+		}
+		// Legacy for sent newsletters without meta.
+		if ( 'publish' === get_post_status( $post_id ) ) {
+			$post = get_post( $post_id );
+			$sent = strtotime( $post->post_date );
+			self::set_newsletter_sent( $post_id, $sent );
+			return $sent;
+		}
+		return false;
 	}
 }
 Newspack_Newsletters::instance();

--- a/includes/class-newspack-newsletters.php
+++ b/includes/class-newspack-newsletters.php
@@ -488,7 +488,7 @@ final class Newspack_Newsletters {
 				$post_states[ $post_status->name ] = sprintf( __( 'Sent %1$s ago', 'newspack-newsletters' ), $sent_from_now );
 			} else {
 				/* translators:  Absolute time stamp of sent/published date */
-				$post_states[ $post_status->name ] = sprintf( __( 'Sent %1$s', 'newspack-newsletters' ), ( new DateTime( $sent ) )->format( get_option( 'date_format' ) ) );
+				$post_states[ $post_status->name ] = sprintf( __( 'Sent %1$s', 'newspack-newsletters' ), ( new DateTime( '@' . $sent ) )->format( get_option( 'date_format' ) ) );
 			}
 		}
 

--- a/includes/service-providers/active_campaign/class-newspack-newsletters-active-campaign.php
+++ b/includes/service-providers/active_campaign/class-newspack-newsletters-active-campaign.php
@@ -403,29 +403,12 @@ final class Newspack_Newsletters_Active_Campaign extends \Newspack_Newsletters_S
 	/**
 	 * Send a campaign.
 	 *
-	 * @param string  $new_status New status of the post.
-	 * @param string  $old_status Old status of the post.
-	 * @param WP_Post $post       Post to send.
+	 * @param WP_Post $post Post to send.
 	 *
-	 * @throws Exception Error message if sending fails.
+	 * @return true|WP_Error True if the campaign was sent or error if failed.
 	 */
-	public function send( $new_status, $old_status, $post ) {
-
+	public function send( $post ) {
 		$post_id = $post->ID;
-		
-		// Only run if the current service provider is ActiveCampaign.
-		if ( 'active_campaign' !== Newspack_Newsletters::service_provider() ) {
-			return;
-		}
-
-		// Only run if changing to publish.
-		if ( 'publish' !== $new_status || 'publish' === $old_status ) {
-			return;
-		}
-
-		if ( ! Newspack_Newsletters::validate_newsletter_id( $post_id ) ) {
-			return;
-		}
 
 		$error = null;
 
@@ -463,19 +446,7 @@ final class Newspack_Newsletters_Active_Campaign extends \Newspack_Newsletters_S
 			}
 		}
 
-		if ( $error ) {
-			$transient = sprintf( 'newspack_newsletters_error_%s_%s', $post_id, get_current_user_id() );
-			set_transient( $transient, $error->get_error_message(), 45 );
-			// Reset publish status.
-			wp_update_post(
-				[
-					'ID'          => $post_id,
-					'post_status' => 'draft',
-				],
-				true
-			);
-			wp_die( esc_html( $error->get_error_message() ) );
-		}
+		return $error ?? true;
 	}
 
 	/**

--- a/includes/service-providers/campaign_monitor/class-newspack-newsletters-campaign-monitor.php
+++ b/includes/service-providers/campaign_monitor/class-newspack-newsletters-campaign-monitor.php
@@ -352,7 +352,6 @@ final class Newspack_Newsletters_Campaign_Monitor extends \Newspack_Newsletters_
 
 		$cm_campaigns = new CS_REST_Campaigns( null, [ 'api_key' => $api_key ] );
 		$args         = $this->format_campaign_args( $post_id );
-		$send_date    = 'future' === $new_status ? $post->post_date : 'Immediately';
 
 		// Set the current user's email address as the email to receive sent confirmation.
 		$current_user       = wp_get_current_user();
@@ -364,7 +363,7 @@ final class Newspack_Newsletters_Campaign_Monitor extends \Newspack_Newsletters_
 		if ( ! $new_campaign->was_successful() ) {
 			return new WP_Error(
 				'newspack_newsletter_error',
-				__( 'Failed sending Campaign Monitor campaign: ', 'newspack-newsletters' ) . $new_campaign->response->Message
+				__( 'Failed creating Campaign Monitor campaign: ', 'newspack-newsletters' ) . $new_campaign->response->Message
 			);
 		}
 
@@ -374,7 +373,7 @@ final class Newspack_Newsletters_Campaign_Monitor extends \Newspack_Newsletters_
 			$campaign_to_send->send(
 				[
 					'ConfirmationEmail' => $confirmation_email,
-					'SendDate'          => $send_date,
+					'SendDate'          => 'Immediately',
 				]
 			);
 		} catch ( Exception $e ) {

--- a/includes/service-providers/campaign_monitor/class-newspack-newsletters-campaign-monitor.php
+++ b/includes/service-providers/campaign_monitor/class-newspack-newsletters-campaign-monitor.php
@@ -23,7 +23,6 @@ final class Newspack_Newsletters_Campaign_Monitor extends \Newspack_Newsletters_
 		$this->controller = new Newspack_Newsletters_Campaign_Monitor_Controller( $this );
 
 		add_action( 'save_post_' . Newspack_Newsletters::NEWSPACK_NEWSLETTERS_CPT, [ $this, 'save' ], 10, 3 );
-		add_action( 'transition_post_status', [ $this, 'send' ], 10, 3 );
 
 		parent::__construct( $this );
 	}
@@ -328,75 +327,64 @@ final class Newspack_Newsletters_Campaign_Monitor extends \Newspack_Newsletters_
 	/**
 	 * Send a campaign.
 	 *
-	 * @param string  $new_status New status of the post.
-	 * @param string  $old_status Old status of the post.
-	 * @param WP_POST $post Post to send.
+	 * @param WP_Post $post Post to send.
 	 *
-	 * @throws Exception Error message if sending fails.
+	 * @return true|WP_Error True if the campaign was sent or error if failed.
 	 */
-	public function send( $new_status, $old_status, $post ) {
+	public function send( $post ) {
 		$post_id = $post->ID;
 
-		// Only run if the current post is a newsletter.
-		if ( ! Newspack_Newsletters::validate_newsletter_id( $post_id ) ) {
-			return;
+		$api_key   = $this->api_key();
+		$client_id = $this->client_id();
+
+		if ( ! $api_key ) {
+			return new WP_Error(
+				'newspack_newsletter_error',
+				__( 'No Campaign Monitor API key available.', 'newspack-newsletters' )
+			);
+		}
+		if ( ! $client_id ) {
+			return new WP_Error(
+				'newspack_newsletter_error',
+				__( 'No Campaign Monitor Client ID available.', 'newspack-newsletters' ) 
+			);
 		}
 
-		// Only run if the current service provider is Campaign Monitor.
-		if ( 'campaign_monitor' !== get_option( 'newspack_newsletters_service_provider', false ) ) {
-			return;
+		$cm_campaigns = new CS_REST_Campaigns( null, [ 'api_key' => $api_key ] );
+		$args         = $this->format_campaign_args( $post_id );
+		$send_date    = 'future' === $new_status ? $post->post_date : 'Immediately';
+
+		// Set the current user's email address as the email to receive sent confirmation.
+		$current_user       = wp_get_current_user();
+		$confirmation_email = $current_user->user_email;
+
+		// Create a draft campaign and get the ID from the response.
+		$new_campaign = $cm_campaigns->create( $client_id, $args );
+
+		if ( ! $new_campaign->was_successful() ) {
+			return new WP_Error(
+				'newspack_newsletter_error',
+				__( 'Failed sending Campaign Monitor campaign: ', 'newspack-newsletters' ) . $new_campaign->response->Message
+			);
 		}
 
-		if ( ( 'publish' === $new_status && 'publish' !== $old_status ) || ( 'future' === $new_status && 'future' !== $old_status ) ) {
-			try {
-				$api_key   = $this->api_key();
-				$client_id = $this->client_id();
-
-				if ( ! $api_key ) {
-					throw new Exception( __( 'No Campaign Monitor API key available.', 'newspack-newsletters' ) );
-				}
-				if ( ! $client_id ) {
-					throw new Exception( __( 'No Campaign Monitor Client ID available.', 'newspack-newsletters' ) );
-				}
-
-				$cm_campaigns = new CS_REST_Campaigns( null, [ 'api_key' => $api_key ] );
-				$args         = $this->format_campaign_args( $post_id );
-				$send_date    = 'future' === $new_status ? $post->post_date : 'Immediately';
-
-				// Set the current user's email address as the email to receive sent confirmation.
-				$current_user       = wp_get_current_user();
-				$confirmation_email = $current_user->user_email;
-
-				// Create a draft campaign and get the ID from the response.
-				$new_campaign = $cm_campaigns->create( $client_id, $args );
-
-				if ( ! $new_campaign->was_successful() ) {
-					throw new Exception(
-						__( 'Failed sending Campaign Monitor test campaign: ', 'newspack-newsletters' ) . $new_campaign->response->Message
-					);
-				}
-
-				// Send the draft campaign.
-				$campaign_to_send = new CS_REST_Campaigns( $new_campaign->response, [ 'api_key' => $api_key ] );
-				$campaign_to_send->send(
-					[
-						'ConfirmationEmail' => $confirmation_email,
-						'SendDate'          => $send_date,
-					]
-				);
-			} catch ( Exception $e ) {
-				// Reset publish status.
-				wp_update_post(
-					[
-						'ID'          => $post_id,
-						'post_status' => 'draft',
-					],
-					true
-				);
-
-				wp_die( esc_html( $e->getMessage() ) );
-			}
+		try {
+			// Send the draft campaign.
+			$campaign_to_send = new CS_REST_Campaigns( $new_campaign->response, [ 'api_key' => $api_key ] );
+			$campaign_to_send->send(
+				[
+					'ConfirmationEmail' => $confirmation_email,
+					'SendDate'          => $send_date,
+				]
+			);
+		} catch ( Exception $e ) {
+			return new WP_Error(
+				'newspack_newsletters_campaign_monitor_error',
+				$e->getMessage()
+			);
 		}
+
+		return true;
 	}
 
 	/**

--- a/includes/service-providers/class-newspack-newsletters-service-provider.php
+++ b/includes/service-providers/class-newspack-newsletters-service-provider.php
@@ -84,6 +84,7 @@ abstract class Newspack_Newsletters_Service_Provider implements Newspack_Newslet
 		$post       = get_post( $post_id );
 		$old_status = $post->post_status;
 		$new_status = $data['post_status'];
+		$sent       = Newspack_Newsletters::is_newsletter_sent( $post_id );
 
 		// Only run if it's a newsletter post.
 		if ( ! Newspack_Newsletters::validate_newsletter_id( $post_id ) ) {
@@ -101,11 +102,7 @@ abstract class Newspack_Newsletters_Service_Provider implements Newspack_Newslet
 		}
 
 		// Prevent status change if newsletter has been sent.
-		if (
-			'publish' === $old_status &&
-			'publish' !== $new_status &&
-			get_post_meta( $post_id, '_newspack_newsletters_sent', true )
-		) {
+		if ( 'publish' === $old_status && 'publish' !== $new_status && $sent ) {
 			wp_die( esc_html( __( 'You cannot change a sent newsletter status.', 'newspack-newsletters' ) ) );
 		}
 
@@ -130,8 +127,7 @@ abstract class Newspack_Newsletters_Service_Provider implements Newspack_Newslet
 	public function send_newsletter( $post ) {
 		$post_id = $post->ID;
 
-		// Newsletter was already sent.
-		if ( get_post_meta( $post_id, '_newspack_newsletters_sent', true ) ) {
+		if ( Newspack_Newsletters::is_newsletter_sent( $post_id ) ) {
 			return;
 		}
 
@@ -142,7 +138,7 @@ abstract class Newspack_Newsletters_Service_Provider implements Newspack_Newslet
 		}
 
 		if ( true === $result ) {
-			update_post_meta( $post_id, '_newspack_newsletters_sent', time() );
+			Newspack_Newsletters::set_newsletter_sent( $post_id );
 		}
 
 		return $result;

--- a/includes/service-providers/class-newspack-newsletters-service-provider.php
+++ b/includes/service-providers/class-newspack-newsletters-service-provider.php
@@ -105,7 +105,8 @@ abstract class Newspack_Newsletters_Service_Provider implements Newspack_Newslet
 
 		// Prevent status change from 'publish' if newsletter has been sent.
 		if ( 'publish' === $old_status && 'publish' !== $new_status && $sent ) {
-			wp_die( esc_html( __( 'You cannot change a sent newsletter status.', 'newspack-newsletters' ) ) );
+			$error = new WP_Error( 'newspack_newsletters_error', __( 'You cannot change a sent newsletter status.', 'newspack-newsletters' ) );
+			wp_die( $error ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 		}
 
 		// Send if changing from any status to publish.
@@ -114,7 +115,7 @@ abstract class Newspack_Newsletters_Service_Provider implements Newspack_Newslet
 			if ( is_wp_error( $result ) ) {
 				$transient = sprintf( 'newspack_newsletters_error_%s_%s', $post->ID, get_current_user_id() );
 				set_transient( $transient, $result->get_error_message(), 45 );
-				wp_die( esc_html( $result->get_error_message() ) );
+				wp_die( $result ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 			}
 		}
 	}

--- a/includes/service-providers/class-newspack-newsletters-service-provider.php
+++ b/includes/service-providers/class-newspack-newsletters-service-provider.php
@@ -42,6 +42,7 @@ abstract class Newspack_Newsletters_Service_Provider implements Newspack_Newslet
 		if ( $this->controller && $this->controller instanceof \WP_REST_Controller ) {
 			add_action( 'rest_api_init', [ $this->controller, 'register_routes' ] );
 		}
+		add_action( 'pre_post_update', [ $this, 'pre_post_update' ], 10, 2 );
 	}
 
 	/**
@@ -71,5 +72,74 @@ abstract class Newspack_Newsletters_Service_Provider implements Newspack_Newslet
 			);
 		}
 		return true;
+	}
+
+	/**
+	 * Handle newsletter post status changes.
+	 *
+	 * @param int   $post_id The post ID.
+	 * @param array $data    Unslashed post data.
+	 */
+	public function pre_post_update( $post_id, $data ) {
+		$post       = get_post( $post_id );
+		$old_status = $post->post_status;
+		$new_status = $data['post_status'];
+
+		// Only run if it's a newsletter post.
+		if ( ! Newspack_Newsletters::validate_newsletter_id( $post_id ) ) {
+			return;
+		}
+
+		// Only run if this is the active provider.
+		if ( Newspack_Newsletters::service_provider() !== $this->service ) {
+			return;
+		}
+
+		// Send if changing from any status to publish.
+		if ( 'publish' === $new_status && 'publish' !== $old_status ) {
+			$result = $this->send_newsletter( $post );
+			if ( is_wp_error( $result ) ) {
+				$transient = sprintf( 'newspack_newsletters_error_%s_%s', $post->ID, get_current_user_id() );
+				set_transient( $transient, $result->get_error_message(), 45 );
+				wp_die( esc_html( $result->get_error_message() ) );
+			}
+		}
+
+		// Prevent status change if newsletter has been sent.
+		if (
+			'publish' === $old_status &&
+			'publish' !== $new_status &&
+			get_post_meta( $post_id, '_newspack_newsletters_sent', true )
+		) {
+			wp_die( esc_html( __( 'You cannot change a sent newsletter status.', 'newspack-newsletters' ) ) );
+		}
+	}
+
+	/**
+	 * Send a newsletter.
+	 *
+	 * @param WP_Post $post The newsletter post.
+	 *
+	 * @return true|WP_Error True if successful, WP_Error if not.
+	 */
+	public function send_newsletter( $post ) {
+		$post_id = $post->ID;
+
+		// Newsletter was already sent.
+		if ( get_post_meta( $post_id, '_newspack_newsletters_sent', true ) ) {
+			return;
+		}
+
+		try {
+			$result = $this->send( $post );
+		} catch ( Exception $e ) {
+			$result = new WP_Error( 'newspack_newsletter_error', $e->getMessage() );
+		}
+
+		if ( true === $result ) {
+			update_post_meta( $post_id, '_newspack_newsletters_sent', time() );
+		}
+
+		return $result;
 	}
 }

--- a/includes/service-providers/class-newspack-newsletters-service-provider.php
+++ b/includes/service-providers/class-newspack-newsletters-service-provider.php
@@ -87,7 +87,7 @@ abstract class Newspack_Newsletters_Service_Provider implements Newspack_Newslet
 		if ( ! Newspack_Newsletters::validate_newsletter_id( $post_id ) ) {
 			return;
 		}
-		
+
 		// Only run if this is the active provider.
 		if ( Newspack_Newsletters::service_provider() !== $this->service ) {
 			return;

--- a/includes/service-providers/class-newspack-newsletters-service-provider.php
+++ b/includes/service-providers/class-newspack-newsletters-service-provider.php
@@ -95,6 +95,15 @@ abstract class Newspack_Newsletters_Service_Provider implements Newspack_Newslet
 			return;
 		}
 
+		// Prevent status change if newsletter has been sent.
+		if (
+			'publish' === $old_status &&
+			'publish' !== $new_status &&
+			get_post_meta( $post_id, '_newspack_newsletters_sent', true )
+		) {
+			wp_die( esc_html( __( 'You cannot change a sent newsletter status.', 'newspack-newsletters' ) ) );
+		}
+
 		// Send if changing from any status to publish.
 		if ( 'publish' === $new_status && 'publish' !== $old_status ) {
 			$result = $this->send_newsletter( $post );
@@ -103,15 +112,6 @@ abstract class Newspack_Newsletters_Service_Provider implements Newspack_Newslet
 				set_transient( $transient, $result->get_error_message(), 45 );
 				wp_die( esc_html( $result->get_error_message() ) );
 			}
-		}
-
-		// Prevent status change if newsletter has been sent.
-		if (
-			'publish' === $old_status &&
-			'publish' !== $new_status &&
-			get_post_meta( $post_id, '_newspack_newsletters_sent', true )
-		) {
-			wp_die( esc_html( __( 'You cannot change a sent newsletter status.', 'newspack-newsletters' ) ) );
 		}
 	}
 

--- a/includes/service-providers/class-newspack-newsletters-service-provider.php
+++ b/includes/service-providers/class-newspack-newsletters-service-provider.php
@@ -95,6 +95,11 @@ abstract class Newspack_Newsletters_Service_Provider implements Newspack_Newslet
 			return;
 		}
 
+		// Don't run if moving to/from trash.
+		if ( 'trash' === $new_status || 'trash' === $old_status ) {
+			return;
+		}
+
 		// Prevent status change if newsletter has been sent.
 		if (
 			'publish' === $old_status &&

--- a/includes/service-providers/interface-newspack-newsletters-wp-hookable.php
+++ b/includes/service-providers/interface-newspack-newsletters-wp-hookable.php
@@ -22,11 +22,9 @@ interface Newspack_Newsletters_WP_Hookable_Interface {
 	/**
 	 * Send a campaign.
 	 *
-	 * @param string   $new_status New status of the post.
-	 * @param string   $old_status Old status of the post.
-	 * @param \WP_POST $post Post to send.
+	 * @param \WP_Post $post Post to send.
 	 */
-	public function send( $new_status, $old_status, $post );
+	public function send( $post );
 
 	/**
 	 * After Newsletter post is deleted, clean up by deleting corresponding ESP campaign.

--- a/includes/service-providers/letterhead/class-newspack-newsletters-letterhead.php
+++ b/includes/service-providers/letterhead/class-newspack-newsletters-letterhead.php
@@ -199,11 +199,9 @@ final class Newspack_Newsletters_Letterhead extends \Newspack_Newsletters_Servic
 	/**
 	 * `send` will send the email - 🤞 one day.
 	 *
-	 * @param string  $new_status The new status.
-	 * @param string  $old_status The old status :(.
-	 * @param WP_POST $post The WP Post.
+	 * @param WP_Post $post The WP Post.
 	 */
-	public function send( $new_status, $old_status, $post ) {}
+	public function send( $post ) {}
 
 	/**
 	 * `sender` is set aside to set an email's sender information - that is, the

--- a/src/components/send-button/index.js
+++ b/src/components/send-button/index.js
@@ -28,6 +28,7 @@ export default compose( [
 	withSelect( ( select, { forceIsDirty } ) => {
 		const {
 			getCurrentPost,
+			getCurrentPostAttribute,
 			getEditedPostAttribute,
 			getEditedPostVisibility,
 			isEditedPostPublishable,
@@ -45,6 +46,7 @@ export default compose( [
 			hasPublishAction: get( getCurrentPost(), [ '_links', 'wp:action-publish' ], false ),
 			visibility: getEditedPostVisibility(),
 			meta: getEditedPostAttribute( 'meta' ),
+			sent: getCurrentPostAttribute( 'meta' ).newsletter_sent,
 			isPublished: isCurrentPostPublished(),
 			postDate: getEditedPostAttribute( 'date' ),
 		};
@@ -61,6 +63,7 @@ export default compose( [
 		hasPublishAction,
 		visibility,
 		meta,
+		sent,
 		isPublished,
 		postDate,
 	} ) => {
@@ -176,7 +179,7 @@ export default compose( [
 		const [ modalVisible, setModalVisible ] = useState( false );
 
 		// For sent newsletters, display the generic button text.
-		if ( isPublished ) {
+		if ( isPublished || sent ) {
 			return (
 				<Fragment>
 					<Button

--- a/src/editor/api/index.js
+++ b/src/editor/api/index.js
@@ -8,8 +8,7 @@ import mjml2html from 'mjml-browser';
  * WordPress dependencies
  */
 import apiFetch from '@wordpress/api-fetch';
-import { dispatch as globalDispatch, select as globalSelect } from '@wordpress/data';
-import { __ } from '@wordpress/i18n';
+import { select as globalSelect } from '@wordpress/data';
 import { NEWSLETTER_CPT_SLUG } from '../../utils/consts';
 
 const POST_META_WHITELIST = [
@@ -77,13 +76,7 @@ apiFetch.use( async ( options, next ) => {
 					path: `/wp/v2/${ postType }/${ data.id }`,
 				} );
 			} )
-			.then( () => next( options ) ) // Proceed with the post update request.
-			.catch( error => {
-				// In case of an error, display notice and proceed with the post update request.
-				const { createErrorNotice } = globalDispatch( 'core/notices' );
-				createErrorNotice( error.message || __( 'Something went wrong', 'newspack-newsletters' ) );
-				return next( options );
-			} );
+			.then( () => next( options ) ); // Proceed with the post update request.
 	}
 	return next( options );
 } );

--- a/src/editor/api/index.js
+++ b/src/editor/api/index.js
@@ -20,6 +20,7 @@ const POST_META_WHITELIST = [
 	'font_header',
 	'background_color',
 	'custom_css',
+	'newsletter_sent',
 ];
 
 /**

--- a/src/newsletter-editor/editor/index.js
+++ b/src/newsletter-editor/editor/index.js
@@ -35,8 +35,9 @@ const Editor = compose( [
 		const { getActiveGeneralSidebarName } = select( 'core/edit-post' );
 		const { getSettings } = select( 'core/block-editor' );
 		const meta = getEditedPostAttribute( 'meta' );
+		// const currentMeta = getCurrentPostAttribute( 'meta' );
 		const status = getCurrentPostAttribute( 'status' );
-		const sentDate = getCurrentPostAttribute( 'date' );
+		const sentDate = 0 < meta.newsletter_sent ? new Date( meta.newsletter_sent * 1000 ) : null;
 		const settings = getSettings();
 		const experimentalSettingsColors = get( settings, [
 			'__experimentalFeatures',
@@ -129,8 +130,8 @@ const Editor = compose( [
 	}, [ props.isReady ] );
 
 	useEffect( () => {
-		if ( 'publish' === props.status && ! props.isPublishingOrSavingPost ) {
-			const dateTime = props.sentDate ? new Date( props.sentDate ).toLocaleString() : '';
+		if ( props.sentDate && ! props.isPublishingOrSavingPost ) {
+			const dateTime = props.sentDate ? props.sentDate.toLocaleString() : '';
 
 			// Lock autosaving after a newsletter is sent.
 			props.lockPostAutosaving();

--- a/src/newsletter-editor/editor/index.js
+++ b/src/newsletter-editor/editor/index.js
@@ -35,9 +35,8 @@ const Editor = compose( [
 		const { getActiveGeneralSidebarName } = select( 'core/edit-post' );
 		const { getSettings } = select( 'core/block-editor' );
 		const meta = getEditedPostAttribute( 'meta' );
-		// const currentMeta = getCurrentPostAttribute( 'meta' );
 		const status = getCurrentPostAttribute( 'status' );
-		const sentDate = 0 < meta.newsletter_sent ? new Date( meta.newsletter_sent * 1000 ) : null;
+		const sent = getCurrentPostAttribute( 'meta' ).newsletter_sent;
 		const settings = getSettings();
 		const experimentalSettingsColors = get( settings, [
 			'__experimentalFeatures',
@@ -60,7 +59,7 @@ const Editor = compose( [
 				{}
 			),
 			status,
-			sentDate,
+			sent,
 			isPublic: meta.is_public,
 			html: meta[ window.newspack_email_editor_data.email_html_meta ],
 		};
@@ -130,8 +129,9 @@ const Editor = compose( [
 	}, [ props.isReady ] );
 
 	useEffect( () => {
-		if ( props.sentDate && ! props.isPublishingOrSavingPost ) {
-			const dateTime = props.sentDate ? props.sentDate.toLocaleString() : '';
+		if ( props.sent ) {
+			const sentDate = 0 < props.sent ? new Date( props.sent * 1000 ) : null;
+			const dateTime = sentDate ? sentDate.toLocaleString() : '';
 
 			// Lock autosaving after a newsletter is sent.
 			props.lockPostAutosaving();
@@ -141,7 +141,7 @@ const Editor = compose( [
 				isDismissible: false,
 			} );
 		}
-	}, [ props.status ] );
+	}, [ props.sent ] );
 
 	// Notify if email content is larger than ~100kb.
 	useEffect( () => {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR refactors how the plugin handles sending Newsletters on status changes by moving the hook to the abstract class, avoiding duplicate logic for improved readability and maintenance. It also simplifies each provider's `send()` method to only perform the send action and return `true|WP_Error`  to be handled by the `send_newsletter()` abstract class method.

The hook was changed from `post_status_changes` to `pre_post_update` so it can prevent the status change in case of a failed send. The current method requires a `wp_update_post()` to revert the post back to draft, which is not ideal.

The new `pre_post_update()` hooked method also verifies if a sent newsletter is changing status after being sent and prevents such action - unless it's changing to/from trash, which it should always allow.

With the plan of detaching the post status value to the newsletter "sent" status in mind, this PR also implements the `newsletter_sent` meta. It's populated with a timestamp in case the final provider `send()` method succeeds but also has backward compatibility, being populated with the `post_date` if the newsletter is `publish`.

By using the meta, changing a trashed sent newsletter to publish will not trigger a send attempt. A hook also ensures that restoring a trashed sent newsletter automatically moves it to publish instead of the default "draft" (closes #785)

### How to test the changes in this Pull Request:

1. Send a newsletter using each provider and confirm you receive the email and it's marked as sent as expected. (Constant Contact is currently unavailable due to #802)
2. Using the "Quick edit", attempt to modify a sent newsletter status to "Draft" and confirm you see an appropriate error message
3. Confirm you are able to move newsletters to the trash (sent or drafts)
4. Restore a trashed sent newsletter and confirm its status is `publish`
5. Restore a trashed draft newsletter and confirm its status is `draft`

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
