### PR TITLE
fix: api middleware execution logic

### DIFF
--- a/src/editor/api/index.js
+++ b/src/editor/api/index.js
@@ -9,7 +9,6 @@ import mjml2html from 'mjml-browser';
  */
 import apiFetch from '@wordpress/api-fetch';
 import { select as globalSelect } from '@wordpress/data';
-import { NEWSLETTER_CPT_SLUG } from '../../utils/consts';
 
 const POST_META_WHITELIST = [
 	'is_public',
@@ -29,54 +28,67 @@ const POST_META_WHITELIST = [
  */
 apiFetch.use( async ( options, next ) => {
 	const { method, path, data = {} } = options;
-	if (
-		path.indexOf( NEWSLETTER_CPT_SLUG ) > 0 &&
-		data.content &&
-		data.id &&
-		( method === 'POST' || method === 'PUT' )
-	) {
-		const emailHTMLMetaName = window.newspack_email_editor_data.email_html_meta;
-		const mjmlHandlingPostTypes = window.newspack_email_editor_data.mjml_handling_post_types;
-		const editorSelector = globalSelect( 'core/editor' );
-		const postType = editorSelector.getCurrentPostType();
-		if ( ! includes( mjmlHandlingPostTypes, postType ) ) {
-			return next( options );
-		}
 
-		// Strip the meta which will be updated explicitly from post update payload.
-		options.data.meta = omit( options.data.meta, [ ...POST_META_WHITELIST, emailHTMLMetaName ] );
-
-		// First, save post meta. It is not saved when saving a draft, so
-		// it's saved here in order for the backend to have access to these.
-		const postMeta = editorSelector.getEditedPostAttribute( 'meta' );
-		await apiFetch( {
-			data: { meta: pick( postMeta, POST_META_WHITELIST ) },
-			method: 'POST',
-			path: `/wp/v2/${ postType }/${ data.id }`,
-		} );
-
-		// Then, send the content over to the server to convert the post content
-		// into MJML markup.
-		return apiFetch( {
-			path: `/newspack-newsletters/v1/post-mjml`,
-			method: 'POST',
-			data: {
-				post_id: data.id,
-				title: data.title,
-				content: data.content,
-			},
-		} )
-			.then( ( { mjml } ) => {
-				// Once received MJML markup, convert it to email-compliant HTML
-				// and save as post meta for later retrieval.
-				const { html } = mjml2html( mjml, { keepComments: false, minify: true } );
-				return apiFetch( {
-					data: { meta: { [ emailHTMLMetaName ]: html } },
-					method: 'POST',
-					path: `/wp/v2/${ postType }/${ data.id }`,
-				} );
-			} )
-			.then( () => next( options ) ); // Proceed with the post update request.
+	// Only run in update request.
+	if ( method !== 'POST' && method !== 'PUT' ) {
+		return next( options );
 	}
-	return next( options );
+
+	// Only run if the update contains the newsletter content.
+	if ( ! data.content || ! data.id ) {
+		return next( options );
+	}
+
+	const mjmlHandlingPostTypes = window.newspack_email_editor_data.mjml_handling_post_types;
+
+	// Only run if the request is for a post type that is handled by MJML.
+	if ( ! mjmlHandlingPostTypes.some( postType => path.indexOf( postType ) !== -1 ) ) {
+		return next( options );
+	}
+
+	const editorSelector = globalSelect( 'core/editor' );
+	const postType = editorSelector.getCurrentPostType();
+
+	// Only run if the current post type is allowed to be handled by MJML.
+	if ( ! includes( mjmlHandlingPostTypes, postType ) ) {
+		return next( options );
+	}
+
+	const emailHTMLMetaName = window.newspack_email_editor_data.email_html_meta;
+	// Strip the meta which will be updated explicitly from post update payload.
+	if ( options.data.meta ) {
+		options.data.meta = omit( options.data.meta, [ ...POST_META_WHITELIST, emailHTMLMetaName ] );
+	}
+
+	// First, save post meta. It is not saved when saving a draft, so
+	// it's saved here in order for the backend to have access to these.
+	const postMeta = editorSelector.getEditedPostAttribute( 'meta' );
+	await apiFetch( {
+		data: { meta: pick( postMeta, POST_META_WHITELIST ) },
+		method: 'POST',
+		path: `/wp/v2/${ postType }/${ data.id }`,
+	} );
+
+	// Then, send the content over to the server to convert the post content
+	// into MJML markup.
+	const { mjml } = await apiFetch( {
+		path: `/newspack-newsletters/v1/post-mjml`,
+		method: 'POST',
+		data: {
+			post_id: data.id,
+			title: data.title,
+			content: data.content,
+		},
+	} );
+
+	// Once received MJML markup, convert it to email-compliant HTML
+	// and save as post meta for later retrieval.
+	const { html } = mjml2html( mjml, { keepComments: false, minify: true } );
+	await apiFetch( {
+		data: { meta: { [ emailHTMLMetaName ]: html } },
+		method: 'POST',
+		path: `/wp/v2/${ postType }/${ data.id }`,
+	} );
+
+	return next( options ); // Proceed with the post update request.
 } );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

#754 introduced a couple of bugs to the API middleware for handling MJML updates:

1. A logic error caused #816, not allowing other post meta - outside of newsletters meta - to be updated.
2. Using only `NEWSLETTER_CPT_SLUG` to filter out requests from the middleware breaks the support for Reader Revenue emails and other CPTs that may use the editor

This PR fixes the logic issue and ensures that requests from any of the `mjmlHandlingPostTypes` go through the middleware:

https://github.com/Automattic/newspack-newsletters/blob/0c349a4942a03efabb2acef0da7f36c9e3b83769/src/editor/api/index.js#L44-L47

It also refactors to exit early for better readability and to follow the standard practice across the plugin. It also removes promises to consolidate the use of async/await.

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes #816

### How to test the changes in this Pull Request:

1. On the master branch, confirm the existing bugs:
   1. on a draft newsletter, attempt to save a Yoast meta, refresh the page and confirm the meta is not saved
   2. on the Reader Revenue > Emails, edit the email and confirm the changes are not applied by either inspecting the `XHR` requests and confirming that no requests to the `post-mjml` endpoint were made or making and donation and confirming you've received the outdated message
2. Check out this branch, repeat the above steps, and confirm they are resolved
3. Create a new newsletter, edit, send and confirm you receive the email and the middleware continues to behave as expected
4. Confirm #607 is also not reproducible

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
