### PR TITLE
fix: allow Co-Authors Plus assets on editor

### DIFF
--- a/includes/class-newspack-newsletters-editor.php
+++ b/includes/class-newspack-newsletters-editor.php
@@ -133,13 +133,25 @@ final class Newspack_Newsletters_Editor {
 			return;
 		}
 
+		$allowed_actions = [
+			__CLASS__ . '::enqueue_block_editor_assets',
+			'newspack_enqueue_scripts',
+			'wp_enqueue_editor_format_library_assets',
+		];
+
+		if ( isset( $GLOBALS['coauthors_plus'] ) ) {
+			$hash              = spl_object_hash( $GLOBALS['coauthors_plus'] );
+			$allowed_actions[] = $hash . 'enqueue_sidebar_plugin_assets';
+		}
+
+		/**
+		 * Filters allowed 'enqueue_block_editor_assets' actions inside a newsletter editor.
+		 *
+		 * @param string[] $allowed_actions Array of allowed actions.
+		 */
 		$allowed_actions = apply_filters(
 			'newspack_newsletters_allowed_editor_actions',
-			[
-				__CLASS__ . '::enqueue_block_editor_assets',
-				'newspack_enqueue_scripts',
-				'wp_enqueue_editor_format_library_assets',
-			]
+			$allowed_actions
 		);
 
 		$enqueue_block_editor_assets_filters = $GLOBALS['wp_filter']['enqueue_block_editor_assets']->callbacks;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Enable CoAuthors Plus functionality by allowing Co-Authors Plus editor assets to be enqueued on the newsletter editor.

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes #805 

### How to test the changes in this Pull Request:

1. Instal Co-Authors Plus, add a new guest author, check out this branch and create a new newsletter draft
2. Confirm you see the Co-Authors Plus settings on the editor sidebar
3. Add the guest author and save the draft
4. Refresh the editor and confirm the guest author is saved

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
