### PR TITLE
fix: sending scheduled newsletters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [1.46.1-hotfix.1](https://github.com/Automattic/newspack-newsletters/compare/v1.46.0...v1.46.1-hotfix.1) (2022-05-25)
+
+
+### Bug Fixes
+
+* sending scheduled newsletters ([2a25225](https://github.com/Automattic/newspack-newsletters/commit/2a25225f79e032ae454fe3e47fd40708f3b8c6e9))
+
 # [1.46.0](https://github.com/Automattic/newspack-newsletters/compare/v1.45.0...v1.46.0) (2022-05-18)
 
 

--- a/includes/class-newspack-newsletters.php
+++ b/includes/class-newspack-newsletters.php
@@ -1300,6 +1300,10 @@ final class Newspack_Newsletters {
 	 * @return false|int False if not sent, or timestamp of when it was sent.
 	 */
 	public static function is_newsletter_sent( $post_id ) {
+		$scheduling_error = get_transient( sprintf( 'newspack_newsletters_scheduling_error_%s', $post_id ) );
+		if ( $scheduling_error ) {
+			return false;
+		}
 		$sent = get_post_meta( $post_id, 'newsletter_sent', true );
 		if ( 0 < $sent ) {
 			return $sent;

--- a/includes/service-providers/class-newspack-newsletters-service-provider.php
+++ b/includes/service-providers/class-newspack-newsletters-service-provider.php
@@ -43,6 +43,7 @@ abstract class Newspack_Newsletters_Service_Provider implements Newspack_Newslet
 			add_action( 'rest_api_init', [ $this->controller, 'register_routes' ] );
 		}
 		add_action( 'pre_post_update', [ $this, 'pre_post_update' ], 10, 2 );
+		add_action( 'transition_post_status', [ $this, 'transition_post_status' ], 10, 3 );
 		add_filter( 'wp_insert_post_data', [ $this, 'insert_post_data' ], 10, 2 );
 	}
 
@@ -110,12 +111,46 @@ abstract class Newspack_Newsletters_Service_Provider implements Newspack_Newslet
 		}
 
 		// Send if changing from any status to publish.
-		if ( 'publish' === $new_status && 'publish' !== $old_status ) {
+		if ( ! $sent && 'publish' === $new_status && 'publish' !== $old_status ) {
 			$result = $this->send_newsletter( $post );
 			if ( is_wp_error( $result ) ) {
 				$transient = sprintf( 'newspack_newsletters_error_%s_%s', $post->ID, get_current_user_id() );
 				set_transient( $transient, $result->get_error_message(), 45 );
 				wp_die( $result ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+			}
+		}
+	}
+
+	/**
+	 * Handle post status transition for scheduled newsletters.
+	 *
+	 * This is executed after the post is updated.
+	 *
+	 * Scheduling a post (future -> publish) does not trigger the
+	 * `pre_post_update` action hook because it uses the `wp_publish_post()`
+	 * function. Unfortunately, this function does not fire any action hook prior
+	 * to updating the post, so, for this case, we need to handle sending after
+	 * the post is published.
+	 *
+	 * @param string  $new_status New post status.
+	 * @param string  $old_status Old post status.
+	 * @param WP_Post $post       Post object.
+	 */
+	public function transition_post_status( $new_status, $old_status, $post ) {
+		if ( 'publish' === $new_status && 'future' === $old_status ) {
+			$result              = $this->send_newsletter( $post );
+			$error_transient_key = sprintf( 'newspack_newsletters_scheduling_error_%s', $post->ID );
+			if ( is_wp_error( $result ) ) {
+				set_transient( $error_transient_key, $result->get_error_message() );
+				wp_update_post(
+					[
+						'ID'          => $post->ID,
+						'post_status' => 'draft',
+					] 
+				);
+				wp_die( $result ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+			} else {
+				delete_transient( $error_transient_key );
 			}
 		}
 	}

--- a/newspack-newsletters.php
+++ b/newspack-newsletters.php
@@ -6,7 +6,7 @@
  * Author:          Automattic
  * Text Domain:     newspack-newsletters
  * Domain Path:     /languages
- * Version:         1.46.0
+ * Version:         1.46.1-hotfix.1
  *
  * @package         Newspack_Newsletters
  */

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "newspack-newsletters",
-	"version": "1.46.0",
+	"version": "1.46.1-hotfix.1",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "newspack-newsletters",
-			"version": "1.46.0",
+			"version": "1.46.1-hotfix.1",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@uiw/react-codemirror": "^3.2.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "newspack-newsletters",
-	"version": "1.46.0",
+	"version": "1.46.1-hotfix.1",
 	"description": "",
 	"scripts": {
 		"cm": "newspack-scripts commit",

--- a/src/components/send-button/index.js
+++ b/src/components/send-button/index.js
@@ -133,7 +133,7 @@ export default compose( [
 				? __( 'Mark as sent and publish', 'newspack-newsletters' )
 				: __( 'Mark as sent', 'newspack-newsletters' );
 		} else {
-			modalSubmitLabel = __( 'Send', 'newspack-newsletters' );
+			modalSubmitLabel = label;
 		}
 
 		useEffect( () => {

--- a/src/service-providers/constant_contact/index.js
+++ b/src/service-providers/constant_contact/index.js
@@ -51,7 +51,7 @@ const renderPreSendInfo = newsletterData => {
 
 	return (
 		<p>
-			{ __( "You're about to send a newsletter to:", 'newspack-newsletters' ) }
+			{ __( "You're sending a newsletter to:", 'newspack-newsletters' ) }
 			<br />
 			<strong>{ campaignLists.map( list => list.name ).join( ', ' ) }</strong>
 			<br />

--- a/src/service-providers/mailchimp/index.js
+++ b/src/service-providers/mailchimp/index.js
@@ -67,7 +67,7 @@ const renderPreSendInfo = newsletterData => {
 
 	return (
 		<p>
-			{ __( "You're about to send a newsletter to:", 'newspack-newsletters' ) }
+			{ __( "You're sending a newsletter to:", 'newspack-newsletters' ) }
 			<br />
 			<strong>{ listData.name }</strong>
 			<br />


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

The refactor from #798 was missing the integration with scheduled posts. WP scheduling uses `wp_publish_post()`, which does not fire `pre_post_update` or any other hook before updating the database 😢 

This requires us to use a hook after the post is published (`transition_post_status`) to handle sending scheduled newsletters.

This PR implements that case and also updates some phrasing on the UI. The sending confirmation modal for scheduled newsletters should state "Schedule newsletter" instead of "Send".

The error handling of scheduled newsletters should later be adjusted, along with the other error transients, to have a better UI integration. Currently it only serves to allow the failed send to return to draft after publishing. It should properly display the error message regardless of current user ID or a time frame, which is how the transients are currently implemented.

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

### How to test the changes in this Pull Request:

1. Check out this branch and set up a valid ESP
2. Start a new newsletter and click to send without scheduling
5. Confirm the modal have appropriate messaging and close
4. Schedule the newsletter for a couple of minutes from now and click to schedule sending
5. Confirm the modal have appropriate messaging and confirm the scheduled sending
7. After the scheduled time passes, confirm the newsletter is sent and marked as sent on your dashboard
8. Simulate an error by adding `return new WP_Error( 'newspack_newsletters_error', 'Temporary error' );` to line 201 of `includes/service-providers/class-newspack-newsletters-service-provider.php`
9. Create a new newsletter, schedule the send and after the time passes confirm the newsletter is back to draft

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
