### PR TITLE
chore: restore code overwritten by release merge

### DIFF
--- a/includes/service-providers/class-newspack-newsletters-service-provider.php
+++ b/includes/service-providers/class-newspack-newsletters-service-provider.php
@@ -117,8 +117,13 @@ abstract class Newspack_Newsletters_Service_Provider implements Newspack_Newslet
 			wp_die( $error ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 		}
 
-		// Send if changing from any status to publish.
-		if ( ! $sent && 'publish' === $new_status && 'publish' !== $old_status ) {
+		// Send if changing from any status to controlled statuses - 'publish' or 'private'.
+		if (
+			! $sent &&
+			$old_status !== $new_status &&
+			in_array( $new_status, self::$controlled_statuses, true ) && 
+			! in_array( $old_status, self::$controlled_statuses, true )
+		) {
 			$result = $this->send_newsletter( $post );
 			if ( is_wp_error( $result ) ) {
 				$transient = sprintf( 'newspack_newsletters_error_%s_%s', $post->ID, get_current_user_id() );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

The release auto-merge has a very aggressive rule and overwrites `master` code. This PR restores some code removed from [the latest hotfix merge](https://github.com/Automattic/newspack-newsletters/commit/3ebe7dfea2602f98068319d67f879b3d97451f2d#diff-746392f50a90cb7179a3928b87ef9cc9d8062f62480df31e02293ad5527dc1f3).

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
