### PR TITLE
fix: ensure scheduled newsletter is sent through a lock meta

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [1.46.2-hotfix.1](https://github.com/Automattic/newspack-newsletters/compare/v1.46.1...v1.46.2-hotfix.1) (2022-05-26)
+
+
+### Bug Fixes
+
+* ensure scheduled newsletter is sent through a lock meta ([e5bcd89](https://github.com/Automattic/newspack-newsletters/commit/e5bcd89e3204f8df690709ad2b0c2b8563e983e8))
+
 ## [1.46.1](https://github.com/Automattic/newspack-newsletters/compare/v1.46.0...v1.46.1) (2022-05-25)
 
 

--- a/includes/class-newspack-newsletters.php
+++ b/includes/class-newspack-newsletters.php
@@ -1300,21 +1300,32 @@ final class Newspack_Newsletters {
 	 * @return false|int False if not sent, or timestamp of when it was sent.
 	 */
 	public static function is_newsletter_sent( $post_id ) {
+		/** Handle scheduled newsletter state. */
+		$sending_scheduled = get_post_meta( $post_id, 'sending_scheduled', true );
+		if ( $sending_scheduled ) {
+			return false;
+		}
+
+		/** Handle scheduled newsletter error. */
 		$scheduling_error = get_transient( sprintf( 'newspack_newsletters_scheduling_error_%s', $post_id ) );
 		if ( $scheduling_error ) {
 			return false;
 		}
+
+		/** Detect meta that determines the sent state */
 		$sent = get_post_meta( $post_id, 'newsletter_sent', true );
 		if ( 0 < $sent ) {
 			return $sent;
 		}
-		// Legacy for sent newsletters without meta.
+
+		/** Legacy check for sent/publish newsletters without meta. */
 		if ( 'publish' === get_post_status( $post_id ) ) {
 			$post = get_post( $post_id );
 			$sent = strtotime( $post->post_date );
 			self::set_newsletter_sent( $post_id, $sent );
 			return $sent;
 		}
+
 		return false;
 	}
 }

--- a/includes/service-providers/class-newspack-newsletters-service-provider.php
+++ b/includes/service-providers/class-newspack-newsletters-service-provider.php
@@ -138,6 +138,7 @@ abstract class Newspack_Newsletters_Service_Provider implements Newspack_Newslet
 	 */
 	public function transition_post_status( $new_status, $old_status, $post ) {
 		if ( 'publish' === $new_status && 'future' === $old_status ) {
+			update_post_meta( $post->ID, 'sending_scheduled', true );
 			$result              = $this->send_newsletter( $post );
 			$error_transient_key = sprintf( 'newspack_newsletters_scheduling_error_%s', $post->ID );
 			if ( is_wp_error( $result ) ) {
@@ -152,6 +153,7 @@ abstract class Newspack_Newsletters_Service_Provider implements Newspack_Newslet
 			} else {
 				delete_transient( $error_transient_key );
 			}
+			delete_post_meta( $post->ID, 'sending_scheduled' );
 		}
 	}
 

--- a/newspack-newsletters.php
+++ b/newspack-newsletters.php
@@ -6,7 +6,7 @@
  * Author:          Automattic
  * Text Domain:     newspack-newsletters
  * Domain Path:     /languages
- * Version:         1.46.1
+ * Version:         1.46.2-hotfix.1
  *
  * @package         Newspack_Newsletters
  */

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "newspack-newsletters",
-	"version": "1.46.1",
+	"version": "1.46.2-hotfix.1",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "newspack-newsletters",
-			"version": "1.46.1",
+			"version": "1.46.2-hotfix.1",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@uiw/react-codemirror": "^3.2.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "newspack-newsletters",
-	"version": "1.46.1",
+	"version": "1.46.2-hotfix.1",
 	"description": "",
 	"scripts": {
 		"cm": "newspack-scripts commit",


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Sending scheduled newsletters is still not working appropriately due to how we approach the `is_newsletter_sent()` method. For legacy reasons, it has to assume that `publish` newsletters are sent. By the time `send_newsletter()` checks that on scheduled newsletters, WP scheduling has already called `wp_publish_post()`, so our check method will assume the newsletter is sent and bail.

This PR implements a lock mechanism through a disposable meta, just to guarantee that the scheduled sending window goes through the legacy check.

### How to test the changes in this Pull Request:

Repeat steps from #831 and confirm the newsletter is sent from the ESP dashboard.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
