### PR TITLE
fix: ensure scheduled sending only fires for newsletters

### DIFF
--- a/includes/service-providers/class-newspack-newsletters-service-provider.php
+++ b/includes/service-providers/class-newspack-newsletters-service-provider.php
@@ -137,6 +137,16 @@ abstract class Newspack_Newsletters_Service_Provider implements Newspack_Newslet
 	 * @param WP_Post $post       Post object.
 	 */
 	public function transition_post_status( $new_status, $old_status, $post ) {
+		// Only run if it's a newsletter post.
+		if ( ! Newspack_Newsletters::validate_newsletter_id( $post->ID ) ) {
+			return;
+		}
+
+		// Only run if this is the active provider.
+		if ( Newspack_Newsletters::service_provider() !== $this->service ) {
+			return;
+		}
+
 		if ( 'publish' === $new_status && 'future' === $old_status ) {
 			update_post_meta( $post->ID, 'sending_scheduled', true );
 			$result              = $this->send_newsletter( $post );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

The recently implemented hotfix for scheduled newsletters is being executed for all posts. This PR ensures to only execute for newsletters.

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

### How to test the changes in this Pull Request:

1. Schedule a regular post and confirm it publishes at the appropriate time
2. Schedule a new newsletter send and confirm it sends at the appropriate time
3. Confirm on your ESP dashboard that the post is not stored as a newsletter draft and the scheduled newsletter is sent

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
