### PR TITLE
feat: active campaign segments support

### DIFF
--- a/includes/class-newspack-newsletters-layouts.php
+++ b/includes/class-newspack-newsletters-layouts.php
@@ -209,9 +209,13 @@ final class Newspack_Newsletters_Layouts {
 		foreach ( scandir( $layouts_base_path ) as $layout ) {
 			if ( strpos( $layout, '.json' ) !== false ) {
 				$decoded_layout  = json_decode( file_get_contents( $layouts_base_path . $layout, true ) ); //phpcs:ignore
-				$layouts[]      = array(
+				$title          = '';
+				if ( property_exists( $decoded_layout, 'title' ) ) {
+					$title = $decoded_layout->title;
+				}
+				$layouts[] = array(
 					'ID'           => $layout_id,
-					'post_title'   => $decoded_layout->title,
+					'post_title'   => $title,
 					'post_content' => self::layout_token_replacement( $decoded_layout->content ),
 				);
 				$layout_id++;

--- a/includes/service-providers/active_campaign/class-newspack-newsletters-active-campaign-controller.php
+++ b/includes/service-providers/active_campaign/class-newspack-newsletters-active-campaign-controller.php
@@ -44,6 +44,21 @@ class Newspack_Newsletters_Active_Campaign_Controller extends Newspack_Newslette
 		);
 		\register_meta(
 			'post',
+			'ac_segment_id',
+			[
+				'object_subtype' => Newspack_Newsletters::NEWSPACK_NEWSLETTERS_CPT,
+				'show_in_rest'   => [
+					'schema' => [
+						'context' => [ 'edit' ],
+					],
+				],
+				'type'           => 'string',
+				'single'         => true,
+				'auth_callback'  => '__return_true',
+			]
+		);
+		\register_meta(
+			'post',
 			'ac_from_name',
 			[
 				'object_subtype' => Newspack_Newsletters::NEWSPACK_NEWSLETTERS_CPT,

--- a/includes/service-providers/active_campaign/class-newspack-newsletters-active-campaign.php
+++ b/includes/service-providers/active_campaign/class-newspack-newsletters-active-campaign.php
@@ -307,7 +307,14 @@ final class Newspack_Newsletters_Active_Campaign extends \Newspack_Newsletters_S
 		if ( ! is_wp_error( $delete_res ) ) {
 			delete_post_meta( $post_id, 'ac_test_campaign', $campaign['id'] );
 		}
-		return $test_result;
+		return [
+			'message' => sprintf(
+				// translators: %s are comma-separated emails.
+				__( 'ActiveCampaign test message sent successfully to %s.', 'newspack-newsletters' ),
+				implode( ', ', $emails )
+			),
+			'result'  => $test_result,
+		];
 	}
 
 	/**

--- a/includes/service-providers/active_campaign/class-newspack-newsletters-active-campaign.php
+++ b/includes/service-providers/active_campaign/class-newspack-newsletters-active-campaign.php
@@ -281,7 +281,11 @@ final class Newspack_Newsletters_Active_Campaign extends \Newspack_Newsletters_S
 				__( 'ActiveCampaign API credentials are missing.', 'newspack-newsletters' )
 			);
 		}
-		$post = get_post( $post_id );
+		$post        = get_post( $post_id );
+		$sync_result = $this->sync( $post );
+		if ( is_wp_error( $sync_result ) ) {
+			return \rest_ensure_response( $sync_result );
+		}
 		/** Create disposable campaign for sending a test. */
 		$campaign_name = sprintf( 'Test for %s', $this->get_campaign_name( $post ) );
 		$campaign      = $this->create_campaign( get_post( $post_id ), $campaign_name );

--- a/includes/service-providers/active_campaign/class-newspack-newsletters-active-campaign.php
+++ b/includes/service-providers/active_campaign/class-newspack-newsletters-active-campaign.php
@@ -281,6 +281,16 @@ final class Newspack_Newsletters_Active_Campaign extends \Newspack_Newsletters_S
 				__( 'ActiveCampaign API credentials are missing.', 'newspack-newsletters' )
 			);
 		}
+		/** Clear existing test campaigns for this post. */
+		$test_campaigns = get_post_meta( $post_id, 'ac_test_campaign' );
+		if ( ! empty( $test_campaigns ) ) {
+			foreach ( $test_campaigns as $test_campaign_id ) {
+				$delete_res = $this->delete_campaign( $test_campaign_id, true );
+				if ( ! is_wp_error( $delete_res ) ) {
+					delete_post_meta( $post_id, 'ac_test_campaign', $test_campaign_id );
+				}
+			}
+		}
 		$post        = get_post( $post_id );
 		$sync_result = $this->sync( $post );
 		if ( is_wp_error( $sync_result ) ) {
@@ -306,11 +316,6 @@ final class Newspack_Newsletters_Active_Campaign extends \Newspack_Newsletters_S
 				],
 			]
 		);
-		/** Delete the disposable campaign. */
-		$delete_res = $this->delete_campaign( $campaign['id'], true );
-		if ( ! is_wp_error( $delete_res ) ) {
-			delete_post_meta( $post_id, 'ac_test_campaign', $campaign['id'] );
-		}
 		return [
 			'message' => sprintf(
 				// translators: %s are comma-separated emails.
@@ -350,17 +355,6 @@ final class Newspack_Newsletters_Active_Campaign extends \Newspack_Newsletters_S
 				'newspack_newsletter_error',
 				__( 'The newsletter subject cannot be empty.', 'newspack-newsletters' )
 			);
-		}
-
-		/** Clear existing test campaigns for this post. */
-		$test_campaigns = get_post_meta( $post->ID, 'ac_test_campaign' );
-		if ( ! empty( $test_campaigns ) ) {
-			foreach ( $test_campaigns as $test_campaign_id ) {
-				$delete_res = $this->delete_campaign( $test_campaign_id );
-				if ( ! is_wp_error( $delete_res ) ) {
-					delete_post_meta( $post->ID, 'ac_test_campaign', $test_campaign_id );
-				}
-			}
 		}
 
 		$from_name  = get_post_meta( $post->ID, 'ac_from_name', true );
@@ -528,6 +522,16 @@ final class Newspack_Newsletters_Active_Campaign extends \Newspack_Newsletters_S
 		$campaign_id = get_post_meta( $post_id, 'ac_campaign_id', true );
 		if ( $campaign_id ) {
 			$this->delete_campaign( $campaign_id, true );
+		}
+		/** Clean up existing test campaigns. */
+		$test_campaigns = get_post_meta( $post_id, 'ac_test_campaign' );
+		if ( ! empty( $test_campaigns ) ) {
+			foreach ( $test_campaigns as $test_campaign_id ) {
+				$delete_res = $this->delete_campaign( $test_campaign_id, true );
+				if ( ! is_wp_error( $delete_res ) ) {
+					delete_post_meta( $post_id, 'ac_test_campaign', $test_campaign_id );
+				}
+			}
 		}
 		/** Create new campaign for sending. */
 		$campaign = $this->create_campaign( $post );

--- a/includes/service-providers/active_campaign/class-newspack-newsletters-active-campaign.php
+++ b/includes/service-providers/active_campaign/class-newspack-newsletters-active-campaign.php
@@ -20,7 +20,6 @@ final class Newspack_Newsletters_Active_Campaign extends \Newspack_Newsletters_S
 		$this->controller = new Newspack_Newsletters_Active_Campaign_Controller( $this );
 
 		add_action( 'save_post_' . Newspack_Newsletters::NEWSPACK_NEWSLETTERS_CPT, [ $this, 'save' ], 10, 3 );
-		add_action( 'transition_post_status', [ $this, 'send' ], 10, 3 );
 		add_action( 'wp_trash_post', [ $this, 'trash' ], 10, 1 );
 
 		parent::__construct( $this );

--- a/includes/service-providers/active_campaign/class-newspack-newsletters-active-campaign.php
+++ b/includes/service-providers/active_campaign/class-newspack-newsletters-active-campaign.php
@@ -303,7 +303,7 @@ final class Newspack_Newsletters_Active_Campaign extends \Newspack_Newsletters_S
 			]
 		);
 		/** Delete the disposable campaign. */
-		$delete_res = $this->delete_campaign( $campaing['id'], true );
+		$delete_res = $this->delete_campaign( $campaign['id'], true );
 		if ( ! is_wp_error( $delete_res ) ) {
 			delete_post_meta( $post_id, 'ac_test_campaign', $campaign['id'] );
 		}

--- a/includes/service-providers/active_campaign/class-newspack-newsletters-active-campaign.php
+++ b/includes/service-providers/active_campaign/class-newspack-newsletters-active-campaign.php
@@ -236,7 +236,7 @@ final class Newspack_Newsletters_Active_Campaign extends \Newspack_Newsletters_S
 		$list_id     = get_post_meta( $post_id, 'ac_list_id', true );
 		$segment_id  = get_post_meta( $post_id, 'ac_segment_id', true );
 		$result      = [
-			'campaign'    => (bool) $campaign_id, // Whether campaign exists, to satisfy the JS API. 
+			'campaign'    => (bool) $campaign_id, // Whether campaign exists, to satisfy the JS API.
 			'campaign_id' => $campaign_id,
 			'from_name'   => $from_name,
 			'from_email'  => $from_email,
@@ -297,7 +297,7 @@ final class Newspack_Newsletters_Active_Campaign extends \Newspack_Newsletters_S
 					'messageid'  => $sync_result['message_id'],
 					'email'      => implode( ',', $emails ),
 				],
-			] 
+			]
 		);
 		return $test_result;
 	}
@@ -337,17 +337,14 @@ final class Newspack_Newsletters_Active_Campaign extends \Newspack_Newsletters_S
 
 		$message_action = 'message_add';
 		$message_data   = [];
-		$campaign_data  = [];
-		$campaign       = null;
 
 		if ( $message_id ) {
 			$message = $this->api_v1_request( 'message_view', 'GET', [ 'query' => [ 'id' => $message_id ] ] );
 			if ( is_wp_error( $message ) ) {
 				return $message;
 			}
-			$message_action      = 'message_edit';
-			$message_data['id']  = $message['id'];
-			$campaign_data['id'] = $campaign['id'];
+			$message_action     = 'message_edit';
+			$message_data['id'] = $message['id'];
 
 			// If sender data is not available locally, update from ESP.
 			if ( ! $from_name || ! $from_email ) {
@@ -355,12 +352,6 @@ final class Newspack_Newsletters_Active_Campaign extends \Newspack_Newsletters_S
 				$from_email = $message['fromemail'];
 				update_post_meta( $post->ID, 'ac_from_name', $from_name );
 				update_post_meta( $post->ID, 'ac_from_email', $from_email );
-			}
-
-			// If list is not available locally, update from ESP.
-			if ( ! $list_id ) {
-				$list_id = $campaign['lists'][0]['id'];
-				update_post_meta( $post->ID, 'ac_list_id', $list_id );
 			}
 		} else {
 			// Validate required meta if campaign and message are not yet created.
@@ -449,20 +440,17 @@ final class Newspack_Newsletters_Active_Campaign extends \Newspack_Newsletters_S
 		 * Create campaign if it doesn't exist yet.
 		 */
 		if ( ! $campaign_id ) {
-			$campaign_data = wp_parse_args(
-				[
-					'type'                               => 'single',
-					'status'                             => 0, // 0 = Draft; 1 = Scheduled.
-					'public'                             => (int) $is_public,
-					'name'                               => $this->get_campaign_name( $post ),
-					'fromname'                           => $sync_result['from_name'],
-					'fromemail'                          => $sync_result['from_email'],
-					'segmentid'                          => $segment_id ?? 0, // 0 = No segment. 
-					'p[' . $sync_result['list_id'] . ']' => 1,
-					'm[' . $sync_result['message_id'] . ']' => 1,
-				],
-				$campaign_data
-			);
+			$campaign_data = [
+				'type'                                  => 'single',
+				'status'                                => 0, // 0 = Draft; 1 = Scheduled.
+				'public'                                => (int) $is_public,
+				'name'                                  => $this->get_campaign_name( $post ),
+				'fromname'                              => $sync_result['from_name'],
+				'fromemail'                             => $sync_result['from_email'],
+				'segmentid'                             => $segment_id ?? 0, // 0 = No segment.
+				'p[' . $sync_result['list_id'] . ']'    => 1,
+				'm[' . $sync_result['message_id'] . ']' => 1,
+			];
 			$campaign      = $this->api_v1_request( 'campaign_create', 'POST', [ 'body' => $campaign_data ] );
 			if ( is_wp_error( $campaign ) ) {
 				// Remove hold in case of creation error.
@@ -490,7 +478,7 @@ final class Newspack_Newsletters_Active_Campaign extends \Newspack_Newsletters_S
 					'status' => 1,
 					'sdate'  => $schedule_date->format( 'Y-m-d H:i:s' ),
 				],
-			] 
+			]
 		);
 		if ( is_wp_error( $send_result ) ) {
 			return $send_result;

--- a/includes/service-providers/active_campaign/class-newspack-newsletters-active-campaign.php
+++ b/includes/service-providers/active_campaign/class-newspack-newsletters-active-campaign.php
@@ -435,6 +435,7 @@ final class Newspack_Newsletters_Active_Campaign extends \Newspack_Newsletters_S
 
 		$campaign_id = get_post_meta( $post_id, 'ac_campaign_id', true );
 		$segment_id  = get_post_meta( $post->ID, 'ac_segment_id', true );
+		$is_public   = get_post_meta( $post->ID, 'is_public', true );
 
 		$sync_result = $this->sync( $post );
 		if ( is_wp_error( $sync_result ) ) {
@@ -452,7 +453,7 @@ final class Newspack_Newsletters_Active_Campaign extends \Newspack_Newsletters_S
 				'name'                                  => $this->get_campaign_name( $post ),
 				'fromname'                              => $sync_result['from_name'],
 				'fromemail'                             => $sync_result['from_email'],
-				'segmentid'                             => $segment_id ?? 0, // 0 = No segment.
+				'segmentid'                             => $is_public ?? 0, // 0 = No segment.
 				'p[' . $sync_result['list_id'] . ']'    => 1,
 				'm[' . $sync_result['message_id'] . ']' => 1,
 			];

--- a/src/service-providers/active_campaign/ProviderSidebar.js
+++ b/src/service-providers/active_campaign/ProviderSidebar.js
@@ -63,7 +63,8 @@ const ProviderSidebarComponent = ( {
 } ) => {
 	const [ isLoading, setIsLoading ] = useState( false );
 	const [ lists, setLists ] = useState( [] );
-	const { listId, senderName, senderEmail } = acData;
+	const [ segments, setSegments ] = useState( [] );
+	const { listId, segmentId, senderName, senderEmail } = acData;
 
 	useEffect( () => {
 		fetchListsAndSegments();
@@ -76,6 +77,7 @@ const ProviderSidebarComponent = ( {
 				path: `/newspack-newsletters/v1/active_campaign/${ postId }/retrieve`,
 			} );
 			setLists( response.lists );
+			setSegments( response.segments );
 		} catch ( e ) {
 			createErrorNotice(
 				e.message || __( 'Error retrieving campaign information.', 'newspack-newsletters' )
@@ -89,6 +91,7 @@ const ProviderSidebarComponent = ( {
 			...newsletterData,
 			lists,
 			list_id: listId,
+			segment_id: segmentId,
 			from_email: senderEmail,
 			from_name: senderName,
 			campaign: true,
@@ -138,13 +141,12 @@ const ProviderSidebarComponent = ( {
 			</strong>
 			<BaseControl className="newspack-newsletters__list-select">
 				<SelectControl
-					className="newspack-newsletters__campaign-monitor-send-to"
 					label={ __( 'To', 'newspack-newsletters' ) }
 					value={ listId }
 					options={ [
 						{
 							value: '',
-							label: __( '-- Select a subscriber list --', 'newspack-newsletters' ),
+							label: __( '-- Select a list --', 'newspack-newsletters' ),
 						},
 						...lists.map( ( { id, name } ) => ( {
 							value: id,
@@ -154,6 +156,24 @@ const ProviderSidebarComponent = ( {
 					onChange={ value => updateMetaValue( 'ac_list_id', value ) }
 					disabled={ isLoading }
 				/>
+				{ listId && (
+					<SelectControl
+						label={ __( 'Segment', 'newspack-newsletters' ) }
+						value={ segmentId }
+						options={ [
+							{
+								value: '',
+								label: __( '-- Select a segment (optional) --', 'newspack-newsletters' ),
+							},
+							...segments.map( ( { id, name } ) => ( {
+								value: id,
+								label: name,
+							} ) ),
+						] }
+						onChange={ value => updateMetaValue( 'ac_segment_id', value ) }
+						disabled={ isLoading }
+					/>
+				) }
 				{ isLoading && <Spinner /> }
 			</BaseControl>
 		</div>
@@ -167,6 +187,7 @@ const mapStateToProps = select => {
 	return {
 		acData: {
 			listId: meta.ac_list_id,
+			segmentId: meta.ac_segment_id,
 			senderName: meta.ac_from_name,
 			senderEmail: meta.ac_from_email,
 		},

--- a/src/service-providers/active_campaign/index.js
+++ b/src/service-providers/active_campaign/index.js
@@ -52,8 +52,7 @@ const renderPreSendInfo = ( newsletterData = {} ) => {
 				<strong>{ list.name }</strong>
 				{ segment && (
 					<>
-						{ __( ', segmented to: ', 'newspack-newsletters' ) }
-						<strong> { segment.name }</strong>
+						{ __( ', segmented to:', 'newspack-newsletters' ) } <strong>{ segment.name }</strong>
 					</>
 				) }
 			</p>

--- a/src/service-providers/active_campaign/index.js
+++ b/src/service-providers/active_campaign/index.js
@@ -31,13 +31,14 @@ const getFetchDataConfig = ( { postId } ) => ( {
  * @return {any} A React component
  */
 const renderPreSendInfo = ( newsletterData = {} ) => {
-	const { list_id, lists } = newsletterData;
+	const { list_id, segment_id, lists, segments } = newsletterData;
 
 	if ( ! lists?.length ) {
 		return <Spinner />;
 	}
 
 	const list = lists.find( thisList => list_id === thisList.id );
+	const segment = segments?.find( thisSegment => segment_id === thisSegment.id );
 
 	if ( ! list ) return null;
 
@@ -47,8 +48,14 @@ const renderPreSendInfo = ( newsletterData = {} ) => {
 				{ __(
 					'You’re about to send an ActiveCampaign newsletter to the following list:',
 					'newspack-newsletters'
-				) }
+				) }{ ' ' }
 				<strong>{ list.name }</strong>
+				{ segment && (
+					<>
+						{ __( ', segmented to: ', 'newspack-newsletters' ) }
+						<strong> { segment.name }</strong>
+					</>
+				) }
 			</p>
 			<p>{ __( 'Are you sure you want to proceed?', 'newspack-newsletters' ) }</p>
 		</Fragment>


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Implements support for sending newsletters to Active Campaign's segments.

Active Campaign currently supports APIs v1 and v3 and to implement this feature we must use both versions. v1 does not have a method for fetching existing segments whereas v3 does not have a method to create campaigns. To handle that in an organized manner, `api_v1_request()` and `api_v3_request()` methods were implemented.

This ESP has campaigns and messages, a campaign can hold multiple messages and choose which message to send on the scheduling/sending action of the campaign. The current sync action creates a message and a campaign, attaching the message to the campaign. This is problematic because neither API (v1 or v3) has an endpoint for editing a campaign. Once a sync occurs with a specific target (sender and list) it cannot be edited through us.

This PR also changes this behavior to only sync the message while editing, the campaign is only created on sending. This fixes the issue by not having to edit a campaign prior to sending.

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes #812.

### How to test the changes in this Pull Request:

1. Connect to an existing Active Campaign account that has segments
2. Create a new newsletter and select a list and a segment to send to
3. Send and confirm on the ESP dashboard that it was sent to the selected list and segment

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
