### PR TITLE
fix: validate newsletter subject

### DIFF
--- a/includes/service-providers/active_campaign/class-newspack-newsletters-active-campaign.php
+++ b/includes/service-providers/active_campaign/class-newspack-newsletters-active-campaign.php
@@ -261,7 +261,7 @@ final class Newspack_Newsletters_Active_Campaign extends \Newspack_Newsletters_S
 	/**
 	 * Synchronize post with corresponding ESP campaign.
 	 *
-	 * @param WP_POST $post Post to synchronize.
+	 * @param WP_Post $post Post to synchronize.
 	 *
 	 * @return array|WP_Error Campaign data or error.
 	 */
@@ -270,6 +270,12 @@ final class Newspack_Newsletters_Active_Campaign extends \Newspack_Newsletters_S
 			return new \WP_Error(
 				'newspack_newsletters_active_campaign_api_credentials_missing',
 				__( 'ActiveCampaign API credentials are missing.', 'newspack-newsletters' )
+			);
+		}
+		if ( empty( $post->post_title ) ) {
+			return new WP_Error(
+				'newspack_newsletter_error',
+				__( 'The newsletter subject cannot be empty.', 'newspack-newsletters' )
 			);
 		}
 		$campaign_id = get_post_meta( $post->ID, 'ac_campaign_id', true );

--- a/includes/service-providers/campaign_monitor/class-newspack-newsletters-campaign-monitor.php
+++ b/includes/service-providers/campaign_monitor/class-newspack-newsletters-campaign-monitor.php
@@ -343,6 +343,12 @@ final class Newspack_Newsletters_Campaign_Monitor extends \Newspack_Newsletters_
 				__( 'No Campaign Monitor API key available.', 'newspack-newsletters' )
 			);
 		}
+		if ( empty( $post->post_title ) ) {
+			return new WP_Error(
+				'newspack_newsletter_error',
+				__( 'The newsletter subject cannot be empty.', 'newspack-newsletters' )
+			);
+		}
 		if ( ! $client_id ) {
 			return new WP_Error(
 				'newspack_newsletter_error',

--- a/includes/service-providers/constant_contact/class-newspack-newsletters-constant-contact.php
+++ b/includes/service-providers/constant_contact/class-newspack-newsletters-constant-contact.php
@@ -461,18 +461,26 @@ final class Newspack_Newsletters_Constant_Contact extends \Newspack_Newsletters_
 	/**
 	 * Synchronize post with corresponding ESP campaign.
 	 *
-	 * @param WP_POST $post Post to synchronize.
-	 * @return object|null API Response or error.
+	 * @param WP_Post $post Post to synchronize.
+	 *
+	 * @return object|WP_Error API Response or error.
+	 *
 	 * @throws Exception Error message.
 	 */
 	public function sync( $post ) {
-		$api_key = $this->api_key();
-		if ( ! $api_key ) {
-			throw new Exception(
-				__( 'No Constant Contact API key available.', 'newspack-newsletters' )
-			);
-		}
 		try {
+			$api_key = $this->api_key();
+			if ( ! $api_key ) {
+				throw new Exception(
+					__( 'No Constant Contact API key available.', 'newspack-newsletters' )
+				);
+			}
+			if ( empty( $post->post_title ) ) {
+				throw new Exception(
+					__( 'The newsletter subject cannot be empty.', 'newspack-newsletters' )
+				);
+			}
+
 			if ( ! $this->has_valid_connection() ) {
 				return;
 			}

--- a/includes/service-providers/interface-newspack-newsletters-esp-service.php
+++ b/includes/service-providers/interface-newspack-newsletters-esp-service.php
@@ -36,7 +36,8 @@ interface Newspack_Newsletters_ESP_API_Interface {
 	 *
 	 * @param string $post_id Campaign Id.
 	 * @param string $list_id ID of the list.
-	 * @return object|WP_Error API Response or error.
+	 *
+	 * @return array|WP_Error API Response or error.
 	 */
 	public function list( $post_id, $list_id );
 
@@ -44,17 +45,19 @@ interface Newspack_Newsletters_ESP_API_Interface {
 	 * Retrieve a campaign.
 	 *
 	 * @param integer $post_id Numeric ID of the Newsletter post.
-	 * @return object|WP_Error API Response or error.
+	 *
+	 * @return array|WP_Error API Response or error.
 	 */
 	public function retrieve( $post_id );
 
 	/**
 	 * Set sender data.
 	 *
-	 * @param string $post_id Numeric ID of the campaign.
+	 * @param string $post_id   Numeric ID of the campaign.
 	 * @param string $from_name Sender name.
-	 * @param string $reply_to Reply to email address.
-	 * @return object|WP_Error API Response or error.
+	 * @param string $reply_to  Reply to email address.
+	 *
+	 * @return array|WP_Error API Response or error.
 	 */
 	public function sender( $post_id, $from_name, $reply_to );
 
@@ -62,23 +65,25 @@ interface Newspack_Newsletters_ESP_API_Interface {
 	 * Send test email or emails.
 	 *
 	 * @param integer $post_id Numeric ID of the Newsletter post.
-	 * @param array   $emails Array of email addresses to send to.
-	 * @return object|WP_Error API Response or error.
+	 * @param array   $emails  Array of email addresses to send to.
+	 *
+	 * @return array|WP_Error API Response or error.
 	 */
 	public function test( $post_id, $emails );
 
 	/**
 	 * Synchronize post with corresponding ESP campaign.
 	 *
-	 * @param WP_POST $post Post to synchronize.
-	 * @return object|null API Response or error.
+	 * @param WP_Post $post Post to synchronize.
+	 *
+	 * @return array|WP_Error API Response or error.
 	 */
 	public function sync( $post );
 
 	/**
 	 * List the ESP's contact lists.
 	 *
-	 * @return object|null API Response or error.
+	 * @return array|WP_Error API Response or error.
 	 */
 	public function get_lists();
 
@@ -86,8 +91,9 @@ interface Newspack_Newsletters_ESP_API_Interface {
 	 * Add contact to a list.
 	 *
 	 * @param array  $contact Contact data.
-	 * @param strine $list_id List ID.
-	 * @return object|null API Response or error.
+	 * @param string $list_id List ID.
+	 *
+	 * @return array|WP_Error API Response or error.
 	 */
 	public function add_contact( $contact, $list_id);
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Use a common error message for newsletters without a subject. Such cases usually display an error thrown from the ESP. We can avoid a confusing message by providing our own intelligible notice.

<img width="445" alt="image" src="https://user-images.githubusercontent.com/820752/172459205-f0f03e14-2676-489a-b5d5-7a9e4742c140.png">

Closes #851.

### How to test the changes in this Pull Request:

1. Check out this branch and setup keys for Mailchimp, ActiveCampaign, and Campaign Monitor (Constant Contact is currently unsupported due to #802)
2. Using each provider, start a new newsletter draft, erase the subject and attempt to send
3. Confirm you see the message as shown above on the screenshot

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
