### PR TITLE
fix: separator background rendering

### DIFF
--- a/includes/class-newspack-newsletters-renderer.php
+++ b/includes/class-newspack-newsletters-renderer.php
@@ -581,12 +581,14 @@ final class Newspack_Newsletters_Renderer {
 			 * Separator block.
 			 */
 			case 'core/separator':
-				$is_style_default = isset( $attrs['className'] ) ? 'is-style-default' == $attrs['className'] : true;
-				$divider_attrs    = array(
+				$is_wide       = isset( $block['attrs']['className'] ) && 'is-style-wide' === $block['attrs']['className'];
+				$divider_attrs = array(
 					'padding'      => '0',
 					'border-width' => '1px',
-					'width'        => $is_style_default ? '128px' : '100%',
+					'width'        => $is_wide ? '100%' : '128px',
 				);
+				// Remove colors from section attrs.
+				unset( $section_attrs['background-color'] );
 				if ( $block['attrs']['backgroundColor'] && isset( self::$color_palette[ $block['attrs']['backgroundColor'] ] ) ) {
 					$divider_attrs['border-color'] = self::$color_palette[ $block['attrs']['backgroundColor'] ];
 				}

--- a/includes/class-newspack-newsletters-renderer.php
+++ b/includes/class-newspack-newsletters-renderer.php
@@ -581,15 +581,18 @@ final class Newspack_Newsletters_Renderer {
 			 * Separator block.
 			 */
 			case 'core/separator':
-				$is_style_default   = isset( $attrs['className'] ) ? 'is-style-default' == $attrs['className'] : true;
-				$divider_attrs      = array_merge(
-					array(
-						'padding'      => '0',
-						'border-width' => '1px',
-						'width'        => $is_style_default ? '128px' : '100%',
-					),
-					self::get_colors( $attrs )
+				$is_style_default = isset( $attrs['className'] ) ? 'is-style-default' == $attrs['className'] : true;
+				$divider_attrs    = array(
+					'padding'      => '0',
+					'border-width' => '1px',
+					'width'        => $is_style_default ? '128px' : '100%',
 				);
+				if ( $block['attrs']['backgroundColor'] && isset( self::$color_palette[ $block['attrs']['backgroundColor'] ] ) ) {
+					$divider_attrs['border-color'] = self::$color_palette[ $block['attrs']['backgroundColor'] ];
+				}
+				if ( isset( $block['attrs']['style']['color']['background'] ) ) {
+					$divider_attrs['border-color'] = $block['attrs']['style']['color']['background'];
+				}
 				$block_mjml_markup .= '<mj-divider ' . self::array_to_attributes( $divider_attrs ) . '/>';
 
 				break;
@@ -825,6 +828,7 @@ final class Newspack_Newsletters_Renderer {
 			'core/columns' != $block_name &&
 			'core/column' != $block_name &&
 			'core/buttons' != $block_name &&
+			'core/separator' != $block_name &&
 			! $is_posts_inserter_block
 		) {
 			$column_attrs['width'] = '100%';


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Fixes the rendered separator block.

| Master | This branch |
| --- | --- |
| <img width="648" alt="image" src="https://user-images.githubusercontent.com/820752/172248433-87b37575-d72d-4ef6-b0d0-8100a44145cd.png"> | <img width="629" alt="image" src="https://user-images.githubusercontent.com/820752/172251091-ffa8b7c2-2d78-413e-acd3-ac53e5fe1bae.png"> |


<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes #838 

### How to test the changes in this Pull Request:

1. Check out this branch and create a new newsletter with 2 separator blocks
2. To the first, apply a color from the palette and set it to "wide"
3. The second, apply a custom color from the picker
4. Send the email and confirm they are rendered as expected

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
