### PR TITLE
fix: remove reminiscent action hook

### DIFF
--- a/includes/class-newspack-newsletters-layouts.php
+++ b/includes/class-newspack-newsletters-layouts.php
@@ -209,9 +209,13 @@ final class Newspack_Newsletters_Layouts {
 		foreach ( scandir( $layouts_base_path ) as $layout ) {
 			if ( strpos( $layout, '.json' ) !== false ) {
 				$decoded_layout  = json_decode( file_get_contents( $layouts_base_path . $layout, true ) ); //phpcs:ignore
-				$layouts[]      = array(
+				$title          = '';
+				if ( property_exists( $decoded_layout, 'title' ) ) {
+					$title = $decoded_layout->title;
+				}
+				$layouts[] = array(
 					'ID'           => $layout_id,
-					'post_title'   => $decoded_layout->title,
+					'post_title'   => $title,
 					'post_content' => self::layout_token_replacement( $decoded_layout->content ),
 				);
 				$layout_id++;

--- a/includes/service-providers/active_campaign/class-newspack-newsletters-active-campaign.php
+++ b/includes/service-providers/active_campaign/class-newspack-newsletters-active-campaign.php
@@ -20,7 +20,6 @@ final class Newspack_Newsletters_Active_Campaign extends \Newspack_Newsletters_S
 		$this->controller = new Newspack_Newsletters_Active_Campaign_Controller( $this );
 
 		add_action( 'save_post_' . Newspack_Newsletters::NEWSPACK_NEWSLETTERS_CPT, [ $this, 'save' ], 10, 3 );
-		add_action( 'transition_post_status', [ $this, 'send' ], 10, 3 );
 		add_action( 'wp_trash_post', [ $this, 'trash' ], 10, 1 );
 
 		parent::__construct( $this );
@@ -184,7 +183,7 @@ final class Newspack_Newsletters_Active_Campaign extends \Newspack_Newsletters_S
 		$from_email  = get_post_meta( $post_id, 'ac_from_email', true );
 		$list_id     = get_post_meta( $post_id, 'ac_list_id', true );
 		$result      = [
-			'campaign'    => (bool) $campaign_id, // Whether campaign exists, to satisfy the JS API. 
+			'campaign'    => (bool) $campaign_id, // Whether campaign exists, to satisfy the JS API.
 			'campaign_id' => $campaign_id,
 			'from_name'   => $from_name,
 			'from_email'  => $from_email,
@@ -243,7 +242,7 @@ final class Newspack_Newsletters_Active_Campaign extends \Newspack_Newsletters_S
 					'messageid'  => $sync_result['message_id'],
 					'email'      => implode( ',', $emails ),
 				],
-			] 
+			]
 		);
 		return $test_result;
 	}
@@ -438,7 +437,7 @@ final class Newspack_Newsletters_Active_Campaign extends \Newspack_Newsletters_S
 							'status' => 1,
 							'sdate'  => $schedule_date->format( 'Y-m-d H:i:s' ),
 						],
-					] 
+					]
 				);
 				if ( is_wp_error( $send_result ) ) {
 					$error = $send_result;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Removes a reminiscent action hook that generates errors editing posts when ActiveCampaign is selected as ESP.

ea36fa763f386c32235577ab2e0eea209c85ab0a also fixes a warning introduced by #796, which created layouts without titles.

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

### How to test the changes in this Pull Request:

1. With debug mode on, select AC as your ESP
2. Confirm the errors displayed while creating any post
3. Check out this branch and confirm the errors are gone

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
