### PR TITLE
fix: display newsletters in archives

### DIFF
--- a/includes/class-newspack-newsletters.php
+++ b/includes/class-newspack-newsletters.php
@@ -81,6 +81,7 @@ final class Newspack_Newsletters {
 		add_filter( 'newspack_theme_featured_image_post_types', [ __CLASS__, 'support_featured_image_options' ] );
 		add_filter( 'gform_force_hooks_js_output', [ __CLASS__, 'suppress_gravityforms_js_on_newsletters' ] );
 		add_filter( 'render_block', [ __CLASS__, 'remove_email_only_block' ], 10, 2 );
+		add_action( 'pre_get_posts', [ __CLASS__, 'display_newsletters_in_archives' ] );
 		add_action( 'the_post', [ __CLASS__, 'fix_public_status' ] );
 		self::set_service_provider( self::service_provider() );
 
@@ -1195,6 +1196,25 @@ final class Newspack_Newsletters {
 		}
 
 		return false;
+	}
+
+	/**
+	 * Display newsletters in archive pages.
+	 *
+	 * @param WP_Query $query The query.
+	 */
+	public static function display_newsletters_in_archives( $query ) {
+		if ( is_admin() || ! $query->is_main_query() ) {
+			return;
+		}
+		if ( $query->is_archive() && ! $query->is_post_type_archive() ) {
+			$post_type = $query->get( 'post_type' );
+			if ( empty( $post_type ) ) {
+				$post_type = [ 'post' ];
+			}
+			$post_type[] = self::NEWSPACK_NEWSLETTERS_CPT;
+			$query->set( 'post_type', $post_type );
+		}
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Restores the expected behavior of newsletter display in archives.

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes #863.

### How to test the changes in this Pull Request:

1. Send a newsletter with a category and marked as public
2. In the master branch, visit the category page and confirm the newsletter is not visible
3. Check out this branch and confirm the newsletter is visible
4. Send a newsletter with a category and private
5. visit the category page and confirm the newsletter is not visible
6. Navigate through other archive pages (date, search, post type archives) and confirm the expected posts are displayed

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
