### PR TITLE
feat: subscription lists and subscription block

### DIFF
--- a/includes/class-newspack-newsletters-blocks.php
+++ b/includes/class-newspack-newsletters-blocks.php
@@ -23,15 +23,23 @@ final class Newspack_Newsletters_Blocks {
 	 * Enqueue blocks scripts and styles for editor.
 	 */
 	public static function enqueue_block_editor_assets() {
+		$handle = 'newspack-newsletters-blocks';
 		wp_enqueue_script(
-			'newspack-newsletters-blocks',
+			$handle,
 			plugins_url( '../dist/blocks.js', __FILE__ ),
 			[],
 			filemtime( NEWSPACK_NEWSLETTERS_PLUGIN_FILE . 'dist/blocks.js' ),
 			true
 		);
+		wp_localize_script(
+			$handle,
+			'newspack_newsletters_blocks',
+			[
+				'settings_url' => Newspack_Newsletters_Settings::get_settings_url(),
+			]
+		);
 		wp_enqueue_style(
-			'newspack-newsletters-blocks',
+			$handle,
 			plugins_url( '../dist/blocks.css', __FILE__ ),
 			[],
 			filemtime( NEWSPACK_NEWSLETTERS_PLUGIN_FILE . 'dist/blocks.css' )

--- a/includes/class-newspack-newsletters-blocks.php
+++ b/includes/class-newspack-newsletters-blocks.php
@@ -32,9 +32,9 @@ final class Newspack_Newsletters_Blocks {
 		);
 		wp_enqueue_style(
 			'newspack-newsletters-blocks',
-			plugins_url( '../dist/blocks.js', __FILE__ ),
+			plugins_url( '../dist/blocks.css', __FILE__ ),
 			[],
-			filemtime( NEWSPACK_NEWSLETTERS_PLUGIN_FILE . 'dist/blocks.js' )
+			filemtime( NEWSPACK_NEWSLETTERS_PLUGIN_FILE . 'dist/blocks.css' )
 		);
 	}
 }

--- a/includes/class-newspack-newsletters-blocks.php
+++ b/includes/class-newspack-newsletters-blocks.php
@@ -1,0 +1,41 @@
+<?php
+/**
+ * Newspack Newsletters Blocks.
+ *
+ * @package Newspack
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Newspack Blocks Class.
+ */
+final class Newspack_Newsletters_Blocks {
+	/**
+	 * Initialize Hooks.
+	 */
+	public static function init() {
+		require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/src/blocks/subscribe/index.php';
+		add_action( 'enqueue_block_editor_assets', [ __CLASS__, 'enqueue_block_editor_assets' ] );
+	}
+
+	/**
+	 * Enqueue blocks scripts and styles for editor.
+	 */
+	public static function enqueue_block_editor_assets() {
+		wp_enqueue_script(
+			'newspack-newsletters-blocks',
+			plugins_url( '../dist/blocks.js', __FILE__ ),
+			[],
+			filemtime( NEWSPACK_NEWSLETTERS_PLUGIN_FILE . 'dist/blocks.js' ),
+			true
+		);
+		wp_enqueue_style(
+			'newspack-newsletters-blocks',
+			plugins_url( '../dist/blocks.js', __FILE__ ),
+			[],
+			filemtime( NEWSPACK_NEWSLETTERS_PLUGIN_FILE . 'dist/blocks.js' )
+		);
+	}
+}
+Newspack_Newsletters_Blocks::init();

--- a/includes/class-newspack-newsletters-editor.php
+++ b/includes/class-newspack-newsletters-editor.php
@@ -100,7 +100,7 @@ final class Newspack_Newsletters_Editor {
 	 * Get CSS rules for color palette.
 	 *
 	 * @param string $container_selector Optional selector to prefix as a container to every rule.
-	 * 
+	 *
 	 * @return string CSS rules.
 	 */
 	public static function get_color_palette_css( $container_selector = '' ) {
@@ -118,7 +118,7 @@ final class Newspack_Newsletters_Editor {
 				function( $rule ) use ( $container_selector ) {
 					return $container_selector . ' ' . $rule;
 				},
-				$rules 
+				$rules
 			);
 		}
 		return implode( "\n", $rules );
@@ -334,20 +334,20 @@ final class Newspack_Newsletters_Editor {
 		// If it's a reusable block, register this plugin's blocks.
 		if ( 'wp_block' === get_post_type() ) {
 			\wp_enqueue_script(
-				'newspack-newsletters-blocks',
-				plugins_url( '../dist/blocks.js', __FILE__ ),
+				'newspack-newsletters-editor-blocks',
+				plugins_url( '../dist/editorBlocks.js', __FILE__ ),
 				[],
-				filemtime( NEWSPACK_NEWSLETTERS_PLUGIN_FILE . 'dist/blocks.js' ),
+				filemtime( NEWSPACK_NEWSLETTERS_PLUGIN_FILE . 'dist/editorBlocks.js' ),
 				true
 			);
 			wp_register_style(
-				'newspack-newsletters-blocks',
-				plugins_url( '../dist/blocks.css', __FILE__ ),
+				'newspack-newsletters-editor-blocks',
+				plugins_url( '../dist/editorBlocks.css', __FILE__ ),
 				[],
-				filemtime( NEWSPACK_NEWSLETTERS_PLUGIN_FILE . 'dist/blocks.css' )
+				filemtime( NEWSPACK_NEWSLETTERS_PLUGIN_FILE . 'dist/editorBlocks.css' )
 			);
-			wp_style_add_data( 'newspack-newsletters-blocks', 'rtl', 'replace' );
-			wp_enqueue_style( 'newspack-newsletters-blocks' );
+			wp_style_add_data( 'newspack-newsletters-editor-blocks', 'rtl', 'replace' );
+			wp_enqueue_style( 'newspack-newsletters-editor-blocks' );
 		}
 	}
 

--- a/includes/class-newspack-newsletters-settings.php
+++ b/includes/class-newspack-newsletters-settings.php
@@ -24,6 +24,22 @@ class Newspack_Newsletters_Settings {
 	}
 
 	/**
+	 * Get newsletters settings url.
+	 *
+	 * @return string URL to settings page.
+	 */
+	public static function get_settings_url() {
+		$url = admin_url( 'edit.php?post_type=newspack_nl_cpt&page=newspack-newsletters-settings-admin' );
+
+		/**
+		 * Filters the URL to the Newspack Newsletters settings page.
+		 *
+		 * @param string $url URL to the Newspack Newsletters settings page.
+		 */
+		return apply_filters( 'newspack_newsletters_settings_url', $url );
+	}
+
+	/**
 	 * Retreives list of settings.
 	 *
 	 * @return array Settings list.

--- a/includes/class-newspack-newsletters-settings.php
+++ b/includes/class-newspack-newsletters-settings.php
@@ -17,6 +17,7 @@ class Newspack_Newsletters_Settings {
 	public static function init() {
 		add_action( 'admin_menu', [ __CLASS__, 'add_plugin_page' ] );
 		add_action( 'admin_init', [ __CLASS__, 'page_init' ] );
+		add_action( 'admin_head', [ __CLASS__, 'admin_head' ] );
 		add_action( 'update_option_newspack_newsletters_public_posts_slug', [ __CLASS__, 'update_option_newspack_newsletters_public_posts_slug' ], 10, 2 );
 	}
 
@@ -180,17 +181,80 @@ class Newspack_Newsletters_Settings {
 	 * Options page callback
 	 */
 	public static function create_admin_page() {
+		$lists = Newspack_Newsletters_Subscribe::get_lists();
 		?>
 		<div class="wrap">
 			<h1><?php esc_html_e( 'Newsletters Settings', 'newspack-newsletters' ); ?></h1>
 			<form method="post" action="options.php">
 			<?php
-				settings_fields( 'newspack_newsletters_options_group' );
-				do_settings_sections( 'newspack-newsletters-settings-admin' );
-				submit_button();
+			settings_fields( 'newspack_newsletters_options_group' );
+			do_settings_sections( 'newspack-newsletters-settings-admin' );
+			?>
+			<?php if ( ! is_wp_error( $lists ) && ! empty( $lists ) ) : ?>
+				<h2><?php esc_html_e( 'Lists for subscription', 'newspack-newsletters' ); ?></h2>
+				<p><?php esc_html_e( 'Manage the lists available for subscription.', 'newspack-newsletters' ); ?></p>
+				<table class="newspack-newsletters-lists-table">
+					<thead>
+						<tr>
+							<th><?php esc_html_e( 'Active', 'newspack-newsletters' ); ?></th>
+							<th><?php esc_html_e( 'List name', 'newspack-newsletters' ); ?></th>
+							<th><?php esc_html_e( 'List details', 'newspack-newsletters' ); ?></th>
+						</tr>
+					</thead>
+					<tbody>
+						<?php
+						foreach ( $lists as $list_index => $list ) :
+							if ( ! is_array( $list ) || ! isset( $list['name'] ) ) {
+								continue;
+							}
+							?>
+							<tr>
+								<td>
+									<input type="checkbox" />
+								</td>
+								<td>
+									<strong><?php echo esc_html( $list['name'] ); ?></strong>
+								</td>
+								<td>
+									<input type="text" placeholder="<?php echo esc_attr_e( 'List title', 'newspack-newsletters' ); ?>" name="list[<?php echo esc_attr( $list['id'] ); ?>][title]" />
+									<textarea placeholder="<?php echo esc_attr_e( 'List description', 'newspack-newsletters' ); ?>" name="list[<?php echo esc_attr( $list['id'] ); ?>][description]"></textarea>
+								</td>
+							</tr>
+						<?php endforeach; ?>
+					</tbody>
+				</table>
+			<?php endif; ?>
+			<?php
+			submit_button();
 			?>
 			</form>
 		</div>
+		<?php
+	}
+
+	/**
+	 * Print settings page styles.
+	 */
+	public static function admin_head() {
+		?>
+		<style>
+			.newspack-newsletters-lists-table th,
+			.newspack-newsletters-lists-table td {
+				text-align: left;
+				padding-right: 2em;
+				padding-bottom: 1em;
+				vertical-align: top;
+			}
+			.newspack-newsletters-lists-table td input[type=text],
+			.newspack-newsletters-lists-table td textarea {
+				width: 300px;
+				display: block;
+				margin: 0 0 1rem;
+			}
+			.newspack-newsletters-lists-table td textarea {
+				height: 150px;
+			}
+		</style>
 		<?php
 	}
 

--- a/includes/class-newspack-newsletters-settings.php
+++ b/includes/class-newspack-newsletters-settings.php
@@ -202,7 +202,7 @@ class Newspack_Newsletters_Settings {
 	 * Render table for subscription lists management.
 	 */
 	private static function render_lists_table() {
-		$lists = Newspack_Newsletters_Subscribe::get_lists();
+		$lists = Newspack_Newsletters_Subscription::get_lists();
 		if ( is_wp_error( $lists ) || empty( $lists ) ) {
 			return;
 		}
@@ -357,7 +357,7 @@ class Newspack_Newsletters_Settings {
 				'description' => isset( $list_data['description'] ) ? sanitize_text_field( $list_data['description'] ) : '',
 			];
 		}
-		Newspack_Newsletters_Subscribe::update_lists( $lists );
+		Newspack_Newsletters_Subscription::update_lists( $lists );
 	}
 
 	/**

--- a/includes/class-newspack-newsletters-settings.php
+++ b/includes/class-newspack-newsletters-settings.php
@@ -246,7 +246,7 @@ class Newspack_Newsletters_Settings {
 							</td>
 							<td class="details">
 								<input type="text" placeholder="<?php echo esc_attr_e( 'List title', 'newspack-newsletters' ); ?>" name="lists[<?php echo esc_attr( $list['id'] ); ?>][title]" value="<?php echo esc_attr( $list['title'] ); ?>" />
-								<textarea placeholder="<?php echo esc_attr_e( 'List description', 'newspack-newsletters' ); ?>" name="lists[<?php echo esc_attr( $list['id'] ); ?>][description]"><?php echo esc_html( $list['description'] ); ?></textarea>
+								<textarea placeholder="<?php echo esc_attr_e( 'List description', 'newspack-newsletters' ); ?>" name="lists[<?php echo esc_attr( $list['id'] ); ?>][description]"><?php echo esc_textarea( $list['description'] ); ?></textarea>
 							</td>
 						</tr>
 					<?php endforeach; ?>
@@ -281,7 +281,7 @@ class Newspack_Newsletters_Settings {
 				margin: 0 0 1rem;
 			}
 			.newspack-newsletters-lists-table td textarea {
-				height: 150px;
+				height: 80px;
 			}
 			.newspack-newsletters-lists-table .active {
 				width: 1%;
@@ -354,7 +354,7 @@ class Newspack_Newsletters_Settings {
 				'id'          => $list_id,
 				'active'      => isset( $list_data['active'] ) ? (bool) $list_data['active'] : false,
 				'title'       => isset( $list_data['title'] ) ? sanitize_text_field( $list_data['title'] ) : '',
-				'description' => isset( $list_data['description'] ) ? sanitize_text_field( $list_data['description'] ) : '',
+				'description' => isset( $list_data['description'] ) ? sanitize_textarea_field( wp_unslash( $list_data['description'] ) ) : '',
 			];
 		}
 		Newspack_Newsletters_Subscription::update_lists( $lists );

--- a/includes/class-newspack-newsletters-settings.php
+++ b/includes/class-newspack-newsletters-settings.php
@@ -18,6 +18,8 @@ class Newspack_Newsletters_Settings {
 		add_action( 'admin_menu', [ __CLASS__, 'add_plugin_page' ] );
 		add_action( 'admin_init', [ __CLASS__, 'page_init' ] );
 		add_action( 'admin_head', [ __CLASS__, 'admin_head' ] );
+		add_action( 'admin_footer', [ __CLASS__, 'admin_footer' ] );
+		add_action( 'admin_init', [ __CLASS__, 'process_subscription_lists_update' ] );
 		add_action( 'update_option_newspack_newsletters_public_posts_slug', [ __CLASS__, 'update_option_newspack_newsletters_public_posts_slug' ], 10, 2 );
 	}
 
@@ -181,53 +183,75 @@ class Newspack_Newsletters_Settings {
 	 * Options page callback
 	 */
 	public static function create_admin_page() {
-		$lists = Newspack_Newsletters_Subscribe::get_lists();
 		?>
 		<div class="wrap">
 			<h1><?php esc_html_e( 'Newsletters Settings', 'newspack-newsletters' ); ?></h1>
 			<form method="post" action="options.php">
-			<?php
-			settings_fields( 'newspack_newsletters_options_group' );
-			do_settings_sections( 'newspack-newsletters-settings-admin' );
-			?>
-			<?php if ( ! is_wp_error( $lists ) && ! empty( $lists ) ) : ?>
-				<h2><?php esc_html_e( 'Lists for subscription', 'newspack-newsletters' ); ?></h2>
-				<p><?php esc_html_e( 'Manage the lists available for subscription.', 'newspack-newsletters' ); ?></p>
-				<table class="newspack-newsletters-lists-table">
-					<thead>
-						<tr>
-							<th><?php esc_html_e( 'Active', 'newspack-newsletters' ); ?></th>
-							<th><?php esc_html_e( 'List name', 'newspack-newsletters' ); ?></th>
-							<th><?php esc_html_e( 'List details', 'newspack-newsletters' ); ?></th>
-						</tr>
-					</thead>
-					<tbody>
-						<?php
-						foreach ( $lists as $list_index => $list ) :
-							if ( ! is_array( $list ) || ! isset( $list['name'] ) ) {
-								continue;
-							}
-							?>
-							<tr>
-								<td>
-									<input type="checkbox" />
-								</td>
-								<td>
-									<strong><?php echo esc_html( $list['name'] ); ?></strong>
-								</td>
-								<td>
-									<input type="text" placeholder="<?php echo esc_attr_e( 'List title', 'newspack-newsletters' ); ?>" name="list[<?php echo esc_attr( $list['id'] ); ?>][title]" />
-									<textarea placeholder="<?php echo esc_attr_e( 'List description', 'newspack-newsletters' ); ?>" name="list[<?php echo esc_attr( $list['id'] ); ?>][description]"></textarea>
-								</td>
-							</tr>
-						<?php endforeach; ?>
-					</tbody>
-				</table>
-			<?php endif; ?>
-			<?php
-			submit_button();
-			?>
+				<?php
+				settings_fields( 'newspack_newsletters_options_group' );
+				do_settings_sections( 'newspack-newsletters-settings-admin' );
+				self::render_lists_table();
+				submit_button();
+				?>
 			</form>
+		</div>
+		<?php
+	}
+
+	/**
+	 * Render table for subscription lists management.
+	 */
+	private static function render_lists_table() {
+		$lists = Newspack_Newsletters_Subscribe::get_lists();
+		if ( is_wp_error( $lists ) || empty( $lists ) ) {
+			return;
+		}
+		?>
+		<div class="newspack-newsletters-subscription-lists">
+			<h2><?php esc_html_e( 'Subscription Lists', 'newspack-newsletters' ); ?></h2>
+			<div class="notice notice-warning changed-provider">
+				<p><?php esc_html_e( 'Save changes to display the selected provider lists.', 'newspack-newsletters' ); ?></p>
+			</div>
+			<p><?php esc_html_e( 'Manage the lists available for subscription.', 'newspack-newsletters' ); ?></p>
+			<table class="newspack-newsletters-lists-table">
+				<thead>
+					<tr>
+						<th colspan="2" class="name"><?php esc_html_e( 'List name', 'newspack-newsletters' ); ?></th>
+						<th class="details"><?php esc_html_e( 'List details', 'newspack-newsletters' ); ?></th>
+					</tr>
+				</thead>
+				<tbody>
+					<?php
+					foreach ( $lists as $list_index => $list ) :
+						if ( ! is_array( $list ) || ! isset( $list['name'] ) ) {
+							continue;
+						}
+						$checkbox_id = sprintf( 'newspack_newsletters_lists_%s_active', $list['id'] );
+						?>
+						<tr>
+							<td class="active">
+								<input
+									id="<?php echo esc_attr( $checkbox_id ); ?>"
+									type="checkbox"
+									name="lists[<?php echo esc_attr( $list['id'] ); ?>][active]"
+									<?php
+									if ( $list['active'] ) {
+										echo 'checked';
+									}
+									?>
+								/>
+							</td>
+							<td class="name">
+								<label for="<?php echo esc_attr( $checkbox_id ); ?>"><?php echo esc_html( $list['name'] ); ?></strong>
+							</td>
+							<td class="details">
+								<input type="text" placeholder="<?php echo esc_attr_e( 'List title', 'newspack-newsletters' ); ?>" name="lists[<?php echo esc_attr( $list['id'] ); ?>][title]" value="<?php echo esc_attr( $list['title'] ); ?>" />
+								<textarea placeholder="<?php echo esc_attr_e( 'List description', 'newspack-newsletters' ); ?>" name="lists[<?php echo esc_attr( $list['id'] ); ?>][description]"><?php echo esc_html( $list['description'] ); ?></textarea>
+							</td>
+						</tr>
+					<?php endforeach; ?>
+				</tbody>
+			</table>
 		</div>
 		<?php
 	}
@@ -236,26 +260,104 @@ class Newspack_Newsletters_Settings {
 	 * Print settings page styles.
 	 */
 	public static function admin_head() {
+		if ( ! isset( $_GET['page'] ) || 'newspack-newsletters-settings-admin' !== $_GET['page'] ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			return;
+		}
 		?>
 		<style>
+			.newspack-newsletters-lists-table {
+				width: 100%;
+			}
 			.newspack-newsletters-lists-table th,
 			.newspack-newsletters-lists-table td {
 				text-align: left;
-				padding-right: 2em;
 				padding-bottom: 1em;
 				vertical-align: top;
 			}
 			.newspack-newsletters-lists-table td input[type=text],
 			.newspack-newsletters-lists-table td textarea {
-				width: 300px;
+				width: 100%;
 				display: block;
 				margin: 0 0 1rem;
 			}
 			.newspack-newsletters-lists-table td textarea {
 				height: 150px;
 			}
+			.newspack-newsletters-lists-table .active {
+				width: 1%;
+			}
+			.newspack-newsletters-lists-table .name {
+				padding-right: 1rem;
+			}
+			.newspack-newsletters-lists-table .details {
+				width: 85%;
+			}
 		</style>
 		<?php
+	}
+
+	/**
+	 * Print settings scripts.
+	 */
+	public static function admin_footer() {
+		if ( ! isset( $_GET['page'] ) || 'newspack-newsletters-settings-admin' !== $_GET['page'] ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			return;
+		}
+		?>
+		<script type="text/javascript">
+			( function($) {
+				$( document ).ready( function() {
+					$( '.newspack-newsletters-subscription-lists' ).each( function() {
+						var $container = $( this );
+						var $changedNotice = $container.find( '.changed-provider' );
+						$changedNotice.hide();
+						$( 'select#newspack_newsletters_service_provider' ).on( 'change', function() {
+							$container.hide();
+							$changedNotice.show();
+						} );
+						$container.find( 'tr' ).each( function() {
+							var $row      = $( this );
+							var $checkbox = $row.find( 'input[type="checkbox"]' );
+							var $inputs   = $row.find( 'input[type="text"],textarea' );
+							$inputs.attr( 'disabled', ! $checkbox.is( ':checked' ) );
+							$checkbox.on( 'change', function() {
+								$inputs.attr( 'disabled', ! $checkbox.is( ':checked' ) );
+							} );
+						} );
+					} );
+				} );
+			} )( jQuery );
+		</script>
+		<?php
+	}
+
+	/**
+	 * Process subscription lists update.
+	 */
+	public static function process_subscription_lists_update() {
+		$action = 'newspack_newsletters_options_group';
+		if ( ! isset( $_POST['option_page'] ) || $action !== $_POST['option_page'] ) {
+			return;
+		}
+		if ( ! \check_admin_referer( "$action-options" ) ) {
+			\wp_die( \esc_html__( 'Invalid request.', 'newspack' ) );
+		}
+		if ( ! isset( $_POST['lists'] ) ) {
+			return;
+		}
+		if ( ! is_array( $_POST['lists'] ) ) {
+			\wp_die( \esc_html__( 'Invalid request.', 'newspack' ) );
+		}
+		$lists = [];
+		foreach ( $_POST['lists'] as $list_id => $list_data ) { // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+			$lists[] = [
+				'id'          => $list_id,
+				'active'      => isset( $list_data['active'] ) ? (bool) $list_data['active'] : false,
+				'title'       => isset( $list_data['title'] ) ? sanitize_text_field( $list_data['title'] ) : '',
+				'description' => isset( $list_data['description'] ) ? sanitize_text_field( $list_data['description'] ) : '',
+			];
+		}
+		Newspack_Newsletters_Subscribe::update_lists( $lists );
 	}
 
 	/**

--- a/includes/class-newspack-newsletters-subscribe.php
+++ b/includes/class-newspack-newsletters-subscribe.php
@@ -1,0 +1,79 @@
+<?php
+/**
+ * Newspack Newsletters ESP-Agnostic Subscription Functionality
+ *
+ * @package Newspack
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Manages Settings Subscribe Class.
+ */
+class Newspack_Newsletters_Subscribe {
+
+	const API_NAMESPACE = 'newspack-newsletters/v1';
+
+	/**
+	 * Initialize hooks.
+	 */
+	public static function init() {
+		add_action( 'rest_api_init', [ __CLASS__, 'register_api_endpoints' ] );
+	}
+
+	/**
+	 * Register API endpoints.
+	 */
+	public static function register_api_endpoints() {
+		register_rest_route(
+			self::API_NAMESPACE,
+			'/lists',
+			[
+				'methods'             => \WP_REST_Server::READABLE,
+				'callback'            => [ __CLASS__, 'api_get_lists' ],
+				'permission_callback' => '__return_true',
+			]
+		);
+	}
+
+	/**
+	 * API method to retrieve lists available for subscription.
+	 */
+	public static function api_get_lists() {
+		return \rest_ensure_response( self::get_lists() );
+	}
+
+	/**
+	 * Get the lists available for subscription.
+	 *
+	 * @return array Lists.
+	 */
+	public static function get_lists() {
+		$provider = Newspack_Newsletters::get_service_provider();
+		if ( empty( $provider ) ) {
+			return new WP_Error( 'newspack_newsletters_invalid_provider', __( 'Provider is not set' ) );
+		}
+		try {
+			return $provider->get_lists();
+		} catch ( \Exception $e ) {
+			return new WP_Error(
+				'newspack_newsletters_get_lists',
+				$e->getMessage()
+			);
+		}
+		return [];
+	}
+
+	/**
+	 * Add a contact to a list.
+	 *
+	 * @param string $email   Contact email.
+	 * @param string $list_id List ID.
+	 *
+	 * @return bool|WP_Error Whether the contact was added or error.
+	 */
+	public static function add_contact( $email, $list_id ) {
+		return false;
+	}
+}
+Newspack_Newsletters_Subscribe::init();

--- a/includes/class-newspack-newsletters-subscribe.php
+++ b/includes/class-newspack-newsletters-subscribe.php
@@ -27,6 +27,15 @@ class Newspack_Newsletters_Subscribe {
 	public static function register_api_endpoints() {
 		register_rest_route(
 			self::API_NAMESPACE,
+			'/lists_config',
+			[
+				'methods'             => \WP_REST_Server::READABLE,
+				'callback'            => [ __CLASS__, 'api_get_lists_config' ],
+				'permission_callback' => '__return_true',
+			]
+		);
+		register_rest_route(
+			self::API_NAMESPACE,
 			'/lists',
 			[
 				'methods'             => \WP_REST_Server::READABLE,
@@ -78,7 +87,16 @@ class Newspack_Newsletters_Subscribe {
 	}
 
 	/**
-	 * API method to retrieve lists available for subscription.
+	 * API method to retrieve the current lists configuration.
+	 *
+	 * @return WP_REST_Response|WP_Error WP_REST_Response on success, or WP_Error object on failure.
+	 */
+	public static function api_get_lists_config() {
+		return \rest_ensure_response( self::get_lists_config() );
+	}
+
+	/**
+	 * API method to retrieve the current ESP lists.
 	 *
 	 * @return WP_REST_Response|WP_Error WP_REST_Response on success, or WP_Error object on failure.
 	 */
@@ -87,7 +105,7 @@ class Newspack_Newsletters_Subscribe {
 	}
 
 	/**
-	 * API method to retrieve lists available for subscription.
+	 * API method to update the list configuration.
 	 *
 	 * @param WP_REST_Request $request Full details about the request.
 	 *
@@ -162,7 +180,13 @@ class Newspack_Newsletters_Subscribe {
 		}
 		$provider_name = $provider->service;
 		$option_name   = sprintf( '_newspack_newsletters_%s_lists', $provider_name );
-		return get_option( $option_name, [] );
+		$config        = get_option( $option_name, [] );
+		return array_filter(
+			$config,
+			function( $item ) {
+				return true === isset( $item['active'] ) && (bool) $item['active'];
+			}
+		);
 	}
 
 	/**

--- a/includes/class-newspack-newsletters-subscribe.php
+++ b/includes/class-newspack-newsletters-subscribe.php
@@ -31,15 +31,73 @@ class Newspack_Newsletters_Subscribe {
 			[
 				'methods'             => \WP_REST_Server::READABLE,
 				'callback'            => [ __CLASS__, 'api_get_lists' ],
-				'permission_callback' => '__return_true',
+				'permission_callback' => [ __CLASS__, 'api_permission_callback' ],
+			]
+		);
+		register_rest_route(
+			self::API_NAMESPACE,
+			'/lists',
+			[
+				'methods'             => \WP_REST_Server::EDITABLE,
+				'callback'            => [ __CLASS__, 'api_update_lists' ],
+				'permission_callback' => [ __CLASS__, 'api_permission_callback' ],
+				'args'                => [
+					'lists' => [
+						'type'     => 'array',
+						'required' => true,
+						'items'    => [
+							'type'       => 'object',
+							'properties' => [
+								'id'          => [
+									'type' => 'string',
+								],
+								'active'      => [
+									'type' => 'boolean',
+								],
+								'title'       => [
+									'type' => 'string',
+								],
+								'description' => [
+									'type' => 'string',
+								],
+							],
+						],
+					],
+				],
 			]
 		);
 	}
 
 	/**
+	 * Whether the current user can manage subscription lists.
+	 *
+	 * @return bool Whether the current user can manage subscription lists.
+	 */
+	public static function api_permission_callback() {
+		return current_user_can( 'manage_options' );
+	}
+
+	/**
 	 * API method to retrieve lists available for subscription.
+	 *
+	 * @return WP_REST_Response|WP_Error WP_REST_Response on success, or WP_Error object on failure.
 	 */
 	public static function api_get_lists() {
+		return \rest_ensure_response( self::get_lists() );
+	}
+
+	/**
+	 * API method to retrieve lists available for subscription.
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 *
+	 * @return WP_REST_Response|WP_Error WP_REST_Response on success, or WP_Error object on failure.
+	 */
+	public static function api_update_lists( $request ) {
+		$update = self::update_lists( $request['lists'] );
+		if ( is_wp_error( $update ) ) {
+			return \rest_ensure_response( $update );
+		}
 		return \rest_ensure_response( self::get_lists() );
 	}
 

--- a/includes/class-newspack-newsletters-subscription.php
+++ b/includes/class-newspack-newsletters-subscription.php
@@ -8,9 +8,9 @@
 defined( 'ABSPATH' ) || exit;
 
 /**
- * Manages Settings Subscribe Class.
+ * Manages Settings Subscription Class.
  */
-class Newspack_Newsletters_Subscribe {
+class Newspack_Newsletters_Subscription {
 
 	const API_NAMESPACE = 'newspack-newsletters/v1';
 
@@ -250,5 +250,16 @@ class Newspack_Newsletters_Subscribe {
 	public static function add_contact( $email, $list_id ) {
 		return false;
 	}
+
+	/**
+	 * Get an email subscription status from the current ESP.
+	 *
+	 * @param string $email Email address.
+	 *
+	 * @return array Subscription status.
+	 */
+	public static function get_email_status( $email ) {
+		return [];
+	}
 }
-Newspack_Newsletters_Subscribe::init();
+Newspack_Newsletters_Subscription::init();

--- a/includes/class-newspack-newsletters-subscription.php
+++ b/includes/class-newspack-newsletters-subscription.php
@@ -144,7 +144,7 @@ class Newspack_Newsletters_Subscription {
 						'id'          => $list['id'],
 						'name'        => $list['name'],
 						'active'      => false,
-						'title'       => '',
+						'title'       => $list['name'],
 						'description' => '',
 					];
 					if ( isset( $config[ $list['id'] ] ) ) {

--- a/includes/class-newspack-newsletters-subscription.php
+++ b/includes/class-newspack-newsletters-subscription.php
@@ -251,7 +251,7 @@ class Newspack_Newsletters_Subscription {
 	 * @param string[] $lists        Array of list IDs to subscribe the contact to.
 	 * @param bool     $double_optin Whether to send a double opt-in confirmation email.
 	 *
-	 * @return bool|WP_Error Whether the email was added or error.
+	 * @return bool|WP_Error Whether the contact was added or error.
 	 */
 	public static function add_contact( $contact, $lists = [], $double_optin = false ) {
 		$provider = Newspack_Newsletters::get_service_provider();

--- a/includes/class-newspack-newsletters-subscription.php
+++ b/includes/class-newspack-newsletters-subscription.php
@@ -127,7 +127,7 @@ class Newspack_Newsletters_Subscription {
 	public static function get_lists() {
 		$provider = Newspack_Newsletters::get_service_provider();
 		if ( empty( $provider ) ) {
-			return new WP_Error( 'newspack_newsletters_invalid_provider', __( 'Provider is not set' ) );
+			return new WP_Error( 'newspack_newsletters_invalid_provider', __( 'Provider is not set.' ) );
 		}
 		try {
 			$lists  = $provider->get_lists();
@@ -176,7 +176,7 @@ class Newspack_Newsletters_Subscription {
 	public static function get_lists_config() {
 		$provider = Newspack_Newsletters::get_service_provider();
 		if ( empty( $provider ) ) {
-			return new WP_Error( 'newspack_newsletters_invalid_provider', __( 'Provider is not set' ) );
+			return new WP_Error( 'newspack_newsletters_invalid_provider', __( 'Provider is not set.' ) );
 		}
 		$provider_name = $provider->service;
 		$option_name   = sprintf( '_newspack_newsletters_%s_lists', $provider_name );
@@ -206,11 +206,11 @@ class Newspack_Newsletters_Subscription {
 	public static function update_lists( $lists ) {
 		$provider = Newspack_Newsletters::get_service_provider();
 		if ( empty( $provider ) ) {
-			return new WP_Error( 'newspack_newsletters_invalid_provider', __( 'Provider is not set' ) );
+			return new WP_Error( 'newspack_newsletters_invalid_provider', __( 'Provider is not set.' ) );
 		}
 		$lists = self::sanitize_lists( $lists );
 		if ( empty( $lists ) ) {
-			return new WP_Error( 'newspack_newsletters_invalid_lists', __( 'Invalid list configuration' ) );
+			return new WP_Error( 'newspack_newsletters_invalid_lists', __( 'Invalid list configuration.' ) );
 		}
 		$provider_name = $provider->service;
 		$option_name   = sprintf( '_newspack_newsletters_%s_lists', $provider_name );
@@ -242,12 +242,25 @@ class Newspack_Newsletters_Subscription {
 	/**
 	 * Add a contact to a list.
 	 *
-	 * @param string $email   Contact email.
-	 * @param string $list_id List ID.
+	 * @param array    $contact      {
+	 *    Contact information.
 	 *
-	 * @return bool|WP_Error Whether the contact was added or error.
+	 *    @type string email The contact email address.
+	 *    @type string name  The contact name. Optional.
+	 * }
+	 * @param string[] $lists        Array of list IDs to subscribe the contact to.
+	 * @param bool     $double_optin Whether to send a double opt-in confirmation email.
+	 *
+	 * @return bool|WP_Error Whether the email was added or error.
 	 */
-	public static function add_contact( $email, $list_id ) {
+	public static function add_contact( $contact, $lists = [], $double_optin = false ) {
+		$provider = Newspack_Newsletters::get_service_provider();
+		if ( empty( $provider ) ) {
+			return new WP_Error( 'newspack_newsletters_invalid_provider', __( 'Provider is not set.' ) );
+		}
+		if ( empty( $lists ) ) {
+			return new WP_Error( 'newspack_newsletters_invalid_lists', __( 'No lists specified.' ) );
+		}
 		return false;
 	}
 

--- a/includes/class-newspack-newsletters.php
+++ b/includes/class-newspack-newsletters.php
@@ -116,6 +116,13 @@ final class Newspack_Newsletters {
 	}
 
 	/**
+	 * Get the current service provider instance.
+	 */
+	public static function get_service_provider() {
+		return self::$provider;
+	}
+
+	/**
 	 * Register custom fields for use in the editor only.
 	 * These have to be registered so the updates are handles correctly.
 	 */
@@ -1133,6 +1140,9 @@ final class Newspack_Newsletters {
 
 	/**
 	 * Add contact to a mailing list of the configured ESP.
+	 *
+	 * This method has been deprecated, use
+	 * Newspack_Newsletters_Subscribe::subscribe() instead.
 	 *
 	 * @param array  $contact The contact to add to the list.
 	 * @param string $list_id ID of the list to add the contact to.

--- a/includes/class-newspack-newsletters.php
+++ b/includes/class-newspack-newsletters.php
@@ -1141,6 +1141,9 @@ final class Newspack_Newsletters {
 	/**
 	 * Add contact to a mailing list of the configured ESP.
 	 *
+	 * This method is soon to be deprecated.
+	 * Use Newspack_Newsletters_Subscription::add_contact() instead.
+	 *
 	 * @param array  $contact The contact to add to the list.
 	 * @param string $list_id ID of the list to add the contact to.
 	 */

--- a/includes/class-newspack-newsletters.php
+++ b/includes/class-newspack-newsletters.php
@@ -1141,9 +1141,6 @@ final class Newspack_Newsletters {
 	/**
 	 * Add contact to a mailing list of the configured ESP.
 	 *
-	 * This method has been deprecated, use
-	 * Newspack_Newsletters_Subscribe::subscribe() instead.
-	 *
 	 * @param array  $contact The contact to add to the list.
 	 * @param string $list_id ID of the list to add the contact to.
 	 */

--- a/includes/service-providers/active_campaign/class-newspack-newsletters-active-campaign.php
+++ b/includes/service-providers/active_campaign/class-newspack-newsletters-active-campaign.php
@@ -594,15 +594,15 @@ final class Newspack_Newsletters_Active_Campaign extends \Newspack_Newsletters_S
 	 * @return bool|WP_Error True if the contact was added or error if failed.
 	 */
 	public function add_contact( $contact, $list_id ) {
-		$action  = 'contact_add';
-		$payload = [
+		$action           = 'contact_add';
+		$payload          = [
 			'p[' . $list_id . ']' => $list_id,
 			'email'               => $contact['email'],
 		];
-		$contact = $this->api_v1_request( 'contact_list', 'GET', [ 'query' => [ 'filters[email]' => $contact['email'] ] ] );
-		if ( ! is_wp_error( $contact ) ) {
+		$existing_contact = $this->api_v1_request( 'contact_list', 'GET', [ 'query' => [ 'filters[email]' => $contact['email'] ] ] );
+		if ( ! is_wp_error( $existing_contact ) ) {
 			$action        = 'contact_edit';
-			$payload['id'] = $contact[0]['id'];
+			$payload['id'] = $existing_contact[0]['id'];
 		}
 		if ( isset( $contact['name'] ) && ! empty( $contact['name'] ) ) {
 			$name_fragments = explode( ' ', $contact['name'], 2 );

--- a/includes/service-providers/campaign_monitor/class-newspack-newsletters-campaign-monitor.php
+++ b/includes/service-providers/campaign_monitor/class-newspack-newsletters-campaign-monitor.php
@@ -598,18 +598,20 @@ final class Newspack_Newsletters_Campaign_Monitor extends \Newspack_Newsletters_
 					},
 					$cm_list->get_custom_fields()->response
 				);
-				foreach ( $contact['metadata'] as $key => $value ) {
-					$update_payload['CustomFields'][] = [
-						'Key'   => $key,
-						'Value' => (string) $value,
-					];
-					if ( ! in_array( $key, $custom_fields_keys ) ) {
-						$cm_list->create_custom_field(
-							[
-								'FieldName' => $key,
-								'DataType'  => CS_REST_CUSTOM_FIELD_TYPE_TEXT,
-							]
-						);
+				if ( isset( $contact['metadata'] ) && is_array( $contact['metadata'] && ! empty( $contact['metadata'] ) ) ) {
+					foreach ( $contact['metadata'] as $key => $value ) {
+						$update_payload['CustomFields'][] = [
+							'Key'   => $key,
+							'Value' => (string) $value,
+						];
+						if ( ! in_array( $key, $custom_fields_keys ) ) {
+							$cm_list->create_custom_field(
+								[
+									'FieldName' => $key,
+									'DataType'  => CS_REST_CUSTOM_FIELD_TYPE_TEXT,
+								]
+							);
+						}
 					}
 				}
 

--- a/includes/service-providers/campaign_monitor/class-newspack-newsletters-campaign-monitor.php
+++ b/includes/service-providers/campaign_monitor/class-newspack-newsletters-campaign-monitor.php
@@ -563,8 +563,16 @@ final class Newspack_Newsletters_Campaign_Monitor extends \Newspack_Newsletters_
 	/**
 	 * Add contact to a list.
 	 *
-	 * @param array  $contact Contact data.
-	 * @param strine $list_id List ID.
+	 * @param array  $contact      {
+	 *    Contact data.
+	 *
+	 *    @type string   $email    Contact email address.
+	 *    @type string   $name     Contact name. Optional.
+	 *    @type string[] $metadata Contact additional metadata. Optional.
+	 * }
+	 * @param string $list_id      List to add the contact to.
+	 *
+	 * @return bool|WP_Error True if the contact was added or error if failed.
 	 */
 	public function add_contact( $contact, $list_id ) {
 		try {

--- a/includes/service-providers/campaign_monitor/class-newspack-newsletters-campaign-monitor.php
+++ b/includes/service-providers/campaign_monitor/class-newspack-newsletters-campaign-monitor.php
@@ -125,9 +125,10 @@ final class Newspack_Newsletters_Campaign_Monitor extends \Newspack_Newsletters_
 
 		return array_map(
 			function ( $item ) {
-				$item->id   = $item->ListID; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
-				$item->name = $item->Name; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
-				return $item;
+				return [
+					'id'   => $item->ListID, // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+					'name' => $item->Name, // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+				];
 			},
 			$lists->response
 		);
@@ -352,7 +353,7 @@ final class Newspack_Newsletters_Campaign_Monitor extends \Newspack_Newsletters_
 		if ( ! $client_id ) {
 			return new WP_Error(
 				'newspack_newsletter_error',
-				__( 'No Campaign Monitor Client ID available.', 'newspack-newsletters' ) 
+				__( 'No Campaign Monitor Client ID available.', 'newspack-newsletters' )
 			);
 		}
 

--- a/includes/service-providers/campaign_monitor/class-newspack-newsletters-campaign-monitor.php
+++ b/includes/service-providers/campaign_monitor/class-newspack-newsletters-campaign-monitor.php
@@ -584,11 +584,14 @@ final class Newspack_Newsletters_Campaign_Monitor extends \Newspack_Newsletters_
 				$found_subscriber = $cm_subscribers->get( $email_address, true );
 				$update_payload   = [
 					'EmailAddress'   => $email_address,
-					'Name'           => $contact['name'],
 					'CustomFields'   => [],
 					'ConsentToTrack' => 'yes',
 					'Resubscribe'    => true,
 				];
+
+				if ( isset( $contact['name'] ) ) {
+					$update_payload['Name'] = $contact['name'];
+				}
 
 				// Get custom fields (metadata) to create them if needed.
 				$cm_list            = new CS_REST_Lists( $list_id, [ 'api_key' => $api_key ] );

--- a/includes/service-providers/interface-newspack-newsletters-esp-service.php
+++ b/includes/service-providers/interface-newspack-newsletters-esp-service.php
@@ -90,10 +90,16 @@ interface Newspack_Newsletters_ESP_API_Interface {
 	/**
 	 * Add contact to a list.
 	 *
-	 * @param array  $contact Contact data.
-	 * @param string $list_id List ID.
+	 * @param array  $contact      {
+	 *    Contact data.
 	 *
-	 * @return array|WP_Error API Response or error.
+	 *    @type string   $email    Contact email address.
+	 *    @type string   $name     Contact name. Optional.
+	 *    @type string[] $metadata Contact additional metadata. Optional.
+	 * }
+	 * @param string $list_id      List to add the contact to.
+	 *
+	 * @return bool|WP_Error True if the contact was added or error if failed.
 	 */
-	public function add_contact( $contact, $list_id);
+	public function add_contact( $contact, $list_id );
 }

--- a/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp.php
+++ b/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp.php
@@ -804,7 +804,7 @@ final class Newspack_Newsletters_Mailchimp extends \Newspack_Newsletters_Service
 		try {
 			$mc            = new Mailchimp( $this->api_key() );
 			$email_address = $contact['email'];
-			$merged_fields = [];
+			$merge_fields = [];
 			if ( isset( $contact['name'] ) ) {
 				$name_fragments = explode( ' ', $contact['name'], 2 );
 				$merge_fields   = [

--- a/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp.php
+++ b/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp.php
@@ -565,7 +565,7 @@ final class Newspack_Newsletters_Mailchimp extends \Newspack_Newsletters_Service
 			$this->validate(
 				$mc->post( "campaigns/$mc_campaign_id/actions/send", $payload ),
 				__( 'Error sending campaign.', 'newspack_newsletters' )
-			);  
+			);
 		} catch ( Exception $e ) {
 			return new WP_Error(
 				'newspack_newsletters_error',
@@ -790,7 +790,7 @@ final class Newspack_Newsletters_Mailchimp extends \Newspack_Newsletters_Service
 	 * Add contact to a list.
 	 *
 	 * @param array  $contact Contact data.
-	 * @param strine $list_id List ID.
+	 * @param string $list_id List ID.
 	 */
 	public function add_contact( $contact, $list_id ) {
 		try {

--- a/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp.php
+++ b/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp.php
@@ -861,8 +861,19 @@ final class Newspack_Newsletters_Mailchimp extends \Newspack_Newsletters_Service
 				$member_id = $found_subscribers[0]['id'];
 				$result    = $mc->patch( "lists/$list_id/members/$member_id", $update_payload );
 			}
-			if ( ! $result || ( isset( $result['errors'] ) && count( $result['errors'] ) ) ) {
-				return new WP_Error( 'newspack_newsletters_mailchimp_add_contact_failed', __( 'Failed to add contact to list.', 'newspack-newsletters' ) );
+			if (
+				! $result ||
+				( isset( $result['status'] ) && 400 === absint( $result['status'] ) ) ||
+				( isset( $result['errors'] ) && count( $result['errors'] ) )
+			) {
+				return new WP_Error(
+					'newspack_newsletters_mailchimp_add_contact_failed',
+					sprintf(
+						/* translators: %s: Mailchimp error message */
+						__( 'Failed to add contact to list. %s', 'newspack-newsletters' ),
+						isset( $result['detail'] ) ? $result['detail'] : ''
+					)
+				);
 			}
 		} catch ( \Exception $e ) {
 			return new \WP_Error(

--- a/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp.php
+++ b/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp.php
@@ -863,7 +863,7 @@ final class Newspack_Newsletters_Mailchimp extends \Newspack_Newsletters_Service
 			}
 			if (
 				! $result ||
-				( isset( $result['status'] ) && 400 === absint( $result['status'] ) ) ||
+				( ! isset( $result['status'] ) || 'subscribed' !== $result['status'] ) ||
 				( isset( $result['errors'] ) && count( $result['errors'] ) )
 			) {
 				return new WP_Error(

--- a/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp.php
+++ b/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp.php
@@ -789,19 +789,30 @@ final class Newspack_Newsletters_Mailchimp extends \Newspack_Newsletters_Service
 	/**
 	 * Add contact to a list.
 	 *
-	 * @param array  $contact Contact data.
-	 * @param string $list_id List ID.
+	 * @param array  $contact      {
+	 *    Contact data.
+	 *
+	 *    @type string   $email    Contact email address.
+	 *    @type string   $name     Contact name. Optional.
+	 *    @type string[] $metadata Contact additional metadata. Optional.
+	 * }
+	 * @param string $list_id      List to add the contact to.
+	 *
+	 * @return bool|WP_Error True if the contact was added or error if failed.
 	 */
 	public function add_contact( $contact, $list_id ) {
 		try {
-			$mc             = new Mailchimp( $this->api_key() );
-			$email_address  = $contact['email'];
-			$name_fragments = explode( ' ', $contact['name'], 2 );
-			$merge_fields   = [
-				'FNAME' => $name_fragments[0],
-			];
-			if ( isset( $name_fragments[1] ) ) {
-				$merge_fields['LNAME'] = $name_fragments[1];
+			$mc            = new Mailchimp( $this->api_key() );
+			$email_address = $contact['email'];
+			$merged_fields = [];
+			if ( isset( $contact['name'] ) ) {
+				$name_fragments = explode( ' ', $contact['name'], 2 );
+				$merge_fields   = [
+					'FNAME' => $name_fragments[0],
+				];
+				if ( isset( $name_fragments[1] ) ) {
+					$merge_fields['LNAME'] = $name_fragments[1];
+				}
 			}
 			$update_payload = [
 				'email_address' => $email_address,
@@ -810,26 +821,30 @@ final class Newspack_Newsletters_Mailchimp extends \Newspack_Newsletters_Service
 			];
 
 			// Get list merge fields (metadata) to create them if needed.
-			$list_merge_fields = array_reduce(
-				$mc->get( "lists/$list_id/merge-fields" )['merge_fields'],
-				function( $acc, $field ) {
-					$acc[ $field['name'] ] = $field['tag'];
-					return $acc;
-				},
-				[]
-			);
-			foreach ( $contact['metadata'] as $key => $value ) {
-				if ( isset( $list_merge_fields[ $key ] ) ) {
-					$update_payload['merge_fields'][ $list_merge_fields[ $key ] ] = (string) $value;
-				} else {
-					$created_merge_field = $mc->post(
-						"lists/$list_id/merge-fields",
-						[
-							'name' => $key,
-							'type' => 'text',
-						]
-					);
-					$update_payload['merge_fields'][ $created_merge_field['tag'] ] = (string) $value;
+			if ( ! empty( $merge_fields ) ) {
+				$list_merge_fields = array_reduce(
+					$mc->get( "lists/$list_id/merge-fields" )['merge_fields'],
+					function( $acc, $field ) {
+						$acc[ $field['name'] ] = $field['tag'];
+						return $acc;
+					},
+					[]
+				);
+			}
+			if ( isset( $contact['metadata'] ) && is_array( $contact['metadata'] && ! empty( $contact['metadata'] ) ) ) {
+				foreach ( $contact['metadata'] as $key => $value ) {
+					if ( isset( $list_merge_fields[ $key ] ) ) {
+						$update_payload['merge_fields'][ $list_merge_fields[ $key ] ] = (string) $value;
+					} else {
+						$created_merge_field = $mc->post(
+							"lists/$list_id/merge-fields",
+							[
+								'name' => $key,
+								'type' => 'text',
+							]
+						);
+						$update_payload['merge_fields'][ $created_merge_field['tag'] ] = (string) $value;
+					}
 				}
 			}
 
@@ -837,8 +852,7 @@ final class Newspack_Newsletters_Mailchimp extends \Newspack_Newsletters_Service
 			$found_subscribers = $mc->get(
 				'search-members',
 				[
-					'list_id' => $list_id,
-					'query'   => $email_address,
+					'query' => $email_address,
 				]
 			)['exact_matches']['members'];
 			if ( empty( $found_subscribers ) ) {
@@ -853,5 +867,6 @@ final class Newspack_Newsletters_Mailchimp extends \Newspack_Newsletters_Service
 				$e->getMessage()
 			);
 		}
+		return true;
 	}
 }

--- a/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp.php
+++ b/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp.php
@@ -804,7 +804,7 @@ final class Newspack_Newsletters_Mailchimp extends \Newspack_Newsletters_Service
 		try {
 			$mc            = new Mailchimp( $this->api_key() );
 			$email_address = $contact['email'];
-			$merge_fields = [];
+			$merge_fields  = [];
 			if ( isset( $contact['name'] ) ) {
 				$name_fragments = explode( ' ', $contact['name'], 2 );
 				$merge_fields   = [

--- a/newspack-newsletters.php
+++ b/newspack-newsletters.php
@@ -43,7 +43,7 @@ require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/service-providers/act
 require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/service-providers/letterhead/class-newspack-newsletters-letterhead.php';
 require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/service-providers/letterhead/dtos/class-newspack-newsletters-letterhead-promotion-dto.php';
 require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/service-providers/letterhead/models/class-newspack-newsletters-letterhead-promotion.php';
-require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/class-newspack-newsletters-subscribe.php';
+require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/class-newspack-newsletters-subscription.php';
 require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/class-newspack-newsletters-blocks.php';
 require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/class-newspack-newsletters-editor.php';
 require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/class-newspack-newsletters-layouts.php';

--- a/newspack-newsletters.php
+++ b/newspack-newsletters.php
@@ -44,6 +44,7 @@ require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/service-providers/let
 require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/service-providers/letterhead/dtos/class-newspack-newsletters-letterhead-promotion-dto.php';
 require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/service-providers/letterhead/models/class-newspack-newsletters-letterhead-promotion.php';
 require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/class-newspack-newsletters-subscribe.php';
+require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/class-newspack-newsletters-blocks.php';
 require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/class-newspack-newsletters-editor.php';
 require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/class-newspack-newsletters-layouts.php';
 require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/class-newspack-newsletters-settings.php';

--- a/newspack-newsletters.php
+++ b/newspack-newsletters.php
@@ -43,6 +43,7 @@ require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/service-providers/act
 require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/service-providers/letterhead/class-newspack-newsletters-letterhead.php';
 require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/service-providers/letterhead/dtos/class-newspack-newsletters-letterhead-promotion-dto.php';
 require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/service-providers/letterhead/models/class-newspack-newsletters-letterhead-promotion.php';
+require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/class-newspack-newsletters-subscribe.php';
 require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/class-newspack-newsletters-editor.php';
 require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/class-newspack-newsletters-layouts.php';
 require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/class-newspack-newsletters-settings.php';

--- a/src/blocks/index.js
+++ b/src/blocks/index.js
@@ -1,0 +1,31 @@
+/**
+ * WordPress dependencies
+ */
+import { registerBlockType } from '@wordpress/blocks';
+
+/**
+ * Internal dependencies
+ */
+import * as subscribe from './subscribe';
+
+export const blocks = [ subscribe ];
+
+/**
+ * Function to register an individual block.
+ *
+ * @param {Object} block The block to be registered.
+ *
+ */
+const registerBlock = block => {
+	if ( ! block ) {
+		return;
+	}
+
+	const { metadata, settings, name } = block;
+
+	registerBlockType( { name, ...metadata }, settings );
+};
+
+for ( const block of blocks ) {
+	registerBlock( block );
+}

--- a/src/blocks/subscribe/block.json
+++ b/src/blocks/subscribe/block.json
@@ -14,6 +14,15 @@
 		"label": {
 			"type": "string",
 			"default": "Register"
+		},
+		"lists": {
+			"type": "array",
+			"default": [],
+			"items": { "type": "string" }
+		},
+		"displayDescription": {
+			"type": "boolean",
+			"default": true
 		}
 	},
 	"supports": {

--- a/src/blocks/subscribe/block.json
+++ b/src/blocks/subscribe/block.json
@@ -13,16 +13,16 @@
 		},
 		"label": {
 			"type": "string",
-			"default": "Register"
+			"default": "Subscribe"
+		},
+		"displayDescription": {
+			"type": "boolean",
+			"default": true
 		},
 		"lists": {
 			"type": "array",
 			"default": [],
 			"items": { "type": "string" }
-		},
-		"displayDescription": {
-			"type": "boolean",
-			"default": true
 		}
 	},
 	"supports": {

--- a/src/blocks/subscribe/block.json
+++ b/src/blocks/subscribe/block.json
@@ -2,7 +2,7 @@
 	"$schema": "https://schemas.wp.org/trunk/block.json",
 	"apiVersion": 2,
 	"name": "newspack-newsletters/subscribe",
-	"title": "Newsletter List Subscription Form",
+	"title": "Newsletter Subscription Form",
 	"category": "newspack",
 	"description": "Subscribe an email to a newsletter list.",
 	"textdomain": "newspack-newsletters",

--- a/src/blocks/subscribe/block.json
+++ b/src/blocks/subscribe/block.json
@@ -1,0 +1,24 @@
+{
+	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"apiVersion": 2,
+	"name": "newspack-newsletters/subscribe",
+	"title": "Newsletter List Subscription Form",
+	"category": "newspack",
+	"description": "Subscribe an email to a newsletter list.",
+	"textdomain": "newspack-newsletters",
+	"attributes": {
+		"placeholder": {
+			"type": "string",
+			"default": "Enter your email address"
+		},
+		"label": {
+			"type": "string",
+			"default": "Register"
+		}
+	},
+	"supports": {
+		"html": false,
+		"align": true,
+		"multiple": false
+	}
+}

--- a/src/blocks/subscribe/block.json
+++ b/src/blocks/subscribe/block.json
@@ -27,7 +27,6 @@
 	},
 	"supports": {
 		"html": false,
-		"align": true,
-		"multiple": false
+		"align": true
 	}
 }

--- a/src/blocks/subscribe/edit.js
+++ b/src/blocks/subscribe/edit.js
@@ -60,10 +60,11 @@ export default function SubscribeEdit( {
 					<ToggleControl
 						label={ __( 'Display list description', 'newspack-newsletters' ) }
 						checked={ displayDescription }
+						disabled={ lists.length <= 1 }
 						onChange={ () => setAttributes( { displayDescription: ! displayDescription } ) }
 					/>
 				</PanelBody>
-				<PanelBody title={ __( 'Lists', 'newspack-newsletters' ) }>
+				<PanelBody title={ __( 'Subscription Lists', 'newspack-newsletters' ) }>
 					{ Object.keys( listConfig ).map( listId => (
 						<ToggleControl
 							key={ listId }
@@ -96,7 +97,7 @@ export default function SubscribeEdit( {
 								{ lists.map( listId => (
 									<li key={ listId }>
 										<span className="list-checkbox">
-											<input id={ getListCheckboxId( listId ) } type="checkbox" />
+											<input id={ getListCheckboxId( listId ) } type="checkbox" checked />
 										</span>
 										<span className="list-details">
 											<label htmlFor={ getListCheckboxId( listId ) }>

--- a/src/blocks/subscribe/edit.js
+++ b/src/blocks/subscribe/edit.js
@@ -1,8 +1,15 @@
 /**
+ * External dependencies.
+ */
+import classnames from 'classnames';
+
+/**
  * WordPress dependencies
  */
+import apiFetch from '@wordpress/api-fetch';
 import { __ } from '@wordpress/i18n';
-import { TextControl, PanelBody } from '@wordpress/components';
+import { useState, useEffect } from '@wordpress/element';
+import { TextControl, ToggleControl, PanelBody } from '@wordpress/components';
 import { useBlockProps, InspectorControls } from '@wordpress/block-editor';
 
 /**
@@ -10,32 +17,97 @@ import { useBlockProps, InspectorControls } from '@wordpress/block-editor';
  */
 import './editor.scss';
 
-export default function SubscribeEdit( { setAttributes, attributes: { placeholder, label } } ) {
-	const defaultPlaceholder = __( 'Enter your email address', 'newspack' );
-	const defaultLabel = __( 'Register', 'newspack' );
+const getListCheckboxId = listId => {
+	return 'newspack-newsletters-list-checkbox-' + listId;
+};
+
+export default function SubscribeEdit( {
+	setAttributes,
+	attributes: { placeholder, label, lists, displayDescription },
+} ) {
+	const defaultPlaceholder = __( 'Enter your email address', 'newspack-newsletters' );
+	const defaultLabel = __( 'Register', 'newspack-newsletters' );
 	const blockProps = useBlockProps();
+	const [ listConfig, setListConfig ] = useState( {} );
+	const fetchLists = () => {
+		apiFetch( {
+			path: '/newspack-newsletters/v1/lists_config',
+		} ).then( setListConfig );
+	};
+	useEffect( fetchLists, [] );
+	useEffect( () => {
+		const listIds = Object.keys( listConfig );
+		if ( listIds.length && ! lists.length ) {
+			setAttributes( { lists: [ Object.keys( listConfig )[ 0 ] ] } );
+		}
+	}, [ listConfig ] );
 	return (
 		<>
 			<InspectorControls>
-				<PanelBody title={ __( 'Form settings', 'newspack' ) }>
+				<PanelBody title={ __( 'Form settings', 'newspack-newsletters' ) }>
 					<TextControl
-						label={ __( 'Input placeholder', 'newspack' ) }
+						label={ __( 'Input placeholder', 'newspack-newsletters' ) }
 						value={ placeholder }
 						placeholder={ defaultPlaceholder }
 						onChange={ value => setAttributes( { placeholder: value } ) }
 					/>
 					<TextControl
-						label={ __( 'Button label', 'newspack' ) }
+						label={ __( 'Button label', 'newspack-newsletters' ) }
 						value={ label }
 						placeholder={ defaultLabel }
 						onChange={ value => setAttributes( { label: value } ) }
 					/>
+					<ToggleControl
+						label={ __( 'Display list description', 'newspack-newsletters' ) }
+						checked={ displayDescription }
+						onChange={ () => setAttributes( { displayDescription: ! displayDescription } ) }
+					/>
+				</PanelBody>
+				<PanelBody title={ __( 'Lists', 'newspack-newsletters' ) }>
+					{ Object.keys( listConfig ).map( listId => (
+						<ToggleControl
+							key={ listId }
+							label={ listConfig[ listId ].title }
+							checked={ lists.includes( listId ) }
+							onChange={ () => {
+								if ( ! lists.includes( listId ) ) {
+									setAttributes( { lists: lists.concat( listId ) } );
+								} else {
+									setAttributes( { lists: lists.filter( id => id !== listId ) } );
+								}
+							} }
+						/>
+					) ) }
 				</PanelBody>
 			</InspectorControls>
 			<div { ...blockProps }>
-				<div className="newspack-newsletters-subscribe">
+				<div
+					className={ classnames( {
+						'newspack-newsletters-subscribe': true,
+						'multiple-lists': lists.length > 1,
+					} ) }
+				>
 					<form onSubmit={ ev => ev.preventDefault() }>
-						<input type="email" placeholder={ placeholder || defaultPlaceholder } />
+						<div className="newspack-newsletters-email-input">
+							<input type="email" placeholder={ placeholder || defaultPlaceholder } />
+						</div>
+						{ lists.length > 1 && (
+							<ul className="newspack-newsletters-lists">
+								{ lists.map( listId => (
+									<li key={ listId }>
+										<div className="list-checkbox">
+											<input id={ getListCheckboxId( listId ) } type="checkbox" />
+										</div>
+										<div className="list-details">
+											<label htmlFor={ getListCheckboxId( listId ) }>
+												{ listConfig[ listId ]?.title }
+											</label>
+											{ displayDescription && <p>{ listConfig[ listId ]?.description }</p> }
+										</div>
+									</li>
+								) ) }
+							</ul>
+						) }
 						<input type="submit" value={ label || defaultLabel } />
 					</form>
 				</div>

--- a/src/blocks/subscribe/edit.js
+++ b/src/blocks/subscribe/edit.js
@@ -73,9 +73,11 @@ export default function SubscribeEdit( {
 						</Notice>
 					) }
 					{ lists.length < 1 && (
-						<Notice isDismissible={ false } status="error">
-							{ __( 'You must select at least one list.', 'newspack-newsletters' ) }
-						</Notice>
+						<div style={ { marginBottom: '1.5rem' } }>
+							<Notice isDismissible={ false } status="error">
+								{ __( 'You must select at least one list.', 'newspack-newsletters' ) }
+							</Notice>
+						</div>
 					) }
 					{ Object.keys( listConfig ).map( listId => (
 						<ToggleControl

--- a/src/blocks/subscribe/edit.js
+++ b/src/blocks/subscribe/edit.js
@@ -1,3 +1,5 @@
+/* global newspack_newsletters_blocks */
+
 /**
  * External dependencies.
  */
@@ -21,6 +23,8 @@ import './editor.scss';
 const getListCheckboxId = listId => {
 	return 'newspack-newsletters-list-checkbox-' + listId;
 };
+
+const settingsUrl = window.newspack_newsletters_blocks.settings_url;
 
 export default function SubscribeEdit( {
 	setAttributes,
@@ -68,9 +72,11 @@ export default function SubscribeEdit( {
 				<PanelBody title={ __( 'Subscription Lists', 'newspack-newsletters' ) }>
 					{ inFlight && <Spinner /> }
 					{ ! inFlight && ! Object.keys( listConfig ).length && (
-						<Notice isDismissible={ false } status="error">
-							{ __( 'You must enable lists for subscription.', 'newspack-newsletters' ) }
-						</Notice>
+						<div style={ { marginBottom: '1.5rem' } }>
+							<Notice isDismissible={ false } status="error">
+								{ __( 'You must enable lists for subscription.', 'newspack-newsletters' ) }
+							</Notice>
+						</div>
 					) }
 					{ lists.length < 1 && (
 						<div style={ { marginBottom: '1.5rem' } }>
@@ -93,6 +99,11 @@ export default function SubscribeEdit( {
 							} }
 						/>
 					) ) }
+					<p>
+						<a href={ settingsUrl }>
+							{ __( 'Manage your subscription lists', 'newspack-newsletters' ) }
+						</a>
+					</p>
 				</PanelBody>
 			</InspectorControls>
 			<div { ...blockProps }>

--- a/src/blocks/subscribe/edit.js
+++ b/src/blocks/subscribe/edit.js
@@ -9,7 +9,7 @@ import classnames from 'classnames';
 import apiFetch from '@wordpress/api-fetch';
 import { __ } from '@wordpress/i18n';
 import { useState, useEffect } from '@wordpress/element';
-import { TextControl, ToggleControl, PanelBody } from '@wordpress/components';
+import { TextControl, ToggleControl, PanelBody, Notice } from '@wordpress/components';
 import { useBlockProps, InspectorControls } from '@wordpress/block-editor';
 
 /**
@@ -65,6 +65,11 @@ export default function SubscribeEdit( {
 					/>
 				</PanelBody>
 				<PanelBody title={ __( 'Subscription Lists', 'newspack-newsletters' ) }>
+					{ lists.length < 1 && (
+						<Notice isDismissible={ false } status="error">
+							{ __( 'You must select at least one list.', 'newspack-newsletters' ) }
+						</Notice>
+					) }
 					{ Object.keys( listConfig ).map( listId => (
 						<ToggleControl
 							key={ listId }

--- a/src/blocks/subscribe/edit.js
+++ b/src/blocks/subscribe/edit.js
@@ -10,14 +10,7 @@ import { intersection } from 'lodash';
 import apiFetch from '@wordpress/api-fetch';
 import { __ } from '@wordpress/i18n';
 import { useState, useEffect } from '@wordpress/element';
-import {
-	TextControl,
-	ToggleControl,
-	PanelBody,
-	Notice,
-	Placeholder,
-	Spinner,
-} from '@wordpress/components';
+import { TextControl, ToggleControl, PanelBody, Notice, Spinner } from '@wordpress/components';
 import { useBlockProps, InspectorControls } from '@wordpress/block-editor';
 
 /**
@@ -33,8 +26,6 @@ export default function SubscribeEdit( {
 	setAttributes,
 	attributes: { placeholder, label, lists, displayDescription },
 } ) {
-	const defaultPlaceholder = __( 'Enter your email address', 'newspack-newsletters' );
-	const defaultLabel = __( 'Register', 'newspack-newsletters' );
 	const blockProps = useBlockProps();
 	const [ inFlight, setInFlight ] = useState( false );
 	const [ listConfig, setListConfig ] = useState( {} );
@@ -60,13 +51,11 @@ export default function SubscribeEdit( {
 					<TextControl
 						label={ __( 'Input placeholder', 'newspack-newsletters' ) }
 						value={ placeholder }
-						placeholder={ defaultPlaceholder }
 						onChange={ value => setAttributes( { placeholder: value } ) }
 					/>
 					<TextControl
 						label={ __( 'Button label', 'newspack-newsletters' ) }
 						value={ label }
-						placeholder={ defaultLabel }
 						onChange={ value => setAttributes( { label: value } ) }
 					/>
 					<ToggleControl
@@ -116,7 +105,7 @@ export default function SubscribeEdit( {
 					>
 						<form onSubmit={ ev => ev.preventDefault() }>
 							<div className="newspack-newsletters-email-input">
-								<input type="email" placeholder={ placeholder || defaultPlaceholder } />
+								<input type="email" placeholder={ placeholder } />
 							</div>
 							{ lists.length > 1 && (
 								<ul className="newspack-newsletters-lists">
@@ -139,7 +128,7 @@ export default function SubscribeEdit( {
 									) ) }
 								</ul>
 							) }
-							<input type="submit" value={ label || defaultLabel } />
+							<input type="submit" value={ label } />
 						</form>
 					</div>
 				) }

--- a/src/blocks/subscribe/edit.js
+++ b/src/blocks/subscribe/edit.js
@@ -2,6 +2,7 @@
  * External dependencies.
  */
 import classnames from 'classnames';
+import { intersection } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -37,7 +38,7 @@ export default function SubscribeEdit( {
 	useEffect( fetchLists, [] );
 	useEffect( () => {
 		const listIds = Object.keys( listConfig );
-		if ( listIds.length && ! lists.length ) {
+		if ( listIds.length && ( ! lists.length || ! intersection( lists, listIds ).length ) ) {
 			setAttributes( { lists: [ Object.keys( listConfig )[ 0 ] ] } );
 		}
 	}, [ listConfig ] );

--- a/src/blocks/subscribe/edit.js
+++ b/src/blocks/subscribe/edit.js
@@ -62,12 +62,13 @@ export default function SubscribeEdit( {
 						value={ label }
 						onChange={ value => setAttributes( { label: value } ) }
 					/>
-					<ToggleControl
-						label={ __( 'Display list description', 'newspack-newsletters' ) }
-						checked={ displayDescription }
-						disabled={ lists.length <= 1 }
-						onChange={ () => setAttributes( { displayDescription: ! displayDescription } ) }
-					/>
+					{ lists.length > 1 && (
+						<ToggleControl
+							label={ __( 'Display list description', 'newspack-newsletters' ) }
+							checked={ displayDescription }
+							onChange={ () => setAttributes( { displayDescription: ! displayDescription } ) }
+						/>
+					) }
 				</PanelBody>
 				<PanelBody title={ __( 'Subscription Lists', 'newspack-newsletters' ) }>
 					{ inFlight && <Spinner /> }

--- a/src/blocks/subscribe/edit.js
+++ b/src/blocks/subscribe/edit.js
@@ -1,5 +1,3 @@
-/* global newspack_newsletters_blocks */
-
 /**
  * External dependencies.
  */

--- a/src/blocks/subscribe/edit.js
+++ b/src/blocks/subscribe/edit.js
@@ -95,15 +95,19 @@ export default function SubscribeEdit( {
 							<ul className="newspack-newsletters-lists">
 								{ lists.map( listId => (
 									<li key={ listId }>
-										<div className="list-checkbox">
+										<span className="list-checkbox">
 											<input id={ getListCheckboxId( listId ) } type="checkbox" />
-										</div>
-										<div className="list-details">
+										</span>
+										<span className="list-details">
 											<label htmlFor={ getListCheckboxId( listId ) }>
-												{ listConfig[ listId ]?.title }
+												<span className="list-title">{ listConfig[ listId ]?.title }</span>
+												{ displayDescription && (
+													<span className="list-description">
+														{ listConfig[ listId ]?.description }
+													</span>
+												) }
 											</label>
-											{ displayDescription && <p>{ listConfig[ listId ]?.description }</p> }
-										</div>
+										</span>
 									</li>
 								) ) }
 							</ul>

--- a/src/blocks/subscribe/edit.js
+++ b/src/blocks/subscribe/edit.js
@@ -114,7 +114,12 @@ export default function SubscribeEdit( {
 									{ lists.map( listId => (
 										<li key={ listId }>
 											<span className="list-checkbox">
-												<input id={ getListCheckboxId( listId ) } type="checkbox" checked />
+												<input
+													id={ getListCheckboxId( listId ) }
+													type="checkbox"
+													checked
+													readOnly
+												/>
 											</span>
 											<span className="list-details">
 												<label htmlFor={ getListCheckboxId( listId ) }>

--- a/src/blocks/subscribe/edit.js
+++ b/src/blocks/subscribe/edit.js
@@ -1,0 +1,45 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { TextControl, PanelBody } from '@wordpress/components';
+import { useBlockProps, InspectorControls } from '@wordpress/block-editor';
+
+/**
+ * Internal dependencies
+ */
+import './editor.scss';
+
+export default function SubscribeEdit( { setAttributes, attributes: { placeholder, label } } ) {
+	const defaultPlaceholder = __( 'Enter your email address', 'newspack' );
+	const defaultLabel = __( 'Register', 'newspack' );
+	const blockProps = useBlockProps();
+	return (
+		<>
+			<InspectorControls>
+				<PanelBody title={ __( 'Form settings', 'newspack' ) }>
+					<TextControl
+						label={ __( 'Input placeholder', 'newspack' ) }
+						value={ placeholder }
+						placeholder={ defaultPlaceholder }
+						onChange={ value => setAttributes( { placeholder: value } ) }
+					/>
+					<TextControl
+						label={ __( 'Button label', 'newspack' ) }
+						value={ label }
+						placeholder={ defaultLabel }
+						onChange={ value => setAttributes( { label: value } ) }
+					/>
+				</PanelBody>
+			</InspectorControls>
+			<div { ...blockProps }>
+				<div className="newspack-newsletters-subscribe">
+					<form onSubmit={ ev => ev.preventDefault() }>
+						<input type="email" placeholder={ placeholder || defaultPlaceholder } />
+						<input type="submit" value={ label || defaultLabel } />
+					</form>
+				</div>
+			</div>
+		</>
+	);
+}

--- a/src/blocks/subscribe/editor.scss
+++ b/src/blocks/subscribe/editor.scss
@@ -1,0 +1,34 @@
+@import './style.scss';
+
+.newspack-newsletters-subscribe {
+	form {
+		input[type='email'] {
+			background: #fff;
+			border: solid 1px #ccc;
+			box-sizing: border-box;
+			outline: none;
+			padding: 0.36rem 0.66rem;
+			-webkit-appearance: none;
+			outline-offset: 0;
+			border-radius: 0;
+		}
+		input[type='submit'] {
+			transition: background 150ms ease-in-out;
+			background: #555;
+			border: none;
+			border-radius: 5px;
+			box-sizing: border-box;
+			display: inline-block;
+			color: #fff;
+			font-family: -apple-system, blinkmacsystemfont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell,
+				'Fira Sans', 'Droid Sans', 'Helvetica Neue', sans-serif;
+			font-size: 0.8em;
+			font-weight: 700;
+			line-height: 1.2;
+			outline: none;
+			padding: 0.76rem 1rem;
+			text-decoration: none;
+			vertical-align: bottom;
+		}
+	}
+}

--- a/src/blocks/subscribe/index.js
+++ b/src/blocks/subscribe/index.js
@@ -1,0 +1,19 @@
+/**
+ * WordPress dependencies
+ */
+import { box as icon } from '@wordpress/icons';
+
+/**
+ * Internal dependencies
+ */
+import edit from './edit';
+import metadata from './block.json';
+
+const { name } = metadata;
+
+export { metadata, name };
+
+export const settings = {
+	icon,
+	edit,
+};

--- a/src/blocks/subscribe/index.js
+++ b/src/blocks/subscribe/index.js
@@ -14,6 +14,9 @@ const { name } = metadata;
 export { metadata, name };
 
 export const settings = {
-	icon,
+	icon: {
+		src: icon,
+		foreground: '#36f',
+	},
 	edit,
 };

--- a/src/blocks/subscribe/index.js
+++ b/src/blocks/subscribe/index.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { box as icon } from '@wordpress/icons';
+import { inbox as icon } from '@wordpress/icons';
 
 /**
  * Internal dependencies

--- a/src/blocks/subscribe/index.php
+++ b/src/blocks/subscribe/index.php
@@ -54,51 +54,85 @@ add_action( 'wp_enqueue_scripts', __NAMESPACE__ . '\\enqueue_scripts' );
  */
 function render_block( $attrs ) {
 	$list_config = \Newspack_Newsletters_Subscription::get_lists_config();
+	$subscribed  = false;
+	$message     = '';
+	$email       = '';
+	$lists       = array_flip( array_keys( $list_config ) );
+	// phpcs:disable WordPress.Security.NonceVerification.Recommended
+	if ( isset( $_REQUEST['newspack_newsletters_subscribed'] ) ) {
+		$subscribed = \absint( $_REQUEST['newspack_newsletters_subscribed'] );
+		if ( isset( $_REQUEST['message'] ) ) {
+			$message = \sanitize_text_field( $_REQUEST['message'] );
+		}
+		if ( isset( $_REQUEST['email'] ) ) {
+			$email = \sanitize_text_field( $_REQUEST['email'] );
+		}
+		if ( isset( $_REQUEST['lists'] ) && is_array( $_REQUEST['lists'] ) ) {
+			$lists = array_flip( array_map( 'sanitize_text_field', $_REQUEST['lists'] ) );
+		}
+	}
+	// phpcs:enable
 	ob_start();
 	?>
 	<div class="newspack-newsletters-subscribe <?php echo esc_attr( get_block_classes( $attrs ) ); ?>">
-		<form>
-			<?php \wp_nonce_field( FORM_ACTION, FORM_ACTION ); ?>
-			<div class="newspack-newsletters-email-input">
-				<input type="email" name="email" autocomplete="email" placeholder="<?php echo \esc_attr( $attrs['placeholder'] ); ?>" />
+		<?php if ( $subscribed ) : ?>
+			<p class="message"><?php echo \esc_html( $message ); ?></p>
+		<?php else : ?>
+			<form>
+				<?php \wp_nonce_field( FORM_ACTION, FORM_ACTION ); ?>
+				<div class="newspack-newsletters-email-input">
+					<input
+						type="email"
+						name="email"
+						autocomplete="email"
+						placeholder="<?php echo \esc_attr( $attrs['placeholder'] ); ?>"
+						value="<?php echo esc_attr( $email ); ?>"
+					/>
+				</div>
+				<?php if ( 1 < count( $attrs['lists'] ) ) : ?>
+					<ul class="newspack-newsletters-lists">
+						<?php
+						foreach ( $attrs['lists'] as $list_id ) :
+							if ( ! isset( $list_config[ $list_id ] ) ) {
+								continue;
+							}
+							$list        = $list_config[ $list_id ];
+							$checkbox_id = sprintf( 'newspack-newsletters-list-checkbox-%s', $list_id );
+							?>
+							<li>
+								<span class="list-checkbox">
+									<input
+										type="checkbox"
+										name="lists[]"
+										value="<?php echo \esc_attr( $list_id ); ?>"
+										id="<?php echo \esc_attr( $checkbox_id ); ?>"
+										<?php if ( isset( $lists[ $list_id ] ) ) : ?>
+											checked
+										<?php endif; ?>
+									/>
+								</span>
+								<span class="list-details">
+									<label for="<?php echo \esc_attr( $checkbox_id ); ?>">
+										<span class="list-title"><?php echo \esc_html( $list['title'] ); ?></span>
+										<?php if ( $attrs['displayDescription'] ) : ?>
+											<span class="list-description"><?php echo \esc_html( $list['description'] ); ?></span>
+										<?php endif; ?>
+									</label>
+								</span>
+							</li>
+						<?php endforeach; ?>
+					</ul>
+				<?php else : ?>
+					<input type="hidden" name="lists[]" value="<?php echo \esc_attr( $attrs['lists'][0] ); ?>" />
+				<?php endif; ?>
+				<input type="submit" value="<?php echo \esc_attr( $attrs['label'] ); ?>" />
+			</form>
+			<div class="newspack-newsletters-subscribe-response">
+				<?php if ( ! empty( $message ) ) : ?>
+					<p><?php echo \esc_html( $message ); ?></p>
+				<?php endif; ?>
 			</div>
-			<?php if ( 1 < count( $attrs['lists'] ) ) : ?>
-				<ul class="newspack-newsletters-lists">
-					<?php
-					foreach ( $attrs['lists'] as $list_id ) :
-						if ( ! isset( $list_config[ $list_id ] ) ) {
-							continue;
-						}
-						$list        = $list_config[ $list_id ];
-						$checkbox_id = sprintf( 'newspack-newsletters-list-checkbox-%s', $list_id );
-						?>
-						<li>
-							<span class="list-checkbox">
-								<input
-									type="checkbox"
-									name="lists[]"
-									value="<?php echo \esc_attr( $list_id ); ?>"
-									id="<?php echo \esc_attr( $checkbox_id ); ?>"
-									checked
-								/>
-							</span>
-							<span class="list-details">
-								<label for="<?php echo \esc_attr( $checkbox_id ); ?>">
-									<span class="list-title"><?php echo \esc_html( $list['title'] ); ?></span>
-									<?php if ( $attrs['displayDescription'] ) : ?>
-										<span class="list-description"><?php echo \esc_html( $list['description'] ); ?></span>
-									<?php endif; ?>
-								</label>
-							</span>
-						</li>
-					<?php endforeach; ?>
-				</ul>
-			<?php else : ?>
-				<input type="hidden" name="lists[]" value="<?php echo \esc_attr( $attrs['lists'][0] ); ?>" />
-			<?php endif; ?>
-			<input type="submit" value="<?php echo \esc_attr( $attrs['label'] ); ?>" />
-		</form>
-		<div class="newspack-newsletters-subscribe-response"></div>
+		<?php endif; ?>
 	</div>
 	<?php
 	return ob_get_clean();
@@ -130,6 +164,42 @@ function get_block_classes( $attrs = [], $extra = [] ) {
 }
 
 /**
+ * Send the form response to the client, whether it's a JSON or GET request.
+ *
+ * @param mixed $data The response to send to the client.
+ */
+function send_form_response( $data ) {
+	$is_error = \is_wp_error( $data );
+	if ( \wp_is_json_request() ) {
+		if ( ! $is_error ) {
+			$message = __( 'Thank you for subscribing!', 'newspack' );
+		} else {
+			$message = $data->get_error_message();
+		}
+		\wp_send_json( compact( 'message', 'data' ), \is_wp_error( $data ) ? 400 : 200 );
+		exit;
+	} elseif ( isset( $_SERVER['REQUEST_METHOD'] ) && 'GET' === $_SERVER['REQUEST_METHOD'] ) {
+		$args_to_remove = [
+			'_wp_http_referer',
+			'newspack_newsletters_subscribe',
+		];
+		if ( ! $is_error ) {
+			$args_to_remove = array_merge( $args_to_remove, [ 'email', 'lists' ] );
+		}
+		\wp_safe_redirect(
+			\add_query_arg(
+				[
+					'newspack_newsletters_subscribed' => $is_error ? '0' : '1',
+					'message'                         => $is_error ? $data->get_error_message() : __( 'Thank you for subscribing!', 'newspack' ),
+				],
+				\remove_query_arg( $args_to_remove )
+			)
+		);
+		exit;
+	}
+}
+
+/**
  * Process registration form.
  */
 function process_form() {
@@ -138,16 +208,14 @@ function process_form() {
 	}
 
 	if ( ! isset( $_REQUEST['email'] ) || empty( $_REQUEST['email'] ) ) {
-		return;
+		return send_form_response( new \WP_Error( 'invalid_email', __( 'You must enter a valid email address.', 'newspack-newsletters' ) ) );
+	}
+
+	if ( ! isset( $_REQUEST['lists'] ) || empty( $_REQUEST['lists'] ) ) {
+		return send_form_response( new \WP_Error( 'no_lists', __( 'You must select a list.', 'newspack-newsletters' ) ) );
 	}
 
 	$email = \sanitize_email( $_REQUEST['email'] );
-
-	$result = false;
-
-	if ( ! isset( $_REQUEST['lists'] ) || empty( $_REQUEST['lists'] ) ) {
-		$result = new \WP_Error( 'no_lists', __( 'You must select a list.', 'newspack-newsletters' ) );
-	}
 
 	// TODO Subscribe user.
 
@@ -159,22 +227,6 @@ function process_form() {
 	 */
 	\do_action( 'newspack_newsletters_subscribe_form_processed', $email, $user_id );
 
-	if ( \wp_is_json_request() ) {
-		if ( ! \is_wp_error( $result ) ) {
-			$message = __( 'Thank you for subscribing!', 'newspack' );
-		} else {
-			$message = $result->get_error_message();
-		}
-		\wp_send_json( compact( 'message', 'email' ), \is_wp_error( $result ) ? 400 : 200 );
-		exit;
-	} elseif ( isset( $_SERVER['REQUEST_METHOD'] ) && 'GET' === $_SERVER['REQUEST_METHOD'] ) {
-		\wp_safe_redirect(
-			\add_query_arg(
-				[ 'newspack_newsletters_subscribed' => is_wp_error( $result ) ? '0' : '1' ],
-				\remove_query_arg( [ '_wp_http_referer', 'newspack_newsletters_subscribe', 'email' ] )
-			)
-		);
-		exit;
-	}
+	return send_form_response( [] );
 }
 add_action( 'template_redirect', __NAMESPACE__ . '\\process_form' );

--- a/src/blocks/subscribe/index.php
+++ b/src/blocks/subscribe/index.php
@@ -211,22 +211,28 @@ function process_form() {
 		return send_form_response( new \WP_Error( 'invalid_email', __( 'You must enter a valid email address.', 'newspack-newsletters' ) ) );
 	}
 
-	if ( ! isset( $_REQUEST['lists'] ) || empty( $_REQUEST['lists'] ) ) {
+	if ( ! isset( $_REQUEST['lists'] ) || ! is_array( $_REQUEST['lists'] ) || empty( $_REQUEST['lists'] ) ) {
 		return send_form_response( new \WP_Error( 'no_lists', __( 'You must select a list.', 'newspack-newsletters' ) ) );
 	}
 
 	$email = \sanitize_email( $_REQUEST['email'] );
+	$lists = array_map( 'sanitize_text_field', $_REQUEST['lists'] );
 
-	// TODO Subscribe user.
+	$result = \Newspack_Newsletters_Subscription::add_contact(
+		[
+			'email' => $email,
+		],
+		$lists
+	);
 
 	/**
-	 * Fires after a reader is registered through the Reader Registration Block.
+	 * Fires after subscribing a user to a list.
 	 *
-	 * @param string              $email   Email address of the reader.
-	 * @param int|false|\WP_Error $user_id The created user ID in case of registration, false if not created or a WP_Error object.
+	 * @param string         $email  Email address of the reader.
+	 * @param bool|\WP_Error $result Whether the contact was added or error.
 	 */
-	\do_action( 'newspack_newsletters_subscribe_form_processed', $email, $user_id );
+	\do_action( 'newspack_newsletters_subscribe_form_processed', $email, $result );
 
-	return send_form_response( [] );
+	return send_form_response( $result );
 }
 add_action( 'template_redirect', __NAMESPACE__ . '\\process_form' );

--- a/src/blocks/subscribe/index.php
+++ b/src/blocks/subscribe/index.php
@@ -53,11 +53,15 @@ add_action( 'wp_enqueue_scripts', __NAMESPACE__ . '\\enqueue_scripts' );
  * @param array[] $attrs Block attributes.
  */
 function render_block( $attrs ) {
-	$list_config = \Newspack_Newsletters_Subscription::get_lists_config();
-	$subscribed  = false;
-	$message     = '';
-	$email       = '';
-	$lists       = array_flip( array_keys( $list_config ) );
+	$list_config     = \Newspack_Newsletters_Subscription::get_lists_config();
+	$block_id        = \wp_rand( 0, 99999 );
+	$subscribed      = false;
+	$message         = '';
+	$email           = '';
+	$lists           = array_keys( $list_config );
+	$list_map        = array_flip( $lists );
+	$available_lists = array_intersect( $lists, $attrs['lists'] );
+
 	// phpcs:disable WordPress.Security.NonceVerification.Recommended
 	if ( isset( $_REQUEST['newspack_newsletters_subscribed'] ) ) {
 		$subscribed = \absint( $_REQUEST['newspack_newsletters_subscribed'] );
@@ -68,7 +72,7 @@ function render_block( $attrs ) {
 			$email = \sanitize_text_field( $_REQUEST['email'] );
 		}
 		if ( isset( $_REQUEST['lists'] ) && is_array( $_REQUEST['lists'] ) ) {
-			$lists = array_flip( array_map( 'sanitize_text_field', $_REQUEST['lists'] ) );
+			$list_map = array_flip( array_map( 'sanitize_text_field', $_REQUEST['lists'] ) );
 		}
 	}
 	// phpcs:enable
@@ -89,15 +93,15 @@ function render_block( $attrs ) {
 						value="<?php echo esc_attr( $email ); ?>"
 					/>
 				</div>
-				<?php if ( 1 < count( $attrs['lists'] ) ) : ?>
+				<?php if ( 1 < count( $available_lists ) ) : ?>
 					<ul class="newspack-newsletters-lists">
 						<?php
-						foreach ( $attrs['lists'] as $list_id ) :
+						foreach ( $available_lists as $list_id ) :
 							if ( ! isset( $list_config[ $list_id ] ) ) {
 								continue;
 							}
 							$list        = $list_config[ $list_id ];
-							$checkbox_id = sprintf( 'newspack-newsletters-list-checkbox-%s', $list_id );
+							$checkbox_id = sprintf( 'newspack-newsletters-%s-list-checkbox-%s', $block_id, $list_id );
 							?>
 							<li>
 								<span class="list-checkbox">
@@ -106,7 +110,7 @@ function render_block( $attrs ) {
 										name="lists[]"
 										value="<?php echo \esc_attr( $list_id ); ?>"
 										id="<?php echo \esc_attr( $checkbox_id ); ?>"
-										<?php if ( isset( $lists[ $list_id ] ) ) : ?>
+										<?php if ( isset( $list_map[ $list_id ] ) ) : ?>
 											checked
 										<?php endif; ?>
 									/>

--- a/src/blocks/subscribe/index.php
+++ b/src/blocks/subscribe/index.php
@@ -53,7 +53,7 @@ add_action( 'wp_enqueue_scripts', __NAMESPACE__ . '\\enqueue_scripts' );
  * @param array[] $attrs Block attributes.
  */
 function render_block( $attrs ) {
-	$list_config = \Newspack_Newsletters_Subscribe::get_lists_config();
+	$list_config = \Newspack_Newsletters_Subscription::get_lists_config();
 	ob_start();
 	?>
 	<div class="newspack-newsletters-subscribe <?php echo esc_attr( get_block_classes( $attrs ) ); ?>">

--- a/src/blocks/subscribe/index.php
+++ b/src/blocks/subscribe/index.php
@@ -65,6 +65,10 @@ function render_block( $attrs ) {
 	$list_map        = array_flip( $lists );
 	$available_lists = array_intersect( $lists, $attrs['lists'] );
 
+	if ( empty( $available_lists ) ) {
+		$available_lists = $lists[0];
+	}
+
 	// phpcs:disable WordPress.Security.NonceVerification.Recommended
 	if ( isset( $_REQUEST['newspack_newsletters_subscribed'] ) ) {
 		$subscribed = \absint( $_REQUEST['newspack_newsletters_subscribed'] );

--- a/src/blocks/subscribe/index.php
+++ b/src/blocks/subscribe/index.php
@@ -66,7 +66,7 @@ function render_block( $attrs ) {
 	$available_lists = array_values( array_intersect( $lists, $attrs['lists'] ) );
 
 	if ( empty( $available_lists ) ) {
-		$available_lists = $lists[0];
+		$available_lists = [ $lists[0] ];
 	}
 
 	// phpcs:disable WordPress.Security.NonceVerification.Recommended

--- a/src/blocks/subscribe/index.php
+++ b/src/blocks/subscribe/index.php
@@ -130,7 +130,7 @@ function render_block( $attrs ) {
 						<?php endforeach; ?>
 					</ul>
 				<?php else : ?>
-					<input type="hidden" name="lists[]" value="<?php echo \esc_attr( $attrs['lists'][0] ); ?>" />
+					<input type="hidden" name="lists[]" value="<?php echo \esc_attr( $available_lists[0] ); ?>" />
 				<?php endif; ?>
 				<input type="submit" value="<?php echo \esc_attr( $attrs['label'] ); ?>" />
 			</form>

--- a/src/blocks/subscribe/index.php
+++ b/src/blocks/subscribe/index.php
@@ -149,11 +149,10 @@ function render_block( $attrs ) {
  * Utility to assemble the class for a server-side rendered block.
  *
  * @param array $attrs Block attributes.
- * @param array $extra Additional classes to be added to the class list.
  *
  * @return string Class list separated by spaces.
  */
-function get_block_classes( $attrs = [], $extra = [] ) {
+function get_block_classes( $attrs = [] ) {
 	$classes = [];
 	if ( isset( $attrs['align'] ) && ! empty( $attrs['align'] ) ) {
 		$classes[] = 'align' . $attrs['align'];
@@ -163,9 +162,6 @@ function get_block_classes( $attrs = [], $extra = [] ) {
 	}
 	if ( 1 < count( $attrs['lists'] ) ) {
 		$classes[] = 'multiple-lists';
-	}
-	if ( is_array( $extra ) && ! empty( $extra ) ) {
-		$classes = array_merge( $classes, $extra );
 	}
 	return implode( ' ', $classes );
 }
@@ -188,7 +184,7 @@ function send_form_response( $data ) {
 	} elseif ( isset( $_SERVER['REQUEST_METHOD'] ) && 'GET' === $_SERVER['REQUEST_METHOD'] ) {
 		$args_to_remove = [
 			'_wp_http_referer',
-			'newspack_newsletters_subscribe',
+			FORM_ACTION,
 		];
 		if ( ! $is_error ) {
 			$args_to_remove = array_merge( $args_to_remove, [ 'email', 'lists' ] );

--- a/src/blocks/subscribe/index.php
+++ b/src/blocks/subscribe/index.php
@@ -1,0 +1,134 @@
+<?php
+/**
+ * Newspack Blocks.
+ *
+ * @package Newspack
+ */
+
+namespace Newspack_Newsletters\Blocks\Subscribe;
+
+defined( 'ABSPATH' ) || exit;
+
+const FORM_ACTION = 'newspack_newsletters_subscribe';
+
+/**
+ * Register block from metadata.
+ */
+function register_block() {
+	register_block_type_from_metadata(
+		__DIR__ . '/block.json',
+		array(
+			'render_callback' => __NAMESPACE__ . '\\render_block',
+		)
+	);
+}
+add_action( 'init', __NAMESPACE__ . '\\register_block' );
+
+/**
+ * Enqueue front-end scripts.
+ */
+function enqueue_scripts() {
+	$handle = 'newspack-newsletters-subscribe-block';
+	\wp_enqueue_style(
+		$handle,
+		plugins_url( '../../../dist/subscribeBlock.css', __FILE__ ),
+		[],
+		filemtime( NEWSPACK_NEWSLETTERS_PLUGIN_FILE . 'dist/subscribeBlock.css' )
+	);
+	\wp_enqueue_script(
+		$handle,
+		plugins_url( '../../../dist/subscribeBlock.js', __FILE__ ),
+		[ 'wp-polyfill' ],
+		filemtime( NEWSPACK_NEWSLETTERS_PLUGIN_FILE . 'dist/subscribeBlock.js' ),
+		true
+	);
+	\wp_script_add_data( $handle, 'async', true );
+	\wp_script_add_data( $handle, 'amp-plus', true );
+}
+add_action( 'wp_enqueue_scripts', __NAMESPACE__ . '\\enqueue_scripts' );
+
+/**
+ * Render Registration Block.
+ *
+ * @param array[] $attrs Block attributes.
+ */
+function render_block( $attrs ) {
+	ob_start();
+	?>
+	<div class="newspack-newsletters-subscribe <?php echo esc_attr( get_block_classes( $attrs ) ); ?>">
+		<form>
+			<?php \wp_nonce_field( FORM_ACTION, FORM_ACTION ); ?>
+			<input type="email" name="email" autocomplete="email" placeholder="<?php echo \esc_attr( $attrs['placeholder'] ); ?>" />
+			<input type="submit" value="<?php echo \esc_attr( $attrs['label'] ); ?>" />
+		</form>
+	</div>
+	<?php
+	return ob_get_clean();
+}
+
+/**
+ * Utility to assemble the class for a server-side rendered block.
+ *
+ * @param array $attrs Block attributes.
+ * @param array $extra Additional classes to be added to the class list.
+ *
+ * @return string Class list separated by spaces.
+ */
+function get_block_classes( $attrs = [], $extra = [] ) {
+	$classes = [];
+	if ( isset( $attrs['align'] ) && ! empty( $attrs['align'] ) ) {
+		$classes[] = 'align' . $attrs['align'];
+	}
+	if ( isset( $attrs['className'] ) ) {
+		array_push( $classes, $attrs['className'] );
+	}
+	if ( is_array( $extra ) && ! empty( $extra ) ) {
+		$classes = array_merge( $classes, $extra );
+	}
+	return implode( ' ', $classes );
+}
+
+/**
+ * Process registration form.
+ */
+function process_form() {
+	if ( ! isset( $_REQUEST[ FORM_ACTION ] ) || ! \wp_verify_nonce( \sanitize_text_field( $_REQUEST[ FORM_ACTION ] ), FORM_ACTION ) ) {
+		return;
+	}
+
+	if ( ! isset( $_REQUEST['email'] ) || empty( $_REQUEST['email'] ) ) {
+		return;
+	}
+
+	$email = \sanitize_email( $_REQUEST['email'] );
+
+	// TODO Subscribe user.
+	$result = false;
+
+	/**
+	 * Fires after a reader is registered through the Reader Registration Block.
+	 *
+	 * @param string              $email   Email address of the reader.
+	 * @param int|false|\WP_Error $user_id The created user ID in case of registration, false if not created or a WP_Error object.
+	 */
+	\do_action( 'newspack_newsletters_subscribe_form_processed', $email, $user_id );
+
+	if ( \wp_is_json_request() ) {
+		if ( ! \is_wp_error( $result ) ) {
+			$message = __( 'Thank you for registering!', 'newspack' );
+		} else {
+			$message = $result->get_error_message();
+		}
+		\wp_send_json( compact( 'message', 'email' ), \is_wp_error( $result ) ? 400 : 200 );
+		exit;
+	} elseif ( isset( $_SERVER['REQUEST_METHOD'] ) && 'GET' === $_SERVER['REQUEST_METHOD'] ) {
+		\wp_safe_redirect(
+			\add_query_arg(
+				[ 'newspack_newsletters_subscribed' => is_wp_error( $result ) ? '0' : '1' ],
+				\remove_query_arg( [ '_wp_http_referer', 'newspack_newsletters_subscribe', 'email' ] )
+			)
+		);
+		exit;
+	}
+}
+add_action( 'template_redirect', __NAMESPACE__ . '\\process_form' );

--- a/src/blocks/subscribe/index.php
+++ b/src/blocks/subscribe/index.php
@@ -53,7 +53,10 @@ add_action( 'wp_enqueue_scripts', __NAMESPACE__ . '\\enqueue_scripts' );
  * @param array[] $attrs Block attributes.
  */
 function render_block( $attrs ) {
-	$list_config     = \Newspack_Newsletters_Subscription::get_lists_config();
+	$list_config = \Newspack_Newsletters_Subscription::get_lists_config();
+	if ( empty( $list_config ) ) {
+		return;
+	}
 	$block_id        = \wp_rand( 0, 99999 );
 	$subscribed      = false;
 	$message         = '';

--- a/src/blocks/subscribe/index.php
+++ b/src/blocks/subscribe/index.php
@@ -63,7 +63,7 @@ function render_block( $attrs ) {
 	$email           = '';
 	$lists           = array_keys( $list_config );
 	$list_map        = array_flip( $lists );
-	$available_lists = array_intersect( $lists, $attrs['lists'] );
+	$available_lists = array_values( array_intersect( $lists, $attrs['lists'] ) );
 
 	if ( empty( $available_lists ) ) {
 		$available_lists = $lists[0];

--- a/src/blocks/subscribe/style.scss
+++ b/src/blocks/subscribe/style.scss
@@ -4,10 +4,36 @@
 		display: flex;
 		align-items: center;
 		margin: 0;
-		input[type='email'] {
-			flex: 1 1 100%;
-			min-width: 250px;
-			margin-right: 1em;
+	}
+	&.multiple-lists {
+		form {
+			display: block;
+		}
+	}
+	.newspack-newsletters-email-input {
+		flex: 1 1 100%;
+	}
+	input[type='email'] {
+		width: 100%;
+		min-width: 250px;
+		margin-right: 1em;
+	}
+	.newspack-newsletters-lists {
+		list-style: none;
+		margin: 1rem 0;
+		padding: 0;
+		li {
+			display: flex;
+			margin: 0 0 1rem;
+			.list-checkbox {
+				flex: 0 0 auto;
+				margin-right: 1rem;
+			}
+		}
+		p {
+			font-size: 0.8em;
+			color: #777;
+			margin: 0;
 		}
 	}
 }

--- a/src/blocks/subscribe/style.scss
+++ b/src/blocks/subscribe/style.scss
@@ -31,7 +31,7 @@
 		}
 		.list-checkbox {
 			flex: 0 0 auto;
-			margin: 0.2rem 0.5rem 0 0;
+			margin: 0 0.5rem 0 0;
 		}
 		.list-title {
 			display: block;
@@ -42,5 +42,10 @@
 			color: #777;
 			margin: 0;
 		}
+	}
+	.newspack-newsletters-subscribe-response {
+		margin: 0.5rem 0;
+		font-size: 0.8rem;
+		color: #777;
 	}
 }

--- a/src/blocks/subscribe/style.scss
+++ b/src/blocks/subscribe/style.scss
@@ -22,16 +22,23 @@
 		list-style: none;
 		margin: 1rem 0;
 		padding: 0;
+		display: flex;
+		font-size: 0.8rem;
 		li {
 			display: flex;
-			margin: 0 0 1rem;
-			.list-checkbox {
-				flex: 0 0 auto;
-				margin-right: 1rem;
-			}
+			margin: 0 1.4rem 1rem 0;
+			flex-wrap: wrap;
 		}
-		p {
-			font-size: 0.8em;
+		.list-checkbox {
+			flex: 0 0 auto;
+			margin: 0.2rem 0.5rem 0 0;
+		}
+		.list-title {
+			display: block;
+		}
+		.list-description {
+			display: block;
+			font-size: 0.8rem;
 			color: #777;
 			margin: 0;
 		}

--- a/src/blocks/subscribe/style.scss
+++ b/src/blocks/subscribe/style.scss
@@ -1,0 +1,13 @@
+.newspack-newsletters-subscribe {
+	form {
+		width: 100%;
+		display: flex;
+		align-items: center;
+		margin: 0;
+		input[type='email'] {
+			flex: 1 1 100%;
+			min-width: 250px;
+			margin-right: 1em;
+		}
+	}
+}

--- a/src/blocks/subscribe/style.scss
+++ b/src/blocks/subscribe/style.scss
@@ -5,29 +5,28 @@
 		align-items: center;
 		margin: 0;
 	}
-	&.multiple-lists {
-		form {
-			display: block;
-		}
-	}
 	.newspack-newsletters-email-input {
 		flex: 1 1 100%;
+		margin-right: 1rem;
 	}
 	input[type='email'] {
 		width: 100%;
-		min-width: 250px;
-		margin-right: 1em;
+		margin-right: 1rem;
 	}
 	.newspack-newsletters-lists {
 		list-style: none;
-		margin: 1rem 0;
+		margin: 1rem 0 0;
 		padding: 0;
 		display: flex;
 		font-size: 0.8rem;
+		flex-wrap: wrap;
 		li {
+			flex: 1 1 33.3333%;
 			display: flex;
-			margin: 0 1.4rem 1rem 0;
-			flex-wrap: wrap;
+			min-width: 200px;
+			box-sizing: border-box;
+			margin: 0;
+			padding: 0 1.4rem 1rem 0;
 		}
 		.list-checkbox {
 			flex: 0 0 auto;
@@ -47,5 +46,13 @@
 		margin: 0.5rem 0;
 		font-size: 0.8rem;
 		color: #777;
+	}
+	&.multiple-lists {
+		form {
+			display: block;
+		}
+		.newspack-newsletters-email-input {
+			margin-right: 0;
+		}
 	}
 }

--- a/src/blocks/subscribe/view.js
+++ b/src/blocks/subscribe/view.js
@@ -13,6 +13,7 @@ import './style.scss';
 			const messageContainer = container.querySelector(
 				'.newspack-newsletters-subscribe-response'
 			);
+			const emailInput = container.querySelector( 'input[type="email"]' );
 			const submit = container.querySelector( 'input[type="submit"]' );
 			form.addEventListener( 'submit', ev => {
 				ev.preventDefault();
@@ -20,6 +21,7 @@ import './style.scss';
 				if ( ! body.has( 'email' ) || ! body.get( 'email' ) ) {
 					return;
 				}
+				emailInput.disabled = true;
 				submit.disabled = true;
 				messageContainer.innerHTML = '';
 				fetch( form.getAttribute( 'action' ) || window.location.pathname, {
@@ -29,6 +31,7 @@ import './style.scss';
 					},
 					body,
 				} ).then( res => {
+					emailInput.disabled = false;
 					submit.disabled = false;
 					res.json().then( ( { message } ) => {
 						const messageNode = document.createElement( 'p' );

--- a/src/blocks/subscribe/view.js
+++ b/src/blocks/subscribe/view.js
@@ -4,11 +4,13 @@
 import './style.scss';
 
 ( function () {
-	[ ...document.querySelectorAll( '.newspack-reader-registration' ) ].forEach( container => {
+	[ ...document.querySelectorAll( '.newspack-newsletters-subscribe' ) ].forEach( container => {
 		const form = container.querySelector( 'form' );
 		if ( ! form ) {
 			return;
 		}
+		const messageContainer = container.querySelector( '.newspack-newsletters-subscribe-response' );
+		messageContainer.style.display = 'none';
 		form.addEventListener( 'submit', ev => {
 			ev.preventDefault();
 			const body = new FormData( form );
@@ -26,7 +28,13 @@ import './style.scss';
 					const messageNode = document.createElement( 'p' );
 					messageNode.innerHTML = message;
 					messageNode.className = `message status-${ res.status }`;
-					container.replaceChild( messageNode, form );
+					if ( res.status === 200 ) {
+						container.replaceChild( messageNode, form );
+					} else {
+						messageContainer.innerHTML = '';
+						messageContainer.appendChild( messageNode );
+						messageContainer.style.display = 'block';
+					}
 				} );
 			} );
 		} );

--- a/src/blocks/subscribe/view.js
+++ b/src/blocks/subscribe/view.js
@@ -1,41 +1,50 @@
 /**
+ * WordPress dependencies
+ */
+import domReady from '@wordpress/dom-ready';
+
+/**
  * Internal dependencies
  */
 import './style.scss';
 
 ( function () {
-	[ ...document.querySelectorAll( '.newspack-newsletters-subscribe' ) ].forEach( container => {
-		const form = container.querySelector( 'form' );
-		if ( ! form ) {
-			return;
-		}
-		const messageContainer = container.querySelector( '.newspack-newsletters-subscribe-response' );
-		const submit = container.querySelector( 'input[type="submit"]' );
-		form.addEventListener( 'submit', ev => {
-			ev.preventDefault();
-			const body = new FormData( form );
-			if ( ! body.has( 'email' ) || ! body.get( 'email' ) ) {
+	domReady( function () {
+		[ ...document.querySelectorAll( '.newspack-newsletters-subscribe' ) ].forEach( container => {
+			const form = container.querySelector( 'form' );
+			if ( ! form ) {
 				return;
 			}
-			submit.disabled = true;
-			messageContainer.innerHTML = '';
-			fetch( form.getAttribute( 'action' ) || window.location.pathname, {
-				method: 'POST',
-				headers: {
-					Accept: 'application/json',
-				},
-				body,
-			} ).then( res => {
-				submit.disabled = false;
-				res.json().then( ( { message } ) => {
-					const messageNode = document.createElement( 'p' );
-					messageNode.innerHTML = message;
-					messageNode.className = `message status-${ res.status }`;
-					if ( res.status === 200 ) {
-						container.replaceChild( messageNode, form );
-					} else {
-						messageContainer.appendChild( messageNode );
-					}
+			const messageContainer = container.querySelector(
+				'.newspack-newsletters-subscribe-response'
+			);
+			const submit = container.querySelector( 'input[type="submit"]' );
+			form.addEventListener( 'submit', ev => {
+				ev.preventDefault();
+				const body = new FormData( form );
+				if ( ! body.has( 'email' ) || ! body.get( 'email' ) ) {
+					return;
+				}
+				submit.disabled = true;
+				messageContainer.innerHTML = '';
+				fetch( form.getAttribute( 'action' ) || window.location.pathname, {
+					method: 'POST',
+					headers: {
+						Accept: 'application/json',
+					},
+					body,
+				} ).then( res => {
+					submit.disabled = false;
+					res.json().then( ( { message } ) => {
+						const messageNode = document.createElement( 'p' );
+						messageNode.innerHTML = message;
+						messageNode.className = `message status-${ res.status }`;
+						if ( res.status === 200 ) {
+							container.replaceChild( messageNode, form );
+						} else {
+							messageContainer.appendChild( messageNode );
+						}
+					} );
 				} );
 			} );
 		} );

--- a/src/blocks/subscribe/view.js
+++ b/src/blocks/subscribe/view.js
@@ -1,15 +1,10 @@
 /**
- * WordPress dependencies
- */
-import domReady from '@wordpress/dom-ready';
-
-/**
  * Internal dependencies
  */
 import './style.scss';
 
 ( function () {
-	domReady( function () {
+	window.onload = function () {
 		[ ...document.querySelectorAll( '.newspack-newsletters-subscribe' ) ].forEach( container => {
 			const form = container.querySelector( 'form' );
 			if ( ! form ) {
@@ -48,5 +43,5 @@ import './style.scss';
 				} );
 			} );
 		} );
-	} );
+	};
 } )();

--- a/src/blocks/subscribe/view.js
+++ b/src/blocks/subscribe/view.js
@@ -1,0 +1,34 @@
+/**
+ * Internal dependencies
+ */
+import './style.scss';
+
+( function () {
+	[ ...document.querySelectorAll( '.newspack-reader-registration' ) ].forEach( container => {
+		const form = container.querySelector( 'form' );
+		if ( ! form ) {
+			return;
+		}
+		form.addEventListener( 'submit', ev => {
+			ev.preventDefault();
+			const body = new FormData( form );
+			if ( ! body.has( 'email' ) || ! body.get( 'email' ) ) {
+				return;
+			}
+			fetch( form.getAttribute( 'action' ) || window.location.pathname, {
+				method: 'POST',
+				headers: {
+					Accept: 'application/json',
+				},
+				body,
+			} ).then( res => {
+				res.json().then( ( { message } ) => {
+					const messageNode = document.createElement( 'p' );
+					messageNode.innerHTML = message;
+					messageNode.className = `message status-${ res.status }`;
+					container.replaceChild( messageNode, form );
+				} );
+			} );
+		} );
+	} );
+} )();

--- a/src/blocks/subscribe/view.js
+++ b/src/blocks/subscribe/view.js
@@ -10,13 +10,15 @@ import './style.scss';
 			return;
 		}
 		const messageContainer = container.querySelector( '.newspack-newsletters-subscribe-response' );
-		messageContainer.style.display = 'none';
+		const submit = container.querySelector( 'input[type="submit"]' );
 		form.addEventListener( 'submit', ev => {
 			ev.preventDefault();
 			const body = new FormData( form );
 			if ( ! body.has( 'email' ) || ! body.get( 'email' ) ) {
 				return;
 			}
+			submit.disabled = true;
+			messageContainer.innerHTML = '';
 			fetch( form.getAttribute( 'action' ) || window.location.pathname, {
 				method: 'POST',
 				headers: {
@@ -24,6 +26,7 @@ import './style.scss';
 				},
 				body,
 			} ).then( res => {
+				submit.disabled = false;
 				res.json().then( ( { message } ) => {
 					const messageNode = document.createElement( 'p' );
 					messageNode.innerHTML = message;
@@ -31,9 +34,7 @@ import './style.scss';
 					if ( res.status === 200 ) {
 						container.replaceChild( messageNode, form );
 					} else {
-						messageContainer.innerHTML = '';
 						messageContainer.appendChild( messageNode );
-						messageContainer.style.display = 'block';
 					}
 				} );
 			} );

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -2,6 +2,7 @@
  **** WARNING: No ES6 modules here. Not transpiled! ****
  */
 /* eslint-disable import/no-nodejs-modules */
+/* eslint-disable @typescript-eslint/no-var-requires */
 
 /**
  * External dependencies
@@ -17,8 +18,10 @@ const admin = path.join( __dirname, 'src', 'admin' );
 const adsEditor = path.join( __dirname, 'src', 'ads-admin', 'editor' );
 const branding = path.join( __dirname, 'src', 'branding' );
 const quickEdit = path.join( __dirname, 'src', 'quick-edit' );
-const blocks = path.join( __dirname, 'src', 'editor', 'blocks' );
+const editorBlocks = path.join( __dirname, 'src', 'editor', 'blocks' );
 const newsletterEditor = path.join( __dirname, 'src', 'newsletter-editor' );
+const blocks = path.join( __dirname, 'src', 'blocks' );
+const subscribeBlock = path.join( __dirname, 'src', 'blocks', 'subscribe', 'view.js' );
 
 const webpackConfig = getBaseWebpackConfig(
 	{ WP: true },
@@ -29,8 +32,10 @@ const webpackConfig = getBaseWebpackConfig(
 			adsEditor,
 			branding,
 			quickEdit,
-			blocks,
+			editorBlocks,
 			newsletterEditor,
+			blocks,
+			subscribeBlock,
 		},
 		'output-path': path.join( __dirname, 'dist' ),
 	}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Implements subscription lists management and ESP-agnostic subscription block. It currently supports Campaign Monitor, Mailchimp, and ActiveCampaign. Constant Contact is currently unavailable due to #802.

## Subscription Lists

Once a provider is selected, the existing lists become available to configure as subscription lists with a custom title and description:

### Engagement Wizard

<img width="1099" alt="image" src="https://user-images.githubusercontent.com/820752/176779916-cabdd35f-d258-49e8-9a0a-845106f6f2ae.png">

### Newsletters Settings Page

<img width="650" alt="image" src="https://user-images.githubusercontent.com/820752/176779860-4e287e1b-a78a-4d5c-8e95-7beaada2d66c.png">

## Subscription Block

Once the subscription lists are configured by an admin, an editor can use the **Newsletters Subscription Block** to configure one or multiple lists to subscribe to.

### Multiple lists with narrow width

<img width="426" alt="image" src="https://user-images.githubusercontent.com/820752/176778030-5130b1d3-6b9d-4e76-8db4-bcfb801312bd.png">

### Multiple lists with wider width

<img width="847" alt="image" src="https://user-images.githubusercontent.com/820752/176778179-bff5784f-9640-4a0c-a24d-18ebbda25392.png">

### Single list

<img width="853" alt="image" src="https://user-images.githubusercontent.com/820752/176778233-2b298d6d-56b2-45e1-92f5-3ba7ae8ee80f.png">

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes #430
Closes #636 

### How to test the changes in this Pull Request:

1. Check out this branch and https://github.com/Automattic/newspack-plugin/pull/1734
2. Visit the Engagement wizard, select a provider you have multiple lists and save
3. Confirm the "Subscription Lists" section is updated once the config is saved
4. Enable, apply custom titles and descriptions to your lists and save
5. Edit a page and add a "Newsletter Subscription Form" block
6. Tweak different values and list selections and confirm they behave as expected
7. Save the page with the block with multiple lists selected
8. Subscribe an email selecting some but not all lists
9. Confirm on the ESP that the email is subscribed
10. Test subscription with all 3 supported ESPs
11. Access the page with mobile viewport and confirm the lists are displayed vertically

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
