### PR TITLE
fix(activecampaign): paginate through segments

### DIFF
--- a/includes/service-providers/active_campaign/class-newspack-newsletters-active-campaign.php
+++ b/includes/service-providers/active_campaign/class-newspack-newsletters-active-campaign.php
@@ -43,7 +43,11 @@ final class Newspack_Newsletters_Active_Campaign extends \Newspack_Newsletters_S
 		}
 		$credentials = $this->api_credentials();
 		$api_path    = '/api/3/';
-		$url         = rtrim( $credentials['url'], '/' ) . $api_path . $resource;
+		$query       = isset( $options['query'] ) ? $options['query'] : [];
+		$url         = add_query_arg(
+			$query,
+			rtrim( $credentials['url'], '/' ) . $api_path . $resource
+		);
 		$args        = [
 			'method'  => $method,
 			'headers' => [
@@ -185,11 +189,41 @@ final class Newspack_Newsletters_Active_Campaign extends \Newspack_Newsletters_S
 	 * @return array|WP_Error List os existing segments or error.
 	 */
 	public function get_segments() {
-		$result = $this->api_v3_request( 'segments' );
+		$max    = 100;
+		$offset = 0;
+		$result = $this->api_v3_request(
+			'segments',
+			'GET',
+			[
+				'query' => [
+					'limit'  => $max,
+					'offset' => $offset,
+				],
+			]
+		);
 		if ( is_wp_error( $result ) ) {
 			return $result;
 		}
-		return $result['segments'];
+		$segments = $result['segments'];
+		$total    = $result['meta']['total'];
+		while ( $total > $offset + $max ) {
+			$offset = $offset + $max;
+			$result = $this->api_v3_request(
+				'segments',
+				'GET',
+				[
+					'query' => [
+						'limit'  => $max,
+						'offset' => $offset,
+					],
+				]
+			);
+			if ( is_wp_error( $result ) ) {
+				return $result;
+			}
+			$segments = array_merge( $segments, $result['segments'] );
+		}
+		return $segments;
 	}
 
 	/**

--- a/includes/service-providers/active_campaign/class-newspack-newsletters-active-campaign.php
+++ b/includes/service-providers/active_campaign/class-newspack-newsletters-active-campaign.php
@@ -189,14 +189,14 @@ final class Newspack_Newsletters_Active_Campaign extends \Newspack_Newsletters_S
 	 * @return array|WP_Error List os existing segments or error.
 	 */
 	public function get_segments() {
-		$max    = 100;
+		$limit  = 100;
 		$offset = 0;
 		$result = $this->api_v3_request(
 			'segments',
 			'GET',
 			[
 				'query' => [
-					'limit'  => $max,
+					'limit'  => $limit,
 					'offset' => $offset,
 				],
 			]
@@ -206,14 +206,14 @@ final class Newspack_Newsletters_Active_Campaign extends \Newspack_Newsletters_S
 		}
 		$segments = $result['segments'];
 		$total    = $result['meta']['total'];
-		while ( $total > $offset + $max ) {
-			$offset = $offset + $max;
+		while ( $total > $offset + $limit ) {
+			$offset = $offset + $limit;
 			$result = $this->api_v3_request(
 				'segments',
 				'GET',
 				[
 					'query' => [
-						'limit'  => $max,
+						'limit'  => $limit,
 						'offset' => $offset,
 					],
 				]


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Fixes segment selection for ActiveCampaign by ensuring that all existing segments are fetched. It increases the limit to `100`, the maximum provided by the API, and paginates if necessary.

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

### How to test the changes in this Pull Request:

1. Select ActiveCampaign as your ESP with valid credentials
2. Change line `192` of `includes/service-providers/active_campaign/class-newspack-newsletters-active-campaign.php` to `$limit = 5;`
3. Make sure your account has at least 6 segments and draft a new newsletter
4. Select a list and open the segments dropdown
5. Confirm pagination is working by confirming all segments are displayed

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
