### PR TITLE
feat: email verification and subscription management

### DIFF
--- a/includes/class-newspack-newsletters-subscription.php
+++ b/includes/class-newspack-newsletters-subscription.php
@@ -350,7 +350,7 @@ class Newspack_Newsletters_Subscription {
 	 *
 	 * @return bool|WP_Error Whether the contact was updated or error.
 	 */
-	public static function update_contact_lists( $email, $lists = [] ) {
+	private static function update_contact_lists( $email, $lists = [] ) {
 		if ( ! self::has_subscription_management() ) {
 			return new WP_Error( 'newspack_newsletters_not_supported', __( 'Not supported for this provider', 'newspack-newsletters' ) );
 		}

--- a/includes/class-newspack-newsletters-subscription.php
+++ b/includes/class-newspack-newsletters-subscription.php
@@ -28,6 +28,8 @@ class Newspack_Newsletters_Subscription {
 		add_action( 'rest_api_init', [ __CLASS__, 'register_api_endpoints' ] );
 
 		/** User email verification for subscription management. */
+		add_action( 'resetpass_form', [ __CLASS__, 'set_current_user_email_verified' ] );
+		add_action( 'password_reset', [ __CLASS__, 'set_current_user_email_verified' ] );
 		add_action( 'template_redirect', [ __CLASS__, 'process_email_verification_request' ] );
 		add_action( 'template_redirect', [ __CLASS__, 'process_email_verification' ] );
 
@@ -399,6 +401,21 @@ class Newspack_Newsletters_Subscription {
 			return update_user_meta( $user_id, self::EMAIL_VERIFIED_META, $verified_emails );
 		}
 		return false;
+	}
+
+	/**
+	 * Set current user's email as verified.
+	 */
+	public static function set_current_user_email_verified() {
+		if ( ! is_user_logged_in() ) {
+			return;
+		}
+		$user_id = get_current_user_id();
+		if ( ! $user_id ) {
+			return;
+		}
+		$email = get_user_by( 'id', $user_id )->user_email;
+		self::set_email_verified( $user_id, $email );
 	}
 
 	/**

--- a/includes/class-newspack-newsletters-subscription.php
+++ b/includes/class-newspack-newsletters-subscription.php
@@ -106,7 +106,7 @@ class Newspack_Newsletters_Subscription {
 		if ( empty( $email ) ) {
 			$email = get_user_by( 'id', $user_id )->user_email;
 		}
-		return sprintf( 'newspack_newsletters_confirm_email_%s_%s', $user_id, wp_hash( $email ) );
+		return sprintf( 'newspack_newsletters_email_verification_%s_%s', $user_id, wp_hash( $email ) );
 	}
 
 	/**
@@ -211,6 +211,8 @@ class Newspack_Newsletters_Subscription {
 		}
 
 		self::set_email_verified( get_current_user_id() );
+
+		delete_transient( $transient_key );
 
 		wp_safe_redirect( remove_query_arg( [ self::EMAIL_VERIFIED_CONFIRM, 'token' ] ) );
 		exit;

--- a/includes/class-newspack-newsletters-subscription.php
+++ b/includes/class-newspack-newsletters-subscription.php
@@ -14,6 +14,7 @@ class Newspack_Newsletters_Subscription {
 
 	const API_NAMESPACE = 'newspack-newsletters/v1';
 
+	const WC_ENDPOINT      = 'newsletters';
 	const USER_FORM_ACTION = 'newspack_newsletters_subscription';
 
 	/**
@@ -24,7 +25,7 @@ class Newspack_Newsletters_Subscription {
 
 		/** Subscription management through WC's "My Account".  */
 		add_filter( 'woocommerce_get_query_vars', [ __CLASS__, 'add_query_var' ] );
-		add_filter( 'woocommerce_account_menu_items', [ __CLASS__, 'add_menu_items' ], 20 );
+		add_filter( 'woocommerce_account_menu_items', [ __CLASS__, 'add_menu_item' ], 20 );
 		add_action( 'woocommerce_account_newsletters_endpoint', [ __CLASS__, 'endpoint_content' ] );
 	}
 
@@ -316,12 +317,12 @@ class Newspack_Newsletters_Subscription {
 	 *
 	 * @return string[]|false|WP_Error Contact subscribed list names keyed by ID, false if not found or error.
 	 */
-	public static function get_contact_status( $email ) {
+	public static function get_contact_lists( $email ) {
 		$provider = Newspack_Newsletters::get_service_provider();
 		if ( empty( $provider ) ) {
 			return new WP_Error( 'newspack_newsletters_invalid_provider', __( 'Provider is not set.' ) );
 		}
-		return $provider->get_contact_status( $email );
+		return $provider->get_contact_lists( $email );
 	}
 
 	/**
@@ -332,28 +333,21 @@ class Newspack_Newsletters_Subscription {
 	 * @return array
 	 */
 	public static function add_query_var( $vars ) {
-		$vars[] = 'newsletters';
+		$vars[] = self::WC_ENDPOINT;
 		return $vars;
-	}
-
-	/**
-	 * Get WC's endpoint title for newsletters management.
-	 */
-	public static function wc_endpoint_title() {
-		return __( 'Newsletters', 'newspack-newsletters' );
 	}
 
 	/**
 	 * Insert the new endpoint into the My Account menu.
 	 *
 	 * @param array $menu_items Menu items.
+	 *
 	 * @return array
 	 */
-	public static function add_menu_items( $menu_items ) {
-		$position = 1;
-		$slug     = 'newsletters';
-		$name     = __( 'Newsletters', 'newspack-newsletters' );
-		return array_slice( $menu_items, 0, $position, true ) + [ $slug => $name ] + array_slice( $menu_items, $position, null, true );
+	public static function add_menu_item( $menu_items ) {
+		$position       = -1;
+		$menu_item_name = __( 'Newsletters', 'newspack-newsletters' );
+		return array_slice( $menu_items, 0, $position, true ) + [ self::WC_ENDPOINT => $menu_item_name ] + array_slice( $menu_items, $position, null, true );
 	}
 
 	/**
@@ -363,7 +357,7 @@ class Newspack_Newsletters_Subscription {
 		$email       = get_userdata( get_current_user_id() )->user_email;
 		$list_config = self::get_lists_config();
 		$list_map    = [];
-		$user_lists  = array_flip( self::get_contact_status( $email ) );
+		$user_lists  = array_flip( self::get_contact_lists( $email ) );
 		?>
 		<div class="newspack-newsletters__user-subscription">
 			<p>

--- a/includes/class-newspack-newsletters-subscription.php
+++ b/includes/class-newspack-newsletters-subscription.php
@@ -40,6 +40,7 @@ class Newspack_Newsletters_Subscription {
 		add_filter( 'woocommerce_account_menu_items', [ __CLASS__, 'add_menu_item' ], 20 );
 		add_action( 'woocommerce_account_newsletters_endpoint', [ __CLASS__, 'endpoint_content' ] );
 		add_action( 'template_redirect', [ __CLASS__, 'process_subscription_update' ] );
+		add_action( 'admin_init', [ __CLASS__, 'flush_rewrite_rules' ] );
 	}
 
 	/**
@@ -631,6 +632,17 @@ class Newspack_Newsletters_Subscription {
 	public static function add_query_var( $vars ) {
 		$vars[] = self::WC_ENDPOINT;
 		return $vars;
+	}
+
+	/**
+	 * Flush rewrite rules for WC_ENDPOINT.
+	 */
+	public static function flush_rewrite_rules() {
+		$option_name = 'newspack_newsletters_has_flushed_rewrite_rules';
+		if ( ! get_option( $option_name ) ) {
+			flush_rewrite_rules(); // phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.flush_rewrite_rules_flush_rewrite_rules
+			update_option( $option_name, true );
+		}
 	}
 
 	/**

--- a/includes/class-newspack-newsletters-subscription.php
+++ b/includes/class-newspack-newsletters-subscription.php
@@ -30,6 +30,7 @@ class Newspack_Newsletters_Subscription {
 		/** User email verification for subscription management. */
 		add_action( 'resetpass_form', [ __CLASS__, 'set_current_user_email_verified' ] );
 		add_action( 'password_reset', [ __CLASS__, 'set_current_user_email_verified' ] );
+		add_action( 'newspack_magic_link_authenticated', [ __CLASS__, 'set_current_user_email_verified' ] );
 		add_action( 'template_redirect', [ __CLASS__, 'process_email_verification_request' ] );
 		add_action( 'template_redirect', [ __CLASS__, 'process_email_verification' ] );
 

--- a/includes/class-newspack-newsletters-subscription.php
+++ b/includes/class-newspack-newsletters-subscription.php
@@ -32,196 +32,10 @@ class Newspack_Newsletters_Subscription {
 		add_action( 'template_redirect', [ __CLASS__, 'process_email_verification' ] );
 
 		/** Subscription management through WC's "My Account".  */
+		add_action( 'wp_enqueue_scripts', [ __CLASS__, 'enqueue_scripts' ] );
 		add_filter( 'woocommerce_get_query_vars', [ __CLASS__, 'add_query_var' ] );
 		add_filter( 'woocommerce_account_menu_items', [ __CLASS__, 'add_menu_item' ], 20 );
 		add_action( 'woocommerce_account_newsletters_endpoint', [ __CLASS__, 'endpoint_content' ] );
-	}
-
-	/**
-	 * Whether the current user has its email verified in order to manage their
-	 * newletters subscriptions.
-	 *
-	 * @param int    $user_id User ID.
-	 * @param string $email   Email address being verified. Default is the current user's email.
-	 *
-	 * @return bool
-	 */
-	public static function is_email_verified( $user_id, $email = '' ) {
-		$user = get_user_by( 'id', $user_id );
-		if ( ! $user ) {
-			return false;
-		}
-
-		if ( empty( $email ) ) {
-			$email = $user->user_email;
-		}
-
-		$verified_emails = get_user_meta( $user_id, self::EMAIL_VERIFIED_META, true );
-		if ( ! is_array( $verified_emails ) ) {
-			$verified_emails = [];
-		}
-
-		$verified = in_array( $email, $verified_emails, true );
-
-		/**
-		 * Filters whether the current user has its email verified.
-		 *
-		 * @param bool    $verified Whether the current user has its email verified.
-		 * @param WP_User $user     User object.
-		 * @param string  $email    Email address being verified.
-		 */
-		return (bool) apply_filters( 'newspack_newsletters_is_email_verified', $verified, $user, $email );
-	}
-
-	/**
-	 * Set email as verified for a user.
-	 *
-	 * @param int    $user_id User ID.
-	 * @param string $email   Email address being verified. Default is the current user's email.
-	 *
-	 * @return bool Wether the email was marked as verified successfully.
-	 */
-	public static function set_email_verified( $user_id, $email = '' ) {
-		$verified_emails = get_user_meta( $user_id, self::EMAIL_VERIFIED_META, true );
-		if ( ! is_array( $verified_emails ) ) {
-			$verified_emails = [];
-		}
-		if ( empty( $email ) ) {
-			$email = get_user_by( 'id', $user_id )->user_email;
-		}
-		if ( ! in_array( $email, $verified_emails, true ) ) {
-			$verified_emails[] = $email;
-			return update_user_meta( $user_id, self::EMAIL_VERIFIED_META, $verified_emails );
-		}
-		return false;
-	}
-
-	/**
-	 * Get current user email verification transient key.
-	 *
-	 * @param string $email Email address being verified. Default is the current user's email.
-	 */
-	private static function get_email_verification_transient_key( $email = '' ) {
-		$user_id = get_current_user_id();
-		if ( empty( $email ) ) {
-			$email = get_user_by( 'id', $user_id )->user_email;
-		}
-		return sprintf( 'newspack_newsletters_email_verification_%s_%s', $user_id, wp_hash( $email ) );
-	}
-
-	/**
-	 * Process request to verify a user's email.
-	 *
-	 * A 1-day transient will hold a token to verify the email.
-	 */
-	public static function process_email_verification_request() {
-		if ( ! isset( $_GET[ self::EMAIL_VERIFIED_REQUEST ] ) || ! wp_verify_nonce( sanitize_text_field( $_GET[ self::EMAIL_VERIFIED_REQUEST ] ), self::EMAIL_VERIFIED_REQUEST ) ) {
-			return;
-		}
-
-		if ( ! is_user_logged_in() ) {
-			wp_die( esc_html( __( 'Invalid request.', 'newspack-newsletters' ) ) );
-		}
-
-		$user               = wp_get_current_user();
-		$transient_key      = self::get_email_verification_transient_key();
-		$token              = \wp_generate_password( 43, false, false );
-		$verification_nonce = wp_create_nonce( self::EMAIL_VERIFIED_CONFIRM );
-
-		$url = home_url();
-		if ( function_exists( 'wc_get_account_endpoint_url' ) ) {
-			$url = wc_get_account_endpoint_url( 'newsletters' );
-		}
-		$url = add_query_arg(
-			[
-				self::EMAIL_VERIFIED_CONFIRM => $verification_nonce,
-				'token'                      => $token,
-			],
-			$url
-		);
-
-		set_transient( $transient_key, $token, DAY_IN_SECONDS );
-
-		$blogname = wp_specialchars_decode( get_option( 'blogname' ), ENT_QUOTES );
-
-		$switched_locale = switch_to_locale( get_user_locale( $user ) );
-
-		/* translators: %s: User display name. */
-		$message  = sprintf( __( 'Hello, %s!', 'newspack-newsletters' ), $user->display_name ) . "\r\n\r\n";
-		$message .= __( 'Verify your email address by visiting the following address:', 'newspack-newsletters' ) . "\r\n\r\n";
-		$message .= $url . "\r\n";
-
-		$email = [
-			'to'      => $user->user_email,
-			/* translators: %s Site title. */
-			'subject' => __( '[%s] Verify your email', 'newspack' ),
-			'message' => $message,
-			'headers' => '',
-		];
-
-		/**
-		 * Filters the email verification email.
-		 *
-		 * @param array    $email          Email arguments. {
-		 *   Used to build wp_mail().
-		 *
-		 *   @type string $to      The intended recipient - New user email address.
-		 *   @type string $subject The subject of the email.
-		 *   @type string $message The body of the email.
-		 *   @type string $headers The headers of the email.
-		 * }
-		 * @param \WP_User $user           User to send the magic link to.
-		 * @param string   $magic_link_url Magic link url.
-		 */
-		$email = \apply_filters( 'newspack_newsletters_email_verification_email', $email, $user, $url );
-
-		// phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.wp_mail_wp_mail
-		$sent = \wp_mail(
-			$email['to'],
-			\wp_specialchars_decode( sprintf( $email['subject'], $blogname ) ),
-			$email['message'],
-			$email['headers']
-		);
-
-		if ( $switched_locale ) {
-			\restore_previous_locale();
-		}
-
-		if ( function_exists( 'wc_add_notice' ) ) {
-			wc_add_notice( __( 'Check your email address for a verification link.', 'newspack-newsletters' ), 'success' );
-		}
-		wp_safe_redirect( add_query_arg( [ 'verification_sent' => 1 ], remove_query_arg( self::EMAIL_VERIFIED_REQUEST, wp_get_referer() ) ) );
-		exit;
-	}
-
-	/**
-	 * Process email verification.
-	 */
-	public static function process_email_verification() {
-		if ( ! isset( $_GET[ self::EMAIL_VERIFIED_CONFIRM ] ) || ! wp_verify_nonce( sanitize_text_field( $_GET[ self::EMAIL_VERIFIED_CONFIRM ] ), self::EMAIL_VERIFIED_CONFIRM ) ) {
-			return;
-		}
-		if ( ! is_user_logged_in() ) {
-			wp_die( esc_html( __( 'You\'re not logged in.', 'newspack-newsletters' ) ) );
-		}
-		$transient_key = self::get_email_verification_transient_key();
-		$token         = get_transient( $transient_key );
-		if ( ! $token ) {
-			wp_die( esc_html( __( 'Invalid request.', 'newspack-newsletters' ) ) );
-		}
-		if ( ! isset( $_GET['token'] ) || sanitize_text_field( $_GET['token'] ) !== $token ) {
-			wp_die( esc_html( __( 'Invalid request.', 'newspack-newsletters' ) ) );
-		}
-
-		self::set_email_verified( get_current_user_id() );
-
-		delete_transient( $transient_key );
-
-		if ( function_exists( 'wc_add_notice' ) ) {
-			wc_add_notice( __( 'Your email has been verified.', 'newspack-newsletters' ), 'success' );
-		}
-		wp_safe_redirect( remove_query_arg( [ self::EMAIL_VERIFIED_CONFIRM, 'token' ] ) );
-		exit;
 	}
 
 	/**
@@ -521,6 +335,205 @@ class Newspack_Newsletters_Subscription {
 	}
 
 	/**
+	 * Whether the current user has its email verified in order to manage their
+	 * newletters subscriptions.
+	 *
+	 * @param int    $user_id User ID.
+	 * @param string $email   Email address being verified. Default is the current user's email.
+	 *
+	 * @return bool
+	 */
+	public static function is_email_verified( $user_id, $email = '' ) {
+		$user = get_user_by( 'id', $user_id );
+		if ( ! $user ) {
+			return false;
+		}
+
+		if ( empty( $email ) ) {
+			$email = $user->user_email;
+		}
+
+		$verified_emails = get_user_meta( $user_id, self::EMAIL_VERIFIED_META, true );
+		if ( ! is_array( $verified_emails ) ) {
+			$verified_emails = [];
+		}
+
+		$verified = in_array( $email, $verified_emails, true );
+
+		/**
+		 * Filters whether the current user has its email verified.
+		 *
+		 * @param bool    $verified Whether the current user has its email verified.
+		 * @param WP_User $user     User object.
+		 * @param string  $email    Email address being verified.
+		 */
+		return (bool) apply_filters( 'newspack_newsletters_is_email_verified', $verified, $user, $email );
+	}
+
+	/**
+	 * Set email as verified for a user.
+	 *
+	 * @param int    $user_id User ID.
+	 * @param string $email   Email address being verified. Default is the current user's email.
+	 *
+	 * @return bool Wether the email was marked as verified successfully.
+	 */
+	public static function set_email_verified( $user_id, $email = '' ) {
+		$verified_emails = get_user_meta( $user_id, self::EMAIL_VERIFIED_META, true );
+		if ( ! is_array( $verified_emails ) ) {
+			$verified_emails = [];
+		}
+		if ( empty( $email ) ) {
+			$email = get_user_by( 'id', $user_id )->user_email;
+		}
+		if ( ! in_array( $email, $verified_emails, true ) ) {
+			$verified_emails[] = $email;
+			return update_user_meta( $user_id, self::EMAIL_VERIFIED_META, $verified_emails );
+		}
+		return false;
+	}
+
+	/**
+	 * Get current user email verification transient key.
+	 *
+	 * @param string $email Email address being verified. Default is the current user's email.
+	 */
+	private static function get_email_verification_transient_key( $email = '' ) {
+		$user_id = get_current_user_id();
+		if ( empty( $email ) ) {
+			$email = get_user_by( 'id', $user_id )->user_email;
+		}
+		return sprintf( 'newspack_newsletters_email_verification_%s_%s', $user_id, wp_hash( $email ) );
+	}
+
+	/**
+	 * Process request to verify a user's email.
+	 *
+	 * A 1-day transient will hold a token to verify the email.
+	 */
+	public static function process_email_verification_request() {
+		if ( ! isset( $_GET[ self::EMAIL_VERIFIED_REQUEST ] ) || ! wp_verify_nonce( sanitize_text_field( $_GET[ self::EMAIL_VERIFIED_REQUEST ] ), self::EMAIL_VERIFIED_REQUEST ) ) {
+			return;
+		}
+
+		if ( ! is_user_logged_in() ) {
+			wp_die( esc_html( __( 'Invalid request.', 'newspack-newsletters' ) ) );
+		}
+
+		$user               = wp_get_current_user();
+		$transient_key      = self::get_email_verification_transient_key();
+		$token              = \wp_generate_password( 43, false, false );
+		$verification_nonce = wp_create_nonce( self::EMAIL_VERIFIED_CONFIRM );
+
+		$url = home_url();
+		if ( function_exists( 'wc_get_account_endpoint_url' ) ) {
+			$url = wc_get_account_endpoint_url( 'newsletters' );
+		}
+		$url = add_query_arg(
+			[
+				self::EMAIL_VERIFIED_CONFIRM => $verification_nonce,
+				'token'                      => $token,
+			],
+			$url
+		);
+
+		set_transient( $transient_key, $token, DAY_IN_SECONDS );
+
+		$blogname = wp_specialchars_decode( get_option( 'blogname' ), ENT_QUOTES );
+
+		$switched_locale = switch_to_locale( get_user_locale( $user ) );
+
+		/* translators: %s: User display name. */
+		$message  = sprintf( __( 'Hello, %s!', 'newspack-newsletters' ), $user->display_name ) . "\r\n\r\n";
+		$message .= __( 'Verify your email address by visiting the following address:', 'newspack-newsletters' ) . "\r\n\r\n";
+		$message .= $url . "\r\n";
+
+		$email = [
+			'to'      => $user->user_email,
+			/* translators: %s Site title. */
+			'subject' => __( '[%s] Verify your email', 'newspack' ),
+			'message' => $message,
+			'headers' => '',
+		];
+
+		/**
+		 * Filters the email verification email.
+		 *
+		 * @param array    $email          Email arguments. {
+		 *   Used to build wp_mail().
+		 *
+		 *   @type string $to      The intended recipient - New user email address.
+		 *   @type string $subject The subject of the email.
+		 *   @type string $message The body of the email.
+		 *   @type string $headers The headers of the email.
+		 * }
+		 * @param \WP_User $user           User to send the magic link to.
+		 * @param string   $magic_link_url Magic link url.
+		 */
+		$email = \apply_filters( 'newspack_newsletters_email_verification_email', $email, $user, $url );
+
+		// phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.wp_mail_wp_mail
+		$sent = \wp_mail(
+			$email['to'],
+			\wp_specialchars_decode( sprintf( $email['subject'], $blogname ) ),
+			$email['message'],
+			$email['headers']
+		);
+
+		if ( $switched_locale ) {
+			\restore_previous_locale();
+		}
+
+		if ( function_exists( 'wc_add_notice' ) ) {
+			wc_add_notice( __( 'Check your email address for a verification link.', 'newspack-newsletters' ), 'success' );
+		}
+		wp_safe_redirect( add_query_arg( [ 'verification_sent' => 1 ], remove_query_arg( self::EMAIL_VERIFIED_REQUEST, wp_get_referer() ) ) );
+		exit;
+	}
+
+	/**
+	 * Process email verification.
+	 */
+	public static function process_email_verification() {
+		if ( ! isset( $_GET[ self::EMAIL_VERIFIED_CONFIRM ] ) || ! wp_verify_nonce( sanitize_text_field( $_GET[ self::EMAIL_VERIFIED_CONFIRM ] ), self::EMAIL_VERIFIED_CONFIRM ) ) {
+			return;
+		}
+		if ( ! is_user_logged_in() ) {
+			wp_die( esc_html( __( 'You\'re not logged in.', 'newspack-newsletters' ) ) );
+		}
+		$transient_key = self::get_email_verification_transient_key();
+		$token         = get_transient( $transient_key );
+		if ( ! $token ) {
+			wp_die( esc_html( __( 'Invalid request.', 'newspack-newsletters' ) ) );
+		}
+		if ( ! isset( $_GET['token'] ) || sanitize_text_field( $_GET['token'] ) !== $token ) {
+			wp_die( esc_html( __( 'Invalid request.', 'newspack-newsletters' ) ) );
+		}
+
+		self::set_email_verified( get_current_user_id() );
+
+		delete_transient( $transient_key );
+
+		if ( function_exists( 'wc_add_notice' ) ) {
+			wc_add_notice( __( 'Your email has been verified.', 'newspack-newsletters' ), 'success' );
+		}
+		wp_safe_redirect( remove_query_arg( [ self::EMAIL_VERIFIED_CONFIRM, 'token' ] ) );
+		exit;
+	}
+
+	/**
+	 * Enqueue subscription lists scripts and styles.
+	 */
+	public static function enqueue_scripts() {
+		wp_enqueue_style(
+			'newspack-newsletters-subscriptions',
+			plugins_url( '../dist/subscriptions.css', __FILE__ ),
+			[],
+			filemtime( NEWSPACK_NEWSLETTERS_PLUGIN_FILE . 'dist/subscriptions.css' )
+		);
+	}
+
+	/**
 	 * Add query var
 	 *
 	 * @param array $vars Query var.
@@ -575,34 +588,36 @@ class Newspack_Newsletters_Subscription {
 				</p>
 				<form method="post">
 					<?php wp_nonce_field( self::USER_FORM_ACTION ); ?>
-					<ul>
-						<?php
-						foreach ( $list_config as $list_id => $list ) :
-							$checkbox_id = sprintf( 'newspack-%s-list-checkbox-%s', $block_id, $list_id );
-							?>
-							<li>
-								<span class="newspack-newsletters__lists__checkbox">
-									<input
-										type="checkbox"
-										name="lists[]"
-										value="<?php echo \esc_attr( $list_id ); ?>"
-										id="<?php echo \esc_attr( $checkbox_id ); ?>"
-										<?php if ( isset( $user_lists[ $list_id ] ) ) : ?>
-											checked
-										<?php endif; ?>
-									/>
-								</span>
-								<span class="newspack-newsletters__lists__details">
-									<label class="newspack-newsletters__lists__label" for="<?php echo \esc_attr( $checkbox_id ); ?>">
-										<span class="newspack-newsletters__lists__title">
-											<?php echo \esc_html( $list['title'] ); ?>
-										</span>
-										<span class="newspack-newsletters__lists__description"><?php echo \esc_html( $list['description'] ); ?></span>
-									</label>
-								</span>
-							</li>
-						<?php endforeach; ?>
-					</ul>
+					<div class="newspack-newsletters__lists">
+						<ul>
+							<?php
+							foreach ( $list_config as $list_id => $list ) :
+								$checkbox_id = sprintf( 'newspack-%s-list-checkbox-%s', $block_id, $list_id );
+								?>
+								<li>
+									<span class="newspack-newsletters__lists__checkbox">
+										<input
+											type="checkbox"
+											name="lists[]"
+											value="<?php echo \esc_attr( $list_id ); ?>"
+											id="<?php echo \esc_attr( $checkbox_id ); ?>"
+											<?php if ( isset( $user_lists[ $list_id ] ) ) : ?>
+												checked
+											<?php endif; ?>
+										/>
+									</span>
+									<span class="newspack-newsletters__lists__details">
+										<label class="newspack-newsletters__lists__label" for="<?php echo \esc_attr( $checkbox_id ); ?>">
+											<span class="newspack-newsletters__lists__title">
+												<?php echo \esc_html( $list['title'] ); ?>
+											</span>
+											<span class="newspack-newsletters__lists__description"><?php echo \esc_html( $list['description'] ); ?></span>
+										</label>
+									</span>
+								</li>
+							<?php endforeach; ?>
+						</ul>
+					</div>
 					<button type="submit"><?php _e( 'Update subscriptions', 'newspack-newsletters' ); ?></button>
 				</form>
 			<?php endif; ?>

--- a/includes/class-newspack-newsletters-subscription.php
+++ b/includes/class-newspack-newsletters-subscription.php
@@ -350,8 +350,10 @@ class Newspack_Newsletters_Subscription {
 	 * @return array
 	 */
 	public static function add_menu_items( $menu_items ) {
-		$offset = 1;
-		return array_slice( $menu_items, 0, $offset, true ) + [ 'newsletters' => __( 'Newsletters', 'newspack-newsletters' ) ] + array_slice( $menu_items, $offset, null, true );
+		$position = 1;
+		$slug     = 'newsletters';
+		$name     = __( 'Newsletters', 'newspack-newsletters' );
+		return array_slice( $menu_items, 0, $position, true ) + [ $slug => $name ] + array_slice( $menu_items, $position, null, true );
 	}
 
 	/**

--- a/includes/class-newspack-newsletters-subscription.php
+++ b/includes/class-newspack-newsletters-subscription.php
@@ -40,7 +40,7 @@ class Newspack_Newsletters_Subscription {
 		add_filter( 'woocommerce_account_menu_items', [ __CLASS__, 'add_menu_item' ], 20 );
 		add_action( 'woocommerce_account_newsletters_endpoint', [ __CLASS__, 'endpoint_content' ] );
 		add_action( 'template_redirect', [ __CLASS__, 'process_subscription_update' ] );
-		add_action( 'admin_init', [ __CLASS__, 'flush_rewrite_rules' ] );
+		add_action( 'init', [ __CLASS__, 'flush_rewrite_rules' ] );
 	}
 
 	/**

--- a/includes/class-newspack-newsletters-subscription.php
+++ b/includes/class-newspack-newsletters-subscription.php
@@ -146,7 +146,7 @@ class Newspack_Newsletters_Subscription {
 
 		$switched_locale = switch_to_locale( get_user_locale( $user ) );
 
-		/* translators: %s: Site title. */
+		/* translators: %s: User display name. */
 		$message  = sprintf( __( 'Hello, %s!', 'newspack-newsletters' ), $user->display_name ) . "\r\n\r\n";
 		$message .= __( 'Verify your email address by visiting the following address:', 'newspack-newsletters' ) . "\r\n\r\n";
 		$message .= $url . "\r\n";

--- a/includes/class-newspack-newsletters-subscription.php
+++ b/includes/class-newspack-newsletters-subscription.php
@@ -543,12 +543,9 @@ class Newspack_Newsletters_Subscription {
 	 * Endpoint content.
 	 */
 	public static function endpoint_content() {
-		$user_id     = get_current_user_id();
-		$email       = get_userdata( $user_id )->user_email;
-		$list_config = self::get_lists_config();
-		$list_map    = [];
-		$user_lists  = array_flip( self::get_contact_lists( $email ) );
-		$verified    = self::is_email_verified( $user_id );
+		$user_id  = get_current_user_id();
+		$email    = get_userdata( $user_id )->user_email;
+		$verified = self::is_email_verified( $user_id, $email );
 		?>
 		<div class="newspack-newsletters__user-subscription">
 			<?php if ( ! $verified ) : ?>
@@ -560,7 +557,12 @@ class Newspack_Newsletters_Subscription {
 						<?php esc_html_e( 'Verify Email', 'newspack-newsletters' ); ?>
 					</a>
 				</p>
-			<?php else : ?>
+				<?php
+			else :
+				$list_config = self::get_lists_config();
+				$list_map    = [];
+				$user_lists  = array_flip( self::get_contact_lists( $email ) );
+				?>
 				<p>
 					<?php _e( 'Manage the newsletters you are subscribed to.', 'newspack-newsletters' ); ?>
 				</p>

--- a/includes/class-newspack-newsletters-subscription.php
+++ b/includes/class-newspack-newsletters-subscription.php
@@ -686,7 +686,7 @@ class Newspack_Newsletters_Subscription {
 						<ul>
 							<?php
 							foreach ( $list_config as $list_id => $list ) :
-								$checkbox_id = sprintf( 'newspack-%s-list-checkbox-%s', $block_id, $list_id );
+								$checkbox_id = sprintf( 'newspack-newsletters-list-checkbox-%s', $list_id );
 								?>
 								<li>
 									<span class="newspack-newsletters__lists__checkbox">

--- a/includes/service-providers/active_campaign/class-newspack-newsletters-active-campaign.php
+++ b/includes/service-providers/active_campaign/class-newspack-newsletters-active-campaign.php
@@ -679,4 +679,25 @@ final class Newspack_Newsletters_Active_Campaign extends \Newspack_Newsletters_S
 		);
 		return is_wp_error( $result ) ? $result : true;
 	}
+
+	/**
+	 * Get a contact status.
+	 *
+	 * @param string $email The contact email.
+	 *
+	 * @return string[] Contact subscribed lists IDs.
+	 */
+	public function get_contact_status( $email ) {
+		$contact = $this->api_v1_request( 'contact_list', 'GET', [ 'query' => [ 'filters[email]' => $email ] ] );
+		if ( is_wp_error( $contact ) ) {
+			return [];
+		}
+		$lists = [];
+		foreach ( $contact as $contact_list ) {
+			if ( isset( $contact_list['listid'] ) && isset( $contact_list['status'] ) && 1 === absint( $contact_list['status'] ) ) {
+				$lists[] = $contact_list['listid'];
+			}
+		}
+		return $lists;
+	}
 }

--- a/includes/service-providers/active_campaign/class-newspack-newsletters-active-campaign.php
+++ b/includes/service-providers/active_campaign/class-newspack-newsletters-active-campaign.php
@@ -744,11 +744,8 @@ final class Newspack_Newsletters_Active_Campaign extends \Newspack_Newsletters_S
 			}
 			$contact_id = $contact['contact']['id'];
 		} else {
-			$contact         = $contact['contacts'][0];
-			$contact_id      = $contact['id'];
-			$current_lists   = self::get_contact_lists( $email );
-			$lists_to_add    = array_diff( $lists_to_add, $current_lists );
-			$lists_to_remove = array_intersect( $current_lists, $lists_to_remove );
+			$contact    = $contact['contacts'][0];
+			$contact_id = $contact['id'];
 			/** Set status to "2" (unsubscribed) for lists to remove. */
 			foreach ( $lists_to_remove as $list ) {
 				$result = $this->api_v3_request(

--- a/includes/service-providers/active_campaign/class-newspack-newsletters-active-campaign.php
+++ b/includes/service-providers/active_campaign/class-newspack-newsletters-active-campaign.php
@@ -688,14 +688,18 @@ final class Newspack_Newsletters_Active_Campaign extends \Newspack_Newsletters_S
 	 * @return string[] Contact subscribed lists IDs.
 	 */
 	public function get_contact_lists( $email ) {
-		$contact = $this->api_v1_request( 'contact_list', 'GET', [ 'query' => [ 'filters[email]' => $email ] ] );
-		if ( is_wp_error( $contact ) ) {
+		$contact = $this->api_v3_request( 'contacts', 'GET', [ 'query' => [ 'email' => $email ] ] );
+		if ( is_wp_error( $contact ) || ! isset( $contact['contacts'], $contact['contacts'][0] ) ) {
+			return [];
+		}
+		$contact_lists = $this->api_v3_request( 'contacts/' . $contact['contacts'][0]['id'] . '/contactLists' );
+		if ( is_wp_error( $contact_lists ) || ! isset( $contact_lists['contactLists'] ) ) {
 			return [];
 		}
 		$lists = [];
-		foreach ( $contact as $contact_list ) {
-			if ( isset( $contact_list['listid'] ) && isset( $contact_list['status'] ) && 1 === absint( $contact_list['status'] ) ) {
-				$lists[] = $contact_list['listid'];
+		foreach ( $contact_lists['contactLists'] as $list ) {
+			if ( isset( $list['status'] ) && 1 === absint( $list['status'] ) ) {
+				$lists[] = $list['list'];
 			}
 		}
 		return $lists;

--- a/includes/service-providers/active_campaign/class-newspack-newsletters-active-campaign.php
+++ b/includes/service-providers/active_campaign/class-newspack-newsletters-active-campaign.php
@@ -687,7 +687,7 @@ final class Newspack_Newsletters_Active_Campaign extends \Newspack_Newsletters_S
 	 *
 	 * @return string[] Contact subscribed lists IDs.
 	 */
-	public function get_contact_status( $email ) {
+	public function get_contact_lists( $email ) {
 		$contact = $this->api_v1_request( 'contact_list', 'GET', [ 'query' => [ 'filters[email]' => $email ] ] );
 		if ( is_wp_error( $contact ) ) {
 			return [];

--- a/includes/service-providers/class-newspack-newsletters-service-provider.php
+++ b/includes/service-providers/class-newspack-newsletters-service-provider.php
@@ -122,7 +122,7 @@ abstract class Newspack_Newsletters_Service_Provider implements Newspack_Newslet
 		if (
 			! $sent &&
 			$old_status !== $new_status &&
-			in_array( $new_status, self::$controlled_statuses, true ) && 
+			in_array( $new_status, self::$controlled_statuses, true ) &&
 			! in_array( $old_status, self::$controlled_statuses, true )
 		) {
 			$result = $this->send_newsletter( $post );
@@ -170,7 +170,7 @@ abstract class Newspack_Newsletters_Service_Provider implements Newspack_Newslet
 					[
 						'ID'          => $post->ID,
 						'post_status' => 'draft',
-					] 
+					]
 				);
 				wp_die( $result ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 			} else {
@@ -192,7 +192,7 @@ abstract class Newspack_Newsletters_Service_Provider implements Newspack_Newslet
 		if ( ! Newspack_Newsletters::validate_newsletter_id( $post_id ) ) {
 			return;
 		}
-		
+
 		// Only run if this is the active provider.
 		if ( Newspack_Newsletters::service_provider() !== $this->service ) {
 			return;
@@ -218,7 +218,7 @@ abstract class Newspack_Newsletters_Service_Provider implements Newspack_Newslet
 				[
 					'ID'          => $post_id,
 					'post_status' => $target_status,
-				] 
+				]
 			);
 		}
 	}
@@ -304,5 +304,18 @@ abstract class Newspack_Newsletters_Service_Provider implements Newspack_Newslet
 		}
 
 		return $result;
+	}
+
+	/**
+	 * Update a contact lists subscription.
+	 *
+	 * @param string   $email           Contact email address.
+	 * @param string[] $lists_to_add    Array of list IDs to subscribe the contact to.
+	 * @param string[] $lists_to_remove Array of list IDs to remove the contact from.
+	 *
+	 * @return true|WP_Error True if the contact was updated or error.
+	 */
+	public function update_contact_lists( $email, $lists_to_add = [], $lists_to_remove = [] ) {
+		return new WP_Error( 'newspack_newsletters_not_implemented', __( 'Not implemented', 'newspack-newsletters' ) );
 	}
 }

--- a/includes/service-providers/interface-newspack-newsletters-esp-service.php
+++ b/includes/service-providers/interface-newspack-newsletters-esp-service.php
@@ -102,4 +102,15 @@ interface Newspack_Newsletters_ESP_API_Interface {
 	 * @return bool|WP_Error True if the contact was added or error if failed.
 	 */
 	public function add_contact( $contact, $list_id );
+
+	/**
+	 * Update a contact lists subscription.
+	 *
+	 * @param string   $email           Contact email address.
+	 * @param string[] $lists_to_add    Array of list IDs to subscribe the contact to.
+	 * @param string[] $lists_to_remove Array of list IDs to remove the contact from.
+	 *
+	 * @return true|WP_Error True if the contact was updated or error.
+	 */
+	public function update_contact_lists( $email, $lists_to_add = [], $lists_to_remove = [] );
 }

--- a/src/subscriptions/index.js
+++ b/src/subscriptions/index.js
@@ -1,0 +1,1 @@
+import './style.scss';

--- a/src/subscriptions/style.scss
+++ b/src/subscriptions/style.scss
@@ -1,0 +1,44 @@
+@use '~@wordpress/base-styles/colors' as wp-colors;
+
+.newspack-newsletters {
+	&__lists {
+		flex: 1 1 100%;
+		font-size: 0.8rem;
+		border: 1px solid wp-colors.$gray-200;
+		border-radius: 2px;
+		padding: 0.5rem 0 0.5rem 1rem;
+		margin: 0 0 1rem;
+
+		ul {
+			list-style: none;
+			padding: 0;
+			display: flex;
+			flex-wrap: wrap;
+			min-width: 250px;
+			li {
+				flex: 1 1 100%;
+				display: flex;
+				min-width: 200px;
+				box-sizing: border-box;
+				margin: 0;
+				padding: 0.5rem 1rem 0.5rem 0;
+			}
+		}
+
+		&__checkbox {
+			flex: 0 0 auto;
+			margin: 0 0.5rem 0 0;
+		}
+
+		&__title {
+			display: block;
+		}
+
+		&__description {
+			display: block;
+			font-size: 0.8rem;
+			color: #757575;
+			margin: 0;
+		}
+	}
+}

--- a/src/subscriptions/style.scss
+++ b/src/subscriptions/style.scss
@@ -1,17 +1,14 @@
-@use '~@wordpress/base-styles/colors' as wp-colors;
-
 .newspack-newsletters {
 	&__lists {
 		flex: 1 1 100%;
 		font-size: 0.8rem;
-		border: 1px solid wp-colors.$gray-200;
 		border-radius: 2px;
-		padding: 0.5rem 0 0.5rem 1rem;
 		margin: 0 0 1rem;
 
 		ul {
 			list-style: none;
 			padding: 0;
+			margin: 0;
 			display: flex;
 			flex-wrap: wrap;
 			min-width: 250px;
@@ -32,6 +29,7 @@
 
 		&__title {
 			display: block;
+			font-weight: 600;
 		}
 
 		&__description {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -22,6 +22,7 @@ const editorBlocks = path.join( __dirname, 'src', 'editor', 'blocks' );
 const newsletterEditor = path.join( __dirname, 'src', 'newsletter-editor' );
 const blocks = path.join( __dirname, 'src', 'blocks' );
 const subscribeBlock = path.join( __dirname, 'src', 'blocks', 'subscribe', 'view.js' );
+const subscriptions = path.join( __dirname, 'src', 'subscriptions' );
 
 const webpackConfig = getBaseWebpackConfig(
 	{ WP: true },
@@ -36,6 +37,7 @@ const webpackConfig = getBaseWebpackConfig(
 			newsletterEditor,
 			blocks,
 			subscribeBlock,
+			subscriptions,
 		},
 		'output-path': path.join( __dirname, 'dist' ),
 	}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Implements email verification for subscription management through WooCommerce's "My Account" page.

For reviewing purposes, this PR implements subscription management only for ActiveCampaign at the moment. Other ESPs should follow.

<img width="1097" alt="image" src="https://user-images.githubusercontent.com/820752/179840385-b0491c8d-7757-46c2-8c0b-97d6e3cab657.png">

<img width="1228" alt="image" src="https://user-images.githubusercontent.com/820752/179840423-403fef79-5555-4dd2-a648-a81919446a2a.png">

<img width="1315" alt="image" src="https://user-images.githubusercontent.com/820752/179840528-ea43f68d-85b9-49f3-ac02-497c314affe8.png">

<img width="1109" alt="image" src="https://user-images.githubusercontent.com/820752/179841680-d70b8109-cbad-4bcd-9f1b-68ed2b589d8b.png">

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Partial of https://github.com/Automattic/newspack-plugin/issues/1743

### How to test the changes in this Pull Request:

1. Make sure you have WC installed and active, a way to intercept WP's sent emails, and ActiveCampaign as your ESP
2. Visit the "Engagement" wizard and make sure you have at least one subscription list enabled
3. Visit "My Account" page and click on "Newsletters"
4. Confirm you see a button to confirm your email
5. Click on the button and confirm you receive an email with a link
6. Click on the link and confirm the success message and the list of subscription lists to toggle
7. Toggle the lists (unsubscribe to one and subscribe to another)
8. Confirm the changes are reflected on the page and on the ESP dashboard

### Changing email

1. Change your account's email
2. Visit the Newsletters page again and confirm you have to verify again
3. Verify the email and confirm you can manage the subscriptions

### Unsupported ESP

1. Change your ESP to Mailchimp
4. Visit the "My Account" page and confirm you **cannot** see the "Newsletter" link

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
