### PR TITLE
feat(subscribe-block): prefill email input

### DIFF
--- a/src/blocks/subscribe/index.php
+++ b/src/blocks/subscribe/index.php
@@ -69,6 +69,18 @@ function render_block( $attrs ) {
 		$available_lists = [ $lists[0] ];
 	}
 
+	if ( \is_user_logged_in() ) {
+		$email = \wp_get_current_user()->user_email;
+	} elseif ( class_exists( '\Newspack\Reader_Activation' ) ) {
+		try {
+			if ( \Newspack\Reader_Activation::is_enabled() ) {
+				$email = \Newspack\Reader_Activation::get_auth_intention_value();
+			}
+		} catch ( \Throwable $th ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch
+			// Fail silently.
+		}
+	}
+
 	// phpcs:disable WordPress.Security.NonceVerification.Recommended
 	if ( isset( $_REQUEST['newspack_newsletters_subscribed'] ) ) {
 		$subscribed = \absint( $_REQUEST['newspack_newsletters_subscribed'] );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Pre-filling of email input of the Subscribe block, if an email is available. 

cc @miguelpeixe in case that was something you had planned :) 

### How to test the changes in this Pull Request:

1. Insert a Subscribe block
2. As a logged in user, observe the email address is pre-filled
3. In a new session, use the Reader Registration block from the Newspack plugin to pre-authenticated as an existing reader
4. Observe the email is pre-filled, despite user not being logged in

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->