### PR TITLE
chore(deps): update newspack-scripts, prettier

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -5,6 +5,6 @@ singleQuote: true
 trailingComma: es5
 bracketSpacing: true
 parenSpacing: true
-jsxBracketSameLine: false
+bracketSameLine: false
 semi: true
 arrowParens: avoid

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,10 +23,11 @@
 				"@rushstack/eslint-patch": "^1.1.4",
 				"eslint": "^7.32.0",
 				"lint-staged": "^13.0.3",
-				"newspack-scripts": "^3.3.2",
+				"newspack-scripts": "^4.3.0",
 				"postcss": "^8.4.14",
-				"prettier": "npm:wp-prettier@^2.2.1-beta-1",
-				"stylelint": "^13.13.1"
+				"postcss-scss": "^4.0.4",
+				"prettier": "npm:wp-prettier@^2.6.2-beta-1",
+				"stylelint": "^14.9.1"
 			}
 		},
 		"node_modules/@automattic/babel-plugin-preserve-i18n": {
@@ -189,11 +190,11 @@
 			}
 		},
 		"node_modules/@babel/code-frame": {
-			"version": "7.14.5",
-			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.14.5.tgz",
-			"integrity": "sha512-9pzDqyc6OLDaqe+zbACgFkb6fKMNG6CObKpnYXChRsvYGyEdc7CA2BaqeOM+vOtCS5ndmJicPJhKAwYRI6UfFw==",
+			"version": "7.18.6",
+			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.18.6.tgz",
+			"integrity": "sha512-TDCmlK5eOvH+eH7cdAFlNXeVJqWIQ7gW9tY1GJIpUtFb6CmjVyq2VM3u71bOyR8CRihcCgMUYoDNyLXao3+70Q==",
 			"dependencies": {
-				"@babel/highlight": "^7.14.5"
+				"@babel/highlight": "^7.18.6"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -236,17 +237,6 @@
 				"url": "https://opencollective.com/babel"
 			}
 		},
-		"node_modules/@babel/core/node_modules/@babel/code-frame": {
-			"version": "7.16.0",
-			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.16.0.tgz",
-			"integrity": "sha512-IF4EOMEV+bfYwOmNxGzSnjR2EmQod7f1UXOpZM3l4i4o4QNwzjtJAu/HxdjHq0aYBvdqMuQEY1eg0nqW9ZPORA==",
-			"dependencies": {
-				"@babel/highlight": "^7.16.0"
-			},
-			"engines": {
-				"node": ">=6.9.0"
-			}
-		},
 		"node_modules/@babel/core/node_modules/debug": {
 			"version": "4.1.1",
 			"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
@@ -284,25 +274,25 @@
 			}
 		},
 		"node_modules/@babel/generator": {
-			"version": "7.16.0",
-			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.16.0.tgz",
-			"integrity": "sha512-RR8hUCfRQn9j9RPKEVXo9LiwoxLPYn6hNZlvUOR8tSnaxlD0p0+la00ZP9/SnRt6HchKr+X0fO2r8vrETiJGew==",
+			"version": "7.18.9",
+			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.18.9.tgz",
+			"integrity": "sha512-wt5Naw6lJrL1/SGkipMiFxJjtyczUWTP38deiP1PO60HsBjDeKk08CGC3S8iVuvf0FmTdgKwU1KIXzSKL1G0Ug==",
 			"dependencies": {
-				"@babel/types": "^7.16.0",
-				"jsesc": "^2.5.1",
-				"source-map": "^0.5.0"
+				"@babel/types": "^7.18.9",
+				"@jridgewell/gen-mapping": "^0.3.2",
+				"jsesc": "^2.5.1"
 			},
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/helper-annotate-as-pure": {
-			"version": "7.16.0",
-			"resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.16.0.tgz",
-			"integrity": "sha512-ItmYF9vR4zA8cByDocY05o0LGUkp1zhbTQOH1NFyl5xXEqlTJQCEJjieriw+aFpxo16swMxUnUiKS7a/r4vtHg==",
+			"version": "7.18.6",
+			"resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.18.6.tgz",
+			"integrity": "sha512-duORpUiYrEpzKIop6iNbjnwKLAKnJ47csTyRACyEmWj0QdUrm5aqNJGHSSEQSUAvNW0ojX0dOmK9dZduvkfeXA==",
 			"dev": true,
 			"dependencies": {
-				"@babel/types": "^7.16.0"
+				"@babel/types": "^7.18.6"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -347,17 +337,18 @@
 			}
 		},
 		"node_modules/@babel/helper-create-class-features-plugin": {
-			"version": "7.16.0",
-			"resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.16.0.tgz",
-			"integrity": "sha512-XLwWvqEaq19zFlF5PTgOod4bUA+XbkR4WLQBct1bkzmxJGB0ZEJaoKF4c8cgH9oBtCDuYJ8BP5NB9uFiEgO5QA==",
+			"version": "7.18.9",
+			"resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.18.9.tgz",
+			"integrity": "sha512-WvypNAYaVh23QcjpMR24CwZY2Nz6hqdOcFdPbNpV56hL5H6KiFheO7Xm1aPdlLQ7d5emYZX7VZwPp9x3z+2opw==",
 			"dev": true,
 			"dependencies": {
-				"@babel/helper-annotate-as-pure": "^7.16.0",
-				"@babel/helper-function-name": "^7.16.0",
-				"@babel/helper-member-expression-to-functions": "^7.16.0",
-				"@babel/helper-optimise-call-expression": "^7.16.0",
-				"@babel/helper-replace-supers": "^7.16.0",
-				"@babel/helper-split-export-declaration": "^7.16.0"
+				"@babel/helper-annotate-as-pure": "^7.18.6",
+				"@babel/helper-environment-visitor": "^7.18.9",
+				"@babel/helper-function-name": "^7.18.9",
+				"@babel/helper-member-expression-to-functions": "^7.18.9",
+				"@babel/helper-optimise-call-expression": "^7.18.6",
+				"@babel/helper-replace-supers": "^7.18.9",
+				"@babel/helper-split-export-declaration": "^7.18.6"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -433,6 +424,14 @@
 				"semver": "bin/semver.js"
 			}
 		},
+		"node_modules/@babel/helper-environment-visitor": {
+			"version": "7.18.9",
+			"resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.18.9.tgz",
+			"integrity": "sha512-3r/aACDJ3fhQ/EVgFy0hpj8oHyHpQc+LPtJoY9SzTThAsStm4Ptegq92vqKoE3vD706ZVFWITnMnxucw+S9Ipg==",
+			"engines": {
+				"node": ">=6.9.0"
+			}
+		},
 		"node_modules/@babel/helper-explode-assignable-expression": {
 			"version": "7.16.0",
 			"resolved": "https://registry.npmjs.org/@babel/helper-explode-assignable-expression/-/helper-explode-assignable-expression-7.16.0.tgz",
@@ -446,46 +445,34 @@
 			}
 		},
 		"node_modules/@babel/helper-function-name": {
-			"version": "7.16.0",
-			"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.16.0.tgz",
-			"integrity": "sha512-BZh4mEk1xi2h4HFjWUXRQX5AEx4rvaZxHgax9gcjdLWdkjsY7MKt5p0otjsg5noXw+pB+clMCjw+aEVYADMjog==",
+			"version": "7.18.9",
+			"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.18.9.tgz",
+			"integrity": "sha512-fJgWlZt7nxGksJS9a0XdSaI4XvpExnNIgRP+rVefWh5U7BL8pPuir6SJUmFKRfjWQ51OtWSzwOxhaH/EBWWc0A==",
 			"dependencies": {
-				"@babel/helper-get-function-arity": "^7.16.0",
-				"@babel/template": "^7.16.0",
-				"@babel/types": "^7.16.0"
-			},
-			"engines": {
-				"node": ">=6.9.0"
-			}
-		},
-		"node_modules/@babel/helper-get-function-arity": {
-			"version": "7.16.0",
-			"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.16.0.tgz",
-			"integrity": "sha512-ASCquNcywC1NkYh/z7Cgp3w31YW8aojjYIlNg4VeJiHkqyP4AzIvr4qx7pYDb4/s8YcsZWqqOSxgkvjUz1kpDQ==",
-			"dependencies": {
-				"@babel/types": "^7.16.0"
+				"@babel/template": "^7.18.6",
+				"@babel/types": "^7.18.9"
 			},
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/helper-hoist-variables": {
-			"version": "7.16.0",
-			"resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.16.0.tgz",
-			"integrity": "sha512-1AZlpazjUR0EQZQv3sgRNfM9mEVWPK3M6vlalczA+EECcPz3XPh6VplbErL5UoMpChhSck5wAJHthlj1bYpcmg==",
+			"version": "7.18.6",
+			"resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.18.6.tgz",
+			"integrity": "sha512-UlJQPkFqFULIcyW5sbzgbkxn2FKRgwWiRexcuaR8RNJRy8+LLveqPjwZV/bwrLZCN0eUHD/x8D0heK1ozuoo6Q==",
 			"dependencies": {
-				"@babel/types": "^7.16.0"
+				"@babel/types": "^7.18.6"
 			},
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/helper-member-expression-to-functions": {
-			"version": "7.16.0",
-			"resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.16.0.tgz",
-			"integrity": "sha512-bsjlBFPuWT6IWhl28EdrQ+gTvSvj5tqVP5Xeftp07SEuz5pLnsXZuDkDD3Rfcxy0IsHmbZ+7B2/9SHzxO0T+sQ==",
+			"version": "7.18.9",
+			"resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.18.9.tgz",
+			"integrity": "sha512-RxifAh2ZoVU67PyKIO4AMi1wTenGfMR/O/ae0CCRqwgBAt5v7xjdtRw7UoSbsreKrQn5t7r89eruK/9JjYHuDg==",
 			"dependencies": {
-				"@babel/types": "^7.16.0"
+				"@babel/types": "^7.18.9"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -521,20 +508,20 @@
 			}
 		},
 		"node_modules/@babel/helper-optimise-call-expression": {
-			"version": "7.16.0",
-			"resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.16.0.tgz",
-			"integrity": "sha512-SuI467Gi2V8fkofm2JPnZzB/SUuXoJA5zXe/xzyPP2M04686RzFKFHPK6HDVN6JvWBIEW8tt9hPR7fXdn2Lgpw==",
+			"version": "7.18.6",
+			"resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.18.6.tgz",
+			"integrity": "sha512-HP59oD9/fEHQkdcbgFCnbmgH5vIQTJbxh2yf+CdM89/glUNnuzr87Q8GIjGEnOktTROemO0Pe0iPAYbqZuOUiA==",
 			"dependencies": {
-				"@babel/types": "^7.16.0"
+				"@babel/types": "^7.18.6"
 			},
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/helper-plugin-utils": {
-			"version": "7.14.5",
-			"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.14.5.tgz",
-			"integrity": "sha512-/37qQCE3K0vvZKwoK4XU/irIJQdIfCJuhU5eKnNxpFDsOkgFaUAwbv+RYw6eYgsC0E4hS7r5KqGULUogqui0fQ==",
+			"version": "7.18.9",
+			"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.18.9.tgz",
+			"integrity": "sha512-aBXPT3bmtLryXaoJLyYPXPlSD4p1ld9aYeR+sJNOZjJJGiOpb+fKfh3NkcCu7J54nUJwCERPBExCCpyCOHnu/w==",
 			"engines": {
 				"node": ">=6.9.0"
 			}
@@ -554,14 +541,15 @@
 			}
 		},
 		"node_modules/@babel/helper-replace-supers": {
-			"version": "7.16.0",
-			"resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.16.0.tgz",
-			"integrity": "sha512-TQxuQfSCdoha7cpRNJvfaYxxxzmbxXw/+6cS7V02eeDYyhxderSoMVALvwupA54/pZcOTtVeJ0xccp1nGWladA==",
+			"version": "7.18.9",
+			"resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.18.9.tgz",
+			"integrity": "sha512-dNsWibVI4lNT6HiuOIBr1oyxo40HvIVmbwPUm3XZ7wMh4k2WxrxTqZwSqw/eEmXDS9np0ey5M2bz9tBmO9c+YQ==",
 			"dependencies": {
-				"@babel/helper-member-expression-to-functions": "^7.16.0",
-				"@babel/helper-optimise-call-expression": "^7.16.0",
-				"@babel/traverse": "^7.16.0",
-				"@babel/types": "^7.16.0"
+				"@babel/helper-environment-visitor": "^7.18.9",
+				"@babel/helper-member-expression-to-functions": "^7.18.9",
+				"@babel/helper-optimise-call-expression": "^7.18.6",
+				"@babel/traverse": "^7.18.9",
+				"@babel/types": "^7.18.9"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -591,28 +579,28 @@
 			}
 		},
 		"node_modules/@babel/helper-split-export-declaration": {
-			"version": "7.16.0",
-			"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.16.0.tgz",
-			"integrity": "sha512-0YMMRpuDFNGTHNRiiqJX19GjNXA4H0E8jZ2ibccfSxaCogbm3am5WN/2nQNj0YnQwGWM1J06GOcQ2qnh3+0paw==",
+			"version": "7.18.6",
+			"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.18.6.tgz",
+			"integrity": "sha512-bde1etTx6ZyTmobl9LLMMQsaizFVZrquTEHOqKeQESMKo4PlObf+8+JA25ZsIpZhT/WEd39+vOdLXAFG/nELpA==",
 			"dependencies": {
-				"@babel/types": "^7.16.0"
+				"@babel/types": "^7.18.6"
 			},
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/helper-validator-identifier": {
-			"version": "7.15.7",
-			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.15.7.tgz",
-			"integrity": "sha512-K4JvCtQqad9OY2+yTU8w+E82ywk/fe+ELNlt1G8z3bVGlZfn/hOcQQsUhGhW/N+tb3fxK800wLtKOE/aM0m72w==",
+			"version": "7.18.6",
+			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.18.6.tgz",
+			"integrity": "sha512-MmetCkz9ej86nJQV+sFCxoGGrUbU3q02kgLciwkrt9QqEB7cP39oKEY0PakknEO0Gu20SskMRi+AYZ3b1TpN9g==",
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/helper-validator-option": {
-			"version": "7.14.5",
-			"resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.14.5.tgz",
-			"integrity": "sha512-OX8D5eeX4XwcroVW45NMvoYaIuFI+GQpA2a8Gi+X/U/cDUIRsV37qQfF905F0htTRCREQIB4KqPeaveRJUl3Ow==",
+			"version": "7.18.6",
+			"resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.18.6.tgz",
+			"integrity": "sha512-XO7gESt5ouv/LRJdrVjkShckw6STTaB7l9BrpBaAHDeF5YZT+01PCwmR0SJHnkW6i8OwW/EVWRShfi4j2x+KQw==",
 			"engines": {
 				"node": ">=6.9.0"
 			}
@@ -646,11 +634,11 @@
 			}
 		},
 		"node_modules/@babel/highlight": {
-			"version": "7.16.0",
-			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.16.0.tgz",
-			"integrity": "sha512-t8MH41kUQylBtu2+4IQA3atqevA2lRgqA2wyVB/YiWmsDSuylZZuXOUy9ric30hfzauEFfdsuk/eXTRrGrfd0g==",
+			"version": "7.18.6",
+			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.18.6.tgz",
+			"integrity": "sha512-u7stbOuYjaPezCuLj29hNW1v64M2Md2qupEKP1fHc7WdOA3DgLh37suiSrZYY7haUB7iBeQZ9P1uiRF359do3g==",
 			"dependencies": {
-				"@babel/helper-validator-identifier": "^7.15.7",
+				"@babel/helper-validator-identifier": "^7.18.6",
 				"chalk": "^2.0.0",
 				"js-tokens": "^4.0.0"
 			},
@@ -659,9 +647,9 @@
 			}
 		},
 		"node_modules/@babel/parser": {
-			"version": "7.16.4",
-			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.16.4.tgz",
-			"integrity": "sha512-6V0qdPUaiVHH3RtZeLIsc+6pDhbYzHR8ogA8w+f+Wc77DuXto19g2QUwveINoS34Uw+W8/hQDGJCx+i4n7xcng==",
+			"version": "7.18.9",
+			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.18.9.tgz",
+			"integrity": "sha512-9uJveS9eY9DJ0t64YbIBZICtJy8a5QrDEVdiLCG97fVLpDTpGX7t8mMSb6OWw6Lrnjqj4O8zwjELX3dhoMgiBg==",
 			"bin": {
 				"parser": "bin/babel-parser.js"
 			},
@@ -1165,12 +1153,12 @@
 			}
 		},
 		"node_modules/@babel/plugin-syntax-typescript": {
-			"version": "7.16.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.16.0.tgz",
-			"integrity": "sha512-Xv6mEXqVdaqCBfJFyeab0fH2DnUoMsDmhamxsSi4j8nLd4Vtw213WMJr55xxqipC/YVWyPY3K0blJncPYji+dQ==",
+			"version": "7.18.6",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.18.6.tgz",
+			"integrity": "sha512-mAWAuq4rvOepWCBid55JuRNvpTNf2UGVgoz4JV0fXEKolsVZDzsa4NqCef758WZJj/GDu0gVGItjKFiClTAmZA==",
 			"dev": true,
 			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.14.5"
+				"@babel/helper-plugin-utils": "^7.18.6"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1747,14 +1735,14 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-typescript": {
-			"version": "7.16.1",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.16.1.tgz",
-			"integrity": "sha512-NO4XoryBng06jjw/qWEU2LhcLJr1tWkhpMam/H4eas/CDKMX/b2/Ylb6EI256Y7+FVPCawwSM1rrJNOpDiz+Lg==",
+			"version": "7.18.8",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.18.8.tgz",
+			"integrity": "sha512-p2xM8HI83UObjsZGofMV/EdYjamsDm6MoN3hXPYIT0+gxIoopE+B7rPYKAxfrz9K9PK7JafTTjqYC6qipLExYA==",
 			"dev": true,
 			"dependencies": {
-				"@babel/helper-create-class-features-plugin": "^7.16.0",
-				"@babel/helper-plugin-utils": "^7.14.5",
-				"@babel/plugin-syntax-typescript": "^7.16.0"
+				"@babel/helper-create-class-features-plugin": "^7.18.6",
+				"@babel/helper-plugin-utils": "^7.18.6",
+				"@babel/plugin-syntax-typescript": "^7.18.6"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1928,14 +1916,14 @@
 			}
 		},
 		"node_modules/@babel/preset-typescript": {
-			"version": "7.16.0",
-			"resolved": "https://registry.npmjs.org/@babel/preset-typescript/-/preset-typescript-7.16.0.tgz",
-			"integrity": "sha512-txegdrZYgO9DlPbv+9QOVpMnKbOtezsLHWsnsRF4AjbSIsVaujrq1qg8HK0mxQpWv0jnejt0yEoW1uWpvbrDTg==",
+			"version": "7.18.6",
+			"resolved": "https://registry.npmjs.org/@babel/preset-typescript/-/preset-typescript-7.18.6.tgz",
+			"integrity": "sha512-s9ik86kXBAnD760aybBucdpnLsAt0jK1xqJn2juOn9lkOvSHV60os5hxoVJsPzMQxvnUJFAlkont2DvvaYEBtQ==",
 			"dev": true,
 			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.14.5",
-				"@babel/helper-validator-option": "^7.14.5",
-				"@babel/plugin-transform-typescript": "^7.16.0"
+				"@babel/helper-plugin-utils": "^7.18.6",
+				"@babel/helper-validator-option": "^7.18.6",
+				"@babel/plugin-transform-typescript": "^7.18.6"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1969,54 +1957,33 @@
 			}
 		},
 		"node_modules/@babel/template": {
-			"version": "7.16.0",
-			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.16.0.tgz",
-			"integrity": "sha512-MnZdpFD/ZdYhXwiunMqqgyZyucaYsbL0IrjoGjaVhGilz+x8YB++kRfygSOIj1yOtWKPlx7NBp+9I1RQSgsd5A==",
+			"version": "7.18.6",
+			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.18.6.tgz",
+			"integrity": "sha512-JoDWzPe+wgBsTTgdnIma3iHNFC7YVJoPssVBDjiHfNlyt4YcunDtcDOUmfVDfCK5MfdsaIoX9PkijPhjH3nYUw==",
 			"dependencies": {
-				"@babel/code-frame": "^7.16.0",
-				"@babel/parser": "^7.16.0",
-				"@babel/types": "^7.16.0"
-			},
-			"engines": {
-				"node": ">=6.9.0"
-			}
-		},
-		"node_modules/@babel/template/node_modules/@babel/code-frame": {
-			"version": "7.16.0",
-			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.16.0.tgz",
-			"integrity": "sha512-IF4EOMEV+bfYwOmNxGzSnjR2EmQod7f1UXOpZM3l4i4o4QNwzjtJAu/HxdjHq0aYBvdqMuQEY1eg0nqW9ZPORA==",
-			"dependencies": {
-				"@babel/highlight": "^7.16.0"
+				"@babel/code-frame": "^7.18.6",
+				"@babel/parser": "^7.18.6",
+				"@babel/types": "^7.18.6"
 			},
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/traverse": {
-			"version": "7.16.3",
-			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.16.3.tgz",
-			"integrity": "sha512-eolumr1vVMjqevCpwVO99yN/LoGL0EyHiLO5I043aYQvwOJ9eR5UsZSClHVCzfhBduMAsSzgA/6AyqPjNayJag==",
+			"version": "7.18.9",
+			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.18.9.tgz",
+			"integrity": "sha512-LcPAnujXGwBgv3/WHv01pHtb2tihcyW1XuL9wd7jqh1Z8AQkTd+QVjMrMijrln0T7ED3UXLIy36P9Ao7W75rYg==",
 			"dependencies": {
-				"@babel/code-frame": "^7.16.0",
-				"@babel/generator": "^7.16.0",
-				"@babel/helper-function-name": "^7.16.0",
-				"@babel/helper-hoist-variables": "^7.16.0",
-				"@babel/helper-split-export-declaration": "^7.16.0",
-				"@babel/parser": "^7.16.3",
-				"@babel/types": "^7.16.0",
+				"@babel/code-frame": "^7.18.6",
+				"@babel/generator": "^7.18.9",
+				"@babel/helper-environment-visitor": "^7.18.9",
+				"@babel/helper-function-name": "^7.18.9",
+				"@babel/helper-hoist-variables": "^7.18.6",
+				"@babel/helper-split-export-declaration": "^7.18.6",
+				"@babel/parser": "^7.18.9",
+				"@babel/types": "^7.18.9",
 				"debug": "^4.1.0",
 				"globals": "^11.1.0"
-			},
-			"engines": {
-				"node": ">=6.9.0"
-			}
-		},
-		"node_modules/@babel/traverse/node_modules/@babel/code-frame": {
-			"version": "7.16.0",
-			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.16.0.tgz",
-			"integrity": "sha512-IF4EOMEV+bfYwOmNxGzSnjR2EmQod7f1UXOpZM3l4i4o4QNwzjtJAu/HxdjHq0aYBvdqMuQEY1eg0nqW9ZPORA==",
-			"dependencies": {
-				"@babel/highlight": "^7.16.0"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -2037,11 +2004,11 @@
 			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
 		},
 		"node_modules/@babel/types": {
-			"version": "7.16.0",
-			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.16.0.tgz",
-			"integrity": "sha512-PJgg/k3SdLsGb3hhisFvtLOw5ts113klrpLuIPtCJIU+BB24fqq6lf8RWqKJEjzqXR9AEH1rIb5XTqwBHB+kQg==",
+			"version": "7.18.9",
+			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.18.9.tgz",
+			"integrity": "sha512-WwMLAg2MvJmt/rKEVQBBhIVffMmnilX4oe0sRe7iPOHIGsqpruFHHdrfj4O1CMMtgMtCU4oPafZjDPCRgO57Wg==",
 			"dependencies": {
-				"@babel/helper-validator-identifier": "^7.15.7",
+				"@babel/helper-validator-identifier": "^7.18.6",
 				"to-fast-properties": "^2.0.0"
 			},
 			"engines": {
@@ -2989,6 +2956,23 @@
 			},
 			"engines": {
 				"node": ">=12"
+			}
+		},
+		"node_modules/@csstools/selector-specificity": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/@csstools/selector-specificity/-/selector-specificity-2.0.2.tgz",
+			"integrity": "sha512-IkpVW/ehM1hWKln4fCA3NzJU8KwD+kIOvPZA4cqxoJHtE21CCzjyp+Kxbu0i5I4tBNOlXPL9mjwnWlL0VEG4Fg==",
+			"dev": true,
+			"engines": {
+				"node": "^12 || ^14 || >=16"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/csstools"
+			},
+			"peerDependencies": {
+				"postcss": "^8.2",
+				"postcss-selector-parser": "^6.0.10"
 			}
 		},
 		"node_modules/@discoveryjs/json-ext": {
@@ -4230,7 +4214,6 @@
 			"version": "0.3.2",
 			"resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.2.tgz",
 			"integrity": "sha512-mh65xKQAzI6iBcFzwv28KVWSmCkdRBWoOh+bYQGW3+6OZvbbN3TqMGo5hqYxQniRcH9F2VZIoJCm4pa3BPDK/A==",
-			"dev": true,
 			"dependencies": {
 				"@jridgewell/set-array": "^1.0.1",
 				"@jridgewell/sourcemap-codec": "^1.4.10",
@@ -4252,7 +4235,6 @@
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.1.2.tgz",
 			"integrity": "sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw==",
-			"dev": true,
 			"engines": {
 				"node": ">=6.0.0"
 			}
@@ -5553,34 +5535,6 @@
 				"@sinonjs/commons": "^1.7.0"
 			}
 		},
-		"node_modules/@stylelint/postcss-css-in-js": {
-			"version": "0.37.2",
-			"resolved": "https://registry.npmjs.org/@stylelint/postcss-css-in-js/-/postcss-css-in-js-0.37.2.tgz",
-			"integrity": "sha512-nEhsFoJurt8oUmieT8qy4nk81WRHmJynmVwn/Vts08PL9fhgIsMhk1GId5yAN643OzqEEb5S/6At2TZW7pqPDA==",
-			"dev": true,
-			"dependencies": {
-				"@babel/core": ">=7.9.0"
-			},
-			"peerDependencies": {
-				"postcss": ">=7.0.0",
-				"postcss-syntax": ">=0.36.2"
-			}
-		},
-		"node_modules/@stylelint/postcss-markdown": {
-			"version": "0.36.2",
-			"resolved": "https://registry.npmjs.org/@stylelint/postcss-markdown/-/postcss-markdown-0.36.2.tgz",
-			"integrity": "sha512-2kGbqUVJUGE8dM+bMzXG/PYUWKkjLIkRLWNh39OaADkiabDRdw8ATFCgbMz5xdIcvwspPAluSL7uY+ZiTWdWmQ==",
-			"deprecated": "Use the original unforked package instead: postcss-markdown",
-			"dev": true,
-			"dependencies": {
-				"remark": "^13.0.0",
-				"unist-util-find-all-after": "^3.0.2"
-			},
-			"peerDependencies": {
-				"postcss": ">=7.0.0",
-				"postcss-syntax": ">=0.36.2"
-			}
-		},
 		"node_modules/@tannin/compile": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/@tannin/compile/-/compile-1.1.0.tgz",
@@ -5974,15 +5928,6 @@
 			"resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.177.tgz",
 			"integrity": "sha512-0fDwydE2clKe9MNfvXHBHF9WEahRuj+msTuQqOmAApNORFvhMYZKNGGJdCzuhheVjMps/ti0Ak/iJPACMaevvw=="
 		},
-		"node_modules/@types/mdast": {
-			"version": "3.0.10",
-			"resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-3.0.10.tgz",
-			"integrity": "sha512-W864tg/Osz1+9f4lrGTZpCSO5/z4608eUp19tbozkq2HJK6i3z1kT0H9tlADXuYIb1YYOBByU4Jsqkk75q48qA==",
-			"dev": true,
-			"dependencies": {
-				"@types/unist": "*"
-			}
-		},
 		"node_modules/@types/minimist": {
 			"version": "1.2.2",
 			"resolved": "https://registry.npmjs.org/@types/minimist/-/minimist-1.2.2.tgz",
@@ -6068,12 +6013,6 @@
 			"dependencies": {
 				"@types/jest": "*"
 			}
-		},
-		"node_modules/@types/unist": {
-			"version": "2.0.6",
-			"resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.6.tgz",
-			"integrity": "sha512-PBjIUxZHOuj0R15/xuwJYjFi+KZdNFrehocChv4g5hu6aFroHue8m0lBP0POdK2nKzbw0cgV1mws8+V/JAcEkQ==",
-			"dev": true
 		},
 		"node_modules/@types/webpack-env": {
 			"version": "1.16.3",
@@ -7637,20 +7576,19 @@
 			}
 		},
 		"node_modules/@wordpress/stylelint-config": {
-			"version": "19.1.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/stylelint-config/-/stylelint-config-19.1.0.tgz",
-			"integrity": "sha512-K/wB9rhB+pH5WvDh3fV3DN5C3Bud+jPGXmnPY8fOXKMYI3twCFozK/j6sVuaJHqGp/0kKEF0hkkGh+HhD30KGQ==",
+			"version": "20.0.2",
+			"resolved": "https://registry.npmjs.org/@wordpress/stylelint-config/-/stylelint-config-20.0.2.tgz",
+			"integrity": "sha512-guP0Cwc4PysbRJroxWcBxViYaqaTlxrkcZ/dfsoB0ZLO+RrZ8YFktt02mt6q6MASLTBEWIBHVQ5nKLVFPWAWJg==",
 			"dev": true,
 			"dependencies": {
-				"stylelint-config-recommended": "^3.0.0",
-				"stylelint-config-recommended-scss": "^4.2.0",
-				"stylelint-scss": "^3.17.2"
+				"stylelint-config-recommended": "^6.0.0",
+				"stylelint-config-recommended-scss": "^5.0.2"
 			},
 			"engines": {
 				"node": ">=12"
 			},
 			"peerDependencies": {
-				"stylelint": "^13.7.0"
+				"stylelint": "^14.2"
 			}
 		},
 		"node_modules/@wordpress/token-list": {
@@ -7734,10 +7672,9 @@
 			"dev": true
 		},
 		"node_modules/acorn": {
-			"version": "7.4.1",
-			"resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
-			"integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
-			"dev": true,
+			"version": "8.7.1",
+			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.7.1.tgz",
+			"integrity": "sha512-Xx54uLJQZ19lKygFXOWsscKUbsBZW0CPykPhVQdhIeIwrbPmJzqeASDInc8nKBnp/JT6igTs82qPXz069H8I/A==",
 			"bin": {
 				"acorn": "bin/acorn"
 			},
@@ -7753,6 +7690,18 @@
 			"dependencies": {
 				"acorn": "^7.1.1",
 				"acorn-walk": "^7.1.1"
+			}
+		},
+		"node_modules/acorn-globals/node_modules/acorn": {
+			"version": "7.4.1",
+			"resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
+			"integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
+			"dev": true,
+			"bin": {
+				"acorn": "bin/acorn"
+			},
+			"engines": {
+				"node": ">=0.4.0"
 			}
 		},
 		"node_modules/acorn-import-assertions": {
@@ -8065,6 +8014,26 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/array.prototype.filter": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/array.prototype.filter/-/array.prototype.filter-1.0.1.tgz",
+			"integrity": "sha512-Dk3Ty7N42Odk7PjU/Ci3zT4pLj20YvuVnneG/58ICM6bt4Ij5kZaJTVQ9TSaWaIECX2sFyz4KItkVZqHNnciqw==",
+			"dev": true,
+			"peer": true,
+			"dependencies": {
+				"call-bind": "^1.0.2",
+				"define-properties": "^1.1.3",
+				"es-abstract": "^1.19.0",
+				"es-array-method-boxes-properly": "^1.0.0",
+				"is-string": "^1.0.7"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
 		"node_modules/array.prototype.find": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/array.prototype.find/-/array.prototype.find-2.1.1.tgz",
@@ -8196,60 +8165,6 @@
 			},
 			"engines": {
 				"node": ">= 4.5.0"
-			}
-		},
-		"node_modules/autoprefixer": {
-			"version": "9.8.6",
-			"resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-9.8.6.tgz",
-			"integrity": "sha512-XrvP4VVHdRBCdX1S3WXVD8+RyG9qeb1D5Sn1DeLiG2xfSpzellk5k54xbUERJ3M5DggQxes39UGOTP8CFrEGbg==",
-			"dev": true,
-			"dependencies": {
-				"browserslist": "^4.12.0",
-				"caniuse-lite": "^1.0.30001109",
-				"colorette": "^1.2.1",
-				"normalize-range": "^0.1.2",
-				"num2fraction": "^1.2.2",
-				"postcss": "^7.0.32",
-				"postcss-value-parser": "^4.1.0"
-			},
-			"bin": {
-				"autoprefixer": "bin/autoprefixer"
-			},
-			"funding": {
-				"type": "tidelift",
-				"url": "https://tidelift.com/funding/github/npm/autoprefixer"
-			}
-		},
-		"node_modules/autoprefixer/node_modules/picocolors": {
-			"version": "0.2.1",
-			"resolved": "https://registry.npmjs.org/picocolors/-/picocolors-0.2.1.tgz",
-			"integrity": "sha512-cMlDqaLEqfSaW8Z7N5Jw+lyIW869EzT73/F5lhtY9cLGoVxSXznfgfXMO0Z5K0o0Q2TkTXq+0KFsdnSe3jDViA==",
-			"dev": true
-		},
-		"node_modules/autoprefixer/node_modules/postcss": {
-			"version": "7.0.39",
-			"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.39.tgz",
-			"integrity": "sha512-yioayjNbHn6z1/Bywyb2Y4s3yvDAeXGOyxqD+LnVOinq6Mdmd++SW2wUNVzavyyHxd6+DxzWGIuosg6P1Rj8uA==",
-			"dev": true,
-			"dependencies": {
-				"picocolors": "^0.2.1",
-				"source-map": "^0.6.1"
-			},
-			"engines": {
-				"node": ">=6.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/postcss/"
-			}
-		},
-		"node_modules/autoprefixer/node_modules/source-map": {
-			"version": "0.6.1",
-			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-			"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-			"dev": true,
-			"engines": {
-				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/autosize": {
@@ -8625,16 +8540,6 @@
 			},
 			"peerDependencies": {
 				"@babel/core": "^7.0.0"
-			}
-		},
-		"node_modules/bail": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/bail/-/bail-1.0.5.tgz",
-			"integrity": "sha512-xFbRxM1tahm08yHBP16MMjVUAvDaBMD38zsM9EMAUN61omwLmKlOpB/Zku5QkjZ8TZ4vn53pj+t518cH0S03RQ==",
-			"dev": true,
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/wooorm"
 			}
 		},
 		"node_modules/balanced-match": {
@@ -9103,41 +9008,228 @@
 				"node": ">=10"
 			}
 		},
-		"node_modules/character-entities": {
-			"version": "1.2.4",
-			"resolved": "https://registry.npmjs.org/character-entities/-/character-entities-1.2.4.tgz",
-			"integrity": "sha512-iBMyeEHxfVnIakwOuDXpVkc54HijNgCyQB2w0VfGQThle6NXn50zU6V/u+LDhxHcDUPojn6Kpga3PTAD8W1bQw==",
-			"dev": true,
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/wooorm"
-			}
-		},
-		"node_modules/character-entities-legacy": {
-			"version": "1.1.4",
-			"resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-1.1.4.tgz",
-			"integrity": "sha512-3Xnr+7ZFS1uxeiUDvV02wQ+QDbc55o97tIV5zHScSPJpcLm/r0DFPcoY3tYRp+VZukxuMeKgXYmsXQHO05zQeA==",
-			"dev": true,
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/wooorm"
-			}
-		},
-		"node_modules/character-reference-invalid": {
-			"version": "1.1.4",
-			"resolved": "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-1.1.4.tgz",
-			"integrity": "sha512-mKKUkUbhPpQlCOfIuZkvSEgktjPFIsZKRRbC6KWVEMvlzblj3i3asQv5ODsrwt0N3pHAEvjP8KTQPHkp0+6jOg==",
-			"dev": true,
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/wooorm"
-			}
-		},
 		"node_modules/chardet": {
 			"version": "0.7.0",
 			"resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
 			"integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
 			"dev": true
+		},
+		"node_modules/cheerio": {
+			"version": "1.0.0-rc.12",
+			"resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.0.0-rc.12.tgz",
+			"integrity": "sha512-VqR8m68vM46BNnuZ5NtnGBKIE/DfN0cRIzg9n40EIq9NOv90ayxLBXA8fXC5gquFRGJSTRqBq25Jt2ECLR431Q==",
+			"dev": true,
+			"peer": true,
+			"dependencies": {
+				"cheerio-select": "^2.1.0",
+				"dom-serializer": "^2.0.0",
+				"domhandler": "^5.0.3",
+				"domutils": "^3.0.1",
+				"htmlparser2": "^8.0.1",
+				"parse5": "^7.0.0",
+				"parse5-htmlparser2-tree-adapter": "^7.0.0"
+			},
+			"engines": {
+				"node": ">= 6"
+			},
+			"funding": {
+				"url": "https://github.com/cheeriojs/cheerio?sponsor=1"
+			}
+		},
+		"node_modules/cheerio-select": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/cheerio-select/-/cheerio-select-2.1.0.tgz",
+			"integrity": "sha512-9v9kG0LvzrlcungtnJtpGNxY+fzECQKhK4EGJX2vByejiMX84MFNQw4UxPJl3bFbTMw+Dfs37XaIkCwTZfLh4g==",
+			"dev": true,
+			"peer": true,
+			"dependencies": {
+				"boolbase": "^1.0.0",
+				"css-select": "^5.1.0",
+				"css-what": "^6.1.0",
+				"domelementtype": "^2.3.0",
+				"domhandler": "^5.0.3",
+				"domutils": "^3.0.1"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/fb55"
+			}
+		},
+		"node_modules/cheerio-select/node_modules/dom-serializer": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+			"integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+			"dev": true,
+			"peer": true,
+			"dependencies": {
+				"domelementtype": "^2.3.0",
+				"domhandler": "^5.0.2",
+				"entities": "^4.2.0"
+			},
+			"funding": {
+				"url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+			}
+		},
+		"node_modules/cheerio-select/node_modules/domelementtype": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+			"integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/fb55"
+				}
+			],
+			"peer": true
+		},
+		"node_modules/cheerio-select/node_modules/domhandler": {
+			"version": "5.0.3",
+			"resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+			"integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+			"dev": true,
+			"peer": true,
+			"dependencies": {
+				"domelementtype": "^2.3.0"
+			},
+			"engines": {
+				"node": ">= 4"
+			},
+			"funding": {
+				"url": "https://github.com/fb55/domhandler?sponsor=1"
+			}
+		},
+		"node_modules/cheerio-select/node_modules/domutils": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/domutils/-/domutils-3.0.1.tgz",
+			"integrity": "sha512-z08c1l761iKhDFtfXO04C7kTdPBLi41zwOZl00WS8b5eiaebNpY00HKbztwBq+e3vyqWNwWF3mP9YLUeqIrF+Q==",
+			"dev": true,
+			"peer": true,
+			"dependencies": {
+				"dom-serializer": "^2.0.0",
+				"domelementtype": "^2.3.0",
+				"domhandler": "^5.0.1"
+			},
+			"funding": {
+				"url": "https://github.com/fb55/domutils?sponsor=1"
+			}
+		},
+		"node_modules/cheerio-select/node_modules/entities": {
+			"version": "4.3.1",
+			"resolved": "https://registry.npmjs.org/entities/-/entities-4.3.1.tgz",
+			"integrity": "sha512-o4q/dYJlmyjP2zfnaWDUC6A3BQFmVTX+tZPezK7k0GLSU9QYCauscf5Y+qcEPzKL+EixVouYDgLQK5H9GrLpkg==",
+			"dev": true,
+			"peer": true,
+			"engines": {
+				"node": ">=0.12"
+			},
+			"funding": {
+				"url": "https://github.com/fb55/entities?sponsor=1"
+			}
+		},
+		"node_modules/cheerio/node_modules/dom-serializer": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+			"integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+			"dev": true,
+			"peer": true,
+			"dependencies": {
+				"domelementtype": "^2.3.0",
+				"domhandler": "^5.0.2",
+				"entities": "^4.2.0"
+			},
+			"funding": {
+				"url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+			}
+		},
+		"node_modules/cheerio/node_modules/domelementtype": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+			"integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/fb55"
+				}
+			],
+			"peer": true
+		},
+		"node_modules/cheerio/node_modules/domhandler": {
+			"version": "5.0.3",
+			"resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+			"integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+			"dev": true,
+			"peer": true,
+			"dependencies": {
+				"domelementtype": "^2.3.0"
+			},
+			"engines": {
+				"node": ">= 4"
+			},
+			"funding": {
+				"url": "https://github.com/fb55/domhandler?sponsor=1"
+			}
+		},
+		"node_modules/cheerio/node_modules/domutils": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/domutils/-/domutils-3.0.1.tgz",
+			"integrity": "sha512-z08c1l761iKhDFtfXO04C7kTdPBLi41zwOZl00WS8b5eiaebNpY00HKbztwBq+e3vyqWNwWF3mP9YLUeqIrF+Q==",
+			"dev": true,
+			"peer": true,
+			"dependencies": {
+				"dom-serializer": "^2.0.0",
+				"domelementtype": "^2.3.0",
+				"domhandler": "^5.0.1"
+			},
+			"funding": {
+				"url": "https://github.com/fb55/domutils?sponsor=1"
+			}
+		},
+		"node_modules/cheerio/node_modules/entities": {
+			"version": "4.3.1",
+			"resolved": "https://registry.npmjs.org/entities/-/entities-4.3.1.tgz",
+			"integrity": "sha512-o4q/dYJlmyjP2zfnaWDUC6A3BQFmVTX+tZPezK7k0GLSU9QYCauscf5Y+qcEPzKL+EixVouYDgLQK5H9GrLpkg==",
+			"dev": true,
+			"peer": true,
+			"engines": {
+				"node": ">=0.12"
+			},
+			"funding": {
+				"url": "https://github.com/fb55/entities?sponsor=1"
+			}
+		},
+		"node_modules/cheerio/node_modules/htmlparser2": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-8.0.1.tgz",
+			"integrity": "sha512-4lVbmc1diZC7GUJQtRQ5yBAeUCL1exyMwmForWkRLnwyzWBFxN633SALPMGYaWZvKe9j1pRZJpauvmxENSp/EA==",
+			"dev": true,
+			"funding": [
+				"https://github.com/fb55/htmlparser2?sponsor=1",
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/fb55"
+				}
+			],
+			"peer": true,
+			"dependencies": {
+				"domelementtype": "^2.3.0",
+				"domhandler": "^5.0.2",
+				"domutils": "^3.0.1",
+				"entities": "^4.3.0"
+			}
+		},
+		"node_modules/cheerio/node_modules/parse5": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/parse5/-/parse5-7.0.0.tgz",
+			"integrity": "sha512-y/t8IXSPWTuRZqXc0ajH/UwDj4mnqLEbSttNbThcFhGrZuOyoyvNBO85PBp2jQa55wY9d07PBNjsK8ZP3K5U6g==",
+			"dev": true,
+			"peer": true,
+			"dependencies": {
+				"entities": "^4.3.0"
+			},
+			"funding": {
+				"url": "https://github.com/inikulin/parse5?sponsor=1"
+			}
 		},
 		"node_modules/chokidar": {
 			"version": "3.5.2",
@@ -9606,12 +9698,6 @@
 			"version": "2.9.2",
 			"resolved": "https://registry.npmjs.org/colord/-/colord-2.9.2.tgz",
 			"integrity": "sha512-Uqbg+J445nc1TKn4FoDPS6ZZqAvEDnwrH42yo8B40JSOgSLxMZ/gt3h4nmCtPLQeXhjJJkqBx7SCY35WnIixaQ=="
-		},
-		"node_modules/colorette": {
-			"version": "1.2.2",
-			"resolved": "https://registry.npmjs.org/colorette/-/colorette-1.2.2.tgz",
-			"integrity": "sha512-MKGMzyfeuutC/ZJ1cba9NqcNpfeqMUcYmyF1ZFY6/Cn7CNSAKx6a+s48sqLqyAiZuaP2TcqMhoo+dlwFnVxT9w==",
-			"dev": true
 		},
 		"node_modules/colors": {
 			"version": "1.4.0",
@@ -10649,17 +10735,6 @@
 				"typescript": ">=3"
 			}
 		},
-		"node_modules/cosmiconfig-typescript-loader/node_modules/acorn": {
-			"version": "8.7.1",
-			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.7.1.tgz",
-			"integrity": "sha512-Xx54uLJQZ19lKygFXOWsscKUbsBZW0CPykPhVQdhIeIwrbPmJzqeASDInc8nKBnp/JT6igTs82qPXz069H8I/A==",
-			"bin": {
-				"acorn": "bin/acorn"
-			},
-			"engines": {
-				"node": ">=0.4.0"
-			}
-		},
 		"node_modules/cosmiconfig-typescript-loader/node_modules/acorn-walk": {
 			"version": "8.2.0",
 			"resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
@@ -10839,6 +10914,15 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/css-functions-list": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/css-functions-list/-/css-functions-list-3.1.0.tgz",
+			"integrity": "sha512-/9lCvYZaUbBGvYUgYGFJ4dcYiyqdhSjG7IPVluoV8A1ILjkF7ilmhp1OGUz8n+nmBcu0RNrQAzgD8B6FJbrt2w==",
+			"dev": true,
+			"engines": {
+				"node": ">=12.22"
+			}
+		},
 		"node_modules/css-loader": {
 			"version": "5.2.7",
 			"resolved": "https://registry.npmjs.org/css-loader/-/css-loader-5.2.7.tgz",
@@ -11013,11 +11097,100 @@
 				"source-map": "~0.6.1"
 			}
 		},
+		"node_modules/css-select": {
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/css-select/-/css-select-5.1.0.tgz",
+			"integrity": "sha512-nwoRF1rvRRnnCqqY7updORDsuqKzqYJ28+oSMaJMMgOauh3fvwHqMS7EZpIPqK8GL+g9mKxF1vP/ZjSeNjEVHg==",
+			"dev": true,
+			"peer": true,
+			"dependencies": {
+				"boolbase": "^1.0.0",
+				"css-what": "^6.1.0",
+				"domhandler": "^5.0.2",
+				"domutils": "^3.0.1",
+				"nth-check": "^2.0.1"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/fb55"
+			}
+		},
 		"node_modules/css-select-base-adapter": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/css-select-base-adapter/-/css-select-base-adapter-0.1.1.tgz",
 			"integrity": "sha512-jQVeeRG70QI08vSTwf1jHxp74JoZsr2XSgETae8/xC8ovSnL2WF87GTLO86Sbwdt2lK4Umg4HnnwMO4YF3Ce7w==",
 			"dev": true
+		},
+		"node_modules/css-select/node_modules/dom-serializer": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+			"integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+			"dev": true,
+			"peer": true,
+			"dependencies": {
+				"domelementtype": "^2.3.0",
+				"domhandler": "^5.0.2",
+				"entities": "^4.2.0"
+			},
+			"funding": {
+				"url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+			}
+		},
+		"node_modules/css-select/node_modules/domelementtype": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+			"integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/fb55"
+				}
+			],
+			"peer": true
+		},
+		"node_modules/css-select/node_modules/domhandler": {
+			"version": "5.0.3",
+			"resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+			"integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+			"dev": true,
+			"peer": true,
+			"dependencies": {
+				"domelementtype": "^2.3.0"
+			},
+			"engines": {
+				"node": ">= 4"
+			},
+			"funding": {
+				"url": "https://github.com/fb55/domhandler?sponsor=1"
+			}
+		},
+		"node_modules/css-select/node_modules/domutils": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/domutils/-/domutils-3.0.1.tgz",
+			"integrity": "sha512-z08c1l761iKhDFtfXO04C7kTdPBLi41zwOZl00WS8b5eiaebNpY00HKbztwBq+e3vyqWNwWF3mP9YLUeqIrF+Q==",
+			"dev": true,
+			"peer": true,
+			"dependencies": {
+				"dom-serializer": "^2.0.0",
+				"domelementtype": "^2.3.0",
+				"domhandler": "^5.0.1"
+			},
+			"funding": {
+				"url": "https://github.com/fb55/domutils?sponsor=1"
+			}
+		},
+		"node_modules/css-select/node_modules/entities": {
+			"version": "4.3.1",
+			"resolved": "https://registry.npmjs.org/entities/-/entities-4.3.1.tgz",
+			"integrity": "sha512-o4q/dYJlmyjP2zfnaWDUC6A3BQFmVTX+tZPezK7k0GLSU9QYCauscf5Y+qcEPzKL+EixVouYDgLQK5H9GrLpkg==",
+			"dev": true,
+			"peer": true,
+			"engines": {
+				"node": ">=0.12"
+			},
+			"funding": {
+				"url": "https://github.com/fb55/entities?sponsor=1"
+			}
 		},
 		"node_modules/css-tree": {
 			"version": "1.0.0-alpha.37",
@@ -11039,6 +11212,19 @@
 			"dev": true,
 			"engines": {
 				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/css-what": {
+			"version": "6.1.0",
+			"resolved": "https://registry.npmjs.org/css-what/-/css-what-6.1.0.tgz",
+			"integrity": "sha512-HTUrgRJ7r4dsZKU6GjmpfRK1O76h97Z8MfS1G0FozR+oF2kG6Vfe8JE6zwrkbxigziPHinCJ+gCPjA9EaBDtRw==",
+			"dev": true,
+			"peer": true,
+			"engines": {
+				"node": ">= 6"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/fb55"
 			}
 		},
 		"node_modules/css.escape": {
@@ -11570,14 +11756,18 @@
 			}
 		},
 		"node_modules/define-properties": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
-			"integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.4.tgz",
+			"integrity": "sha512-uckOqKcfaVvtBdsVkdPv3XjveQJsNQqmhXgRi8uhvWWuPYZCNlzT8qAyblUgNoXdHdjMTzAqeGjAoli8f+bzPA==",
 			"dependencies": {
-				"object-keys": "^1.0.12"
+				"has-property-descriptors": "^1.0.0",
+				"object-keys": "^1.1.1"
 			},
 			"engines": {
 				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
 		"node_modules/define-property": {
@@ -11755,6 +11945,13 @@
 				"url": "https://github.com/sponsors/wooorm"
 			}
 		},
+		"node_modules/discontinuous-range": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/discontinuous-range/-/discontinuous-range-1.0.0.tgz",
+			"integrity": "sha512-c68LpLbO+7kP/b1Hr1qs8/BJ09F5khZGTxqxZuhzxpmwJKOgRFHJWIb9/KmqnqHhLdO55aOxFH/EGBvUQbL/RQ==",
+			"dev": true,
+			"peer": true
+		},
 		"node_modules/doctrine": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
@@ -11821,15 +12018,6 @@
 			"dev": true,
 			"engines": {
 				"node": ">=8"
-			}
-		},
-		"node_modules/domhandler": {
-			"version": "2.4.2",
-			"resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.4.2.tgz",
-			"integrity": "sha512-JiK04h0Ht5u/80fdLMCEmV4zkNh2BcoMFBmZ/91WtYZ8qVXSKjiw7fXMgFPnHcSZgOo3XdinHvmnDUeMf5R4wA==",
-			"dev": true,
-			"dependencies": {
-				"domelementtype": "1"
 			}
 		},
 		"node_modules/domutils": {
@@ -12135,6 +12323,40 @@
 				"node": ">=4"
 			}
 		},
+		"node_modules/enzyme": {
+			"version": "3.11.0",
+			"resolved": "https://registry.npmjs.org/enzyme/-/enzyme-3.11.0.tgz",
+			"integrity": "sha512-Dw8/Gs4vRjxY6/6i9wU0V+utmQO9kvh9XLnz3LIudviOnVYDEe2ec+0k+NQoMamn1VrjKgCUOWj5jG/5M5M0Qw==",
+			"dev": true,
+			"peer": true,
+			"dependencies": {
+				"array.prototype.flat": "^1.2.3",
+				"cheerio": "^1.0.0-rc.3",
+				"enzyme-shallow-equal": "^1.0.1",
+				"function.prototype.name": "^1.1.2",
+				"has": "^1.0.3",
+				"html-element-map": "^1.2.0",
+				"is-boolean-object": "^1.0.1",
+				"is-callable": "^1.1.5",
+				"is-number-object": "^1.0.4",
+				"is-regex": "^1.0.5",
+				"is-string": "^1.0.5",
+				"is-subset": "^0.1.1",
+				"lodash.escape": "^4.0.1",
+				"lodash.isequal": "^4.5.0",
+				"object-inspect": "^1.7.0",
+				"object-is": "^1.0.2",
+				"object.assign": "^4.1.0",
+				"object.entries": "^1.1.1",
+				"object.values": "^1.1.1",
+				"raf": "^3.4.1",
+				"rst-selector-parser": "^2.2.3",
+				"string.prototype.trim": "^1.2.1"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
 		"node_modules/enzyme-matchers": {
 			"version": "7.1.2",
 			"resolved": "https://registry.npmjs.org/enzyme-matchers/-/enzyme-matchers-7.1.2.tgz",
@@ -12204,30 +12426,33 @@
 			}
 		},
 		"node_modules/es-abstract": {
-			"version": "1.19.1",
-			"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.19.1.tgz",
-			"integrity": "sha512-2vJ6tjA/UfqLm2MPs7jxVybLoB8i1t1Jd9R3kISld20sIxPcTbLuggQOUxeWeAvIUkduv/CfMjuh4WmiXr2v9w==",
+			"version": "1.20.1",
+			"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.20.1.tgz",
+			"integrity": "sha512-WEm2oBhfoI2sImeM4OF2zE2V3BYdSF+KnSi9Sidz51fQHd7+JuF8Xgcj9/0o+OWeIeIS/MiuNnlruQrJf16GQA==",
 			"dependencies": {
 				"call-bind": "^1.0.2",
 				"es-to-primitive": "^1.2.1",
 				"function-bind": "^1.1.1",
+				"function.prototype.name": "^1.1.5",
 				"get-intrinsic": "^1.1.1",
 				"get-symbol-description": "^1.0.0",
 				"has": "^1.0.3",
-				"has-symbols": "^1.0.2",
+				"has-property-descriptors": "^1.0.0",
+				"has-symbols": "^1.0.3",
 				"internal-slot": "^1.0.3",
 				"is-callable": "^1.2.4",
-				"is-negative-zero": "^2.0.1",
+				"is-negative-zero": "^2.0.2",
 				"is-regex": "^1.1.4",
-				"is-shared-array-buffer": "^1.0.1",
+				"is-shared-array-buffer": "^1.0.2",
 				"is-string": "^1.0.7",
-				"is-weakref": "^1.0.1",
-				"object-inspect": "^1.11.0",
+				"is-weakref": "^1.0.2",
+				"object-inspect": "^1.12.0",
 				"object-keys": "^1.1.1",
 				"object.assign": "^4.1.2",
-				"string.prototype.trimend": "^1.0.4",
-				"string.prototype.trimstart": "^1.0.4",
-				"unbox-primitive": "^1.0.1"
+				"regexp.prototype.flags": "^1.4.3",
+				"string.prototype.trimend": "^1.0.5",
+				"string.prototype.trimstart": "^1.0.5",
+				"unbox-primitive": "^1.0.2"
 			},
 			"engines": {
 				"node": ">= 0.4"
@@ -12235,6 +12460,13 @@
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
 			}
+		},
+		"node_modules/es-array-method-boxes-properly": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/es-array-method-boxes-properly/-/es-array-method-boxes-properly-1.0.0.tgz",
+			"integrity": "sha512-wd6JXUmyHmt8T5a2xreUwKcGPq6f1f+WwIJkijUqiGcJz1qqnZgP6XIK+QyIWU5lT7imeNxUll48bziG+TSYcA==",
+			"dev": true,
+			"peer": true
 		},
 		"node_modules/es-module-lexer": {
 			"version": "0.9.3",
@@ -12862,6 +13094,18 @@
 			},
 			"engines": {
 				"node": "^10.12.0 || >=12.0.0"
+			}
+		},
+		"node_modules/espree/node_modules/acorn": {
+			"version": "7.4.1",
+			"resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
+			"integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
+			"dev": true,
+			"bin": {
+				"acorn": "bin/acorn"
+			},
+			"engines": {
+				"node": ">=0.4.0"
 			}
 		},
 		"node_modules/esprima": {
@@ -13847,13 +14091,14 @@
 			"integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
 		},
 		"node_modules/function.prototype.name": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.1.2.tgz",
-			"integrity": "sha512-C8A+LlHBJjB2AdcRPorc5JvJ5VUoWlXdEHLOJdCI7kjHEtGTpHQUiqMvCIKUwIsGwZX2jZJy761AXsn356bJQg==",
+			"version": "1.1.5",
+			"resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.1.5.tgz",
+			"integrity": "sha512-uN7m/BzVKQnCUF/iW8jYea67v++2u7m5UgENbHRtdDVclOUP+FMPlCNdmk0h/ysGyo2tavMJEDqJAkJdRa1vMA==",
 			"dependencies": {
+				"call-bind": "^1.0.2",
 				"define-properties": "^1.1.3",
-				"es-abstract": "^1.17.0-next.1",
-				"functions-have-names": "^1.2.0"
+				"es-abstract": "^1.19.0",
+				"functions-have-names": "^1.2.2"
 			},
 			"engines": {
 				"node": ">= 0.4"
@@ -13869,9 +14114,9 @@
 			"dev": true
 		},
 		"node_modules/functions-have-names": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.1.tgz",
-			"integrity": "sha512-j48B/ZI7VKs3sgeI2cZp7WXWmZXu7Iq5pl5/vptV5N2mq+DGFuS/ulaDjtaoLpYzuD6u8UgrUKHfgo7fDTSiBA==",
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.3.tgz",
+			"integrity": "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==",
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
 			}
@@ -14185,21 +14430,6 @@
 			"integrity": "sha1-L0SUrIkZ43Z8XLtpHp9GMyQoXUM=",
 			"dev": true
 		},
-		"node_modules/gonzales-pe": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/gonzales-pe/-/gonzales-pe-4.3.0.tgz",
-			"integrity": "sha512-otgSPpUmdWJ43VXyiNgEYE4luzHCL2pz4wQ0OnDluC6Eg4Ko3Vexy/SrSynglw/eR+OhkzmqFCZa/OFa/RgAOQ==",
-			"dev": true,
-			"dependencies": {
-				"minimist": "^1.2.5"
-			},
-			"bin": {
-				"gonzales": "bin/gonzales.js"
-			},
-			"engines": {
-				"node": ">=0.6.0"
-			}
-		},
 		"node_modules/good-listener": {
 			"version": "1.2.2",
 			"resolved": "https://registry.npmjs.org/good-listener/-/good-listener-1.2.2.tgz",
@@ -14315,9 +14545,9 @@
 			}
 		},
 		"node_modules/has-bigints": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.1.tgz",
-			"integrity": "sha512-LSBS2LjbNBTf6287JEbEzvJgftkF5qFkmCo9hDRpAzKhUOlJ+hx8dd4USs00SgsUNwc4617J9ki5YtEClM2ffA==",
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.2.tgz",
+			"integrity": "sha512-tSvCKtBr9lkF0Ex0aQiP9N+OpV4zi2r/Nee5VkRDbaqv35RLYMzbwQfFSZZH0kR+Rd6302UJZ2p/bJCEoR3VoQ==",
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
 			}
@@ -14330,10 +14560,21 @@
 				"node": ">=4"
 			}
 		},
+		"node_modules/has-property-descriptors": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.0.tgz",
+			"integrity": "sha512-62DVLZGoiEBDHQyqG4w9xCuZ7eJEwNmJRWw2VY84Oedb7WFcA27fiEVe8oUQx9hAUJ4ekurquucTGwsyO1XGdQ==",
+			"dependencies": {
+				"get-intrinsic": "^1.1.1"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
 		"node_modules/has-symbols": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
-			"integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==",
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
+			"integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
 			"engines": {
 				"node": ">= 0.4"
 			},
@@ -14475,6 +14716,20 @@
 			"integrity": "sha1-wc56MWjIxmFAM6S194d/OyJfnDg=",
 			"dev": true
 		},
+		"node_modules/html-element-map": {
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/html-element-map/-/html-element-map-1.3.1.tgz",
+			"integrity": "sha512-6XMlxrAFX4UEEGxctfFnmrFaaZFNf9i5fNuV5wZ3WWQ4FVaNP1aX1LkX9j2mfEx1NpjeE/rL3nmgEn23GdFmrg==",
+			"dev": true,
+			"peer": true,
+			"dependencies": {
+				"array.prototype.filter": "^1.0.0",
+				"call-bind": "^1.0.2"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
 		"node_modules/html-encoding-sniffer": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-2.0.1.tgz",
@@ -14494,40 +14749,15 @@
 			"dev": true
 		},
 		"node_modules/html-tags": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/html-tags/-/html-tags-3.1.0.tgz",
-			"integrity": "sha512-1qYz89hW3lFDEazhjW0yVAV87lw8lVkrJocr72XmBkMKsoSVJCQx3W8BXsC7hO2qAt8BoVjYjtAcZ9perqGnNg==",
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/html-tags/-/html-tags-3.2.0.tgz",
+			"integrity": "sha512-vy7ClnArOZwCnqZgvv+ddgHgJiAFXe3Ge9ML5/mBctVJoUoYPCdxVucOywjDARn6CVoh3dRSFdPHy2sX80L0Wg==",
 			"dev": true,
 			"engines": {
 				"node": ">=8"
-			}
-		},
-		"node_modules/htmlparser2": {
-			"version": "3.10.1",
-			"resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.10.1.tgz",
-			"integrity": "sha512-IgieNijUMbkDovyoKObU1DUhm1iwNYE/fuifEoEHfd1oZKZDaONBSkal7Y01shxsM49R4XaMdGez3WnF9UfiCQ==",
-			"dev": true,
-			"dependencies": {
-				"domelementtype": "^1.3.1",
-				"domhandler": "^2.3.0",
-				"domutils": "^1.5.1",
-				"entities": "^1.1.1",
-				"inherits": "^2.0.1",
-				"readable-stream": "^3.1.1"
-			}
-		},
-		"node_modules/htmlparser2/node_modules/readable-stream": {
-			"version": "3.6.0",
-			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-			"integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
-			"dev": true,
-			"dependencies": {
-				"inherits": "^2.0.3",
-				"string_decoder": "^1.1.1",
-				"util-deprecate": "^1.0.1"
 			},
-			"engines": {
-				"node": ">= 6"
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/http-proxy-agent": {
@@ -14949,39 +15179,18 @@
 				"node": ">=0.10.0"
 			}
 		},
-		"node_modules/is-alphabetical": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-1.0.4.tgz",
-			"integrity": "sha512-DwzsA04LQ10FHTZuL0/grVDk4rFoVH1pjAToYwBrHSxcrBIGQuXrQMtD5U1b0U2XVgKZCTLLP8u2Qxqhy3l2Vg==",
-			"dev": true,
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/wooorm"
-			}
-		},
-		"node_modules/is-alphanumerical": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/is-alphanumerical/-/is-alphanumerical-1.0.4.tgz",
-			"integrity": "sha512-UzoZUr+XfVz3t3v4KyGEniVL9BDRoQtY7tOyrRybkVNjDFWyo1yhXNGrrBTQxp3ib9BLAWs7k2YKBQsFRkZG9A==",
-			"dev": true,
-			"dependencies": {
-				"is-alphabetical": "^1.0.0",
-				"is-decimal": "^1.0.0"
-			},
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/wooorm"
-			}
-		},
 		"node_modules/is-arrayish": {
 			"version": "0.2.1",
 			"resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
 			"integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0="
 		},
 		"node_modules/is-bigint": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.0.2.tgz",
-			"integrity": "sha512-0JV5+SOCQkIdzjBK9buARcV804Ddu7A0Qet6sHi3FimE9ne6m4BGQZfRn+NZiXbBk4F4XmHfDZIipLj9pX8dSA==",
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.0.4.tgz",
+			"integrity": "sha512-zB9CruMamjym81i2JZ3UMn54PKGsQzsJeo6xvN3HJJ4CAsQNB6iRutp2To77OfCNuoxspsIhzaPoO1zyCEhFOg==",
+			"dependencies": {
+				"has-bigints": "^1.0.1"
+			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
 			}
@@ -15101,16 +15310,6 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
-		"node_modules/is-decimal": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/is-decimal/-/is-decimal-1.0.4.tgz",
-			"integrity": "sha512-RGdriMmQQvZ2aqaQq3awNA6dCGtKpiDFcOzrTWrDAT2MiWrKQVPmxLGHl7Y2nNu6led0kEyoX0enY0qXYsv9zw==",
-			"dev": true,
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/wooorm"
-			}
-		},
 		"node_modules/is-descriptor": {
 			"version": "0.1.6",
 			"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
@@ -15191,20 +15390,10 @@
 				"node": ">=0.10.0"
 			}
 		},
-		"node_modules/is-hexadecimal": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-1.0.4.tgz",
-			"integrity": "sha512-gyPJuv83bHMpocVYoqof5VDiZveEoGoFL8m3BXNb2VW8Xs+rz9kqO8LOQ5DH6EsuvilT1ApazU0pyl+ytbPtlw==",
-			"dev": true,
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/wooorm"
-			}
-		},
 		"node_modules/is-negative-zero": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.1.tgz",
-			"integrity": "sha512-2z6JzQvZRa9A2Y7xC6dQQm4FSTSTNWjKIYYTt4246eMTJmIo0Q+ZyOsU66X8lxK1AbB92dFeglPLrhwpeRKO6w==",
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.2.tgz",
+			"integrity": "sha512-dqJvarLawXsFbNDeJW7zAz8ItJ9cd28YufuuFzh0G8pNHjJMnY08Dv7sYX2uF5UpQOwieAeOExEYAWWfu7ZZUA==",
 			"engines": {
 				"node": ">= 0.4"
 			},
@@ -15336,9 +15525,12 @@
 			"dev": true
 		},
 		"node_modules/is-shared-array-buffer": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.1.tgz",
-			"integrity": "sha512-IU0NmyknYZN0rChcKhRO1X8LYz5Isj/Fsqh8NJOSf+N/hCOTwy29F32Ik7a+QszE63IdvmwdTPDd6cZ5pg4cwA==",
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.2.tgz",
+			"integrity": "sha512-sqN2UDu1/0y6uvXyStCOzyhAjCSlHceFoMKJW8W9EU9cvic/QdsZ0kEU93HEy3IUEFZIiH/3w+AH/UQbPHNdhA==",
+			"dependencies": {
+				"call-bind": "^1.0.2"
+			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
 			}
@@ -15364,6 +15556,13 @@
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
 			}
+		},
+		"node_modules/is-subset": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/is-subset/-/is-subset-0.1.1.tgz",
+			"integrity": "sha512-6Ybun0IkarhmEqxXCNw/C0bna6Zb/TkfUX9UbwJtK6ObwAVCxmAP308WWTHviM/zAqXk05cdhYsUsZeGQh99iw==",
+			"dev": true,
+			"peer": true
 		},
 		"node_modules/is-symbol": {
 			"version": "1.0.3",
@@ -15401,18 +15600,6 @@
 			"integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
 			"dev": true
 		},
-		"node_modules/is-unicode-supported": {
-			"version": "0.1.0",
-			"resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
-			"integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==",
-			"dev": true,
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
 		"node_modules/is-url-superb": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/is-url-superb/-/is-url-superb-4.0.0.tgz",
@@ -15432,11 +15619,11 @@
 			"dev": true
 		},
 		"node_modules/is-weakref": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/is-weakref/-/is-weakref-1.0.1.tgz",
-			"integrity": "sha512-b2jKc2pQZjaeFYWEf7ScFj+Be1I+PXmlu572Q8coTXZ+LD/QQZ7ShPMst8h16riVgyXTQwUsFEl74mDvc/3MHQ==",
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/is-weakref/-/is-weakref-1.0.2.tgz",
+			"integrity": "sha512-qctsuLZmIQ0+vSSMfoVvyFe2+GSEvnmZ2ezTup1SBse9+twCCeial6EEi3Nc2KFcf6+qz2FBPnjXsk8xhKSaPQ==",
 			"dependencies": {
-				"call-bind": "^1.0.0"
+				"call-bind": "^1.0.2"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
@@ -18625,18 +18812,6 @@
 				}
 			}
 		},
-		"node_modules/jsdom/node_modules/acorn": {
-			"version": "8.4.0",
-			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.4.0.tgz",
-			"integrity": "sha512-ULr0LDaEqQrMFGyQ3bhJkLsbtrQ8QibAseGZeaSUiT/6zb9IvIkomWHJIvgvwad+hinRAgsI51JcWk2yvwyL+w==",
-			"dev": true,
-			"bin": {
-				"acorn": "bin/acorn"
-			},
-			"engines": {
-				"node": ">=0.4.0"
-			}
-		},
 		"node_modules/jsdom/node_modules/form-data": {
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.1.tgz",
@@ -18836,9 +19011,9 @@
 			}
 		},
 		"node_modules/known-css-properties": {
-			"version": "0.21.0",
-			"resolved": "https://registry.npmjs.org/known-css-properties/-/known-css-properties-0.21.0.tgz",
-			"integrity": "sha512-sZLUnTqimCkvkgRS+kbPlYW5o8q5w1cu+uIisKpEWkj31I8mx8kNG162DwRav8Zirkva6N5uoFsm9kzK4mUXjw==",
+			"version": "0.25.0",
+			"resolved": "https://registry.npmjs.org/known-css-properties/-/known-css-properties-0.25.0.tgz",
+			"integrity": "sha512-b0/9J1O9Jcyik1GC6KC42hJ41jKwdO/Mq8Mdo5sYN+IuRTXs2YFHZC3kZSx6ueusqa95x3wLYe/ytKjbAfGixA==",
 			"dev": true
 		},
 		"node_modules/language-subtag-registry": {
@@ -19505,11 +19680,25 @@
 			"integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168=",
 			"dev": true
 		},
+		"node_modules/lodash.escape": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-4.0.1.tgz",
+			"integrity": "sha512-nXEOnb/jK9g0DYMr1/Xvq6l5xMD7GDG55+GSYIYmS0G4tBk/hURD4JR9WCavs04t33WmJx9kCyp9vJ+mr4BOUw==",
+			"dev": true,
+			"peer": true
+		},
 		"node_modules/lodash.escaperegexp": {
 			"version": "4.1.2",
 			"resolved": "https://registry.npmjs.org/lodash.escaperegexp/-/lodash.escaperegexp-4.1.2.tgz",
 			"integrity": "sha1-ZHYsSGGAglGKw99Mz11YhtriA0c=",
 			"dev": true
+		},
+		"node_modules/lodash.flattendeep": {
+			"version": "4.4.0",
+			"resolved": "https://registry.npmjs.org/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz",
+			"integrity": "sha512-uHaJFihxmJcEX3kT4I23ABqKKalJ/zDrDg0lsFtc1h+3uw49SIJ5beyhx5ExVRti3AvKoOJngIj7xz3oylPdWQ==",
+			"dev": true,
+			"peer": true
 		},
 		"node_modules/lodash.get": {
 			"version": "4.4.2",
@@ -19528,6 +19717,13 @@
 			"resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
 			"integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U=",
 			"dev": true
+		},
+		"node_modules/lodash.isequal": {
+			"version": "4.5.0",
+			"resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+			"integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==",
+			"dev": true,
+			"peer": true
 		},
 		"node_modules/lodash.ismatch": {
 			"version": "4.4.0",
@@ -19605,92 +19801,6 @@
 			"resolved": "https://registry.npmjs.org/lodash.uniqby/-/lodash.uniqby-4.7.0.tgz",
 			"integrity": "sha1-2ZwHpmnp5tJOE2Lf4mbGdhavEwI=",
 			"dev": true
-		},
-		"node_modules/log-symbols": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz",
-			"integrity": "sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==",
-			"dev": true,
-			"dependencies": {
-				"chalk": "^4.1.0",
-				"is-unicode-supported": "^0.1.0"
-			},
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/log-symbols/node_modules/ansi-styles": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-			"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-			"dev": true,
-			"dependencies": {
-				"color-convert": "^2.0.1"
-			},
-			"engines": {
-				"node": ">=8"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
-			}
-		},
-		"node_modules/log-symbols/node_modules/chalk": {
-			"version": "4.1.2",
-			"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-			"integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-			"dev": true,
-			"dependencies": {
-				"ansi-styles": "^4.1.0",
-				"supports-color": "^7.1.0"
-			},
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/chalk?sponsor=1"
-			}
-		},
-		"node_modules/log-symbols/node_modules/color-convert": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-			"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-			"dev": true,
-			"dependencies": {
-				"color-name": "~1.1.4"
-			},
-			"engines": {
-				"node": ">=7.0.0"
-			}
-		},
-		"node_modules/log-symbols/node_modules/color-name": {
-			"version": "1.1.4",
-			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-			"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-			"dev": true
-		},
-		"node_modules/log-symbols/node_modules/has-flag": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-			"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-			"dev": true,
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/log-symbols/node_modules/supports-color": {
-			"version": "7.2.0",
-			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-			"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-			"dev": true,
-			"dependencies": {
-				"has-flag": "^4.0.0"
-			},
-			"engines": {
-				"node": ">=8"
-			}
 		},
 		"node_modules/log-update": {
 			"version": "4.0.0",
@@ -19883,16 +19993,6 @@
 			"dev": true,
 			"engines": {
 				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/longest-streak": {
-			"version": "2.0.4",
-			"resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-2.0.4.tgz",
-			"integrity": "sha512-vM6rUVCVUJJt33bnmHiZEvr7wPT78ztX7rojL+LW51bHtLh6HTjx84LA5W4+oa6aKEJA7jJu5LR6vQRBpA5DVg==",
-			"dev": true,
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/wooorm"
 			}
 		},
 		"node_modules/loose-envify": {
@@ -20136,51 +20236,6 @@
 				"node": ">=0.10.0"
 			}
 		},
-		"node_modules/mdast-util-from-markdown": {
-			"version": "0.8.5",
-			"resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-0.8.5.tgz",
-			"integrity": "sha512-2hkTXtYYnr+NubD/g6KGBS/0mFmBcifAsI0yIWRiRo0PjVs6SSOSOdtzbp6kSGnShDN6G5aWZpKQ2lWRy27mWQ==",
-			"dev": true,
-			"dependencies": {
-				"@types/mdast": "^3.0.0",
-				"mdast-util-to-string": "^2.0.0",
-				"micromark": "~2.11.0",
-				"parse-entities": "^2.0.0",
-				"unist-util-stringify-position": "^2.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/unified"
-			}
-		},
-		"node_modules/mdast-util-to-markdown": {
-			"version": "0.6.5",
-			"resolved": "https://registry.npmjs.org/mdast-util-to-markdown/-/mdast-util-to-markdown-0.6.5.tgz",
-			"integrity": "sha512-XeV9sDE7ZlOQvs45C9UKMtfTcctcaj/pGwH8YLbMHoMOXNNCn2LsqVQOqrF1+/NU8lKDAqozme9SCXWyo9oAcQ==",
-			"dev": true,
-			"dependencies": {
-				"@types/unist": "^2.0.0",
-				"longest-streak": "^2.0.0",
-				"mdast-util-to-string": "^2.0.0",
-				"parse-entities": "^2.0.0",
-				"repeat-string": "^1.0.0",
-				"zwitch": "^1.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/unified"
-			}
-		},
-		"node_modules/mdast-util-to-string": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-2.0.0.tgz",
-			"integrity": "sha512-AW4DRS3QbBayY/jJmD8437V1Gombjf8RSOUCMFBuo5iHi58AGEgVCKQ+ezHkZZDpAQS75hcBMpLqjpJTjtUL7w==",
-			"dev": true,
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/unified"
-			}
-		},
 		"node_modules/mdn-data": {
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.4.tgz",
@@ -20285,49 +20340,6 @@
 			"engines": {
 				"node": ">= 8"
 			}
-		},
-		"node_modules/micromark": {
-			"version": "2.11.4",
-			"resolved": "https://registry.npmjs.org/micromark/-/micromark-2.11.4.tgz",
-			"integrity": "sha512-+WoovN/ppKolQOFIAajxi7Lu9kInbPxFuTBVEavFcL8eAfVstoc5MocPmqBeAdBOJV00uaVjegzH4+MA0DN/uA==",
-			"dev": true,
-			"funding": [
-				{
-					"type": "GitHub Sponsors",
-					"url": "https://github.com/sponsors/unifiedjs"
-				},
-				{
-					"type": "OpenCollective",
-					"url": "https://opencollective.com/unified"
-				}
-			],
-			"dependencies": {
-				"debug": "^4.0.0",
-				"parse-entities": "^2.0.0"
-			}
-		},
-		"node_modules/micromark/node_modules/debug": {
-			"version": "4.3.2",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
-			"integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
-			"dev": true,
-			"dependencies": {
-				"ms": "2.1.2"
-			},
-			"engines": {
-				"node": ">=6.0"
-			},
-			"peerDependenciesMeta": {
-				"supports-color": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/micromark/node_modules/ms": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-			"dev": true
 		},
 		"node_modules/micromatch": {
 			"version": "3.1.10",
@@ -20669,6 +20681,13 @@
 				"node": "*"
 			}
 		},
+		"node_modules/moo": {
+			"version": "0.5.1",
+			"resolved": "https://registry.npmjs.org/moo/-/moo-0.5.1.tgz",
+			"integrity": "sha512-I1mnb5xn4fO80BH9BLcF0yLypy2UKl+Cb01Fu0hJRkJjlCRtxZMWkTdAtDd5ZqCOxtCkhmRwyI57vWT+1iZ67w==",
+			"dev": true,
+			"peer": true
+		},
 		"node_modules/mousetrap": {
 			"version": "1.6.5",
 			"resolved": "https://registry.npmjs.org/mousetrap/-/mousetrap-1.6.5.tgz",
@@ -20732,6 +20751,29 @@
 			"resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
 			"integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
 			"dev": true
+		},
+		"node_modules/nearley": {
+			"version": "2.20.1",
+			"resolved": "https://registry.npmjs.org/nearley/-/nearley-2.20.1.tgz",
+			"integrity": "sha512-+Mc8UaAebFzgV+KpI5n7DasuuQCHA89dmwm7JXw3TV43ukfNQ9DnBH3Mdb2g/I4Fdxc26pwimBWvjIw0UAILSQ==",
+			"dev": true,
+			"peer": true,
+			"dependencies": {
+				"commander": "^2.19.0",
+				"moo": "^0.5.0",
+				"railroad-diagrams": "^1.0.0",
+				"randexp": "0.4.6"
+			},
+			"bin": {
+				"nearley-railroad": "bin/nearley-railroad.js",
+				"nearley-test": "bin/nearley-test.js",
+				"nearley-unparse": "bin/nearley-unparse.js",
+				"nearleyc": "bin/nearleyc.js"
+			},
+			"funding": {
+				"type": "individual",
+				"url": "https://nearley.js.org/#give-to-nearley"
+			}
 		},
 		"node_modules/neo-async": {
 			"version": "2.6.2",
@@ -20825,13 +20867,14 @@
 			}
 		},
 		"node_modules/newspack-scripts": {
-			"version": "3.3.2",
-			"resolved": "https://registry.npmjs.org/newspack-scripts/-/newspack-scripts-3.3.2.tgz",
-			"integrity": "sha512-VERTkqJ5qLL7//plGpco2+7a7xyG7EfyXSUqlmdCFXGO+phtMnP7r69jaGYxUCFAcvYTRp1+jlJX/uixxHoUgQ==",
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/newspack-scripts/-/newspack-scripts-4.3.0.tgz",
+			"integrity": "sha512-AIRSYl5W6vY0k2Ko4gB9ikRWx6kB/JQyCOOwCkNdkE9uP8OAx6bUhDMn+BVGM2WY4mZOAY5sq3Oib4iwe4xNMw==",
 			"dev": true,
 			"dependencies": {
 				"@automattic/calypso-build": "^10.0.0",
 				"@babel/preset-env": "^7.16.4",
+				"@babel/preset-typescript": "^7.18.6",
 				"@commitlint/cli": "^15.0.0",
 				"@commitlint/config-conventional": "^15.0.0",
 				"@semantic-release/changelog": "^6.0.1",
@@ -20860,7 +20903,7 @@
 				"@wordpress/icons": "^6.1.1",
 				"@wordpress/keycodes": "^3.2.4",
 				"@wordpress/plugins": "^4.0.6",
-				"@wordpress/stylelint-config": "^19.1.0",
+				"@wordpress/stylelint-config": "^20.0.2",
 				"@wordpress/url": "^3.3.1",
 				"autoprefixer": "^10.4.0",
 				"babel-jest": "^27.4.2",
@@ -20876,7 +20919,7 @@
 				"jest-environment-jsdom": "^27.4.3",
 				"postcss": "^8.4.4",
 				"postcss-focus-within": "^5.0.1",
-				"prettier": "npm:wp-prettier@2.2.1-beta-1",
+				"prettier": "npm:wp-prettier@^2.6.2-beta-1",
 				"semantic-release": "^18.0.1",
 				"semantic-release-version-bump": "^1.4.1",
 				"stylelint": "^14.1.0",
@@ -21124,16 +21167,17 @@
 				}
 			}
 		},
-		"node_modules/newspack-scripts/node_modules/acorn": {
-			"version": "8.7.0",
-			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.7.0.tgz",
-			"integrity": "sha512-V/LGr1APy+PXIwKebEWrkZPwoeoF+w1jiOBUmuxuiUIaOHtob8Qc9BTrYo7VuI5fR8tqsy+buA2WFooR5olqvQ==",
+		"node_modules/newspack-scripts/node_modules/@wordpress/eslint-plugin/node_modules/prettier": {
+			"name": "wp-prettier",
+			"version": "2.2.1-beta-1",
+			"resolved": "https://registry.npmjs.org/wp-prettier/-/wp-prettier-2.2.1-beta-1.tgz",
+			"integrity": "sha512-+JHkqs9LC/JPp51yy1hzs3lQ7qeuWCwOcSzpQNeeY/G7oSpnF61vxt7hRh87zNRTr6ob2ndy0W8rVzhgrcA+Gw==",
 			"dev": true,
 			"bin": {
-				"acorn": "bin/acorn"
+				"prettier": "bin-prettier.js"
 			},
 			"engines": {
-				"node": ">=0.4.0"
+				"node": ">=10.13.0"
 			}
 		},
 		"node_modules/newspack-scripts/node_modules/ansi-regex": {
@@ -21179,15 +21223,6 @@
 				"node": ">=6.0"
 			}
 		},
-		"node_modules/newspack-scripts/node_modules/array-union": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
-			"integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
-			"dev": true,
-			"engines": {
-				"node": ">=8"
-			}
-		},
 		"node_modules/newspack-scripts/node_modules/autoprefixer": {
 			"version": "10.4.2",
 			"resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.2.tgz",
@@ -21213,24 +21248,6 @@
 			},
 			"peerDependencies": {
 				"postcss": "^8.1.0"
-			}
-		},
-		"node_modules/newspack-scripts/node_modules/balanced-match": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-2.0.0.tgz",
-			"integrity": "sha512-1ugUSr8BHXRnK23KfuYS+gVMC3LB8QGH9W1iGtDPsNWoQbgtXSExkBu2aDR4epiGWZOjZsj6lDl/N/AqqTC3UA==",
-			"dev": true
-		},
-		"node_modules/newspack-scripts/node_modules/braces": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-			"integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
-			"dev": true,
-			"dependencies": {
-				"fill-range": "^7.0.1"
-			},
-			"engines": {
-				"node": ">=8"
 			}
 		},
 		"node_modules/newspack-scripts/node_modules/chalk": {
@@ -21297,12 +21314,6 @@
 					"optional": true
 				}
 			}
-		},
-		"node_modules/newspack-scripts/node_modules/emoji-regex": {
-			"version": "8.0.0",
-			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-			"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-			"dev": true
 		},
 		"node_modules/newspack-scripts/node_modules/escape-string-regexp": {
 			"version": "4.0.0",
@@ -21676,18 +21687,6 @@
 				"node": ">=4.0"
 			}
 		},
-		"node_modules/newspack-scripts/node_modules/fill-range": {
-			"version": "7.0.1",
-			"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-			"integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
-			"dev": true,
-			"dependencies": {
-				"to-regex-range": "^5.0.1"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
 		"node_modules/newspack-scripts/node_modules/glob-parent": {
 			"version": "6.0.2",
 			"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
@@ -21727,26 +21726,6 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/newspack-scripts/node_modules/globby": {
-			"version": "11.1.0",
-			"resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
-			"integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
-			"dev": true,
-			"dependencies": {
-				"array-union": "^2.1.0",
-				"dir-glob": "^3.0.1",
-				"fast-glob": "^3.2.9",
-				"ignore": "^5.2.0",
-				"merge2": "^1.4.1",
-				"slash": "^3.0.0"
-			},
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
 		"node_modules/newspack-scripts/node_modules/has-flag": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -21756,18 +21735,6 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/newspack-scripts/node_modules/hosted-git-info": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-4.1.0.tgz",
-			"integrity": "sha512-kyCuEOWjJqZuDbRHzL8V93NzQhwIB71oFWSyzVo+KPZI+pnQPPxucdkrOZvkLRnrf5URsQM+IJ09Dw29cRALIA==",
-			"dev": true,
-			"dependencies": {
-				"lru-cache": "^6.0.0"
-			},
-			"engines": {
-				"node": ">=10"
-			}
-		},
 		"node_modules/newspack-scripts/node_modules/ignore": {
 			"version": "5.2.0",
 			"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.0.tgz",
@@ -21775,33 +21742,6 @@
 			"dev": true,
 			"engines": {
 				"node": ">= 4"
-			}
-		},
-		"node_modules/newspack-scripts/node_modules/is-fullwidth-code-point": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-			"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-			"dev": true,
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/newspack-scripts/node_modules/is-number": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
-			"integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-			"dev": true,
-			"engines": {
-				"node": ">=0.12.0"
-			}
-		},
-		"node_modules/newspack-scripts/node_modules/is-plain-object": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
-			"integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
-			"dev": true,
-			"engines": {
-				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/newspack-scripts/node_modules/js-yaml": {
@@ -21816,12 +21756,6 @@
 				"js-yaml": "bin/js-yaml.js"
 			}
 		},
-		"node_modules/newspack-scripts/node_modules/known-css-properties": {
-			"version": "0.24.0",
-			"resolved": "https://registry.npmjs.org/known-css-properties/-/known-css-properties-0.24.0.tgz",
-			"integrity": "sha512-RTSoaUAfLvpR357vWzAz/50Q/BmHfmE6ETSWfutT0AJiw10e6CmcdYRQJlLRd95B53D0Y2aD1jSxD3V3ySF+PA==",
-			"dev": true
-		},
 		"node_modules/newspack-scripts/node_modules/levn": {
 			"version": "0.4.1",
 			"resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
@@ -21835,65 +21769,11 @@
 				"node": ">= 0.8.0"
 			}
 		},
-		"node_modules/newspack-scripts/node_modules/meow": {
-			"version": "9.0.0",
-			"resolved": "https://registry.npmjs.org/meow/-/meow-9.0.0.tgz",
-			"integrity": "sha512-+obSblOQmRhcyBt62furQqRAQpNyWXo8BuQ5bN7dG8wmwQ+vwHKp/rCFD4CrTP8CsDQD1sjoZ94K417XEUk8IQ==",
-			"dev": true,
-			"dependencies": {
-				"@types/minimist": "^1.2.0",
-				"camelcase-keys": "^6.2.2",
-				"decamelize": "^1.2.0",
-				"decamelize-keys": "^1.1.0",
-				"hard-rejection": "^2.1.0",
-				"minimist-options": "4.1.0",
-				"normalize-package-data": "^3.0.0",
-				"read-pkg-up": "^7.0.1",
-				"redent": "^3.0.0",
-				"trim-newlines": "^3.0.0",
-				"type-fest": "^0.18.0",
-				"yargs-parser": "^20.2.3"
-			},
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/newspack-scripts/node_modules/micromatch": {
-			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.4.tgz",
-			"integrity": "sha512-pRmzw/XUcwXGpD9aI9q/0XOwLNygjETJ8y0ao0wdqprrzDa4YnxLcz7fQRZr8voh8V10kGhABbNcHVk5wHgWwg==",
-			"dev": true,
-			"dependencies": {
-				"braces": "^3.0.1",
-				"picomatch": "^2.2.3"
-			},
-			"engines": {
-				"node": ">=8.6"
-			}
-		},
 		"node_modules/newspack-scripts/node_modules/ms": {
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
 			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
 			"dev": true
-		},
-		"node_modules/newspack-scripts/node_modules/normalize-package-data": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-3.0.3.tgz",
-			"integrity": "sha512-p2W1sgqij3zMMyRC067Dg16bfzVH+w7hyegmpIvZ4JNjqtGOVAIvLmjBx3yP7YTe9vKJgkoNOPjwQGogDoMXFA==",
-			"dev": true,
-			"dependencies": {
-				"hosted-git-info": "^4.0.1",
-				"is-core-module": "^2.5.0",
-				"semver": "^7.3.4",
-				"validate-npm-package-license": "^3.0.1"
-			},
-			"engines": {
-				"node": ">=10"
-			}
 		},
 		"node_modules/newspack-scripts/node_modules/optionator": {
 			"version": "0.9.1",
@@ -21934,22 +21814,6 @@
 			},
 			"peerDependencies": {
 				"postcss": "^8.3"
-			}
-		},
-		"node_modules/newspack-scripts/node_modules/postcss-safe-parser": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/postcss-safe-parser/-/postcss-safe-parser-6.0.0.tgz",
-			"integrity": "sha512-FARHN8pwH+WiS2OPCxJI8FuRJpTVnn6ZNFiqAM2aeW2LwTHWWmWgIyKC6cUo0L8aeKiF/14MNvnpls6R2PBeMQ==",
-			"dev": true,
-			"engines": {
-				"node": ">=12.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/postcss/"
-			},
-			"peerDependencies": {
-				"postcss": "^8.3.3"
 			}
 		},
 		"node_modules/newspack-scripts/node_modules/prelude-ls": {
@@ -21997,29 +21861,6 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/newspack-scripts/node_modules/slash": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
-			"integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
-			"dev": true,
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/newspack-scripts/node_modules/string-width": {
-			"version": "4.2.3",
-			"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-			"integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-			"dev": true,
-			"dependencies": {
-				"emoji-regex": "^8.0.0",
-				"is-fullwidth-code-point": "^3.0.0",
-				"strip-ansi": "^6.0.1"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
 		"node_modules/newspack-scripts/node_modules/strip-ansi": {
 			"version": "6.0.1",
 			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
@@ -22030,64 +21871,6 @@
 			},
 			"engines": {
 				"node": ">=8"
-			}
-		},
-		"node_modules/newspack-scripts/node_modules/stylelint": {
-			"version": "14.3.0",
-			"resolved": "https://registry.npmjs.org/stylelint/-/stylelint-14.3.0.tgz",
-			"integrity": "sha512-PZXSwtJe4f4qBPWBwAbHL0M0Qjrv8iHN+cLpUNsffaVMS3YzpDDRI73+2lsqLAYfQEzxRwpll6BDKImREbpHWA==",
-			"dev": true,
-			"dependencies": {
-				"balanced-match": "^2.0.0",
-				"colord": "^2.9.2",
-				"cosmiconfig": "^7.0.1",
-				"debug": "^4.3.3",
-				"execall": "^2.0.0",
-				"fast-glob": "^3.2.11",
-				"fastest-levenshtein": "^1.0.12",
-				"file-entry-cache": "^6.0.1",
-				"get-stdin": "^8.0.0",
-				"global-modules": "^2.0.0",
-				"globby": "^11.1.0",
-				"globjoin": "^0.1.4",
-				"html-tags": "^3.1.0",
-				"ignore": "^5.2.0",
-				"import-lazy": "^4.0.0",
-				"imurmurhash": "^0.1.4",
-				"is-plain-object": "^5.0.0",
-				"known-css-properties": "^0.24.0",
-				"mathml-tag-names": "^2.1.3",
-				"meow": "^9.0.0",
-				"micromatch": "^4.0.4",
-				"normalize-path": "^3.0.0",
-				"normalize-selector": "^0.2.0",
-				"picocolors": "^1.0.0",
-				"postcss": "^8.4.5",
-				"postcss-media-query-parser": "^0.2.3",
-				"postcss-resolve-nested-selector": "^0.1.1",
-				"postcss-safe-parser": "^6.0.0",
-				"postcss-selector-parser": "^6.0.9",
-				"postcss-value-parser": "^4.2.0",
-				"resolve-from": "^5.0.0",
-				"specificity": "^0.4.1",
-				"string-width": "^4.2.3",
-				"strip-ansi": "^6.0.1",
-				"style-search": "^0.1.0",
-				"supports-hyperlinks": "^2.2.0",
-				"svg-tags": "^1.0.0",
-				"table": "^6.8.0",
-				"v8-compile-cache": "^2.3.0",
-				"write-file-atomic": "^4.0.0"
-			},
-			"bin": {
-				"stylelint": "bin/stylelint.js"
-			},
-			"engines": {
-				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/stylelint"
 			}
 		},
 		"node_modules/newspack-scripts/node_modules/stylelint-prettier": {
@@ -22118,18 +21901,6 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/newspack-scripts/node_modules/to-regex-range": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
-			"integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-			"dev": true,
-			"dependencies": {
-				"is-number": "^7.0.0"
-			},
-			"engines": {
-				"node": ">=8.0"
-			}
-		},
 		"node_modules/newspack-scripts/node_modules/type-check": {
 			"version": "0.4.0",
 			"resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
@@ -22141,38 +21912,6 @@
 			"engines": {
 				"node": ">= 0.8.0"
 			}
-		},
-		"node_modules/newspack-scripts/node_modules/type-fest": {
-			"version": "0.18.1",
-			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.18.1.tgz",
-			"integrity": "sha512-OIAYXk8+ISY+qTOwkHtKqzAuxchoMiD9Udx+FSGQDuiRR+PJKJHc2NJAXlbhkGwTt/4/nKZxELY1w3ReWOL8mw==",
-			"dev": true,
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/newspack-scripts/node_modules/typedarray-to-buffer": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-4.0.0.tgz",
-			"integrity": "sha512-6dOYeZfS3O9RtRD1caom0sMxgK59b27+IwoNy8RDPsmslSGOyU+mpTamlaIW7aNKi90ZQZ9DFaZL3YRoiSCULQ==",
-			"dev": true,
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/feross"
-				},
-				{
-					"type": "patreon",
-					"url": "https://www.patreon.com/feross"
-				},
-				{
-					"type": "consulting",
-					"url": "https://feross.org/support"
-				}
-			]
 		},
 		"node_modules/newspack-scripts/node_modules/which": {
 			"version": "2.0.2",
@@ -22187,21 +21926,6 @@
 			},
 			"engines": {
 				"node": ">= 8"
-			}
-		},
-		"node_modules/newspack-scripts/node_modules/write-file-atomic": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-4.0.0.tgz",
-			"integrity": "sha512-JhcWoKffJNF7ivO9yflBhc7tn3wKnokMUfWpBriM9yCXj4ePQnRPcWglBkkg1AHC8nsW/EfxwwhqsLtOy59djA==",
-			"dev": true,
-			"dependencies": {
-				"imurmurhash": "^0.1.4",
-				"is-typedarray": "^1.0.0",
-				"signal-exit": "^3.0.2",
-				"typedarray-to-buffer": "^4.0.0"
-			},
-			"engines": {
-				"node": "^12.13.0 || ^14.15.0 || >=16"
 			}
 		},
 		"node_modules/next-tick": {
@@ -22297,12 +22021,6 @@
 			"engines": {
 				"node": ">=0.10.0"
 			}
-		},
-		"node_modules/normalize-selector": {
-			"version": "0.2.0",
-			"resolved": "https://registry.npmjs.org/normalize-selector/-/normalize-selector-0.2.0.tgz",
-			"integrity": "sha1-0LFF62kRicY6eNIB3E/bEpPvDAM=",
-			"dev": true
 		},
 		"node_modules/normalize-url": {
 			"version": "3.3.0",
@@ -25239,11 +24957,18 @@
 			"inBundle": true,
 			"license": "ISC"
 		},
-		"node_modules/num2fraction": {
-			"version": "1.2.2",
-			"resolved": "https://registry.npmjs.org/num2fraction/-/num2fraction-1.2.2.tgz",
-			"integrity": "sha1-b2gragJ6Tp3fpFZM0lidHU5mnt4=",
-			"dev": true
+		"node_modules/nth-check": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
+			"integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
+			"dev": true,
+			"peer": true,
+			"dependencies": {
+				"boolbase": "^1.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/fb55/nth-check?sponsor=1"
+			}
 		},
 		"node_modules/nwsapi": {
 			"version": "2.2.0",
@@ -25629,24 +25354,6 @@
 				"node": ">=6"
 			}
 		},
-		"node_modules/parse-entities": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-2.0.0.tgz",
-			"integrity": "sha512-kkywGpCcRYhqQIchaWqZ875wzpS/bMKhz5HnN3p7wveJTkTtyAB/AlnS0f8DFSqYW1T82t6yEAkEcB+A1I3MbQ==",
-			"dev": true,
-			"dependencies": {
-				"character-entities": "^1.0.0",
-				"character-entities-legacy": "^1.0.0",
-				"character-reference-invalid": "^1.0.0",
-				"is-alphanumerical": "^1.0.0",
-				"is-decimal": "^1.0.0",
-				"is-hexadecimal": "^1.0.0"
-			},
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/wooorm"
-			}
-		},
 		"node_modules/parse-json": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
@@ -25674,6 +25381,75 @@
 			"resolved": "https://registry.npmjs.org/parse5/-/parse5-6.0.1.tgz",
 			"integrity": "sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw==",
 			"dev": true
+		},
+		"node_modules/parse5-htmlparser2-tree-adapter": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/parse5-htmlparser2-tree-adapter/-/parse5-htmlparser2-tree-adapter-7.0.0.tgz",
+			"integrity": "sha512-B77tOZrqqfUfnVcOrUvfdLbz4pu4RopLD/4vmu3HUPswwTA8OH0EMW9BlWR2B0RCoiZRAHEUu7IxeP1Pd1UU+g==",
+			"dev": true,
+			"peer": true,
+			"dependencies": {
+				"domhandler": "^5.0.2",
+				"parse5": "^7.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/inikulin/parse5?sponsor=1"
+			}
+		},
+		"node_modules/parse5-htmlparser2-tree-adapter/node_modules/domelementtype": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+			"integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/fb55"
+				}
+			],
+			"peer": true
+		},
+		"node_modules/parse5-htmlparser2-tree-adapter/node_modules/domhandler": {
+			"version": "5.0.3",
+			"resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+			"integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+			"dev": true,
+			"peer": true,
+			"dependencies": {
+				"domelementtype": "^2.3.0"
+			},
+			"engines": {
+				"node": ">= 4"
+			},
+			"funding": {
+				"url": "https://github.com/fb55/domhandler?sponsor=1"
+			}
+		},
+		"node_modules/parse5-htmlparser2-tree-adapter/node_modules/entities": {
+			"version": "4.3.1",
+			"resolved": "https://registry.npmjs.org/entities/-/entities-4.3.1.tgz",
+			"integrity": "sha512-o4q/dYJlmyjP2zfnaWDUC6A3BQFmVTX+tZPezK7k0GLSU9QYCauscf5Y+qcEPzKL+EixVouYDgLQK5H9GrLpkg==",
+			"dev": true,
+			"peer": true,
+			"engines": {
+				"node": ">=0.12"
+			},
+			"funding": {
+				"url": "https://github.com/fb55/entities?sponsor=1"
+			}
+		},
+		"node_modules/parse5-htmlparser2-tree-adapter/node_modules/parse5": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/parse5/-/parse5-7.0.0.tgz",
+			"integrity": "sha512-y/t8IXSPWTuRZqXc0ajH/UwDj4mnqLEbSttNbThcFhGrZuOyoyvNBO85PBp2jQa55wY9d07PBNjsK8ZP3K5U6g==",
+			"dev": true,
+			"peer": true,
+			"dependencies": {
+				"entities": "^4.3.0"
+			},
+			"funding": {
+				"url": "https://github.com/inikulin/parse5?sponsor=1"
+			}
 		},
 		"node_modules/parserlib": {
 			"version": "1.1.1",
@@ -26292,63 +26068,6 @@
 			}
 		},
 		"node_modules/postcss-discard-overridden/node_modules/source-map": {
-			"version": "0.6.1",
-			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-			"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-			"dev": true,
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/postcss-html": {
-			"version": "0.36.0",
-			"resolved": "https://registry.npmjs.org/postcss-html/-/postcss-html-0.36.0.tgz",
-			"integrity": "sha512-HeiOxGcuwID0AFsNAL0ox3mW6MHH5cstWN1Z3Y+n6H+g12ih7LHdYxWwEA/QmrebctLjo79xz9ouK3MroHwOJw==",
-			"dev": true,
-			"dependencies": {
-				"htmlparser2": "^3.10.0"
-			},
-			"peerDependencies": {
-				"postcss": ">=5.0.0",
-				"postcss-syntax": ">=0.36.0"
-			}
-		},
-		"node_modules/postcss-less": {
-			"version": "3.1.4",
-			"resolved": "https://registry.npmjs.org/postcss-less/-/postcss-less-3.1.4.tgz",
-			"integrity": "sha512-7TvleQWNM2QLcHqvudt3VYjULVB49uiW6XzEUFmvwHzvsOEF5MwBrIXZDJQvJNFGjJQTzSzZnDoCJ8h/ljyGXA==",
-			"dev": true,
-			"dependencies": {
-				"postcss": "^7.0.14"
-			},
-			"engines": {
-				"node": ">=6.14.4"
-			}
-		},
-		"node_modules/postcss-less/node_modules/picocolors": {
-			"version": "0.2.1",
-			"resolved": "https://registry.npmjs.org/picocolors/-/picocolors-0.2.1.tgz",
-			"integrity": "sha512-cMlDqaLEqfSaW8Z7N5Jw+lyIW869EzT73/F5lhtY9cLGoVxSXznfgfXMO0Z5K0o0Q2TkTXq+0KFsdnSe3jDViA==",
-			"dev": true
-		},
-		"node_modules/postcss-less/node_modules/postcss": {
-			"version": "7.0.39",
-			"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.39.tgz",
-			"integrity": "sha512-yioayjNbHn6z1/Bywyb2Y4s3yvDAeXGOyxqD+LnVOinq6Mdmd++SW2wUNVzavyyHxd6+DxzWGIuosg6P1Rj8uA==",
-			"dev": true,
-			"dependencies": {
-				"picocolors": "^0.2.1",
-				"source-map": "^0.6.1"
-			},
-			"engines": {
-				"node": ">=6.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/postcss/"
-			}
-		},
-		"node_modules/postcss-less/node_modules/source-map": {
 			"version": "0.6.1",
 			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
 			"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
@@ -27416,139 +27135,41 @@
 			"dev": true
 		},
 		"node_modules/postcss-safe-parser": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/postcss-safe-parser/-/postcss-safe-parser-4.0.2.tgz",
-			"integrity": "sha512-Uw6ekxSWNLCPesSv/cmqf2bY/77z11O7jZGPax3ycZMFU/oi2DMH9i89AdHc1tRwFg/arFoEwX0IS3LCUxJh1g==",
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/postcss-safe-parser/-/postcss-safe-parser-6.0.0.tgz",
+			"integrity": "sha512-FARHN8pwH+WiS2OPCxJI8FuRJpTVnn6ZNFiqAM2aeW2LwTHWWmWgIyKC6cUo0L8aeKiF/14MNvnpls6R2PBeMQ==",
 			"dev": true,
-			"dependencies": {
-				"postcss": "^7.0.26"
-			},
 			"engines": {
-				"node": ">=6.0.0"
-			}
-		},
-		"node_modules/postcss-safe-parser/node_modules/picocolors": {
-			"version": "0.2.1",
-			"resolved": "https://registry.npmjs.org/picocolors/-/picocolors-0.2.1.tgz",
-			"integrity": "sha512-cMlDqaLEqfSaW8Z7N5Jw+lyIW869EzT73/F5lhtY9cLGoVxSXznfgfXMO0Z5K0o0Q2TkTXq+0KFsdnSe3jDViA==",
-			"dev": true
-		},
-		"node_modules/postcss-safe-parser/node_modules/postcss": {
-			"version": "7.0.39",
-			"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.39.tgz",
-			"integrity": "sha512-yioayjNbHn6z1/Bywyb2Y4s3yvDAeXGOyxqD+LnVOinq6Mdmd++SW2wUNVzavyyHxd6+DxzWGIuosg6P1Rj8uA==",
-			"dev": true,
-			"dependencies": {
-				"picocolors": "^0.2.1",
-				"source-map": "^0.6.1"
-			},
-			"engines": {
-				"node": ">=6.0.0"
+				"node": ">=12.0"
 			},
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/postcss/"
-			}
-		},
-		"node_modules/postcss-safe-parser/node_modules/source-map": {
-			"version": "0.6.1",
-			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-			"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-			"dev": true,
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/postcss-sass": {
-			"version": "0.4.4",
-			"resolved": "https://registry.npmjs.org/postcss-sass/-/postcss-sass-0.4.4.tgz",
-			"integrity": "sha512-BYxnVYx4mQooOhr+zer0qWbSPYnarAy8ZT7hAQtbxtgVf8gy+LSLT/hHGe35h14/pZDTw1DsxdbrwxBN++H+fg==",
-			"dev": true,
-			"dependencies": {
-				"gonzales-pe": "^4.3.0",
-				"postcss": "^7.0.21"
-			}
-		},
-		"node_modules/postcss-sass/node_modules/picocolors": {
-			"version": "0.2.1",
-			"resolved": "https://registry.npmjs.org/picocolors/-/picocolors-0.2.1.tgz",
-			"integrity": "sha512-cMlDqaLEqfSaW8Z7N5Jw+lyIW869EzT73/F5lhtY9cLGoVxSXznfgfXMO0Z5K0o0Q2TkTXq+0KFsdnSe3jDViA==",
-			"dev": true
-		},
-		"node_modules/postcss-sass/node_modules/postcss": {
-			"version": "7.0.39",
-			"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.39.tgz",
-			"integrity": "sha512-yioayjNbHn6z1/Bywyb2Y4s3yvDAeXGOyxqD+LnVOinq6Mdmd++SW2wUNVzavyyHxd6+DxzWGIuosg6P1Rj8uA==",
-			"dev": true,
-			"dependencies": {
-				"picocolors": "^0.2.1",
-				"source-map": "^0.6.1"
 			},
-			"engines": {
-				"node": ">=6.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/postcss/"
-			}
-		},
-		"node_modules/postcss-sass/node_modules/source-map": {
-			"version": "0.6.1",
-			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-			"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-			"dev": true,
-			"engines": {
-				"node": ">=0.10.0"
+			"peerDependencies": {
+				"postcss": "^8.3.3"
 			}
 		},
 		"node_modules/postcss-scss": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/postcss-scss/-/postcss-scss-2.1.1.tgz",
-			"integrity": "sha512-jQmGnj0hSGLd9RscFw9LyuSVAa5Bl1/KBPqG1NQw9w8ND55nY4ZEsdlVuYJvLPpV+y0nwTV5v/4rHPzZRihQbA==",
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/postcss-scss/-/postcss-scss-4.0.4.tgz",
+			"integrity": "sha512-aBBbVyzA8b3hUL0MGrpydxxXKXFZc5Eqva0Q3V9qsBOLEMsjb6w49WfpsoWzpEgcqJGW4t7Rio8WXVU9Gd8vWg==",
 			"dev": true,
-			"dependencies": {
-				"postcss": "^7.0.6"
-			},
 			"engines": {
-				"node": ">=6.0.0"
-			}
-		},
-		"node_modules/postcss-scss/node_modules/picocolors": {
-			"version": "0.2.1",
-			"resolved": "https://registry.npmjs.org/picocolors/-/picocolors-0.2.1.tgz",
-			"integrity": "sha512-cMlDqaLEqfSaW8Z7N5Jw+lyIW869EzT73/F5lhtY9cLGoVxSXznfgfXMO0Z5K0o0Q2TkTXq+0KFsdnSe3jDViA==",
-			"dev": true
-		},
-		"node_modules/postcss-scss/node_modules/postcss": {
-			"version": "7.0.39",
-			"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.39.tgz",
-			"integrity": "sha512-yioayjNbHn6z1/Bywyb2Y4s3yvDAeXGOyxqD+LnVOinq6Mdmd++SW2wUNVzavyyHxd6+DxzWGIuosg6P1Rj8uA==",
-			"dev": true,
-			"dependencies": {
-				"picocolors": "^0.2.1",
-				"source-map": "^0.6.1"
-			},
-			"engines": {
-				"node": ">=6.0.0"
+				"node": ">=12.0"
 			},
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/postcss/"
-			}
-		},
-		"node_modules/postcss-scss/node_modules/source-map": {
-			"version": "0.6.1",
-			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-			"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-			"dev": true,
-			"engines": {
-				"node": ">=0.10.0"
+			},
+			"peerDependencies": {
+				"postcss": "^8.3.3"
 			}
 		},
 		"node_modules/postcss-selector-parser": {
-			"version": "6.0.9",
-			"resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.9.tgz",
-			"integrity": "sha512-UO3SgnZOVTwu4kyLR22UQ1xZh086RyNZppb7lLAKBFK8a32ttG5i87Y/P3+2bRSjZNyJ1B7hfFNo273tKe9YxQ==",
+			"version": "6.0.10",
+			"resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.10.tgz",
+			"integrity": "sha512-IQ7TZdoaqbT+LCpShg46jnZVlhWD2w6iQYAcYXfHARZ7X1t/UGhhceQDs5X0cGqKvYlHNOuv7Oa1xmb0oQuA3w==",
 			"dev": true,
 			"dependencies": {
 				"cssesc": "^3.0.0",
@@ -27608,15 +27229,6 @@
 			"dev": true,
 			"engines": {
 				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/postcss-syntax": {
-			"version": "0.36.2",
-			"resolved": "https://registry.npmjs.org/postcss-syntax/-/postcss-syntax-0.36.2.tgz",
-			"integrity": "sha512-nBRg/i7E3SOHWxF3PpF5WnJM/jQ1YpY9000OaVXlAQj6Zp/kIqJxEDWIZ67tAd7NLuk7zqN4yqe9nc0oNAOs1w==",
-			"dev": true,
-			"peerDependencies": {
-				"postcss": ">=5.0.0"
 			}
 		},
 		"node_modules/postcss-unique-selectors": {
@@ -27734,15 +27346,18 @@
 		},
 		"node_modules/prettier": {
 			"name": "wp-prettier",
-			"version": "2.2.1-beta-1",
-			"resolved": "https://registry.npmjs.org/wp-prettier/-/wp-prettier-2.2.1-beta-1.tgz",
-			"integrity": "sha512-+JHkqs9LC/JPp51yy1hzs3lQ7qeuWCwOcSzpQNeeY/G7oSpnF61vxt7hRh87zNRTr6ob2ndy0W8rVzhgrcA+Gw==",
+			"version": "2.6.2",
+			"resolved": "https://registry.npmjs.org/wp-prettier/-/wp-prettier-2.6.2.tgz",
+			"integrity": "sha512-AV33EzqiFJ3fj+mPlKABN59YFPReLkDxQnj067Z3uEOeRQf3g05WprL0RDuqM7UBhSRo9W1rMSC2KvZmjE5UOA==",
 			"dev": true,
 			"bin": {
 				"prettier": "bin-prettier.js"
 			},
 			"engines": {
 				"node": ">=10.13.0"
+			},
+			"funding": {
+				"url": "https://github.com/prettier/prettier?sponsor=1"
 			}
 		},
 		"node_modules/prettier-linter-helpers": {
@@ -27939,6 +27554,37 @@
 			"integrity": "sha512-ARhCpm70fzdcvNQfPoy49IaanKkTlRWF2JMzqhcJbhSFRZv7nPTvZJdcY7301IPmvW+/p0RgIWnQDLJxifsQ7g==",
 			"engines": {
 				"node": ">=8"
+			}
+		},
+		"node_modules/raf": {
+			"version": "3.4.1",
+			"resolved": "https://registry.npmjs.org/raf/-/raf-3.4.1.tgz",
+			"integrity": "sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA==",
+			"dev": true,
+			"peer": true,
+			"dependencies": {
+				"performance-now": "^2.1.0"
+			}
+		},
+		"node_modules/railroad-diagrams": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/railroad-diagrams/-/railroad-diagrams-1.0.0.tgz",
+			"integrity": "sha512-cz93DjNeLY0idrCNOH6PviZGRN9GJhsdm9hpn1YCS879fj4W+x5IFJhhkRZcwVgMmFF7R82UA/7Oh+R8lLZg6A==",
+			"dev": true,
+			"peer": true
+		},
+		"node_modules/randexp": {
+			"version": "0.4.6",
+			"resolved": "https://registry.npmjs.org/randexp/-/randexp-0.4.6.tgz",
+			"integrity": "sha512-80WNmd9DA0tmZrw9qQa62GPPWfuXJknrmVmLcxvq4uZBdYqb1wYoKTmnlGUchvVWe0XiLupYkBoXVOxz3C8DYQ==",
+			"dev": true,
+			"peer": true,
+			"dependencies": {
+				"discontinuous-range": "1.0.0",
+				"ret": "~0.1.10"
+			},
+			"engines": {
+				"node": ">=0.12"
 			}
 		},
 		"node_modules/randombytes": {
@@ -28598,13 +28244,13 @@
 			}
 		},
 		"node_modules/regexp.prototype.flags": {
-			"version": "1.4.1",
-			"resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.4.1.tgz",
-			"integrity": "sha512-pMR7hBVUUGI7PMA37m2ofIdQCsomVnas+Jn5UPGAHQ+/LlwKm/aTLJHdasmHRzlfeZwHiAOaRSo2rbBDm3nNUQ==",
-			"dev": true,
+			"version": "1.4.3",
+			"resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.4.3.tgz",
+			"integrity": "sha512-fjggEOO3slI6Wvgjwflkc4NFRCTZAu5CnNfBd5qOMYhWdn67nJBBu34/TkD++eeFmd8C9r9jfXJ27+nSiRkSUA==",
 			"dependencies": {
 				"call-bind": "^1.0.2",
-				"define-properties": "^1.1.3"
+				"define-properties": "^1.1.3",
+				"functions-have-names": "^1.2.2"
 			},
 			"engines": {
 				"node": ">= 0.4"
@@ -28688,47 +28334,6 @@
 			"dev": true,
 			"bin": {
 				"jsesc": "bin/jsesc"
-			}
-		},
-		"node_modules/remark": {
-			"version": "13.0.0",
-			"resolved": "https://registry.npmjs.org/remark/-/remark-13.0.0.tgz",
-			"integrity": "sha512-HDz1+IKGtOyWN+QgBiAT0kn+2s6ovOxHyPAFGKVE81VSzJ+mq7RwHFledEvB5F1p4iJvOah/LOKdFuzvRnNLCA==",
-			"dev": true,
-			"dependencies": {
-				"remark-parse": "^9.0.0",
-				"remark-stringify": "^9.0.0",
-				"unified": "^9.1.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/unified"
-			}
-		},
-		"node_modules/remark-parse": {
-			"version": "9.0.0",
-			"resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-9.0.0.tgz",
-			"integrity": "sha512-geKatMwSzEXKHuzBNU1z676sGcDcFoChMK38TgdHJNAYfFtsfHDQG7MoJAjs6sgYMqyLduCYWDIWZIxiPeafEw==",
-			"dev": true,
-			"dependencies": {
-				"mdast-util-from-markdown": "^0.8.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/unified"
-			}
-		},
-		"node_modules/remark-stringify": {
-			"version": "9.0.1",
-			"resolved": "https://registry.npmjs.org/remark-stringify/-/remark-stringify-9.0.1.tgz",
-			"integrity": "sha512-mWmNg3ZtESvZS8fv5PTvaPckdL4iNlCHTt8/e/8oN08nArHRHjNZMKzA/YW3+p7/lYqIw4nx1XsjCBo/AxNChg==",
-			"dev": true,
-			"dependencies": {
-				"mdast-util-to-markdown": "^0.6.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/unified"
 			}
 		},
 		"node_modules/rememo": {
@@ -29046,6 +28651,17 @@
 			},
 			"bin": {
 				"rimraf": "bin.js"
+			}
+		},
+		"node_modules/rst-selector-parser": {
+			"version": "2.2.3",
+			"resolved": "https://registry.npmjs.org/rst-selector-parser/-/rst-selector-parser-2.2.3.tgz",
+			"integrity": "sha512-nDG1rZeP6oFTLN6yNDV/uiAvs1+FS/KlrEwh7+y7dpuApDBy6bI2HTBcc0/V8lv9OTqfyD34eF7au2pm8aBbhA==",
+			"dev": true,
+			"peer": true,
+			"dependencies": {
+				"lodash.flattendeep": "^4.4.0",
+				"nearley": "^2.7.10"
 			}
 		},
 		"node_modules/rsvp": {
@@ -30123,15 +29739,6 @@
 			"resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.5.tgz",
 			"integrity": "sha512-J+FWzZoynJEXGphVIS+XEh3kFSjZX/1i9gFBaWQcB+/tmpe2qUsSBABpcxqxnAxFdiUFEgAX1bjYGQvIZmoz9Q=="
 		},
-		"node_modules/specificity": {
-			"version": "0.4.1",
-			"resolved": "https://registry.npmjs.org/specificity/-/specificity-0.4.1.tgz",
-			"integrity": "sha512-1klA3Gi5PD1Wv9Q0wUoOQN1IWAuPu0D1U03ThXTr0cJ20+/iq2tHSDnK7Kk/0LXJ1ztUB2/1Os0wKmfyNgUQfg==",
-			"dev": true,
-			"bin": {
-				"specificity": "bin/specificity"
-			}
-		},
 		"node_modules/split": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/split/-/split-1.0.1.tgz",
@@ -30375,25 +29982,45 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
-		"node_modules/string.prototype.trimend": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.4.tgz",
-			"integrity": "sha512-y9xCjw1P23Awk8EvTpcyL2NIr1j7wJ39f+k6lvRnSMz+mz9CGz9NYPelDk42kOz6+ql8xjfK8oYzy3jAP5QU5A==",
+		"node_modules/string.prototype.trim": {
+			"version": "1.2.6",
+			"resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.6.tgz",
+			"integrity": "sha512-8lMR2m+U0VJTPp6JjvJTtGyc4FIGq9CdRt7O9p6T0e6K4vjU+OP+SQJpbe/SBmRcCUIvNUnjsbmY6lnMp8MhsQ==",
+			"dev": true,
+			"peer": true,
 			"dependencies": {
 				"call-bind": "^1.0.2",
-				"define-properties": "^1.1.3"
+				"define-properties": "^1.1.4",
+				"es-abstract": "^1.19.5"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/string.prototype.trimend": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.5.tgz",
+			"integrity": "sha512-I7RGvmjV4pJ7O3kdf+LXFpVfdNOxtCW/2C8f6jNiW4+PQchwxkCDzlk1/7p+Wl4bqFIZeF47qAHXLuHHWKAxog==",
+			"dependencies": {
+				"call-bind": "^1.0.2",
+				"define-properties": "^1.1.4",
+				"es-abstract": "^1.19.5"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
 		"node_modules/string.prototype.trimstart": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.4.tgz",
-			"integrity": "sha512-jh6e984OBfvxS50tdY2nRZnoC5/mLFKOREQfw8t5yytkoUsJRNxvI/E39qu1sD0OtWI3OC0XgKSmcWwziwYuZw==",
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.5.tgz",
+			"integrity": "sha512-THx16TJCGlsN0o6dl2o6ncWUsdgnLRSA23rRE5pyGBw/mLr3Ej/R2LaqCtgP8VNMGZsvMWnf9ooZPyY2bHvUFg==",
 			"dependencies": {
 				"call-bind": "^1.0.2",
-				"define-properties": "^1.1.3"
+				"define-properties": "^1.1.4",
+				"es-abstract": "^1.19.5"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
@@ -30541,65 +30168,57 @@
 			}
 		},
 		"node_modules/stylelint": {
-			"version": "13.13.1",
-			"resolved": "https://registry.npmjs.org/stylelint/-/stylelint-13.13.1.tgz",
-			"integrity": "sha512-Mv+BQr5XTUrKqAXmpqm6Ddli6Ief+AiPZkRsIrAoUKFuq/ElkUh9ZMYxXD0iQNZ5ADghZKLOWz1h7hTClB7zgQ==",
+			"version": "14.9.1",
+			"resolved": "https://registry.npmjs.org/stylelint/-/stylelint-14.9.1.tgz",
+			"integrity": "sha512-RdAkJdPiLqHawCSnu21nE27MjNXaVd4WcOHA4vK5GtIGjScfhNnaOuWR2wWdfKFAvcWQPOYe311iveiVKSmwsA==",
 			"dev": true,
 			"dependencies": {
-				"@stylelint/postcss-css-in-js": "^0.37.2",
-				"@stylelint/postcss-markdown": "^0.36.2",
-				"autoprefixer": "^9.8.6",
+				"@csstools/selector-specificity": "^2.0.1",
 				"balanced-match": "^2.0.0",
-				"chalk": "^4.1.1",
-				"cosmiconfig": "^7.0.0",
-				"debug": "^4.3.1",
+				"colord": "^2.9.2",
+				"cosmiconfig": "^7.0.1",
+				"css-functions-list": "^3.1.0",
+				"debug": "^4.3.4",
 				"execall": "^2.0.0",
-				"fast-glob": "^3.2.5",
+				"fast-glob": "^3.2.11",
 				"fastest-levenshtein": "^1.0.12",
 				"file-entry-cache": "^6.0.1",
 				"get-stdin": "^8.0.0",
 				"global-modules": "^2.0.0",
-				"globby": "^11.0.3",
+				"globby": "^11.1.0",
 				"globjoin": "^0.1.4",
-				"html-tags": "^3.1.0",
-				"ignore": "^5.1.8",
+				"html-tags": "^3.2.0",
+				"ignore": "^5.2.0",
 				"import-lazy": "^4.0.0",
 				"imurmurhash": "^0.1.4",
-				"known-css-properties": "^0.21.0",
-				"lodash": "^4.17.21",
-				"log-symbols": "^4.1.0",
+				"is-plain-object": "^5.0.0",
+				"known-css-properties": "^0.25.0",
 				"mathml-tag-names": "^2.1.3",
 				"meow": "^9.0.0",
-				"micromatch": "^4.0.4",
-				"normalize-selector": "^0.2.0",
-				"postcss": "^7.0.35",
-				"postcss-html": "^0.36.0",
-				"postcss-less": "^3.1.4",
+				"micromatch": "^4.0.5",
+				"normalize-path": "^3.0.0",
+				"picocolors": "^1.0.0",
+				"postcss": "^8.4.14",
 				"postcss-media-query-parser": "^0.2.3",
 				"postcss-resolve-nested-selector": "^0.1.1",
-				"postcss-safe-parser": "^4.0.2",
-				"postcss-sass": "^0.4.4",
-				"postcss-scss": "^2.1.1",
-				"postcss-selector-parser": "^6.0.5",
-				"postcss-syntax": "^0.36.2",
-				"postcss-value-parser": "^4.1.0",
+				"postcss-safe-parser": "^6.0.0",
+				"postcss-selector-parser": "^6.0.10",
+				"postcss-value-parser": "^4.2.0",
 				"resolve-from": "^5.0.0",
-				"slash": "^3.0.0",
-				"specificity": "^0.4.1",
-				"string-width": "^4.2.2",
-				"strip-ansi": "^6.0.0",
+				"string-width": "^4.2.3",
+				"strip-ansi": "^6.0.1",
 				"style-search": "^0.1.0",
-				"sugarss": "^2.0.0",
+				"supports-hyperlinks": "^2.2.0",
 				"svg-tags": "^1.0.0",
-				"table": "^6.6.0",
+				"table": "^6.8.0",
 				"v8-compile-cache": "^2.3.0",
-				"write-file-atomic": "^3.0.3"
+				"write-file-atomic": "^4.0.1"
 			},
 			"bin": {
 				"stylelint": "bin/stylelint.js"
 			},
 			"engines": {
-				"node": ">=10.13.0"
+				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
 			},
 			"funding": {
 				"type": "opencollective",
@@ -30623,44 +30242,42 @@
 			}
 		},
 		"node_modules/stylelint-config-recommended": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/stylelint-config-recommended/-/stylelint-config-recommended-3.0.0.tgz",
-			"integrity": "sha512-F6yTRuc06xr1h5Qw/ykb2LuFynJ2IxkKfCMf+1xqPffkxh0S09Zc902XCffcsw/XMFq/OzQ1w54fLIDtmRNHnQ==",
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/stylelint-config-recommended/-/stylelint-config-recommended-6.0.0.tgz",
+			"integrity": "sha512-ZorSSdyMcxWpROYUvLEMm0vSZud2uB7tX1hzBZwvVY9SV/uly4AvvJPPhCcymZL3fcQhEQG5AELmrxWqtmzacw==",
 			"dev": true,
 			"peerDependencies": {
-				"stylelint": ">=10.1.0"
+				"stylelint": "^14.0.0"
 			}
 		},
 		"node_modules/stylelint-config-recommended-scss": {
-			"version": "4.2.0",
-			"resolved": "https://registry.npmjs.org/stylelint-config-recommended-scss/-/stylelint-config-recommended-scss-4.2.0.tgz",
-			"integrity": "sha512-4bI5BYbabo/GCQ6LbRZx/ZlVkK65a1jivNNsD+ix/Lw0U3iAch+jQcvliGnnAX8SUPaZ0UqzNVNNAF3urswa7g==",
+			"version": "5.0.2",
+			"resolved": "https://registry.npmjs.org/stylelint-config-recommended-scss/-/stylelint-config-recommended-scss-5.0.2.tgz",
+			"integrity": "sha512-b14BSZjcwW0hqbzm9b0S/ScN2+3CO3O4vcMNOw2KGf8lfVSwJ4p5TbNEXKwKl1+0FMtgRXZj6DqVUe/7nGnuBg==",
 			"dev": true,
 			"dependencies": {
-				"stylelint-config-recommended": "^3.0.0"
+				"postcss-scss": "^4.0.2",
+				"stylelint-config-recommended": "^6.0.0",
+				"stylelint-scss": "^4.0.0"
 			},
 			"peerDependencies": {
-				"stylelint": "^10.1.0 || ^11.0.0 || ^12.0.0 || ^13.0.0",
-				"stylelint-scss": "^3.0.0"
+				"stylelint": "^14.0.0"
 			}
 		},
 		"node_modules/stylelint-scss": {
-			"version": "3.20.1",
-			"resolved": "https://registry.npmjs.org/stylelint-scss/-/stylelint-scss-3.20.1.tgz",
-			"integrity": "sha512-OTd55O1TTAC5nGKkVmUDLpz53LlK39R3MImv1CfuvsK7/qugktqiZAeQLuuC4UBhzxCnsc7fp9u/gfRZwFAIkA==",
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/stylelint-scss/-/stylelint-scss-4.3.0.tgz",
+			"integrity": "sha512-GvSaKCA3tipzZHoz+nNO7S02ZqOsdBzMiCx9poSmLlb3tdJlGddEX/8QzCOD8O7GQan9bjsvLMsO5xiw6IhhIQ==",
 			"dev": true,
 			"dependencies": {
-				"lodash": "^4.17.15",
+				"lodash": "^4.17.21",
 				"postcss-media-query-parser": "^0.2.3",
 				"postcss-resolve-nested-selector": "^0.1.1",
-				"postcss-selector-parser": "^6.0.2",
+				"postcss-selector-parser": "^6.0.6",
 				"postcss-value-parser": "^4.1.0"
 			},
-			"engines": {
-				"node": ">=8"
-			},
 			"peerDependencies": {
-				"stylelint": "^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0 || ^12.0.0 || ^13.0.0"
+				"stylelint": "^14.5.1"
 			}
 		},
 		"node_modules/stylelint/node_modules/ansi-regex": {
@@ -30670,21 +30287,6 @@
 			"dev": true,
 			"engines": {
 				"node": ">=8"
-			}
-		},
-		"node_modules/stylelint/node_modules/ansi-styles": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-			"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-			"dev": true,
-			"dependencies": {
-				"color-convert": "^2.0.1"
-			},
-			"engines": {
-				"node": ">=8"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
 			}
 		},
 		"node_modules/stylelint/node_modules/array-union": {
@@ -30714,44 +30316,10 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/stylelint/node_modules/chalk": {
-			"version": "4.1.2",
-			"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-			"integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-			"dev": true,
-			"dependencies": {
-				"ansi-styles": "^4.1.0",
-				"supports-color": "^7.1.0"
-			},
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/chalk?sponsor=1"
-			}
-		},
-		"node_modules/stylelint/node_modules/color-convert": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-			"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-			"dev": true,
-			"dependencies": {
-				"color-name": "~1.1.4"
-			},
-			"engines": {
-				"node": ">=7.0.0"
-			}
-		},
-		"node_modules/stylelint/node_modules/color-name": {
-			"version": "1.1.4",
-			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-			"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-			"dev": true
-		},
 		"node_modules/stylelint/node_modules/debug": {
-			"version": "4.3.2",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
-			"integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
+			"version": "4.3.4",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+			"integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
 			"dev": true,
 			"dependencies": {
 				"ms": "2.1.2"
@@ -30784,16 +30352,16 @@
 			}
 		},
 		"node_modules/stylelint/node_modules/globby": {
-			"version": "11.0.4",
-			"resolved": "https://registry.npmjs.org/globby/-/globby-11.0.4.tgz",
-			"integrity": "sha512-9O4MVG9ioZJ08ffbcyVYyLOJLk5JQ688pJ4eMGLpdWLHq/Wr1D9BlriLQyL0E+jbkuePVZXYFj47QM/v093wHg==",
+			"version": "11.1.0",
+			"resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
+			"integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
 			"dev": true,
 			"dependencies": {
 				"array-union": "^2.1.0",
 				"dir-glob": "^3.0.1",
-				"fast-glob": "^3.1.1",
-				"ignore": "^5.1.4",
-				"merge2": "^1.3.0",
+				"fast-glob": "^3.2.9",
+				"ignore": "^5.2.0",
+				"merge2": "^1.4.1",
 				"slash": "^3.0.0"
 			},
 			"engines": {
@@ -30801,15 +30369,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/stylelint/node_modules/has-flag": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-			"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-			"dev": true,
-			"engines": {
-				"node": ">=8"
 			}
 		},
 		"node_modules/stylelint/node_modules/hosted-git-info": {
@@ -30825,9 +30384,9 @@
 			}
 		},
 		"node_modules/stylelint/node_modules/ignore": {
-			"version": "5.1.9",
-			"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.9.tgz",
-			"integrity": "sha512-2zeMQpbKz5dhZ9IwL0gbxSW5w0NK/MSAMtNuhgIHEPmaU3vPdKPL0UdvUCXs5SS4JAwsBxysK5sFMW8ocFiVjQ==",
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.0.tgz",
+			"integrity": "sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==",
 			"dev": true,
 			"engines": {
 				"node": ">= 4"
@@ -30849,6 +30408,15 @@
 			"dev": true,
 			"engines": {
 				"node": ">=0.12.0"
+			}
+		},
+		"node_modules/stylelint/node_modules/is-plain-object": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
+			"integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
+			"dev": true,
+			"engines": {
+				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/stylelint/node_modules/meow": {
@@ -30878,13 +30446,13 @@
 			}
 		},
 		"node_modules/stylelint/node_modules/micromatch": {
-			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.4.tgz",
-			"integrity": "sha512-pRmzw/XUcwXGpD9aI9q/0XOwLNygjETJ8y0ao0wdqprrzDa4YnxLcz7fQRZr8voh8V10kGhABbNcHVk5wHgWwg==",
+			"version": "4.0.5",
+			"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
+			"integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
 			"dev": true,
 			"dependencies": {
-				"braces": "^3.0.1",
-				"picomatch": "^2.2.3"
+				"braces": "^3.0.2",
+				"picomatch": "^2.3.1"
 			},
 			"engines": {
 				"node": ">=8.6"
@@ -30911,29 +30479,6 @@
 				"node": ">=10"
 			}
 		},
-		"node_modules/stylelint/node_modules/picocolors": {
-			"version": "0.2.1",
-			"resolved": "https://registry.npmjs.org/picocolors/-/picocolors-0.2.1.tgz",
-			"integrity": "sha512-cMlDqaLEqfSaW8Z7N5Jw+lyIW869EzT73/F5lhtY9cLGoVxSXznfgfXMO0Z5K0o0Q2TkTXq+0KFsdnSe3jDViA==",
-			"dev": true
-		},
-		"node_modules/stylelint/node_modules/postcss": {
-			"version": "7.0.39",
-			"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.39.tgz",
-			"integrity": "sha512-yioayjNbHn6z1/Bywyb2Y4s3yvDAeXGOyxqD+LnVOinq6Mdmd++SW2wUNVzavyyHxd6+DxzWGIuosg6P1Rj8uA==",
-			"dev": true,
-			"dependencies": {
-				"picocolors": "^0.2.1",
-				"source-map": "^0.6.1"
-			},
-			"engines": {
-				"node": ">=6.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/postcss/"
-			}
-		},
 		"node_modules/stylelint/node_modules/semver": {
 			"version": "7.3.5",
 			"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
@@ -30958,15 +30503,6 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/stylelint/node_modules/source-map": {
-			"version": "0.6.1",
-			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-			"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-			"dev": true,
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
 		"node_modules/stylelint/node_modules/string-width": {
 			"version": "4.2.3",
 			"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
@@ -30988,18 +30524,6 @@
 			"dev": true,
 			"dependencies": {
 				"ansi-regex": "^5.0.1"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/stylelint/node_modules/supports-color": {
-			"version": "7.2.0",
-			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-			"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-			"dev": true,
-			"dependencies": {
-				"has-flag": "^4.0.0"
 			},
 			"engines": {
 				"node": ">=8"
@@ -31029,51 +30553,23 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/stylelint/node_modules/write-file-atomic": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-4.0.1.tgz",
+			"integrity": "sha512-nSKUxgAbyioruk6hU87QzVbY279oYT6uiwgDoujth2ju4mJ+TZau7SQBhtbTmUyuNYTuXnSyRn66FV0+eCgcrQ==",
+			"dev": true,
+			"dependencies": {
+				"imurmurhash": "^0.1.4",
+				"signal-exit": "^3.0.7"
+			},
+			"engines": {
+				"node": "^12.13.0 || ^14.15.0 || >=16"
+			}
+		},
 		"node_modules/stylis": {
 			"version": "4.0.10",
 			"resolved": "https://registry.npmjs.org/stylis/-/stylis-4.0.10.tgz",
 			"integrity": "sha512-m3k+dk7QeJw660eIKRRn3xPF6uuvHs/FFzjX3HQ5ove0qYsiygoAhwn5a3IYKaZPo5LrYD0rfVmtv1gNY1uYwg=="
-		},
-		"node_modules/sugarss": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/sugarss/-/sugarss-2.0.0.tgz",
-			"integrity": "sha512-WfxjozUk0UVA4jm+U1d736AUpzSrNsQcIbyOkoE364GrtWmIrFdk5lksEupgWMD4VaT/0kVx1dobpiDumSgmJQ==",
-			"dev": true,
-			"dependencies": {
-				"postcss": "^7.0.2"
-			}
-		},
-		"node_modules/sugarss/node_modules/picocolors": {
-			"version": "0.2.1",
-			"resolved": "https://registry.npmjs.org/picocolors/-/picocolors-0.2.1.tgz",
-			"integrity": "sha512-cMlDqaLEqfSaW8Z7N5Jw+lyIW869EzT73/F5lhtY9cLGoVxSXznfgfXMO0Z5K0o0Q2TkTXq+0KFsdnSe3jDViA==",
-			"dev": true
-		},
-		"node_modules/sugarss/node_modules/postcss": {
-			"version": "7.0.39",
-			"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.39.tgz",
-			"integrity": "sha512-yioayjNbHn6z1/Bywyb2Y4s3yvDAeXGOyxqD+LnVOinq6Mdmd++SW2wUNVzavyyHxd6+DxzWGIuosg6P1Rj8uA==",
-			"dev": true,
-			"dependencies": {
-				"picocolors": "^0.2.1",
-				"source-map": "^0.6.1"
-			},
-			"engines": {
-				"node": ">=6.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/postcss/"
-			}
-		},
-		"node_modules/sugarss/node_modules/source-map": {
-			"version": "0.6.1",
-			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-			"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-			"dev": true,
-			"engines": {
-				"node": ">=0.10.0"
-			}
 		},
 		"node_modules/supports-color": {
 			"version": "5.5.0",
@@ -31644,18 +31140,6 @@
 				"node": ">=0.10.0"
 			}
 		},
-		"node_modules/terser/node_modules/acorn": {
-			"version": "8.7.1",
-			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.7.1.tgz",
-			"integrity": "sha512-Xx54uLJQZ19lKygFXOWsscKUbsBZW0CPykPhVQdhIeIwrbPmJzqeASDInc8nKBnp/JT6igTs82qPXz069H8I/A==",
-			"dev": true,
-			"bin": {
-				"acorn": "bin/acorn"
-			},
-			"engines": {
-				"node": ">=0.4.0"
-			}
-		},
 		"node_modules/test-exclude": {
 			"version": "6.0.0",
 			"resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-6.0.0.tgz",
@@ -31895,16 +31379,6 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/trough": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/trough/-/trough-1.0.5.tgz",
-			"integrity": "sha512-rvuRbTarPXmMb79SmzEp8aqXNKcK+y0XaB298IXueQ8I2PsrATcPBCSPyK/dDNa2iWOhKlfNnOjdAOTBU/nkFA==",
-			"dev": true,
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/wooorm"
-			}
-		},
 		"node_modules/ts-node": {
 			"version": "9.1.1",
 			"resolved": "https://registry.npmjs.org/ts-node/-/ts-node-9.1.1.tgz",
@@ -32074,13 +31548,13 @@
 			}
 		},
 		"node_modules/unbox-primitive": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.1.tgz",
-			"integrity": "sha512-tZU/3NqK3dA5gpE1KtyiJUrEB0lxnGkMFHptJ7q6ewdZ8s12QrODwNbhIJStmJkd1QDXa1NRA8aF2A1zk/Ypyw==",
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.2.tgz",
+			"integrity": "sha512-61pPlCD9h51VoreyJ0BReideM3MDKMKnh6+V9L08331ipq6Q8OFXZYiqP6n/tbHx4s5I9uRhcye6BrbkizkBDw==",
 			"dependencies": {
-				"function-bind": "^1.1.1",
-				"has-bigints": "^1.0.1",
-				"has-symbols": "^1.0.2",
+				"call-bind": "^1.0.2",
+				"has-bigints": "^1.0.2",
+				"has-symbols": "^1.0.3",
 				"which-boxed-primitive": "^1.0.2"
 			},
 			"funding": {
@@ -32125,56 +31599,6 @@
 			"dev": true,
 			"engines": {
 				"node": ">=4"
-			}
-		},
-		"node_modules/unified": {
-			"version": "9.2.2",
-			"resolved": "https://registry.npmjs.org/unified/-/unified-9.2.2.tgz",
-			"integrity": "sha512-Sg7j110mtefBD+qunSLO1lqOEKdrwBFBrR6Qd8f4uwkhWNlbkaqwHse6e7QvD3AP/MNoJdEDLaf8OxYyoWgorQ==",
-			"dev": true,
-			"dependencies": {
-				"bail": "^1.0.0",
-				"extend": "^3.0.0",
-				"is-buffer": "^2.0.0",
-				"is-plain-obj": "^2.0.0",
-				"trough": "^1.0.0",
-				"vfile": "^4.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/unified"
-			}
-		},
-		"node_modules/unified/node_modules/is-buffer": {
-			"version": "2.0.5",
-			"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.5.tgz",
-			"integrity": "sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==",
-			"dev": true,
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/feross"
-				},
-				{
-					"type": "patreon",
-					"url": "https://www.patreon.com/feross"
-				},
-				{
-					"type": "consulting",
-					"url": "https://feross.org/support"
-				}
-			],
-			"engines": {
-				"node": ">=4"
-			}
-		},
-		"node_modules/unified/node_modules/is-plain-obj": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
-			"integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
-			"dev": true,
-			"engines": {
-				"node": ">=8"
 			}
 		},
 		"node_modules/union-value": {
@@ -32232,42 +31656,6 @@
 			},
 			"engines": {
 				"node": ">=8"
-			}
-		},
-		"node_modules/unist-util-find-all-after": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/unist-util-find-all-after/-/unist-util-find-all-after-3.0.2.tgz",
-			"integrity": "sha512-xaTC/AGZ0rIM2gM28YVRAFPIZpzbpDtU3dRmp7EXlNVA8ziQc4hY3H7BHXM1J49nEmiqc3svnqMReW+PGqbZKQ==",
-			"dev": true,
-			"dependencies": {
-				"unist-util-is": "^4.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/unified"
-			}
-		},
-		"node_modules/unist-util-is": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-4.1.0.tgz",
-			"integrity": "sha512-ZOQSsnce92GrxSqlnEEseX0gi7GH9zTJZ0p9dtu87WRb/37mMPO2Ilx1s/t9vBHrFhbgweUwb+t7cIn5dxPhZg==",
-			"dev": true,
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/unified"
-			}
-		},
-		"node_modules/unist-util-stringify-position": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-2.0.3.tgz",
-			"integrity": "sha512-3faScn5I+hy9VleOq/qNbAd6pAx7iH5jYBMS9I1HgQVijz/4mv5Bvw5iw1sC/90CODiKo81G/ps8AJrISn687g==",
-			"dev": true,
-			"dependencies": {
-				"@types/unist": "^2.0.2"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/unified"
 			}
 		},
 		"node_modules/universal-user-agent": {
@@ -32476,59 +31864,6 @@
 				"assert-plus": "^1.0.0",
 				"core-util-is": "1.0.2",
 				"extsprintf": "^1.2.0"
-			}
-		},
-		"node_modules/vfile": {
-			"version": "4.2.1",
-			"resolved": "https://registry.npmjs.org/vfile/-/vfile-4.2.1.tgz",
-			"integrity": "sha512-O6AE4OskCG5S1emQ/4gl8zK586RqA3srz3nfK/Viy0UPToBc5Trp9BVFb1u0CjsKrAWwnpr4ifM/KBXPWwJbCA==",
-			"dev": true,
-			"dependencies": {
-				"@types/unist": "^2.0.0",
-				"is-buffer": "^2.0.0",
-				"unist-util-stringify-position": "^2.0.0",
-				"vfile-message": "^2.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/unified"
-			}
-		},
-		"node_modules/vfile-message": {
-			"version": "2.0.4",
-			"resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-2.0.4.tgz",
-			"integrity": "sha512-DjssxRGkMvifUOJre00juHoP9DPWuzjxKuMDrhNbk2TdaYYBNMStsNhEOt3idrtI12VQYM/1+iM0KOzXi4pxwQ==",
-			"dev": true,
-			"dependencies": {
-				"@types/unist": "^2.0.0",
-				"unist-util-stringify-position": "^2.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/unified"
-			}
-		},
-		"node_modules/vfile/node_modules/is-buffer": {
-			"version": "2.0.5",
-			"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.5.tgz",
-			"integrity": "sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==",
-			"dev": true,
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/feross"
-				},
-				{
-					"type": "patreon",
-					"url": "https://www.patreon.com/feross"
-				},
-				{
-					"type": "consulting",
-					"url": "https://feross.org/support"
-				}
-			],
-			"engines": {
-				"node": ">=4"
 			}
 		},
 		"node_modules/w3c-hr-time": {
@@ -32869,18 +32204,6 @@
 			"dev": true,
 			"engines": {
 				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/webpack/node_modules/acorn": {
-			"version": "8.6.0",
-			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.6.0.tgz",
-			"integrity": "sha512-U1riIR+lBSNi3IbxtaHOIKdH8sLFv3NYfNv8sg7ZsNhcfl4HF2++BfqqrNAxoCLQW1iiylOj76ecnaUxz+z9yw==",
-			"dev": true,
-			"bin": {
-				"acorn": "bin/acorn"
-			},
-			"engines": {
-				"node": ">=0.4.0"
 			}
 		},
 		"node_modules/webpack/node_modules/webpack-sources": {
@@ -33237,16 +32560,6 @@
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
-		},
-		"node_modules/zwitch": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/zwitch/-/zwitch-1.0.5.tgz",
-			"integrity": "sha512-V50KMwwzqJV0NpZIZFwfOD5/lyny3WlSzRiXgA0G7VUnRlqttta1L6UQIHzd6EuBY/cHGfwTIck7w1yH6Q5zUw==",
-			"dev": true,
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/wooorm"
-			}
 		}
 	},
 	"dependencies": {
@@ -33364,11 +32677,11 @@
 			}
 		},
 		"@babel/code-frame": {
-			"version": "7.14.5",
-			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.14.5.tgz",
-			"integrity": "sha512-9pzDqyc6OLDaqe+zbACgFkb6fKMNG6CObKpnYXChRsvYGyEdc7CA2BaqeOM+vOtCS5ndmJicPJhKAwYRI6UfFw==",
+			"version": "7.18.6",
+			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.18.6.tgz",
+			"integrity": "sha512-TDCmlK5eOvH+eH7cdAFlNXeVJqWIQ7gW9tY1GJIpUtFb6CmjVyq2VM3u71bOyR8CRihcCgMUYoDNyLXao3+70Q==",
 			"requires": {
-				"@babel/highlight": "^7.14.5"
+				"@babel/highlight": "^7.18.6"
 			}
 		},
 		"@babel/compat-data": {
@@ -33398,14 +32711,6 @@
 				"source-map": "^0.5.0"
 			},
 			"dependencies": {
-				"@babel/code-frame": {
-					"version": "7.16.0",
-					"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.16.0.tgz",
-					"integrity": "sha512-IF4EOMEV+bfYwOmNxGzSnjR2EmQod7f1UXOpZM3l4i4o4QNwzjtJAu/HxdjHq0aYBvdqMuQEY1eg0nqW9ZPORA==",
-					"requires": {
-						"@babel/highlight": "^7.16.0"
-					}
-				},
 				"debug": {
 					"version": "4.1.1",
 					"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
@@ -33435,22 +32740,22 @@
 			}
 		},
 		"@babel/generator": {
-			"version": "7.16.0",
-			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.16.0.tgz",
-			"integrity": "sha512-RR8hUCfRQn9j9RPKEVXo9LiwoxLPYn6hNZlvUOR8tSnaxlD0p0+la00ZP9/SnRt6HchKr+X0fO2r8vrETiJGew==",
+			"version": "7.18.9",
+			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.18.9.tgz",
+			"integrity": "sha512-wt5Naw6lJrL1/SGkipMiFxJjtyczUWTP38deiP1PO60HsBjDeKk08CGC3S8iVuvf0FmTdgKwU1KIXzSKL1G0Ug==",
 			"requires": {
-				"@babel/types": "^7.16.0",
-				"jsesc": "^2.5.1",
-				"source-map": "^0.5.0"
+				"@babel/types": "^7.18.9",
+				"@jridgewell/gen-mapping": "^0.3.2",
+				"jsesc": "^2.5.1"
 			}
 		},
 		"@babel/helper-annotate-as-pure": {
-			"version": "7.16.0",
-			"resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.16.0.tgz",
-			"integrity": "sha512-ItmYF9vR4zA8cByDocY05o0LGUkp1zhbTQOH1NFyl5xXEqlTJQCEJjieriw+aFpxo16swMxUnUiKS7a/r4vtHg==",
+			"version": "7.18.6",
+			"resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.18.6.tgz",
+			"integrity": "sha512-duORpUiYrEpzKIop6iNbjnwKLAKnJ47csTyRACyEmWj0QdUrm5aqNJGHSSEQSUAvNW0ojX0dOmK9dZduvkfeXA==",
 			"dev": true,
 			"requires": {
-				"@babel/types": "^7.16.0"
+				"@babel/types": "^7.18.6"
 			}
 		},
 		"@babel/helper-builder-binary-assignment-operator-visitor": {
@@ -33482,17 +32787,18 @@
 			}
 		},
 		"@babel/helper-create-class-features-plugin": {
-			"version": "7.16.0",
-			"resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.16.0.tgz",
-			"integrity": "sha512-XLwWvqEaq19zFlF5PTgOod4bUA+XbkR4WLQBct1bkzmxJGB0ZEJaoKF4c8cgH9oBtCDuYJ8BP5NB9uFiEgO5QA==",
+			"version": "7.18.9",
+			"resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.18.9.tgz",
+			"integrity": "sha512-WvypNAYaVh23QcjpMR24CwZY2Nz6hqdOcFdPbNpV56hL5H6KiFheO7Xm1aPdlLQ7d5emYZX7VZwPp9x3z+2opw==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-annotate-as-pure": "^7.16.0",
-				"@babel/helper-function-name": "^7.16.0",
-				"@babel/helper-member-expression-to-functions": "^7.16.0",
-				"@babel/helper-optimise-call-expression": "^7.16.0",
-				"@babel/helper-replace-supers": "^7.16.0",
-				"@babel/helper-split-export-declaration": "^7.16.0"
+				"@babel/helper-annotate-as-pure": "^7.18.6",
+				"@babel/helper-environment-visitor": "^7.18.9",
+				"@babel/helper-function-name": "^7.18.9",
+				"@babel/helper-member-expression-to-functions": "^7.18.9",
+				"@babel/helper-optimise-call-expression": "^7.18.6",
+				"@babel/helper-replace-supers": "^7.18.9",
+				"@babel/helper-split-export-declaration": "^7.18.6"
 			}
 		},
 		"@babel/helper-create-regexp-features-plugin": {
@@ -33544,6 +32850,11 @@
 				}
 			}
 		},
+		"@babel/helper-environment-visitor": {
+			"version": "7.18.9",
+			"resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.18.9.tgz",
+			"integrity": "sha512-3r/aACDJ3fhQ/EVgFy0hpj8oHyHpQc+LPtJoY9SzTThAsStm4Ptegq92vqKoE3vD706ZVFWITnMnxucw+S9Ipg=="
+		},
 		"@babel/helper-explode-assignable-expression": {
 			"version": "7.16.0",
 			"resolved": "https://registry.npmjs.org/@babel/helper-explode-assignable-expression/-/helper-explode-assignable-expression-7.16.0.tgz",
@@ -33554,37 +32865,28 @@
 			}
 		},
 		"@babel/helper-function-name": {
-			"version": "7.16.0",
-			"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.16.0.tgz",
-			"integrity": "sha512-BZh4mEk1xi2h4HFjWUXRQX5AEx4rvaZxHgax9gcjdLWdkjsY7MKt5p0otjsg5noXw+pB+clMCjw+aEVYADMjog==",
+			"version": "7.18.9",
+			"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.18.9.tgz",
+			"integrity": "sha512-fJgWlZt7nxGksJS9a0XdSaI4XvpExnNIgRP+rVefWh5U7BL8pPuir6SJUmFKRfjWQ51OtWSzwOxhaH/EBWWc0A==",
 			"requires": {
-				"@babel/helper-get-function-arity": "^7.16.0",
-				"@babel/template": "^7.16.0",
-				"@babel/types": "^7.16.0"
-			}
-		},
-		"@babel/helper-get-function-arity": {
-			"version": "7.16.0",
-			"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.16.0.tgz",
-			"integrity": "sha512-ASCquNcywC1NkYh/z7Cgp3w31YW8aojjYIlNg4VeJiHkqyP4AzIvr4qx7pYDb4/s8YcsZWqqOSxgkvjUz1kpDQ==",
-			"requires": {
-				"@babel/types": "^7.16.0"
+				"@babel/template": "^7.18.6",
+				"@babel/types": "^7.18.9"
 			}
 		},
 		"@babel/helper-hoist-variables": {
-			"version": "7.16.0",
-			"resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.16.0.tgz",
-			"integrity": "sha512-1AZlpazjUR0EQZQv3sgRNfM9mEVWPK3M6vlalczA+EECcPz3XPh6VplbErL5UoMpChhSck5wAJHthlj1bYpcmg==",
+			"version": "7.18.6",
+			"resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.18.6.tgz",
+			"integrity": "sha512-UlJQPkFqFULIcyW5sbzgbkxn2FKRgwWiRexcuaR8RNJRy8+LLveqPjwZV/bwrLZCN0eUHD/x8D0heK1ozuoo6Q==",
 			"requires": {
-				"@babel/types": "^7.16.0"
+				"@babel/types": "^7.18.6"
 			}
 		},
 		"@babel/helper-member-expression-to-functions": {
-			"version": "7.16.0",
-			"resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.16.0.tgz",
-			"integrity": "sha512-bsjlBFPuWT6IWhl28EdrQ+gTvSvj5tqVP5Xeftp07SEuz5pLnsXZuDkDD3Rfcxy0IsHmbZ+7B2/9SHzxO0T+sQ==",
+			"version": "7.18.9",
+			"resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.18.9.tgz",
+			"integrity": "sha512-RxifAh2ZoVU67PyKIO4AMi1wTenGfMR/O/ae0CCRqwgBAt5v7xjdtRw7UoSbsreKrQn5t7r89eruK/9JjYHuDg==",
 			"requires": {
-				"@babel/types": "^7.16.0"
+				"@babel/types": "^7.18.9"
 			}
 		},
 		"@babel/helper-module-imports": {
@@ -33611,17 +32913,17 @@
 			}
 		},
 		"@babel/helper-optimise-call-expression": {
-			"version": "7.16.0",
-			"resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.16.0.tgz",
-			"integrity": "sha512-SuI467Gi2V8fkofm2JPnZzB/SUuXoJA5zXe/xzyPP2M04686RzFKFHPK6HDVN6JvWBIEW8tt9hPR7fXdn2Lgpw==",
+			"version": "7.18.6",
+			"resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.18.6.tgz",
+			"integrity": "sha512-HP59oD9/fEHQkdcbgFCnbmgH5vIQTJbxh2yf+CdM89/glUNnuzr87Q8GIjGEnOktTROemO0Pe0iPAYbqZuOUiA==",
 			"requires": {
-				"@babel/types": "^7.16.0"
+				"@babel/types": "^7.18.6"
 			}
 		},
 		"@babel/helper-plugin-utils": {
-			"version": "7.14.5",
-			"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.14.5.tgz",
-			"integrity": "sha512-/37qQCE3K0vvZKwoK4XU/irIJQdIfCJuhU5eKnNxpFDsOkgFaUAwbv+RYw6eYgsC0E4hS7r5KqGULUogqui0fQ=="
+			"version": "7.18.9",
+			"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.18.9.tgz",
+			"integrity": "sha512-aBXPT3bmtLryXaoJLyYPXPlSD4p1ld9aYeR+sJNOZjJJGiOpb+fKfh3NkcCu7J54nUJwCERPBExCCpyCOHnu/w=="
 		},
 		"@babel/helper-remap-async-to-generator": {
 			"version": "7.16.4",
@@ -33635,14 +32937,15 @@
 			}
 		},
 		"@babel/helper-replace-supers": {
-			"version": "7.16.0",
-			"resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.16.0.tgz",
-			"integrity": "sha512-TQxuQfSCdoha7cpRNJvfaYxxxzmbxXw/+6cS7V02eeDYyhxderSoMVALvwupA54/pZcOTtVeJ0xccp1nGWladA==",
+			"version": "7.18.9",
+			"resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.18.9.tgz",
+			"integrity": "sha512-dNsWibVI4lNT6HiuOIBr1oyxo40HvIVmbwPUm3XZ7wMh4k2WxrxTqZwSqw/eEmXDS9np0ey5M2bz9tBmO9c+YQ==",
 			"requires": {
-				"@babel/helper-member-expression-to-functions": "^7.16.0",
-				"@babel/helper-optimise-call-expression": "^7.16.0",
-				"@babel/traverse": "^7.16.0",
-				"@babel/types": "^7.16.0"
+				"@babel/helper-environment-visitor": "^7.18.9",
+				"@babel/helper-member-expression-to-functions": "^7.18.9",
+				"@babel/helper-optimise-call-expression": "^7.18.6",
+				"@babel/traverse": "^7.18.9",
+				"@babel/types": "^7.18.9"
 			}
 		},
 		"@babel/helper-simple-access": {
@@ -33663,22 +32966,22 @@
 			}
 		},
 		"@babel/helper-split-export-declaration": {
-			"version": "7.16.0",
-			"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.16.0.tgz",
-			"integrity": "sha512-0YMMRpuDFNGTHNRiiqJX19GjNXA4H0E8jZ2ibccfSxaCogbm3am5WN/2nQNj0YnQwGWM1J06GOcQ2qnh3+0paw==",
+			"version": "7.18.6",
+			"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.18.6.tgz",
+			"integrity": "sha512-bde1etTx6ZyTmobl9LLMMQsaizFVZrquTEHOqKeQESMKo4PlObf+8+JA25ZsIpZhT/WEd39+vOdLXAFG/nELpA==",
 			"requires": {
-				"@babel/types": "^7.16.0"
+				"@babel/types": "^7.18.6"
 			}
 		},
 		"@babel/helper-validator-identifier": {
-			"version": "7.15.7",
-			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.15.7.tgz",
-			"integrity": "sha512-K4JvCtQqad9OY2+yTU8w+E82ywk/fe+ELNlt1G8z3bVGlZfn/hOcQQsUhGhW/N+tb3fxK800wLtKOE/aM0m72w=="
+			"version": "7.18.6",
+			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.18.6.tgz",
+			"integrity": "sha512-MmetCkz9ej86nJQV+sFCxoGGrUbU3q02kgLciwkrt9QqEB7cP39oKEY0PakknEO0Gu20SskMRi+AYZ3b1TpN9g=="
 		},
 		"@babel/helper-validator-option": {
-			"version": "7.14.5",
-			"resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.14.5.tgz",
-			"integrity": "sha512-OX8D5eeX4XwcroVW45NMvoYaIuFI+GQpA2a8Gi+X/U/cDUIRsV37qQfF905F0htTRCREQIB4KqPeaveRJUl3Ow=="
+			"version": "7.18.6",
+			"resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.18.6.tgz",
+			"integrity": "sha512-XO7gESt5ouv/LRJdrVjkShckw6STTaB7l9BrpBaAHDeF5YZT+01PCwmR0SJHnkW6i8OwW/EVWRShfi4j2x+KQw=="
 		},
 		"@babel/helper-wrap-function": {
 			"version": "7.16.0",
@@ -33703,19 +33006,19 @@
 			}
 		},
 		"@babel/highlight": {
-			"version": "7.16.0",
-			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.16.0.tgz",
-			"integrity": "sha512-t8MH41kUQylBtu2+4IQA3atqevA2lRgqA2wyVB/YiWmsDSuylZZuXOUy9ric30hfzauEFfdsuk/eXTRrGrfd0g==",
+			"version": "7.18.6",
+			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.18.6.tgz",
+			"integrity": "sha512-u7stbOuYjaPezCuLj29hNW1v64M2Md2qupEKP1fHc7WdOA3DgLh37suiSrZYY7haUB7iBeQZ9P1uiRF359do3g==",
 			"requires": {
-				"@babel/helper-validator-identifier": "^7.15.7",
+				"@babel/helper-validator-identifier": "^7.18.6",
 				"chalk": "^2.0.0",
 				"js-tokens": "^4.0.0"
 			}
 		},
 		"@babel/parser": {
-			"version": "7.16.4",
-			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.16.4.tgz",
-			"integrity": "sha512-6V0qdPUaiVHH3RtZeLIsc+6pDhbYzHR8ogA8w+f+Wc77DuXto19g2QUwveINoS34Uw+W8/hQDGJCx+i4n7xcng=="
+			"version": "7.18.9",
+			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.18.9.tgz",
+			"integrity": "sha512-9uJveS9eY9DJ0t64YbIBZICtJy8a5QrDEVdiLCG97fVLpDTpGX7t8mMSb6OWw6Lrnjqj4O8zwjELX3dhoMgiBg=="
 		},
 		"@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": {
 			"version": "7.16.2",
@@ -34048,12 +33351,12 @@
 			}
 		},
 		"@babel/plugin-syntax-typescript": {
-			"version": "7.16.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.16.0.tgz",
-			"integrity": "sha512-Xv6mEXqVdaqCBfJFyeab0fH2DnUoMsDmhamxsSi4j8nLd4Vtw213WMJr55xxqipC/YVWyPY3K0blJncPYji+dQ==",
+			"version": "7.18.6",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.18.6.tgz",
+			"integrity": "sha512-mAWAuq4rvOepWCBid55JuRNvpTNf2UGVgoz4JV0fXEKolsVZDzsa4NqCef758WZJj/GDu0gVGItjKFiClTAmZA==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "^7.14.5"
+				"@babel/helper-plugin-utils": "^7.18.6"
 			}
 		},
 		"@babel/plugin-transform-arrow-functions": {
@@ -34413,14 +33716,14 @@
 			}
 		},
 		"@babel/plugin-transform-typescript": {
-			"version": "7.16.1",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.16.1.tgz",
-			"integrity": "sha512-NO4XoryBng06jjw/qWEU2LhcLJr1tWkhpMam/H4eas/CDKMX/b2/Ylb6EI256Y7+FVPCawwSM1rrJNOpDiz+Lg==",
+			"version": "7.18.8",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.18.8.tgz",
+			"integrity": "sha512-p2xM8HI83UObjsZGofMV/EdYjamsDm6MoN3hXPYIT0+gxIoopE+B7rPYKAxfrz9K9PK7JafTTjqYC6qipLExYA==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-create-class-features-plugin": "^7.16.0",
-				"@babel/helper-plugin-utils": "^7.14.5",
-				"@babel/plugin-syntax-typescript": "^7.16.0"
+				"@babel/helper-create-class-features-plugin": "^7.18.6",
+				"@babel/helper-plugin-utils": "^7.18.6",
+				"@babel/plugin-syntax-typescript": "^7.18.6"
 			}
 		},
 		"@babel/plugin-transform-unicode-escapes": {
@@ -34560,14 +33863,14 @@
 			}
 		},
 		"@babel/preset-typescript": {
-			"version": "7.16.0",
-			"resolved": "https://registry.npmjs.org/@babel/preset-typescript/-/preset-typescript-7.16.0.tgz",
-			"integrity": "sha512-txegdrZYgO9DlPbv+9QOVpMnKbOtezsLHWsnsRF4AjbSIsVaujrq1qg8HK0mxQpWv0jnejt0yEoW1uWpvbrDTg==",
+			"version": "7.18.6",
+			"resolved": "https://registry.npmjs.org/@babel/preset-typescript/-/preset-typescript-7.18.6.tgz",
+			"integrity": "sha512-s9ik86kXBAnD760aybBucdpnLsAt0jK1xqJn2juOn9lkOvSHV60os5hxoVJsPzMQxvnUJFAlkont2DvvaYEBtQ==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-plugin-utils": "^7.14.5",
-				"@babel/helper-validator-option": "^7.14.5",
-				"@babel/plugin-transform-typescript": "^7.16.0"
+				"@babel/helper-plugin-utils": "^7.18.6",
+				"@babel/helper-validator-option": "^7.18.6",
+				"@babel/plugin-transform-typescript": "^7.18.6"
 			}
 		},
 		"@babel/runtime": {
@@ -34589,49 +33892,32 @@
 			}
 		},
 		"@babel/template": {
-			"version": "7.16.0",
-			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.16.0.tgz",
-			"integrity": "sha512-MnZdpFD/ZdYhXwiunMqqgyZyucaYsbL0IrjoGjaVhGilz+x8YB++kRfygSOIj1yOtWKPlx7NBp+9I1RQSgsd5A==",
+			"version": "7.18.6",
+			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.18.6.tgz",
+			"integrity": "sha512-JoDWzPe+wgBsTTgdnIma3iHNFC7YVJoPssVBDjiHfNlyt4YcunDtcDOUmfVDfCK5MfdsaIoX9PkijPhjH3nYUw==",
 			"requires": {
-				"@babel/code-frame": "^7.16.0",
-				"@babel/parser": "^7.16.0",
-				"@babel/types": "^7.16.0"
-			},
-			"dependencies": {
-				"@babel/code-frame": {
-					"version": "7.16.0",
-					"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.16.0.tgz",
-					"integrity": "sha512-IF4EOMEV+bfYwOmNxGzSnjR2EmQod7f1UXOpZM3l4i4o4QNwzjtJAu/HxdjHq0aYBvdqMuQEY1eg0nqW9ZPORA==",
-					"requires": {
-						"@babel/highlight": "^7.16.0"
-					}
-				}
+				"@babel/code-frame": "^7.18.6",
+				"@babel/parser": "^7.18.6",
+				"@babel/types": "^7.18.6"
 			}
 		},
 		"@babel/traverse": {
-			"version": "7.16.3",
-			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.16.3.tgz",
-			"integrity": "sha512-eolumr1vVMjqevCpwVO99yN/LoGL0EyHiLO5I043aYQvwOJ9eR5UsZSClHVCzfhBduMAsSzgA/6AyqPjNayJag==",
+			"version": "7.18.9",
+			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.18.9.tgz",
+			"integrity": "sha512-LcPAnujXGwBgv3/WHv01pHtb2tihcyW1XuL9wd7jqh1Z8AQkTd+QVjMrMijrln0T7ED3UXLIy36P9Ao7W75rYg==",
 			"requires": {
-				"@babel/code-frame": "^7.16.0",
-				"@babel/generator": "^7.16.0",
-				"@babel/helper-function-name": "^7.16.0",
-				"@babel/helper-hoist-variables": "^7.16.0",
-				"@babel/helper-split-export-declaration": "^7.16.0",
-				"@babel/parser": "^7.16.3",
-				"@babel/types": "^7.16.0",
+				"@babel/code-frame": "^7.18.6",
+				"@babel/generator": "^7.18.9",
+				"@babel/helper-environment-visitor": "^7.18.9",
+				"@babel/helper-function-name": "^7.18.9",
+				"@babel/helper-hoist-variables": "^7.18.6",
+				"@babel/helper-split-export-declaration": "^7.18.6",
+				"@babel/parser": "^7.18.9",
+				"@babel/types": "^7.18.9",
 				"debug": "^4.1.0",
 				"globals": "^11.1.0"
 			},
 			"dependencies": {
-				"@babel/code-frame": {
-					"version": "7.16.0",
-					"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.16.0.tgz",
-					"integrity": "sha512-IF4EOMEV+bfYwOmNxGzSnjR2EmQod7f1UXOpZM3l4i4o4QNwzjtJAu/HxdjHq0aYBvdqMuQEY1eg0nqW9ZPORA==",
-					"requires": {
-						"@babel/highlight": "^7.16.0"
-					}
-				},
 				"debug": {
 					"version": "4.1.1",
 					"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
@@ -34648,11 +33934,11 @@
 			}
 		},
 		"@babel/types": {
-			"version": "7.16.0",
-			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.16.0.tgz",
-			"integrity": "sha512-PJgg/k3SdLsGb3hhisFvtLOw5ts113klrpLuIPtCJIU+BB24fqq6lf8RWqKJEjzqXR9AEH1rIb5XTqwBHB+kQg==",
+			"version": "7.18.9",
+			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.18.9.tgz",
+			"integrity": "sha512-WwMLAg2MvJmt/rKEVQBBhIVffMmnilX4oe0sRe7iPOHIGsqpruFHHdrfj4O1CMMtgMtCU4oPafZjDPCRgO57Wg==",
 			"requires": {
-				"@babel/helper-validator-identifier": "^7.15.7",
+				"@babel/helper-validator-identifier": "^7.18.6",
 				"to-fast-properties": "^2.0.0"
 			}
 		},
@@ -35348,6 +34634,13 @@
 			"requires": {
 				"@jridgewell/trace-mapping": "0.3.9"
 			}
+		},
+		"@csstools/selector-specificity": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/@csstools/selector-specificity/-/selector-specificity-2.0.2.tgz",
+			"integrity": "sha512-IkpVW/ehM1hWKln4fCA3NzJU8KwD+kIOvPZA4cqxoJHtE21CCzjyp+Kxbu0i5I4tBNOlXPL9mjwnWlL0VEG4Fg==",
+			"dev": true,
+			"requires": {}
 		},
 		"@discoveryjs/json-ext": {
 			"version": "0.5.5",
@@ -36275,7 +35568,6 @@
 			"version": "0.3.2",
 			"resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.2.tgz",
 			"integrity": "sha512-mh65xKQAzI6iBcFzwv28KVWSmCkdRBWoOh+bYQGW3+6OZvbbN3TqMGo5hqYxQniRcH9F2VZIoJCm4pa3BPDK/A==",
-			"dev": true,
 			"requires": {
 				"@jridgewell/set-array": "^1.0.1",
 				"@jridgewell/sourcemap-codec": "^1.4.10",
@@ -36290,8 +35582,7 @@
 		"@jridgewell/set-array": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.1.2.tgz",
-			"integrity": "sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw==",
-			"dev": true
+			"integrity": "sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw=="
 		},
 		"@jridgewell/source-map": {
 			"version": "0.3.2",
@@ -37281,25 +36572,6 @@
 				"@sinonjs/commons": "^1.7.0"
 			}
 		},
-		"@stylelint/postcss-css-in-js": {
-			"version": "0.37.2",
-			"resolved": "https://registry.npmjs.org/@stylelint/postcss-css-in-js/-/postcss-css-in-js-0.37.2.tgz",
-			"integrity": "sha512-nEhsFoJurt8oUmieT8qy4nk81WRHmJynmVwn/Vts08PL9fhgIsMhk1GId5yAN643OzqEEb5S/6At2TZW7pqPDA==",
-			"dev": true,
-			"requires": {
-				"@babel/core": ">=7.9.0"
-			}
-		},
-		"@stylelint/postcss-markdown": {
-			"version": "0.36.2",
-			"resolved": "https://registry.npmjs.org/@stylelint/postcss-markdown/-/postcss-markdown-0.36.2.tgz",
-			"integrity": "sha512-2kGbqUVJUGE8dM+bMzXG/PYUWKkjLIkRLWNh39OaADkiabDRdw8ATFCgbMz5xdIcvwspPAluSL7uY+ZiTWdWmQ==",
-			"dev": true,
-			"requires": {
-				"remark": "^13.0.0",
-				"unist-util-find-all-after": "^3.0.2"
-			}
-		},
 		"@tannin/compile": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/@tannin/compile/-/compile-1.1.0.tgz",
@@ -37640,15 +36912,6 @@
 			"resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.177.tgz",
 			"integrity": "sha512-0fDwydE2clKe9MNfvXHBHF9WEahRuj+msTuQqOmAApNORFvhMYZKNGGJdCzuhheVjMps/ti0Ak/iJPACMaevvw=="
 		},
-		"@types/mdast": {
-			"version": "3.0.10",
-			"resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-3.0.10.tgz",
-			"integrity": "sha512-W864tg/Osz1+9f4lrGTZpCSO5/z4608eUp19tbozkq2HJK6i3z1kT0H9tlADXuYIb1YYOBByU4Jsqkk75q48qA==",
-			"dev": true,
-			"requires": {
-				"@types/unist": "*"
-			}
-		},
 		"@types/minimist": {
 			"version": "1.2.2",
 			"resolved": "https://registry.npmjs.org/@types/minimist/-/minimist-1.2.2.tgz",
@@ -37734,12 +36997,6 @@
 			"requires": {
 				"@types/jest": "*"
 			}
-		},
-		"@types/unist": {
-			"version": "2.0.6",
-			"resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.6.tgz",
-			"integrity": "sha512-PBjIUxZHOuj0R15/xuwJYjFi+KZdNFrehocChv4g5hu6aFroHue8m0lBP0POdK2nKzbw0cgV1mws8+V/JAcEkQ==",
-			"dev": true
 		},
 		"@types/webpack-env": {
 			"version": "1.16.3",
@@ -38994,14 +38251,13 @@
 			}
 		},
 		"@wordpress/stylelint-config": {
-			"version": "19.1.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/stylelint-config/-/stylelint-config-19.1.0.tgz",
-			"integrity": "sha512-K/wB9rhB+pH5WvDh3fV3DN5C3Bud+jPGXmnPY8fOXKMYI3twCFozK/j6sVuaJHqGp/0kKEF0hkkGh+HhD30KGQ==",
+			"version": "20.0.2",
+			"resolved": "https://registry.npmjs.org/@wordpress/stylelint-config/-/stylelint-config-20.0.2.tgz",
+			"integrity": "sha512-guP0Cwc4PysbRJroxWcBxViYaqaTlxrkcZ/dfsoB0ZLO+RrZ8YFktt02mt6q6MASLTBEWIBHVQ5nKLVFPWAWJg==",
 			"dev": true,
 			"requires": {
-				"stylelint-config-recommended": "^3.0.0",
-				"stylelint-config-recommended-scss": "^4.2.0",
-				"stylelint-scss": "^3.17.2"
+				"stylelint-config-recommended": "^6.0.0",
+				"stylelint-config-recommended-scss": "^5.0.2"
 			}
 		},
 		"@wordpress/token-list": {
@@ -39070,10 +38326,9 @@
 			"dev": true
 		},
 		"acorn": {
-			"version": "7.4.1",
-			"resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
-			"integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
-			"dev": true
+			"version": "8.7.1",
+			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.7.1.tgz",
+			"integrity": "sha512-Xx54uLJQZ19lKygFXOWsscKUbsBZW0CPykPhVQdhIeIwrbPmJzqeASDInc8nKBnp/JT6igTs82qPXz069H8I/A=="
 		},
 		"acorn-globals": {
 			"version": "6.0.0",
@@ -39083,6 +38338,14 @@
 			"requires": {
 				"acorn": "^7.1.1",
 				"acorn-walk": "^7.1.1"
+			},
+			"dependencies": {
+				"acorn": {
+					"version": "7.4.1",
+					"resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
+					"integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
+					"dev": true
+				}
 			}
 		},
 		"acorn-import-assertions": {
@@ -39331,6 +38594,20 @@
 			"integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
 			"dev": true
 		},
+		"array.prototype.filter": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/array.prototype.filter/-/array.prototype.filter-1.0.1.tgz",
+			"integrity": "sha512-Dk3Ty7N42Odk7PjU/Ci3zT4pLj20YvuVnneG/58ICM6bt4Ij5kZaJTVQ9TSaWaIECX2sFyz4KItkVZqHNnciqw==",
+			"dev": true,
+			"peer": true,
+			"requires": {
+				"call-bind": "^1.0.2",
+				"define-properties": "^1.1.3",
+				"es-abstract": "^1.19.0",
+				"es-array-method-boxes-properly": "^1.0.0",
+				"is-string": "^1.0.7"
+			}
+		},
 		"array.prototype.find": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/array.prototype.find/-/array.prototype.find-2.1.1.tgz",
@@ -39427,45 +38704,6 @@
 			"resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
 			"integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
 			"dev": true
-		},
-		"autoprefixer": {
-			"version": "9.8.6",
-			"resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-9.8.6.tgz",
-			"integrity": "sha512-XrvP4VVHdRBCdX1S3WXVD8+RyG9qeb1D5Sn1DeLiG2xfSpzellk5k54xbUERJ3M5DggQxes39UGOTP8CFrEGbg==",
-			"dev": true,
-			"requires": {
-				"browserslist": "^4.12.0",
-				"caniuse-lite": "^1.0.30001109",
-				"colorette": "^1.2.1",
-				"normalize-range": "^0.1.2",
-				"num2fraction": "^1.2.2",
-				"postcss": "^7.0.32",
-				"postcss-value-parser": "^4.1.0"
-			},
-			"dependencies": {
-				"picocolors": {
-					"version": "0.2.1",
-					"resolved": "https://registry.npmjs.org/picocolors/-/picocolors-0.2.1.tgz",
-					"integrity": "sha512-cMlDqaLEqfSaW8Z7N5Jw+lyIW869EzT73/F5lhtY9cLGoVxSXznfgfXMO0Z5K0o0Q2TkTXq+0KFsdnSe3jDViA==",
-					"dev": true
-				},
-				"postcss": {
-					"version": "7.0.39",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.39.tgz",
-					"integrity": "sha512-yioayjNbHn6z1/Bywyb2Y4s3yvDAeXGOyxqD+LnVOinq6Mdmd++SW2wUNVzavyyHxd6+DxzWGIuosg6P1Rj8uA==",
-					"dev": true,
-					"requires": {
-						"picocolors": "^0.2.1",
-						"source-map": "^0.6.1"
-					}
-				},
-				"source-map": {
-					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-					"dev": true
-				}
-			}
 		},
 		"autosize": {
 			"version": "4.0.4",
@@ -39751,12 +38989,6 @@
 				"babel-plugin-jest-hoist": "^27.4.0",
 				"babel-preset-current-node-syntax": "^1.0.0"
 			}
-		},
-		"bail": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/bail/-/bail-1.0.5.tgz",
-			"integrity": "sha512-xFbRxM1tahm08yHBP16MMjVUAvDaBMD38zsM9EMAUN61omwLmKlOpB/Zku5QkjZ8TZ4vn53pj+t518cH0S03RQ==",
-			"dev": true
 		},
 		"balanced-match": {
 			"version": "1.0.0",
@@ -40134,29 +39366,165 @@
 			"integrity": "sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==",
 			"dev": true
 		},
-		"character-entities": {
-			"version": "1.2.4",
-			"resolved": "https://registry.npmjs.org/character-entities/-/character-entities-1.2.4.tgz",
-			"integrity": "sha512-iBMyeEHxfVnIakwOuDXpVkc54HijNgCyQB2w0VfGQThle6NXn50zU6V/u+LDhxHcDUPojn6Kpga3PTAD8W1bQw==",
-			"dev": true
-		},
-		"character-entities-legacy": {
-			"version": "1.1.4",
-			"resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-1.1.4.tgz",
-			"integrity": "sha512-3Xnr+7ZFS1uxeiUDvV02wQ+QDbc55o97tIV5zHScSPJpcLm/r0DFPcoY3tYRp+VZukxuMeKgXYmsXQHO05zQeA==",
-			"dev": true
-		},
-		"character-reference-invalid": {
-			"version": "1.1.4",
-			"resolved": "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-1.1.4.tgz",
-			"integrity": "sha512-mKKUkUbhPpQlCOfIuZkvSEgktjPFIsZKRRbC6KWVEMvlzblj3i3asQv5ODsrwt0N3pHAEvjP8KTQPHkp0+6jOg==",
-			"dev": true
-		},
 		"chardet": {
 			"version": "0.7.0",
 			"resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
 			"integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
 			"dev": true
+		},
+		"cheerio": {
+			"version": "1.0.0-rc.12",
+			"resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.0.0-rc.12.tgz",
+			"integrity": "sha512-VqR8m68vM46BNnuZ5NtnGBKIE/DfN0cRIzg9n40EIq9NOv90ayxLBXA8fXC5gquFRGJSTRqBq25Jt2ECLR431Q==",
+			"dev": true,
+			"peer": true,
+			"requires": {
+				"cheerio-select": "^2.1.0",
+				"dom-serializer": "^2.0.0",
+				"domhandler": "^5.0.3",
+				"domutils": "^3.0.1",
+				"htmlparser2": "^8.0.1",
+				"parse5": "^7.0.0",
+				"parse5-htmlparser2-tree-adapter": "^7.0.0"
+			},
+			"dependencies": {
+				"dom-serializer": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+					"integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+					"dev": true,
+					"peer": true,
+					"requires": {
+						"domelementtype": "^2.3.0",
+						"domhandler": "^5.0.2",
+						"entities": "^4.2.0"
+					}
+				},
+				"domelementtype": {
+					"version": "2.3.0",
+					"resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+					"integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
+					"dev": true,
+					"peer": true
+				},
+				"domhandler": {
+					"version": "5.0.3",
+					"resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+					"integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+					"dev": true,
+					"peer": true,
+					"requires": {
+						"domelementtype": "^2.3.0"
+					}
+				},
+				"domutils": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/domutils/-/domutils-3.0.1.tgz",
+					"integrity": "sha512-z08c1l761iKhDFtfXO04C7kTdPBLi41zwOZl00WS8b5eiaebNpY00HKbztwBq+e3vyqWNwWF3mP9YLUeqIrF+Q==",
+					"dev": true,
+					"peer": true,
+					"requires": {
+						"dom-serializer": "^2.0.0",
+						"domelementtype": "^2.3.0",
+						"domhandler": "^5.0.1"
+					}
+				},
+				"entities": {
+					"version": "4.3.1",
+					"resolved": "https://registry.npmjs.org/entities/-/entities-4.3.1.tgz",
+					"integrity": "sha512-o4q/dYJlmyjP2zfnaWDUC6A3BQFmVTX+tZPezK7k0GLSU9QYCauscf5Y+qcEPzKL+EixVouYDgLQK5H9GrLpkg==",
+					"dev": true,
+					"peer": true
+				},
+				"htmlparser2": {
+					"version": "8.0.1",
+					"resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-8.0.1.tgz",
+					"integrity": "sha512-4lVbmc1diZC7GUJQtRQ5yBAeUCL1exyMwmForWkRLnwyzWBFxN633SALPMGYaWZvKe9j1pRZJpauvmxENSp/EA==",
+					"dev": true,
+					"peer": true,
+					"requires": {
+						"domelementtype": "^2.3.0",
+						"domhandler": "^5.0.2",
+						"domutils": "^3.0.1",
+						"entities": "^4.3.0"
+					}
+				},
+				"parse5": {
+					"version": "7.0.0",
+					"resolved": "https://registry.npmjs.org/parse5/-/parse5-7.0.0.tgz",
+					"integrity": "sha512-y/t8IXSPWTuRZqXc0ajH/UwDj4mnqLEbSttNbThcFhGrZuOyoyvNBO85PBp2jQa55wY9d07PBNjsK8ZP3K5U6g==",
+					"dev": true,
+					"peer": true,
+					"requires": {
+						"entities": "^4.3.0"
+					}
+				}
+			}
+		},
+		"cheerio-select": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/cheerio-select/-/cheerio-select-2.1.0.tgz",
+			"integrity": "sha512-9v9kG0LvzrlcungtnJtpGNxY+fzECQKhK4EGJX2vByejiMX84MFNQw4UxPJl3bFbTMw+Dfs37XaIkCwTZfLh4g==",
+			"dev": true,
+			"peer": true,
+			"requires": {
+				"boolbase": "^1.0.0",
+				"css-select": "^5.1.0",
+				"css-what": "^6.1.0",
+				"domelementtype": "^2.3.0",
+				"domhandler": "^5.0.3",
+				"domutils": "^3.0.1"
+			},
+			"dependencies": {
+				"dom-serializer": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+					"integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+					"dev": true,
+					"peer": true,
+					"requires": {
+						"domelementtype": "^2.3.0",
+						"domhandler": "^5.0.2",
+						"entities": "^4.2.0"
+					}
+				},
+				"domelementtype": {
+					"version": "2.3.0",
+					"resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+					"integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
+					"dev": true,
+					"peer": true
+				},
+				"domhandler": {
+					"version": "5.0.3",
+					"resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+					"integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+					"dev": true,
+					"peer": true,
+					"requires": {
+						"domelementtype": "^2.3.0"
+					}
+				},
+				"domutils": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/domutils/-/domutils-3.0.1.tgz",
+					"integrity": "sha512-z08c1l761iKhDFtfXO04C7kTdPBLi41zwOZl00WS8b5eiaebNpY00HKbztwBq+e3vyqWNwWF3mP9YLUeqIrF+Q==",
+					"dev": true,
+					"peer": true,
+					"requires": {
+						"dom-serializer": "^2.0.0",
+						"domelementtype": "^2.3.0",
+						"domhandler": "^5.0.1"
+					}
+				},
+				"entities": {
+					"version": "4.3.1",
+					"resolved": "https://registry.npmjs.org/entities/-/entities-4.3.1.tgz",
+					"integrity": "sha512-o4q/dYJlmyjP2zfnaWDUC6A3BQFmVTX+tZPezK7k0GLSU9QYCauscf5Y+qcEPzKL+EixVouYDgLQK5H9GrLpkg==",
+					"dev": true,
+					"peer": true
+				}
+			}
 		},
 		"chokidar": {
 			"version": "3.5.2",
@@ -40528,12 +39896,6 @@
 			"version": "2.9.2",
 			"resolved": "https://registry.npmjs.org/colord/-/colord-2.9.2.tgz",
 			"integrity": "sha512-Uqbg+J445nc1TKn4FoDPS6ZZqAvEDnwrH42yo8B40JSOgSLxMZ/gt3h4nmCtPLQeXhjJJkqBx7SCY35WnIixaQ=="
-		},
-		"colorette": {
-			"version": "1.2.2",
-			"resolved": "https://registry.npmjs.org/colorette/-/colorette-1.2.2.tgz",
-			"integrity": "sha512-MKGMzyfeuutC/ZJ1cba9NqcNpfeqMUcYmyF1ZFY6/Cn7CNSAKx6a+s48sqLqyAiZuaP2TcqMhoo+dlwFnVxT9w==",
-			"dev": true
 		},
 		"colors": {
 			"version": "1.4.0",
@@ -41317,11 +40679,6 @@
 				"ts-node": "^10.8.1"
 			},
 			"dependencies": {
-				"acorn": {
-					"version": "8.7.1",
-					"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.7.1.tgz",
-					"integrity": "sha512-Xx54uLJQZ19lKygFXOWsscKUbsBZW0CPykPhVQdhIeIwrbPmJzqeASDInc8nKBnp/JT6igTs82qPXz069H8I/A=="
-				},
 				"acorn-walk": {
 					"version": "8.2.0",
 					"resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
@@ -41451,6 +40808,12 @@
 				}
 			}
 		},
+		"css-functions-list": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/css-functions-list/-/css-functions-list-3.1.0.tgz",
+			"integrity": "sha512-/9lCvYZaUbBGvYUgYGFJ4dcYiyqdhSjG7IPVluoV8A1ILjkF7ilmhp1OGUz8n+nmBcu0RNrQAzgD8B6FJbrt2w==",
+			"dev": true
+		},
 		"css-loader": {
 			"version": "5.2.7",
 			"resolved": "https://registry.npmjs.org/css-loader/-/css-loader-5.2.7.tgz",
@@ -41576,6 +40939,70 @@
 				}
 			}
 		},
+		"css-select": {
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/css-select/-/css-select-5.1.0.tgz",
+			"integrity": "sha512-nwoRF1rvRRnnCqqY7updORDsuqKzqYJ28+oSMaJMMgOauh3fvwHqMS7EZpIPqK8GL+g9mKxF1vP/ZjSeNjEVHg==",
+			"dev": true,
+			"peer": true,
+			"requires": {
+				"boolbase": "^1.0.0",
+				"css-what": "^6.1.0",
+				"domhandler": "^5.0.2",
+				"domutils": "^3.0.1",
+				"nth-check": "^2.0.1"
+			},
+			"dependencies": {
+				"dom-serializer": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+					"integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+					"dev": true,
+					"peer": true,
+					"requires": {
+						"domelementtype": "^2.3.0",
+						"domhandler": "^5.0.2",
+						"entities": "^4.2.0"
+					}
+				},
+				"domelementtype": {
+					"version": "2.3.0",
+					"resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+					"integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
+					"dev": true,
+					"peer": true
+				},
+				"domhandler": {
+					"version": "5.0.3",
+					"resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+					"integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+					"dev": true,
+					"peer": true,
+					"requires": {
+						"domelementtype": "^2.3.0"
+					}
+				},
+				"domutils": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/domutils/-/domutils-3.0.1.tgz",
+					"integrity": "sha512-z08c1l761iKhDFtfXO04C7kTdPBLi41zwOZl00WS8b5eiaebNpY00HKbztwBq+e3vyqWNwWF3mP9YLUeqIrF+Q==",
+					"dev": true,
+					"peer": true,
+					"requires": {
+						"dom-serializer": "^2.0.0",
+						"domelementtype": "^2.3.0",
+						"domhandler": "^5.0.1"
+					}
+				},
+				"entities": {
+					"version": "4.3.1",
+					"resolved": "https://registry.npmjs.org/entities/-/entities-4.3.1.tgz",
+					"integrity": "sha512-o4q/dYJlmyjP2zfnaWDUC6A3BQFmVTX+tZPezK7k0GLSU9QYCauscf5Y+qcEPzKL+EixVouYDgLQK5H9GrLpkg==",
+					"dev": true,
+					"peer": true
+				}
+			}
+		},
 		"css-select-base-adapter": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/css-select-base-adapter/-/css-select-base-adapter-0.1.1.tgz",
@@ -41599,6 +41026,13 @@
 					"dev": true
 				}
 			}
+		},
+		"css-what": {
+			"version": "6.1.0",
+			"resolved": "https://registry.npmjs.org/css-what/-/css-what-6.1.0.tgz",
+			"integrity": "sha512-HTUrgRJ7r4dsZKU6GjmpfRK1O76h97Z8MfS1G0FozR+oF2kG6Vfe8JE6zwrkbxigziPHinCJ+gCPjA9EaBDtRw==",
+			"dev": true,
+			"peer": true
 		},
 		"css.escape": {
 			"version": "1.5.1",
@@ -42007,11 +41441,12 @@
 			"integrity": "sha512-95k0GDqvBjZavkuvzx/YqVLv/6YYa17fz6ILMSf7neqQITCPbnfEnQvEgMPNjH4kgobe7+WIL0yJEHku+H3qtQ=="
 		},
 		"define-properties": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
-			"integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.4.tgz",
+			"integrity": "sha512-uckOqKcfaVvtBdsVkdPv3XjveQJsNQqmhXgRi8uhvWWuPYZCNlzT8qAyblUgNoXdHdjMTzAqeGjAoli8f+bzPA==",
 			"requires": {
-				"object-keys": "^1.0.12"
+				"has-property-descriptors": "^1.0.0",
+				"object-keys": "^1.1.1"
 			}
 		},
 		"define-property": {
@@ -42146,6 +41581,13 @@
 			"resolved": "https://registry.npmjs.org/direction/-/direction-1.0.4.tgz",
 			"integrity": "sha512-GYqKi1aH7PJXxdhTeZBFrg8vUBeKXi+cNprXsC1kpJcbcVnV9wBsrOu1cQEdG0WeQwlfHiy3XvnKfIrJ2R0NzQ=="
 		},
+		"discontinuous-range": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/discontinuous-range/-/discontinuous-range-1.0.0.tgz",
+			"integrity": "sha512-c68LpLbO+7kP/b1Hr1qs8/BJ09F5khZGTxqxZuhzxpmwJKOgRFHJWIb9/KmqnqHhLdO55aOxFH/EGBvUQbL/RQ==",
+			"dev": true,
+			"peer": true
+		},
 		"doctrine": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
@@ -42205,15 +41647,6 @@
 					"integrity": "sha512-VlZwKPCkYKxQgeSbH5EyngOmRp7Ww7I9rQLERETtf5ofd9pGeswWiOtogpEO850jziPRarreGxn5QIiTqpb2wA==",
 					"dev": true
 				}
-			}
-		},
-		"domhandler": {
-			"version": "2.4.2",
-			"resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.4.2.tgz",
-			"integrity": "sha512-JiK04h0Ht5u/80fdLMCEmV4zkNh2BcoMFBmZ/91WtYZ8qVXSKjiw7fXMgFPnHcSZgOo3XdinHvmnDUeMf5R4wA==",
-			"dev": true,
-			"requires": {
-				"domelementtype": "1"
 			}
 		},
 		"domutils": {
@@ -42460,6 +41893,37 @@
 			"integrity": "sha512-/o+BXHmB7ocbHEAs6F2EnG0ogybVVUdkRunTT2glZU9XAaGmhqskrvKwqXuDfNjEO0LZKWdejEEpnq8aM0tOaw==",
 			"dev": true
 		},
+		"enzyme": {
+			"version": "3.11.0",
+			"resolved": "https://registry.npmjs.org/enzyme/-/enzyme-3.11.0.tgz",
+			"integrity": "sha512-Dw8/Gs4vRjxY6/6i9wU0V+utmQO9kvh9XLnz3LIudviOnVYDEe2ec+0k+NQoMamn1VrjKgCUOWj5jG/5M5M0Qw==",
+			"dev": true,
+			"peer": true,
+			"requires": {
+				"array.prototype.flat": "^1.2.3",
+				"cheerio": "^1.0.0-rc.3",
+				"enzyme-shallow-equal": "^1.0.1",
+				"function.prototype.name": "^1.1.2",
+				"has": "^1.0.3",
+				"html-element-map": "^1.2.0",
+				"is-boolean-object": "^1.0.1",
+				"is-callable": "^1.1.5",
+				"is-number-object": "^1.0.4",
+				"is-regex": "^1.0.5",
+				"is-string": "^1.0.5",
+				"is-subset": "^0.1.1",
+				"lodash.escape": "^4.0.1",
+				"lodash.isequal": "^4.5.0",
+				"object-inspect": "^1.7.0",
+				"object-is": "^1.0.2",
+				"object.assign": "^4.1.0",
+				"object.entries": "^1.1.1",
+				"object.values": "^1.1.1",
+				"raf": "^3.4.1",
+				"rst-selector-parser": "^2.2.3",
+				"string.prototype.trim": "^1.2.1"
+			}
+		},
 		"enzyme-matchers": {
 			"version": "7.1.2",
 			"resolved": "https://registry.npmjs.org/enzyme-matchers/-/enzyme-matchers-7.1.2.tgz",
@@ -42514,31 +41978,41 @@
 			}
 		},
 		"es-abstract": {
-			"version": "1.19.1",
-			"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.19.1.tgz",
-			"integrity": "sha512-2vJ6tjA/UfqLm2MPs7jxVybLoB8i1t1Jd9R3kISld20sIxPcTbLuggQOUxeWeAvIUkduv/CfMjuh4WmiXr2v9w==",
+			"version": "1.20.1",
+			"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.20.1.tgz",
+			"integrity": "sha512-WEm2oBhfoI2sImeM4OF2zE2V3BYdSF+KnSi9Sidz51fQHd7+JuF8Xgcj9/0o+OWeIeIS/MiuNnlruQrJf16GQA==",
 			"requires": {
 				"call-bind": "^1.0.2",
 				"es-to-primitive": "^1.2.1",
 				"function-bind": "^1.1.1",
+				"function.prototype.name": "^1.1.5",
 				"get-intrinsic": "^1.1.1",
 				"get-symbol-description": "^1.0.0",
 				"has": "^1.0.3",
-				"has-symbols": "^1.0.2",
+				"has-property-descriptors": "^1.0.0",
+				"has-symbols": "^1.0.3",
 				"internal-slot": "^1.0.3",
 				"is-callable": "^1.2.4",
-				"is-negative-zero": "^2.0.1",
+				"is-negative-zero": "^2.0.2",
 				"is-regex": "^1.1.4",
-				"is-shared-array-buffer": "^1.0.1",
+				"is-shared-array-buffer": "^1.0.2",
 				"is-string": "^1.0.7",
-				"is-weakref": "^1.0.1",
-				"object-inspect": "^1.11.0",
+				"is-weakref": "^1.0.2",
+				"object-inspect": "^1.12.0",
 				"object-keys": "^1.1.1",
 				"object.assign": "^4.1.2",
-				"string.prototype.trimend": "^1.0.4",
-				"string.prototype.trimstart": "^1.0.4",
-				"unbox-primitive": "^1.0.1"
+				"regexp.prototype.flags": "^1.4.3",
+				"string.prototype.trimend": "^1.0.5",
+				"string.prototype.trimstart": "^1.0.5",
+				"unbox-primitive": "^1.0.2"
 			}
+		},
+		"es-array-method-boxes-properly": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/es-array-method-boxes-properly/-/es-array-method-boxes-properly-1.0.0.tgz",
+			"integrity": "sha512-wd6JXUmyHmt8T5a2xreUwKcGPq6f1f+WwIJkijUqiGcJz1qqnZgP6XIK+QyIWU5lT7imeNxUll48bziG+TSYcA==",
+			"dev": true,
+			"peer": true
 		},
 		"es-module-lexer": {
 			"version": "0.9.3",
@@ -43015,6 +42489,14 @@
 				"acorn": "^7.4.0",
 				"acorn-jsx": "^5.3.1",
 				"eslint-visitor-keys": "^1.3.0"
+			},
+			"dependencies": {
+				"acorn": {
+					"version": "7.4.1",
+					"resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
+					"integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
+					"dev": true
+				}
 			}
 		},
 		"esprima": {
@@ -43808,13 +43290,14 @@
 			"integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
 		},
 		"function.prototype.name": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.1.2.tgz",
-			"integrity": "sha512-C8A+LlHBJjB2AdcRPorc5JvJ5VUoWlXdEHLOJdCI7kjHEtGTpHQUiqMvCIKUwIsGwZX2jZJy761AXsn356bJQg==",
+			"version": "1.1.5",
+			"resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.1.5.tgz",
+			"integrity": "sha512-uN7m/BzVKQnCUF/iW8jYea67v++2u7m5UgENbHRtdDVclOUP+FMPlCNdmk0h/ysGyo2tavMJEDqJAkJdRa1vMA==",
 			"requires": {
+				"call-bind": "^1.0.2",
 				"define-properties": "^1.1.3",
-				"es-abstract": "^1.17.0-next.1",
-				"functions-have-names": "^1.2.0"
+				"es-abstract": "^1.19.0",
+				"functions-have-names": "^1.2.2"
 			}
 		},
 		"functional-red-black-tree": {
@@ -43824,9 +43307,9 @@
 			"dev": true
 		},
 		"functions-have-names": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.1.tgz",
-			"integrity": "sha512-j48B/ZI7VKs3sgeI2cZp7WXWmZXu7Iq5pl5/vptV5N2mq+DGFuS/ulaDjtaoLpYzuD6u8UgrUKHfgo7fDTSiBA=="
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.3.tgz",
+			"integrity": "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ=="
 		},
 		"gensync": {
 			"version": "1.0.0-beta.2",
@@ -44073,15 +43556,6 @@
 			"integrity": "sha1-L0SUrIkZ43Z8XLtpHp9GMyQoXUM=",
 			"dev": true
 		},
-		"gonzales-pe": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/gonzales-pe/-/gonzales-pe-4.3.0.tgz",
-			"integrity": "sha512-otgSPpUmdWJ43VXyiNgEYE4luzHCL2pz4wQ0OnDluC6Eg4Ko3Vexy/SrSynglw/eR+OhkzmqFCZa/OFa/RgAOQ==",
-			"dev": true,
-			"requires": {
-				"minimist": "^1.2.5"
-			}
-		},
 		"good-listener": {
 			"version": "1.2.2",
 			"resolved": "https://registry.npmjs.org/good-listener/-/good-listener-1.2.2.tgz",
@@ -44168,19 +43642,27 @@
 			}
 		},
 		"has-bigints": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.1.tgz",
-			"integrity": "sha512-LSBS2LjbNBTf6287JEbEzvJgftkF5qFkmCo9hDRpAzKhUOlJ+hx8dd4USs00SgsUNwc4617J9ki5YtEClM2ffA=="
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.2.tgz",
+			"integrity": "sha512-tSvCKtBr9lkF0Ex0aQiP9N+OpV4zi2r/Nee5VkRDbaqv35RLYMzbwQfFSZZH0kR+Rd6302UJZ2p/bJCEoR3VoQ=="
 		},
 		"has-flag": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
 			"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
 		},
+		"has-property-descriptors": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.0.tgz",
+			"integrity": "sha512-62DVLZGoiEBDHQyqG4w9xCuZ7eJEwNmJRWw2VY84Oedb7WFcA27fiEVe8oUQx9hAUJ4ekurquucTGwsyO1XGdQ==",
+			"requires": {
+				"get-intrinsic": "^1.1.1"
+			}
+		},
 		"has-symbols": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
-			"integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw=="
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
+			"integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A=="
 		},
 		"has-tostringtag": {
 			"version": "1.0.0",
@@ -44297,6 +43779,17 @@
 			"integrity": "sha1-wc56MWjIxmFAM6S194d/OyJfnDg=",
 			"dev": true
 		},
+		"html-element-map": {
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/html-element-map/-/html-element-map-1.3.1.tgz",
+			"integrity": "sha512-6XMlxrAFX4UEEGxctfFnmrFaaZFNf9i5fNuV5wZ3WWQ4FVaNP1aX1LkX9j2mfEx1NpjeE/rL3nmgEn23GdFmrg==",
+			"dev": true,
+			"peer": true,
+			"requires": {
+				"array.prototype.filter": "^1.0.0",
+				"call-bind": "^1.0.2"
+			}
+		},
 		"html-encoding-sniffer": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-2.0.1.tgz",
@@ -44313,37 +43806,10 @@
 			"dev": true
 		},
 		"html-tags": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/html-tags/-/html-tags-3.1.0.tgz",
-			"integrity": "sha512-1qYz89hW3lFDEazhjW0yVAV87lw8lVkrJocr72XmBkMKsoSVJCQx3W8BXsC7hO2qAt8BoVjYjtAcZ9perqGnNg==",
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/html-tags/-/html-tags-3.2.0.tgz",
+			"integrity": "sha512-vy7ClnArOZwCnqZgvv+ddgHgJiAFXe3Ge9ML5/mBctVJoUoYPCdxVucOywjDARn6CVoh3dRSFdPHy2sX80L0Wg==",
 			"dev": true
-		},
-		"htmlparser2": {
-			"version": "3.10.1",
-			"resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.10.1.tgz",
-			"integrity": "sha512-IgieNijUMbkDovyoKObU1DUhm1iwNYE/fuifEoEHfd1oZKZDaONBSkal7Y01shxsM49R4XaMdGez3WnF9UfiCQ==",
-			"dev": true,
-			"requires": {
-				"domelementtype": "^1.3.1",
-				"domhandler": "^2.3.0",
-				"domutils": "^1.5.1",
-				"entities": "^1.1.1",
-				"inherits": "^2.0.1",
-				"readable-stream": "^3.1.1"
-			},
-			"dependencies": {
-				"readable-stream": {
-					"version": "3.6.0",
-					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-					"integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
-					"dev": true,
-					"requires": {
-						"inherits": "^2.0.3",
-						"string_decoder": "^1.1.1",
-						"util-deprecate": "^1.0.1"
-					}
-				}
-			}
 		},
 		"http-proxy-agent": {
 			"version": "4.0.1",
@@ -44674,31 +44140,18 @@
 				}
 			}
 		},
-		"is-alphabetical": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-1.0.4.tgz",
-			"integrity": "sha512-DwzsA04LQ10FHTZuL0/grVDk4rFoVH1pjAToYwBrHSxcrBIGQuXrQMtD5U1b0U2XVgKZCTLLP8u2Qxqhy3l2Vg==",
-			"dev": true
-		},
-		"is-alphanumerical": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/is-alphanumerical/-/is-alphanumerical-1.0.4.tgz",
-			"integrity": "sha512-UzoZUr+XfVz3t3v4KyGEniVL9BDRoQtY7tOyrRybkVNjDFWyo1yhXNGrrBTQxp3ib9BLAWs7k2YKBQsFRkZG9A==",
-			"dev": true,
-			"requires": {
-				"is-alphabetical": "^1.0.0",
-				"is-decimal": "^1.0.0"
-			}
-		},
 		"is-arrayish": {
 			"version": "0.2.1",
 			"resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
 			"integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0="
 		},
 		"is-bigint": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.0.2.tgz",
-			"integrity": "sha512-0JV5+SOCQkIdzjBK9buARcV804Ddu7A0Qet6sHi3FimE9ne6m4BGQZfRn+NZiXbBk4F4XmHfDZIipLj9pX8dSA=="
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.0.4.tgz",
+			"integrity": "sha512-zB9CruMamjym81i2JZ3UMn54PKGsQzsJeo6xvN3HJJ4CAsQNB6iRutp2To77OfCNuoxspsIhzaPoO1zyCEhFOg==",
+			"requires": {
+				"has-bigints": "^1.0.1"
+			}
 		},
 		"is-binary-path": {
 			"version": "2.1.0",
@@ -44784,12 +44237,6 @@
 			"resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.2.tgz",
 			"integrity": "sha512-USlDT524woQ08aoZFzh3/Z6ch9Y/EWXEHQ/AaRN0SkKq4t2Jw2R2339tSXmwuVoY7LLlBCbOIlx2myP/L5zk0g=="
 		},
-		"is-decimal": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/is-decimal/-/is-decimal-1.0.4.tgz",
-			"integrity": "sha512-RGdriMmQQvZ2aqaQq3awNA6dCGtKpiDFcOzrTWrDAT2MiWrKQVPmxLGHl7Y2nNu6led0kEyoX0enY0qXYsv9zw==",
-			"dev": true
-		},
 		"is-descriptor": {
 			"version": "0.1.6",
 			"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
@@ -44848,16 +44295,10 @@
 				"is-extglob": "^2.1.1"
 			}
 		},
-		"is-hexadecimal": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-1.0.4.tgz",
-			"integrity": "sha512-gyPJuv83bHMpocVYoqof5VDiZveEoGoFL8m3BXNb2VW8Xs+rz9kqO8LOQ5DH6EsuvilT1ApazU0pyl+ytbPtlw==",
-			"dev": true
-		},
 		"is-negative-zero": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.1.tgz",
-			"integrity": "sha512-2z6JzQvZRa9A2Y7xC6dQQm4FSTSTNWjKIYYTt4246eMTJmIo0Q+ZyOsU66X8lxK1AbB92dFeglPLrhwpeRKO6w=="
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.2.tgz",
+			"integrity": "sha512-dqJvarLawXsFbNDeJW7zAz8ItJ9cd28YufuuFzh0G8pNHjJMnY08Dv7sYX2uF5UpQOwieAeOExEYAWWfu7ZZUA=="
 		},
 		"is-number": {
 			"version": "3.0.0",
@@ -44949,9 +44390,12 @@
 			"dev": true
 		},
 		"is-shared-array-buffer": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.1.tgz",
-			"integrity": "sha512-IU0NmyknYZN0rChcKhRO1X8LYz5Isj/Fsqh8NJOSf+N/hCOTwy29F32Ik7a+QszE63IdvmwdTPDd6cZ5pg4cwA=="
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.2.tgz",
+			"integrity": "sha512-sqN2UDu1/0y6uvXyStCOzyhAjCSlHceFoMKJW8W9EU9cvic/QdsZ0kEU93HEy3IUEFZIiH/3w+AH/UQbPHNdhA==",
+			"requires": {
+				"call-bind": "^1.0.2"
+			}
 		},
 		"is-stream": {
 			"version": "1.1.0",
@@ -44965,6 +44409,13 @@
 			"requires": {
 				"has-tostringtag": "^1.0.0"
 			}
+		},
+		"is-subset": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/is-subset/-/is-subset-0.1.1.tgz",
+			"integrity": "sha512-6Ybun0IkarhmEqxXCNw/C0bna6Zb/TkfUX9UbwJtK6ObwAVCxmAP308WWTHviM/zAqXk05cdhYsUsZeGQh99iw==",
+			"dev": true,
+			"peer": true
 		},
 		"is-symbol": {
 			"version": "1.0.3",
@@ -44993,12 +44444,6 @@
 			"integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
 			"dev": true
 		},
-		"is-unicode-supported": {
-			"version": "0.1.0",
-			"resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
-			"integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==",
-			"dev": true
-		},
 		"is-url-superb": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/is-url-superb/-/is-url-superb-4.0.0.tgz",
@@ -45012,11 +44457,11 @@
 			"dev": true
 		},
 		"is-weakref": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/is-weakref/-/is-weakref-1.0.1.tgz",
-			"integrity": "sha512-b2jKc2pQZjaeFYWEf7ScFj+Be1I+PXmlu572Q8coTXZ+LD/QQZ7ShPMst8h16riVgyXTQwUsFEl74mDvc/3MHQ==",
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/is-weakref/-/is-weakref-1.0.2.tgz",
+			"integrity": "sha512-qctsuLZmIQ0+vSSMfoVvyFe2+GSEvnmZ2ezTup1SBse9+twCCeial6EEi3Nc2KFcf6+qz2FBPnjXsk8xhKSaPQ==",
 			"requires": {
-				"call-bind": "^1.0.0"
+				"call-bind": "^1.0.2"
 			}
 		},
 		"is-windows": {
@@ -47434,12 +46879,6 @@
 				"xml-name-validator": "^3.0.0"
 			},
 			"dependencies": {
-				"acorn": {
-					"version": "8.4.0",
-					"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.4.0.tgz",
-					"integrity": "sha512-ULr0LDaEqQrMFGyQ3bhJkLsbtrQ8QibAseGZeaSUiT/6zb9IvIkomWHJIvgvwad+hinRAgsI51JcWk2yvwyL+w==",
-					"dev": true
-				},
 				"form-data": {
 					"version": "3.0.1",
 					"resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.1.tgz",
@@ -47594,9 +47033,9 @@
 			"dev": true
 		},
 		"known-css-properties": {
-			"version": "0.21.0",
-			"resolved": "https://registry.npmjs.org/known-css-properties/-/known-css-properties-0.21.0.tgz",
-			"integrity": "sha512-sZLUnTqimCkvkgRS+kbPlYW5o8q5w1cu+uIisKpEWkj31I8mx8kNG162DwRav8Zirkva6N5uoFsm9kzK4mUXjw==",
+			"version": "0.25.0",
+			"resolved": "https://registry.npmjs.org/known-css-properties/-/known-css-properties-0.25.0.tgz",
+			"integrity": "sha512-b0/9J1O9Jcyik1GC6KC42hJ41jKwdO/Mq8Mdo5sYN+IuRTXs2YFHZC3kZSx6ueusqa95x3wLYe/ytKjbAfGixA==",
 			"dev": true
 		},
 		"language-subtag-registry": {
@@ -48089,11 +47528,25 @@
 			"integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168=",
 			"dev": true
 		},
+		"lodash.escape": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-4.0.1.tgz",
+			"integrity": "sha512-nXEOnb/jK9g0DYMr1/Xvq6l5xMD7GDG55+GSYIYmS0G4tBk/hURD4JR9WCavs04t33WmJx9kCyp9vJ+mr4BOUw==",
+			"dev": true,
+			"peer": true
+		},
 		"lodash.escaperegexp": {
 			"version": "4.1.2",
 			"resolved": "https://registry.npmjs.org/lodash.escaperegexp/-/lodash.escaperegexp-4.1.2.tgz",
 			"integrity": "sha1-ZHYsSGGAglGKw99Mz11YhtriA0c=",
 			"dev": true
+		},
+		"lodash.flattendeep": {
+			"version": "4.4.0",
+			"resolved": "https://registry.npmjs.org/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz",
+			"integrity": "sha512-uHaJFihxmJcEX3kT4I23ABqKKalJ/zDrDg0lsFtc1h+3uw49SIJ5beyhx5ExVRti3AvKoOJngIj7xz3oylPdWQ==",
+			"dev": true,
+			"peer": true
 		},
 		"lodash.get": {
 			"version": "4.4.2",
@@ -48112,6 +47565,13 @@
 			"resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
 			"integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U=",
 			"dev": true
+		},
+		"lodash.isequal": {
+			"version": "4.5.0",
+			"resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+			"integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==",
+			"dev": true,
+			"peer": true
 		},
 		"lodash.ismatch": {
 			"version": "4.4.0",
@@ -48189,67 +47649,6 @@
 			"resolved": "https://registry.npmjs.org/lodash.uniqby/-/lodash.uniqby-4.7.0.tgz",
 			"integrity": "sha1-2ZwHpmnp5tJOE2Lf4mbGdhavEwI=",
 			"dev": true
-		},
-		"log-symbols": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz",
-			"integrity": "sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==",
-			"dev": true,
-			"requires": {
-				"chalk": "^4.1.0",
-				"is-unicode-supported": "^0.1.0"
-			},
-			"dependencies": {
-				"ansi-styles": {
-					"version": "4.3.0",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-					"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-					"dev": true,
-					"requires": {
-						"color-convert": "^2.0.1"
-					}
-				},
-				"chalk": {
-					"version": "4.1.2",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-					"integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-					"dev": true,
-					"requires": {
-						"ansi-styles": "^4.1.0",
-						"supports-color": "^7.1.0"
-					}
-				},
-				"color-convert": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-					"dev": true,
-					"requires": {
-						"color-name": "~1.1.4"
-					}
-				},
-				"color-name": {
-					"version": "1.1.4",
-					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-					"dev": true
-				},
-				"has-flag": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-					"dev": true
-				},
-				"supports-color": {
-					"version": "7.2.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-					"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-					"dev": true,
-					"requires": {
-						"has-flag": "^4.0.0"
-					}
-				}
-			}
 		},
 		"log-update": {
 			"version": "4.0.0",
@@ -48387,12 +47786,6 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/longest/-/longest-2.0.1.tgz",
 			"integrity": "sha1-eB4YMpaqlPbU2RbcM10NF676I/g=",
-			"dev": true
-		},
-		"longest-streak": {
-			"version": "2.0.4",
-			"resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-2.0.4.tgz",
-			"integrity": "sha512-vM6rUVCVUJJt33bnmHiZEvr7wPT78ztX7rojL+LW51bHtLh6HTjx84LA5W4+oa6aKEJA7jJu5LR6vQRBpA5DVg==",
 			"dev": true
 		},
 		"loose-envify": {
@@ -48565,39 +47958,6 @@
 				"minimatch": "^3.0.0"
 			}
 		},
-		"mdast-util-from-markdown": {
-			"version": "0.8.5",
-			"resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-0.8.5.tgz",
-			"integrity": "sha512-2hkTXtYYnr+NubD/g6KGBS/0mFmBcifAsI0yIWRiRo0PjVs6SSOSOdtzbp6kSGnShDN6G5aWZpKQ2lWRy27mWQ==",
-			"dev": true,
-			"requires": {
-				"@types/mdast": "^3.0.0",
-				"mdast-util-to-string": "^2.0.0",
-				"micromark": "~2.11.0",
-				"parse-entities": "^2.0.0",
-				"unist-util-stringify-position": "^2.0.0"
-			}
-		},
-		"mdast-util-to-markdown": {
-			"version": "0.6.5",
-			"resolved": "https://registry.npmjs.org/mdast-util-to-markdown/-/mdast-util-to-markdown-0.6.5.tgz",
-			"integrity": "sha512-XeV9sDE7ZlOQvs45C9UKMtfTcctcaj/pGwH8YLbMHoMOXNNCn2LsqVQOqrF1+/NU8lKDAqozme9SCXWyo9oAcQ==",
-			"dev": true,
-			"requires": {
-				"@types/unist": "^2.0.0",
-				"longest-streak": "^2.0.0",
-				"mdast-util-to-string": "^2.0.0",
-				"parse-entities": "^2.0.0",
-				"repeat-string": "^1.0.0",
-				"zwitch": "^1.0.0"
-			}
-		},
-		"mdast-util-to-string": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-2.0.0.tgz",
-			"integrity": "sha512-AW4DRS3QbBayY/jJmD8437V1Gombjf8RSOUCMFBuo5iHi58AGEgVCKQ+ezHkZZDpAQS75hcBMpLqjpJTjtUL7w==",
-			"dev": true
-		},
 		"mdn-data": {
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.4.tgz",
@@ -48677,33 +48037,6 @@
 			"resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
 			"integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
 			"dev": true
-		},
-		"micromark": {
-			"version": "2.11.4",
-			"resolved": "https://registry.npmjs.org/micromark/-/micromark-2.11.4.tgz",
-			"integrity": "sha512-+WoovN/ppKolQOFIAajxi7Lu9kInbPxFuTBVEavFcL8eAfVstoc5MocPmqBeAdBOJV00uaVjegzH4+MA0DN/uA==",
-			"dev": true,
-			"requires": {
-				"debug": "^4.0.0",
-				"parse-entities": "^2.0.0"
-			},
-			"dependencies": {
-				"debug": {
-					"version": "4.3.2",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
-					"integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
-					"dev": true,
-					"requires": {
-						"ms": "2.1.2"
-					}
-				},
-				"ms": {
-					"version": "2.1.2",
-					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-					"dev": true
-				}
-			}
 		},
 		"micromatch": {
 			"version": "3.1.10",
@@ -48953,6 +48286,13 @@
 				"moment": ">= 2.9.0"
 			}
 		},
+		"moo": {
+			"version": "0.5.1",
+			"resolved": "https://registry.npmjs.org/moo/-/moo-0.5.1.tgz",
+			"integrity": "sha512-I1mnb5xn4fO80BH9BLcF0yLypy2UKl+Cb01Fu0hJRkJjlCRtxZMWkTdAtDd5ZqCOxtCkhmRwyI57vWT+1iZ67w==",
+			"dev": true,
+			"peer": true
+		},
 		"mousetrap": {
 			"version": "1.6.5",
 			"resolved": "https://registry.npmjs.org/mousetrap/-/mousetrap-1.6.5.tgz",
@@ -49007,6 +48347,19 @@
 			"resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
 			"integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
 			"dev": true
+		},
+		"nearley": {
+			"version": "2.20.1",
+			"resolved": "https://registry.npmjs.org/nearley/-/nearley-2.20.1.tgz",
+			"integrity": "sha512-+Mc8UaAebFzgV+KpI5n7DasuuQCHA89dmwm7JXw3TV43ukfNQ9DnBH3Mdb2g/I4Fdxc26pwimBWvjIw0UAILSQ==",
+			"dev": true,
+			"peer": true,
+			"requires": {
+				"commander": "^2.19.0",
+				"moo": "^0.5.0",
+				"railroad-diagrams": "^1.0.0",
+				"randexp": "0.4.6"
+			}
 		},
 		"neo-async": {
 			"version": "2.6.2",
@@ -49087,13 +48440,14 @@
 			}
 		},
 		"newspack-scripts": {
-			"version": "3.3.2",
-			"resolved": "https://registry.npmjs.org/newspack-scripts/-/newspack-scripts-3.3.2.tgz",
-			"integrity": "sha512-VERTkqJ5qLL7//plGpco2+7a7xyG7EfyXSUqlmdCFXGO+phtMnP7r69jaGYxUCFAcvYTRp1+jlJX/uixxHoUgQ==",
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/newspack-scripts/-/newspack-scripts-4.3.0.tgz",
+			"integrity": "sha512-AIRSYl5W6vY0k2Ko4gB9ikRWx6kB/JQyCOOwCkNdkE9uP8OAx6bUhDMn+BVGM2WY4mZOAY5sq3Oib4iwe4xNMw==",
 			"dev": true,
 			"requires": {
 				"@automattic/calypso-build": "^10.0.0",
 				"@babel/preset-env": "^7.16.4",
+				"@babel/preset-typescript": "^7.18.6",
 				"@commitlint/cli": "^15.0.0",
 				"@commitlint/config-conventional": "^15.0.0",
 				"@semantic-release/changelog": "^6.0.1",
@@ -49122,7 +48476,7 @@
 				"@wordpress/icons": "^6.1.1",
 				"@wordpress/keycodes": "^3.2.4",
 				"@wordpress/plugins": "^4.0.6",
-				"@wordpress/stylelint-config": "^19.1.0",
+				"@wordpress/stylelint-config": "^20.0.2",
 				"@wordpress/url": "^3.3.1",
 				"autoprefixer": "^10.4.0",
 				"babel-jest": "^27.4.2",
@@ -49138,7 +48492,7 @@
 				"jest-environment-jsdom": "^27.4.3",
 				"postcss": "^8.4.4",
 				"postcss-focus-within": "^5.0.1",
-				"prettier": "npm:wp-prettier@2.2.1-beta-1",
+				"prettier": "npm:wp-prettier@^2.6.2-beta-1",
 				"semantic-release": "^18.0.1",
 				"semantic-release-version-bump": "^1.4.1",
 				"stylelint": "^14.1.0",
@@ -49287,14 +48641,14 @@
 							"requires": {
 								"@typescript-eslint/experimental-utils": "^5.0.0"
 							}
+						},
+						"prettier": {
+							"version": "npm:wp-prettier@2.2.1-beta-1",
+							"resolved": "https://registry.npmjs.org/wp-prettier/-/wp-prettier-2.2.1-beta-1.tgz",
+							"integrity": "sha512-+JHkqs9LC/JPp51yy1hzs3lQ7qeuWCwOcSzpQNeeY/G7oSpnF61vxt7hRh87zNRTr6ob2ndy0W8rVzhgrcA+Gw==",
+							"dev": true
 						}
 					}
-				},
-				"acorn": {
-					"version": "8.7.0",
-					"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.7.0.tgz",
-					"integrity": "sha512-V/LGr1APy+PXIwKebEWrkZPwoeoF+w1jiOBUmuxuiUIaOHtob8Qc9BTrYo7VuI5fR8tqsy+buA2WFooR5olqvQ==",
-					"dev": true
 				},
 				"ansi-regex": {
 					"version": "5.0.1",
@@ -49327,12 +48681,6 @@
 						"@babel/runtime-corejs3": "^7.10.2"
 					}
 				},
-				"array-union": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
-					"integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
-					"dev": true
-				},
 				"autoprefixer": {
 					"version": "10.4.2",
 					"resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.2.tgz",
@@ -49345,21 +48693,6 @@
 						"normalize-range": "^0.1.2",
 						"picocolors": "^1.0.0",
 						"postcss-value-parser": "^4.2.0"
-					}
-				},
-				"balanced-match": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-2.0.0.tgz",
-					"integrity": "sha512-1ugUSr8BHXRnK23KfuYS+gVMC3LB8QGH9W1iGtDPsNWoQbgtXSExkBu2aDR4epiGWZOjZsj6lDl/N/AqqTC3UA==",
-					"dev": true
-				},
-				"braces": {
-					"version": "3.0.2",
-					"resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-					"integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
-					"dev": true,
-					"requires": {
-						"fill-range": "^7.0.1"
 					}
 				},
 				"chalk": {
@@ -49406,12 +48739,6 @@
 					"requires": {
 						"ms": "2.1.2"
 					}
-				},
-				"emoji-regex": {
-					"version": "8.0.0",
-					"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-					"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-					"dev": true
 				},
 				"escape-string-regexp": {
 					"version": "4.0.0",
@@ -49685,15 +49012,6 @@
 					"integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
 					"dev": true
 				},
-				"fill-range": {
-					"version": "7.0.1",
-					"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-					"integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
-					"dev": true,
-					"requires": {
-						"to-regex-range": "^5.0.1"
-					}
-				},
 				"glob-parent": {
 					"version": "6.0.2",
 					"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
@@ -49720,57 +49038,16 @@
 						}
 					}
 				},
-				"globby": {
-					"version": "11.1.0",
-					"resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
-					"integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
-					"dev": true,
-					"requires": {
-						"array-union": "^2.1.0",
-						"dir-glob": "^3.0.1",
-						"fast-glob": "^3.2.9",
-						"ignore": "^5.2.0",
-						"merge2": "^1.4.1",
-						"slash": "^3.0.0"
-					}
-				},
 				"has-flag": {
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
 					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
 					"dev": true
 				},
-				"hosted-git-info": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-4.1.0.tgz",
-					"integrity": "sha512-kyCuEOWjJqZuDbRHzL8V93NzQhwIB71oFWSyzVo+KPZI+pnQPPxucdkrOZvkLRnrf5URsQM+IJ09Dw29cRALIA==",
-					"dev": true,
-					"requires": {
-						"lru-cache": "^6.0.0"
-					}
-				},
 				"ignore": {
 					"version": "5.2.0",
 					"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.0.tgz",
 					"integrity": "sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==",
-					"dev": true
-				},
-				"is-fullwidth-code-point": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-					"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-					"dev": true
-				},
-				"is-number": {
-					"version": "7.0.0",
-					"resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
-					"integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-					"dev": true
-				},
-				"is-plain-object": {
-					"version": "5.0.0",
-					"resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
-					"integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
 					"dev": true
 				},
 				"js-yaml": {
@@ -49782,12 +49059,6 @@
 						"argparse": "^2.0.1"
 					}
 				},
-				"known-css-properties": {
-					"version": "0.24.0",
-					"resolved": "https://registry.npmjs.org/known-css-properties/-/known-css-properties-0.24.0.tgz",
-					"integrity": "sha512-RTSoaUAfLvpR357vWzAz/50Q/BmHfmE6ETSWfutT0AJiw10e6CmcdYRQJlLRd95B53D0Y2aD1jSxD3V3ySF+PA==",
-					"dev": true
-				},
 				"levn": {
 					"version": "0.4.1",
 					"resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
@@ -49798,53 +49069,11 @@
 						"type-check": "~0.4.0"
 					}
 				},
-				"meow": {
-					"version": "9.0.0",
-					"resolved": "https://registry.npmjs.org/meow/-/meow-9.0.0.tgz",
-					"integrity": "sha512-+obSblOQmRhcyBt62furQqRAQpNyWXo8BuQ5bN7dG8wmwQ+vwHKp/rCFD4CrTP8CsDQD1sjoZ94K417XEUk8IQ==",
-					"dev": true,
-					"requires": {
-						"@types/minimist": "^1.2.0",
-						"camelcase-keys": "^6.2.2",
-						"decamelize": "^1.2.0",
-						"decamelize-keys": "^1.1.0",
-						"hard-rejection": "^2.1.0",
-						"minimist-options": "4.1.0",
-						"normalize-package-data": "^3.0.0",
-						"read-pkg-up": "^7.0.1",
-						"redent": "^3.0.0",
-						"trim-newlines": "^3.0.0",
-						"type-fest": "^0.18.0",
-						"yargs-parser": "^20.2.3"
-					}
-				},
-				"micromatch": {
-					"version": "4.0.4",
-					"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.4.tgz",
-					"integrity": "sha512-pRmzw/XUcwXGpD9aI9q/0XOwLNygjETJ8y0ao0wdqprrzDa4YnxLcz7fQRZr8voh8V10kGhABbNcHVk5wHgWwg==",
-					"dev": true,
-					"requires": {
-						"braces": "^3.0.1",
-						"picomatch": "^2.2.3"
-					}
-				},
 				"ms": {
 					"version": "2.1.2",
 					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
 					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
 					"dev": true
-				},
-				"normalize-package-data": {
-					"version": "3.0.3",
-					"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-3.0.3.tgz",
-					"integrity": "sha512-p2W1sgqij3zMMyRC067Dg16bfzVH+w7hyegmpIvZ4JNjqtGOVAIvLmjBx3yP7YTe9vKJgkoNOPjwQGogDoMXFA==",
-					"dev": true,
-					"requires": {
-						"hosted-git-info": "^4.0.1",
-						"is-core-module": "^2.5.0",
-						"semver": "^7.3.4",
-						"validate-npm-package-license": "^3.0.1"
-					}
 				},
 				"optionator": {
 					"version": "0.9.1",
@@ -49874,13 +49103,6 @@
 					"requires": {
 						"postcss-selector-parser": "^6.0.8"
 					}
-				},
-				"postcss-safe-parser": {
-					"version": "6.0.0",
-					"resolved": "https://registry.npmjs.org/postcss-safe-parser/-/postcss-safe-parser-6.0.0.tgz",
-					"integrity": "sha512-FARHN8pwH+WiS2OPCxJI8FuRJpTVnn6ZNFiqAM2aeW2LwTHWWmWgIyKC6cUo0L8aeKiF/14MNvnpls6R2PBeMQ==",
-					"dev": true,
-					"requires": {}
 				},
 				"prelude-ls": {
 					"version": "1.2.1",
@@ -49912,23 +49134,6 @@
 					"integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
 					"dev": true
 				},
-				"slash": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
-					"integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
-					"dev": true
-				},
-				"string-width": {
-					"version": "4.2.3",
-					"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-					"integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-					"dev": true,
-					"requires": {
-						"emoji-regex": "^8.0.0",
-						"is-fullwidth-code-point": "^3.0.0",
-						"strip-ansi": "^6.0.1"
-					}
-				},
 				"strip-ansi": {
 					"version": "6.0.1",
 					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
@@ -49936,54 +49141,6 @@
 					"dev": true,
 					"requires": {
 						"ansi-regex": "^5.0.1"
-					}
-				},
-				"stylelint": {
-					"version": "14.3.0",
-					"resolved": "https://registry.npmjs.org/stylelint/-/stylelint-14.3.0.tgz",
-					"integrity": "sha512-PZXSwtJe4f4qBPWBwAbHL0M0Qjrv8iHN+cLpUNsffaVMS3YzpDDRI73+2lsqLAYfQEzxRwpll6BDKImREbpHWA==",
-					"dev": true,
-					"requires": {
-						"balanced-match": "^2.0.0",
-						"colord": "^2.9.2",
-						"cosmiconfig": "^7.0.1",
-						"debug": "^4.3.3",
-						"execall": "^2.0.0",
-						"fast-glob": "^3.2.11",
-						"fastest-levenshtein": "^1.0.12",
-						"file-entry-cache": "^6.0.1",
-						"get-stdin": "^8.0.0",
-						"global-modules": "^2.0.0",
-						"globby": "^11.1.0",
-						"globjoin": "^0.1.4",
-						"html-tags": "^3.1.0",
-						"ignore": "^5.2.0",
-						"import-lazy": "^4.0.0",
-						"imurmurhash": "^0.1.4",
-						"is-plain-object": "^5.0.0",
-						"known-css-properties": "^0.24.0",
-						"mathml-tag-names": "^2.1.3",
-						"meow": "^9.0.0",
-						"micromatch": "^4.0.4",
-						"normalize-path": "^3.0.0",
-						"normalize-selector": "^0.2.0",
-						"picocolors": "^1.0.0",
-						"postcss": "^8.4.5",
-						"postcss-media-query-parser": "^0.2.3",
-						"postcss-resolve-nested-selector": "^0.1.1",
-						"postcss-safe-parser": "^6.0.0",
-						"postcss-selector-parser": "^6.0.9",
-						"postcss-value-parser": "^4.2.0",
-						"resolve-from": "^5.0.0",
-						"specificity": "^0.4.1",
-						"string-width": "^4.2.3",
-						"strip-ansi": "^6.0.1",
-						"style-search": "^0.1.0",
-						"supports-hyperlinks": "^2.2.0",
-						"svg-tags": "^1.0.0",
-						"table": "^6.8.0",
-						"v8-compile-cache": "^2.3.0",
-						"write-file-atomic": "^4.0.0"
 					}
 				},
 				"stylelint-prettier": {
@@ -50004,15 +49161,6 @@
 						"has-flag": "^4.0.0"
 					}
 				},
-				"to-regex-range": {
-					"version": "5.0.1",
-					"resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
-					"integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-					"dev": true,
-					"requires": {
-						"is-number": "^7.0.0"
-					}
-				},
 				"type-check": {
 					"version": "0.4.0",
 					"resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
@@ -50022,18 +49170,6 @@
 						"prelude-ls": "^1.2.1"
 					}
 				},
-				"type-fest": {
-					"version": "0.18.1",
-					"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.18.1.tgz",
-					"integrity": "sha512-OIAYXk8+ISY+qTOwkHtKqzAuxchoMiD9Udx+FSGQDuiRR+PJKJHc2NJAXlbhkGwTt/4/nKZxELY1w3ReWOL8mw==",
-					"dev": true
-				},
-				"typedarray-to-buffer": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-4.0.0.tgz",
-					"integrity": "sha512-6dOYeZfS3O9RtRD1caom0sMxgK59b27+IwoNy8RDPsmslSGOyU+mpTamlaIW7aNKi90ZQZ9DFaZL3YRoiSCULQ==",
-					"dev": true
-				},
 				"which": {
 					"version": "2.0.2",
 					"resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -50041,18 +49177,6 @@
 					"dev": true,
 					"requires": {
 						"isexe": "^2.0.0"
-					}
-				},
-				"write-file-atomic": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-4.0.0.tgz",
-					"integrity": "sha512-JhcWoKffJNF7ivO9yflBhc7tn3wKnokMUfWpBriM9yCXj4ePQnRPcWglBkkg1AHC8nsW/EfxwwhqsLtOy59djA==",
-					"dev": true,
-					"requires": {
-						"imurmurhash": "^0.1.4",
-						"is-typedarray": "^1.0.0",
-						"signal-exit": "^3.0.2",
-						"typedarray-to-buffer": "^4.0.0"
 					}
 				}
 			}
@@ -50142,12 +49266,6 @@
 			"version": "0.1.2",
 			"resolved": "https://registry.npmjs.org/normalize-range/-/normalize-range-0.1.2.tgz",
 			"integrity": "sha1-LRDAa9/TEuqXd2laTShDlFa3WUI=",
-			"dev": true
-		},
-		"normalize-selector": {
-			"version": "0.2.0",
-			"resolved": "https://registry.npmjs.org/normalize-selector/-/normalize-selector-0.2.0.tgz",
-			"integrity": "sha1-0LFF62kRicY6eNIB3E/bEpPvDAM=",
 			"dev": true
 		},
 		"normalize-url": {
@@ -52259,11 +51377,15 @@
 				"path-key": "^2.0.0"
 			}
 		},
-		"num2fraction": {
-			"version": "1.2.2",
-			"resolved": "https://registry.npmjs.org/num2fraction/-/num2fraction-1.2.2.tgz",
-			"integrity": "sha1-b2gragJ6Tp3fpFZM0lidHU5mnt4=",
-			"dev": true
+		"nth-check": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
+			"integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
+			"dev": true,
+			"peer": true,
+			"requires": {
+				"boolbase": "^1.0.0"
+			}
 		},
 		"nwsapi": {
 			"version": "2.2.0",
@@ -52536,20 +51658,6 @@
 				"callsites": "^3.0.0"
 			}
 		},
-		"parse-entities": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-2.0.0.tgz",
-			"integrity": "sha512-kkywGpCcRYhqQIchaWqZ875wzpS/bMKhz5HnN3p7wveJTkTtyAB/AlnS0f8DFSqYW1T82t6yEAkEcB+A1I3MbQ==",
-			"dev": true,
-			"requires": {
-				"character-entities": "^1.0.0",
-				"character-entities-legacy": "^1.0.0",
-				"character-reference-invalid": "^1.0.0",
-				"is-alphanumerical": "^1.0.0",
-				"is-decimal": "^1.0.0",
-				"is-hexadecimal": "^1.0.0"
-			}
-		},
 		"parse-json": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
@@ -52571,6 +51679,53 @@
 			"resolved": "https://registry.npmjs.org/parse5/-/parse5-6.0.1.tgz",
 			"integrity": "sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw==",
 			"dev": true
+		},
+		"parse5-htmlparser2-tree-adapter": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/parse5-htmlparser2-tree-adapter/-/parse5-htmlparser2-tree-adapter-7.0.0.tgz",
+			"integrity": "sha512-B77tOZrqqfUfnVcOrUvfdLbz4pu4RopLD/4vmu3HUPswwTA8OH0EMW9BlWR2B0RCoiZRAHEUu7IxeP1Pd1UU+g==",
+			"dev": true,
+			"peer": true,
+			"requires": {
+				"domhandler": "^5.0.2",
+				"parse5": "^7.0.0"
+			},
+			"dependencies": {
+				"domelementtype": {
+					"version": "2.3.0",
+					"resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+					"integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
+					"dev": true,
+					"peer": true
+				},
+				"domhandler": {
+					"version": "5.0.3",
+					"resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+					"integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+					"dev": true,
+					"peer": true,
+					"requires": {
+						"domelementtype": "^2.3.0"
+					}
+				},
+				"entities": {
+					"version": "4.3.1",
+					"resolved": "https://registry.npmjs.org/entities/-/entities-4.3.1.tgz",
+					"integrity": "sha512-o4q/dYJlmyjP2zfnaWDUC6A3BQFmVTX+tZPezK7k0GLSU9QYCauscf5Y+qcEPzKL+EixVouYDgLQK5H9GrLpkg==",
+					"dev": true,
+					"peer": true
+				},
+				"parse5": {
+					"version": "7.0.0",
+					"resolved": "https://registry.npmjs.org/parse5/-/parse5-7.0.0.tgz",
+					"integrity": "sha512-y/t8IXSPWTuRZqXc0ajH/UwDj4mnqLEbSttNbThcFhGrZuOyoyvNBO85PBp2jQa55wY9d07PBNjsK8ZP3K5U6g==",
+					"dev": true,
+					"peer": true,
+					"requires": {
+						"entities": "^4.3.0"
+					}
+				}
+			}
 		},
 		"parserlib": {
 			"version": "1.1.1",
@@ -53023,48 +52178,6 @@
 			"dev": true,
 			"requires": {
 				"postcss": "^7.0.0"
-			},
-			"dependencies": {
-				"picocolors": {
-					"version": "0.2.1",
-					"resolved": "https://registry.npmjs.org/picocolors/-/picocolors-0.2.1.tgz",
-					"integrity": "sha512-cMlDqaLEqfSaW8Z7N5Jw+lyIW869EzT73/F5lhtY9cLGoVxSXznfgfXMO0Z5K0o0Q2TkTXq+0KFsdnSe3jDViA==",
-					"dev": true
-				},
-				"postcss": {
-					"version": "7.0.39",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.39.tgz",
-					"integrity": "sha512-yioayjNbHn6z1/Bywyb2Y4s3yvDAeXGOyxqD+LnVOinq6Mdmd++SW2wUNVzavyyHxd6+DxzWGIuosg6P1Rj8uA==",
-					"dev": true,
-					"requires": {
-						"picocolors": "^0.2.1",
-						"source-map": "^0.6.1"
-					}
-				},
-				"source-map": {
-					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-					"dev": true
-				}
-			}
-		},
-		"postcss-html": {
-			"version": "0.36.0",
-			"resolved": "https://registry.npmjs.org/postcss-html/-/postcss-html-0.36.0.tgz",
-			"integrity": "sha512-HeiOxGcuwID0AFsNAL0ox3mW6MHH5cstWN1Z3Y+n6H+g12ih7LHdYxWwEA/QmrebctLjo79xz9ouK3MroHwOJw==",
-			"dev": true,
-			"requires": {
-				"htmlparser2": "^3.10.0"
-			}
-		},
-		"postcss-less": {
-			"version": "3.1.4",
-			"resolved": "https://registry.npmjs.org/postcss-less/-/postcss-less-3.1.4.tgz",
-			"integrity": "sha512-7TvleQWNM2QLcHqvudt3VYjULVB49uiW6XzEUFmvwHzvsOEF5MwBrIXZDJQvJNFGjJQTzSzZnDoCJ8h/ljyGXA==",
-			"dev": true,
-			"requires": {
-				"postcss": "^7.0.14"
 			},
 			"dependencies": {
 				"picocolors": {
@@ -53908,109 +53021,23 @@
 			"dev": true
 		},
 		"postcss-safe-parser": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/postcss-safe-parser/-/postcss-safe-parser-4.0.2.tgz",
-			"integrity": "sha512-Uw6ekxSWNLCPesSv/cmqf2bY/77z11O7jZGPax3ycZMFU/oi2DMH9i89AdHc1tRwFg/arFoEwX0IS3LCUxJh1g==",
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/postcss-safe-parser/-/postcss-safe-parser-6.0.0.tgz",
+			"integrity": "sha512-FARHN8pwH+WiS2OPCxJI8FuRJpTVnn6ZNFiqAM2aeW2LwTHWWmWgIyKC6cUo0L8aeKiF/14MNvnpls6R2PBeMQ==",
 			"dev": true,
-			"requires": {
-				"postcss": "^7.0.26"
-			},
-			"dependencies": {
-				"picocolors": {
-					"version": "0.2.1",
-					"resolved": "https://registry.npmjs.org/picocolors/-/picocolors-0.2.1.tgz",
-					"integrity": "sha512-cMlDqaLEqfSaW8Z7N5Jw+lyIW869EzT73/F5lhtY9cLGoVxSXznfgfXMO0Z5K0o0Q2TkTXq+0KFsdnSe3jDViA==",
-					"dev": true
-				},
-				"postcss": {
-					"version": "7.0.39",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.39.tgz",
-					"integrity": "sha512-yioayjNbHn6z1/Bywyb2Y4s3yvDAeXGOyxqD+LnVOinq6Mdmd++SW2wUNVzavyyHxd6+DxzWGIuosg6P1Rj8uA==",
-					"dev": true,
-					"requires": {
-						"picocolors": "^0.2.1",
-						"source-map": "^0.6.1"
-					}
-				},
-				"source-map": {
-					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-					"dev": true
-				}
-			}
-		},
-		"postcss-sass": {
-			"version": "0.4.4",
-			"resolved": "https://registry.npmjs.org/postcss-sass/-/postcss-sass-0.4.4.tgz",
-			"integrity": "sha512-BYxnVYx4mQooOhr+zer0qWbSPYnarAy8ZT7hAQtbxtgVf8gy+LSLT/hHGe35h14/pZDTw1DsxdbrwxBN++H+fg==",
-			"dev": true,
-			"requires": {
-				"gonzales-pe": "^4.3.0",
-				"postcss": "^7.0.21"
-			},
-			"dependencies": {
-				"picocolors": {
-					"version": "0.2.1",
-					"resolved": "https://registry.npmjs.org/picocolors/-/picocolors-0.2.1.tgz",
-					"integrity": "sha512-cMlDqaLEqfSaW8Z7N5Jw+lyIW869EzT73/F5lhtY9cLGoVxSXznfgfXMO0Z5K0o0Q2TkTXq+0KFsdnSe3jDViA==",
-					"dev": true
-				},
-				"postcss": {
-					"version": "7.0.39",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.39.tgz",
-					"integrity": "sha512-yioayjNbHn6z1/Bywyb2Y4s3yvDAeXGOyxqD+LnVOinq6Mdmd++SW2wUNVzavyyHxd6+DxzWGIuosg6P1Rj8uA==",
-					"dev": true,
-					"requires": {
-						"picocolors": "^0.2.1",
-						"source-map": "^0.6.1"
-					}
-				},
-				"source-map": {
-					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-					"dev": true
-				}
-			}
+			"requires": {}
 		},
 		"postcss-scss": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/postcss-scss/-/postcss-scss-2.1.1.tgz",
-			"integrity": "sha512-jQmGnj0hSGLd9RscFw9LyuSVAa5Bl1/KBPqG1NQw9w8ND55nY4ZEsdlVuYJvLPpV+y0nwTV5v/4rHPzZRihQbA==",
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/postcss-scss/-/postcss-scss-4.0.4.tgz",
+			"integrity": "sha512-aBBbVyzA8b3hUL0MGrpydxxXKXFZc5Eqva0Q3V9qsBOLEMsjb6w49WfpsoWzpEgcqJGW4t7Rio8WXVU9Gd8vWg==",
 			"dev": true,
-			"requires": {
-				"postcss": "^7.0.6"
-			},
-			"dependencies": {
-				"picocolors": {
-					"version": "0.2.1",
-					"resolved": "https://registry.npmjs.org/picocolors/-/picocolors-0.2.1.tgz",
-					"integrity": "sha512-cMlDqaLEqfSaW8Z7N5Jw+lyIW869EzT73/F5lhtY9cLGoVxSXznfgfXMO0Z5K0o0Q2TkTXq+0KFsdnSe3jDViA==",
-					"dev": true
-				},
-				"postcss": {
-					"version": "7.0.39",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.39.tgz",
-					"integrity": "sha512-yioayjNbHn6z1/Bywyb2Y4s3yvDAeXGOyxqD+LnVOinq6Mdmd++SW2wUNVzavyyHxd6+DxzWGIuosg6P1Rj8uA==",
-					"dev": true,
-					"requires": {
-						"picocolors": "^0.2.1",
-						"source-map": "^0.6.1"
-					}
-				},
-				"source-map": {
-					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-					"dev": true
-				}
-			}
+			"requires": {}
 		},
 		"postcss-selector-parser": {
-			"version": "6.0.9",
-			"resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.9.tgz",
-			"integrity": "sha512-UO3SgnZOVTwu4kyLR22UQ1xZh086RyNZppb7lLAKBFK8a32ttG5i87Y/P3+2bRSjZNyJ1B7hfFNo273tKe9YxQ==",
+			"version": "6.0.10",
+			"resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.10.tgz",
+			"integrity": "sha512-IQ7TZdoaqbT+LCpShg46jnZVlhWD2w6iQYAcYXfHARZ7X1t/UGhhceQDs5X0cGqKvYlHNOuv7Oa1xmb0oQuA3w==",
 			"dev": true,
 			"requires": {
 				"cssesc": "^3.0.0",
@@ -54057,13 +53084,6 @@
 					"dev": true
 				}
 			}
-		},
-		"postcss-syntax": {
-			"version": "0.36.2",
-			"resolved": "https://registry.npmjs.org/postcss-syntax/-/postcss-syntax-0.36.2.tgz",
-			"integrity": "sha512-nBRg/i7E3SOHWxF3PpF5WnJM/jQ1YpY9000OaVXlAQj6Zp/kIqJxEDWIZ67tAd7NLuk7zqN4yqe9nc0oNAOs1w==",
-			"dev": true,
-			"requires": {}
 		},
 		"postcss-unique-selectors": {
 			"version": "4.0.1",
@@ -54154,9 +53174,9 @@
 			"dev": true
 		},
 		"prettier": {
-			"version": "npm:wp-prettier@2.2.1-beta-1",
-			"resolved": "https://registry.npmjs.org/wp-prettier/-/wp-prettier-2.2.1-beta-1.tgz",
-			"integrity": "sha512-+JHkqs9LC/JPp51yy1hzs3lQ7qeuWCwOcSzpQNeeY/G7oSpnF61vxt7hRh87zNRTr6ob2ndy0W8rVzhgrcA+Gw==",
+			"version": "npm:wp-prettier@2.6.2",
+			"resolved": "https://registry.npmjs.org/wp-prettier/-/wp-prettier-2.6.2.tgz",
+			"integrity": "sha512-AV33EzqiFJ3fj+mPlKABN59YFPReLkDxQnj067Z3uEOeRQf3g05WprL0RDuqM7UBhSRo9W1rMSC2KvZmjE5UOA==",
 			"dev": true
 		},
 		"prettier-linter-helpers": {
@@ -54305,6 +53325,34 @@
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-4.0.1.tgz",
 			"integrity": "sha512-ARhCpm70fzdcvNQfPoy49IaanKkTlRWF2JMzqhcJbhSFRZv7nPTvZJdcY7301IPmvW+/p0RgIWnQDLJxifsQ7g=="
+		},
+		"raf": {
+			"version": "3.4.1",
+			"resolved": "https://registry.npmjs.org/raf/-/raf-3.4.1.tgz",
+			"integrity": "sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA==",
+			"dev": true,
+			"peer": true,
+			"requires": {
+				"performance-now": "^2.1.0"
+			}
+		},
+		"railroad-diagrams": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/railroad-diagrams/-/railroad-diagrams-1.0.0.tgz",
+			"integrity": "sha512-cz93DjNeLY0idrCNOH6PviZGRN9GJhsdm9hpn1YCS879fj4W+x5IFJhhkRZcwVgMmFF7R82UA/7Oh+R8lLZg6A==",
+			"dev": true,
+			"peer": true
+		},
+		"randexp": {
+			"version": "0.4.6",
+			"resolved": "https://registry.npmjs.org/randexp/-/randexp-0.4.6.tgz",
+			"integrity": "sha512-80WNmd9DA0tmZrw9qQa62GPPWfuXJknrmVmLcxvq4uZBdYqb1wYoKTmnlGUchvVWe0XiLupYkBoXVOxz3C8DYQ==",
+			"dev": true,
+			"peer": true,
+			"requires": {
+				"discontinuous-range": "1.0.0",
+				"ret": "~0.1.10"
+			}
 		},
 		"randombytes": {
 			"version": "2.1.0",
@@ -54833,13 +53881,13 @@
 			}
 		},
 		"regexp.prototype.flags": {
-			"version": "1.4.1",
-			"resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.4.1.tgz",
-			"integrity": "sha512-pMR7hBVUUGI7PMA37m2ofIdQCsomVnas+Jn5UPGAHQ+/LlwKm/aTLJHdasmHRzlfeZwHiAOaRSo2rbBDm3nNUQ==",
-			"dev": true,
+			"version": "1.4.3",
+			"resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.4.3.tgz",
+			"integrity": "sha512-fjggEOO3slI6Wvgjwflkc4NFRCTZAu5CnNfBd5qOMYhWdn67nJBBu34/TkD++eeFmd8C9r9jfXJ27+nSiRkSUA==",
 			"requires": {
 				"call-bind": "^1.0.2",
-				"define-properties": "^1.1.3"
+				"define-properties": "^1.1.3",
+				"functions-have-names": "^1.2.2"
 			}
 		},
 		"regexpp": {
@@ -54898,35 +53946,6 @@
 					"integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0=",
 					"dev": true
 				}
-			}
-		},
-		"remark": {
-			"version": "13.0.0",
-			"resolved": "https://registry.npmjs.org/remark/-/remark-13.0.0.tgz",
-			"integrity": "sha512-HDz1+IKGtOyWN+QgBiAT0kn+2s6ovOxHyPAFGKVE81VSzJ+mq7RwHFledEvB5F1p4iJvOah/LOKdFuzvRnNLCA==",
-			"dev": true,
-			"requires": {
-				"remark-parse": "^9.0.0",
-				"remark-stringify": "^9.0.0",
-				"unified": "^9.1.0"
-			}
-		},
-		"remark-parse": {
-			"version": "9.0.0",
-			"resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-9.0.0.tgz",
-			"integrity": "sha512-geKatMwSzEXKHuzBNU1z676sGcDcFoChMK38TgdHJNAYfFtsfHDQG7MoJAjs6sgYMqyLduCYWDIWZIxiPeafEw==",
-			"dev": true,
-			"requires": {
-				"mdast-util-from-markdown": "^0.8.0"
-			}
-		},
-		"remark-stringify": {
-			"version": "9.0.1",
-			"resolved": "https://registry.npmjs.org/remark-stringify/-/remark-stringify-9.0.1.tgz",
-			"integrity": "sha512-mWmNg3ZtESvZS8fv5PTvaPckdL4iNlCHTt8/e/8oN08nArHRHjNZMKzA/YW3+p7/lYqIw4nx1XsjCBo/AxNChg==",
-			"dev": true,
-			"requires": {
-				"mdast-util-to-markdown": "^0.6.0"
 			}
 		},
 		"rememo": {
@@ -55171,6 +54190,17 @@
 			"dev": true,
 			"requires": {
 				"glob": "^7.1.3"
+			}
+		},
+		"rst-selector-parser": {
+			"version": "2.2.3",
+			"resolved": "https://registry.npmjs.org/rst-selector-parser/-/rst-selector-parser-2.2.3.tgz",
+			"integrity": "sha512-nDG1rZeP6oFTLN6yNDV/uiAvs1+FS/KlrEwh7+y7dpuApDBy6bI2HTBcc0/V8lv9OTqfyD34eF7au2pm8aBbhA==",
+			"dev": true,
+			"peer": true,
+			"requires": {
+				"lodash.flattendeep": "^4.4.0",
+				"nearley": "^2.7.10"
 			}
 		},
 		"rsvp": {
@@ -55992,12 +55022,6 @@
 			"resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.5.tgz",
 			"integrity": "sha512-J+FWzZoynJEXGphVIS+XEh3kFSjZX/1i9gFBaWQcB+/tmpe2qUsSBABpcxqxnAxFdiUFEgAX1bjYGQvIZmoz9Q=="
 		},
-		"specificity": {
-			"version": "0.4.1",
-			"resolved": "https://registry.npmjs.org/specificity/-/specificity-0.4.1.tgz",
-			"integrity": "sha512-1klA3Gi5PD1Wv9Q0wUoOQN1IWAuPu0D1U03ThXTr0cJ20+/iq2tHSDnK7Kk/0LXJ1ztUB2/1Os0wKmfyNgUQfg==",
-			"dev": true
-		},
 		"split": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/split/-/split-1.0.1.tgz",
@@ -56196,22 +55220,36 @@
 				"side-channel": "^1.0.4"
 			}
 		},
-		"string.prototype.trimend": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.4.tgz",
-			"integrity": "sha512-y9xCjw1P23Awk8EvTpcyL2NIr1j7wJ39f+k6lvRnSMz+mz9CGz9NYPelDk42kOz6+ql8xjfK8oYzy3jAP5QU5A==",
+		"string.prototype.trim": {
+			"version": "1.2.6",
+			"resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.6.tgz",
+			"integrity": "sha512-8lMR2m+U0VJTPp6JjvJTtGyc4FIGq9CdRt7O9p6T0e6K4vjU+OP+SQJpbe/SBmRcCUIvNUnjsbmY6lnMp8MhsQ==",
+			"dev": true,
+			"peer": true,
 			"requires": {
 				"call-bind": "^1.0.2",
-				"define-properties": "^1.1.3"
+				"define-properties": "^1.1.4",
+				"es-abstract": "^1.19.5"
+			}
+		},
+		"string.prototype.trimend": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.5.tgz",
+			"integrity": "sha512-I7RGvmjV4pJ7O3kdf+LXFpVfdNOxtCW/2C8f6jNiW4+PQchwxkCDzlk1/7p+Wl4bqFIZeF47qAHXLuHHWKAxog==",
+			"requires": {
+				"call-bind": "^1.0.2",
+				"define-properties": "^1.1.4",
+				"es-abstract": "^1.19.5"
 			}
 		},
 		"string.prototype.trimstart": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.4.tgz",
-			"integrity": "sha512-jh6e984OBfvxS50tdY2nRZnoC5/mLFKOREQfw8t5yytkoUsJRNxvI/E39qu1sD0OtWI3OC0XgKSmcWwziwYuZw==",
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.5.tgz",
+			"integrity": "sha512-THx16TJCGlsN0o6dl2o6ncWUsdgnLRSA23rRE5pyGBw/mLr3Ej/R2LaqCtgP8VNMGZsvMWnf9ooZPyY2bHvUFg==",
 			"requires": {
 				"call-bind": "^1.0.2",
-				"define-properties": "^1.1.3"
+				"define-properties": "^1.1.4",
+				"es-abstract": "^1.19.5"
 			}
 		},
 		"strip-ansi": {
@@ -56323,59 +55361,51 @@
 			}
 		},
 		"stylelint": {
-			"version": "13.13.1",
-			"resolved": "https://registry.npmjs.org/stylelint/-/stylelint-13.13.1.tgz",
-			"integrity": "sha512-Mv+BQr5XTUrKqAXmpqm6Ddli6Ief+AiPZkRsIrAoUKFuq/ElkUh9ZMYxXD0iQNZ5ADghZKLOWz1h7hTClB7zgQ==",
+			"version": "14.9.1",
+			"resolved": "https://registry.npmjs.org/stylelint/-/stylelint-14.9.1.tgz",
+			"integrity": "sha512-RdAkJdPiLqHawCSnu21nE27MjNXaVd4WcOHA4vK5GtIGjScfhNnaOuWR2wWdfKFAvcWQPOYe311iveiVKSmwsA==",
 			"dev": true,
 			"requires": {
-				"@stylelint/postcss-css-in-js": "^0.37.2",
-				"@stylelint/postcss-markdown": "^0.36.2",
-				"autoprefixer": "^9.8.6",
+				"@csstools/selector-specificity": "^2.0.1",
 				"balanced-match": "^2.0.0",
-				"chalk": "^4.1.1",
-				"cosmiconfig": "^7.0.0",
-				"debug": "^4.3.1",
+				"colord": "^2.9.2",
+				"cosmiconfig": "^7.0.1",
+				"css-functions-list": "^3.1.0",
+				"debug": "^4.3.4",
 				"execall": "^2.0.0",
-				"fast-glob": "^3.2.5",
+				"fast-glob": "^3.2.11",
 				"fastest-levenshtein": "^1.0.12",
 				"file-entry-cache": "^6.0.1",
 				"get-stdin": "^8.0.0",
 				"global-modules": "^2.0.0",
-				"globby": "^11.0.3",
+				"globby": "^11.1.0",
 				"globjoin": "^0.1.4",
-				"html-tags": "^3.1.0",
-				"ignore": "^5.1.8",
+				"html-tags": "^3.2.0",
+				"ignore": "^5.2.0",
 				"import-lazy": "^4.0.0",
 				"imurmurhash": "^0.1.4",
-				"known-css-properties": "^0.21.0",
-				"lodash": "^4.17.21",
-				"log-symbols": "^4.1.0",
+				"is-plain-object": "^5.0.0",
+				"known-css-properties": "^0.25.0",
 				"mathml-tag-names": "^2.1.3",
 				"meow": "^9.0.0",
-				"micromatch": "^4.0.4",
-				"normalize-selector": "^0.2.0",
-				"postcss": "^7.0.35",
-				"postcss-html": "^0.36.0",
-				"postcss-less": "^3.1.4",
+				"micromatch": "^4.0.5",
+				"normalize-path": "^3.0.0",
+				"picocolors": "^1.0.0",
+				"postcss": "^8.4.14",
 				"postcss-media-query-parser": "^0.2.3",
 				"postcss-resolve-nested-selector": "^0.1.1",
-				"postcss-safe-parser": "^4.0.2",
-				"postcss-sass": "^0.4.4",
-				"postcss-scss": "^2.1.1",
-				"postcss-selector-parser": "^6.0.5",
-				"postcss-syntax": "^0.36.2",
-				"postcss-value-parser": "^4.1.0",
+				"postcss-safe-parser": "^6.0.0",
+				"postcss-selector-parser": "^6.0.10",
+				"postcss-value-parser": "^4.2.0",
 				"resolve-from": "^5.0.0",
-				"slash": "^3.0.0",
-				"specificity": "^0.4.1",
-				"string-width": "^4.2.2",
-				"strip-ansi": "^6.0.0",
+				"string-width": "^4.2.3",
+				"strip-ansi": "^6.0.1",
 				"style-search": "^0.1.0",
-				"sugarss": "^2.0.0",
+				"supports-hyperlinks": "^2.2.0",
 				"svg-tags": "^1.0.0",
-				"table": "^6.6.0",
+				"table": "^6.8.0",
 				"v8-compile-cache": "^2.3.0",
-				"write-file-atomic": "^3.0.3"
+				"write-file-atomic": "^4.0.1"
 			},
 			"dependencies": {
 				"ansi-regex": {
@@ -56383,15 +55413,6 @@
 					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
 					"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
 					"dev": true
-				},
-				"ansi-styles": {
-					"version": "4.3.0",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-					"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-					"dev": true,
-					"requires": {
-						"color-convert": "^2.0.1"
-					}
 				},
 				"array-union": {
 					"version": "2.1.0",
@@ -56414,35 +55435,10 @@
 						"fill-range": "^7.0.1"
 					}
 				},
-				"chalk": {
-					"version": "4.1.2",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-					"integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-					"dev": true,
-					"requires": {
-						"ansi-styles": "^4.1.0",
-						"supports-color": "^7.1.0"
-					}
-				},
-				"color-convert": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-					"dev": true,
-					"requires": {
-						"color-name": "~1.1.4"
-					}
-				},
-				"color-name": {
-					"version": "1.1.4",
-					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-					"dev": true
-				},
 				"debug": {
-					"version": "4.3.2",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
-					"integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
+					"version": "4.3.4",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+					"integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
 					"dev": true,
 					"requires": {
 						"ms": "2.1.2"
@@ -56464,24 +55460,18 @@
 					}
 				},
 				"globby": {
-					"version": "11.0.4",
-					"resolved": "https://registry.npmjs.org/globby/-/globby-11.0.4.tgz",
-					"integrity": "sha512-9O4MVG9ioZJ08ffbcyVYyLOJLk5JQ688pJ4eMGLpdWLHq/Wr1D9BlriLQyL0E+jbkuePVZXYFj47QM/v093wHg==",
+					"version": "11.1.0",
+					"resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
+					"integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
 					"dev": true,
 					"requires": {
 						"array-union": "^2.1.0",
 						"dir-glob": "^3.0.1",
-						"fast-glob": "^3.1.1",
-						"ignore": "^5.1.4",
-						"merge2": "^1.3.0",
+						"fast-glob": "^3.2.9",
+						"ignore": "^5.2.0",
+						"merge2": "^1.4.1",
 						"slash": "^3.0.0"
 					}
-				},
-				"has-flag": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-					"dev": true
 				},
 				"hosted-git-info": {
 					"version": "4.1.0",
@@ -56493,9 +55483,9 @@
 					}
 				},
 				"ignore": {
-					"version": "5.1.9",
-					"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.9.tgz",
-					"integrity": "sha512-2zeMQpbKz5dhZ9IwL0gbxSW5w0NK/MSAMtNuhgIHEPmaU3vPdKPL0UdvUCXs5SS4JAwsBxysK5sFMW8ocFiVjQ==",
+					"version": "5.2.0",
+					"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.0.tgz",
+					"integrity": "sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==",
 					"dev": true
 				},
 				"is-fullwidth-code-point": {
@@ -56508,6 +55498,12 @@
 					"version": "7.0.0",
 					"resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
 					"integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+					"dev": true
+				},
+				"is-plain-object": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
+					"integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
 					"dev": true
 				},
 				"meow": {
@@ -56531,13 +55527,13 @@
 					}
 				},
 				"micromatch": {
-					"version": "4.0.4",
-					"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.4.tgz",
-					"integrity": "sha512-pRmzw/XUcwXGpD9aI9q/0XOwLNygjETJ8y0ao0wdqprrzDa4YnxLcz7fQRZr8voh8V10kGhABbNcHVk5wHgWwg==",
+					"version": "4.0.5",
+					"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
+					"integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
 					"dev": true,
 					"requires": {
-						"braces": "^3.0.1",
-						"picomatch": "^2.2.3"
+						"braces": "^3.0.2",
+						"picomatch": "^2.3.1"
 					}
 				},
 				"ms": {
@@ -56558,22 +55554,6 @@
 						"validate-npm-package-license": "^3.0.1"
 					}
 				},
-				"picocolors": {
-					"version": "0.2.1",
-					"resolved": "https://registry.npmjs.org/picocolors/-/picocolors-0.2.1.tgz",
-					"integrity": "sha512-cMlDqaLEqfSaW8Z7N5Jw+lyIW869EzT73/F5lhtY9cLGoVxSXznfgfXMO0Z5K0o0Q2TkTXq+0KFsdnSe3jDViA==",
-					"dev": true
-				},
-				"postcss": {
-					"version": "7.0.39",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.39.tgz",
-					"integrity": "sha512-yioayjNbHn6z1/Bywyb2Y4s3yvDAeXGOyxqD+LnVOinq6Mdmd++SW2wUNVzavyyHxd6+DxzWGIuosg6P1Rj8uA==",
-					"dev": true,
-					"requires": {
-						"picocolors": "^0.2.1",
-						"source-map": "^0.6.1"
-					}
-				},
 				"semver": {
 					"version": "7.3.5",
 					"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
@@ -56587,12 +55567,6 @@
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
 					"integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
-					"dev": true
-				},
-				"source-map": {
-					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
 					"dev": true
 				},
 				"string-width": {
@@ -56615,15 +55589,6 @@
 						"ansi-regex": "^5.0.1"
 					}
 				},
-				"supports-color": {
-					"version": "7.2.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-					"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-					"dev": true,
-					"requires": {
-						"has-flag": "^4.0.0"
-					}
-				},
 				"to-regex-range": {
 					"version": "5.0.1",
 					"resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -56638,6 +55603,16 @@
 					"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.18.1.tgz",
 					"integrity": "sha512-OIAYXk8+ISY+qTOwkHtKqzAuxchoMiD9Udx+FSGQDuiRR+PJKJHc2NJAXlbhkGwTt/4/nKZxELY1w3ReWOL8mw==",
 					"dev": true
+				},
+				"write-file-atomic": {
+					"version": "4.0.1",
+					"resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-4.0.1.tgz",
+					"integrity": "sha512-nSKUxgAbyioruk6hU87QzVbY279oYT6uiwgDoujth2ju4mJ+TZau7SQBhtbTmUyuNYTuXnSyRn66FV0+eCgcrQ==",
+					"dev": true,
+					"requires": {
+						"imurmurhash": "^0.1.4",
+						"signal-exit": "^3.0.7"
+					}
 				}
 			}
 		},
@@ -56649,31 +55624,33 @@
 			"requires": {}
 		},
 		"stylelint-config-recommended": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/stylelint-config-recommended/-/stylelint-config-recommended-3.0.0.tgz",
-			"integrity": "sha512-F6yTRuc06xr1h5Qw/ykb2LuFynJ2IxkKfCMf+1xqPffkxh0S09Zc902XCffcsw/XMFq/OzQ1w54fLIDtmRNHnQ==",
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/stylelint-config-recommended/-/stylelint-config-recommended-6.0.0.tgz",
+			"integrity": "sha512-ZorSSdyMcxWpROYUvLEMm0vSZud2uB7tX1hzBZwvVY9SV/uly4AvvJPPhCcymZL3fcQhEQG5AELmrxWqtmzacw==",
 			"dev": true,
 			"requires": {}
 		},
 		"stylelint-config-recommended-scss": {
-			"version": "4.2.0",
-			"resolved": "https://registry.npmjs.org/stylelint-config-recommended-scss/-/stylelint-config-recommended-scss-4.2.0.tgz",
-			"integrity": "sha512-4bI5BYbabo/GCQ6LbRZx/ZlVkK65a1jivNNsD+ix/Lw0U3iAch+jQcvliGnnAX8SUPaZ0UqzNVNNAF3urswa7g==",
+			"version": "5.0.2",
+			"resolved": "https://registry.npmjs.org/stylelint-config-recommended-scss/-/stylelint-config-recommended-scss-5.0.2.tgz",
+			"integrity": "sha512-b14BSZjcwW0hqbzm9b0S/ScN2+3CO3O4vcMNOw2KGf8lfVSwJ4p5TbNEXKwKl1+0FMtgRXZj6DqVUe/7nGnuBg==",
 			"dev": true,
 			"requires": {
-				"stylelint-config-recommended": "^3.0.0"
+				"postcss-scss": "^4.0.2",
+				"stylelint-config-recommended": "^6.0.0",
+				"stylelint-scss": "^4.0.0"
 			}
 		},
 		"stylelint-scss": {
-			"version": "3.20.1",
-			"resolved": "https://registry.npmjs.org/stylelint-scss/-/stylelint-scss-3.20.1.tgz",
-			"integrity": "sha512-OTd55O1TTAC5nGKkVmUDLpz53LlK39R3MImv1CfuvsK7/qugktqiZAeQLuuC4UBhzxCnsc7fp9u/gfRZwFAIkA==",
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/stylelint-scss/-/stylelint-scss-4.3.0.tgz",
+			"integrity": "sha512-GvSaKCA3tipzZHoz+nNO7S02ZqOsdBzMiCx9poSmLlb3tdJlGddEX/8QzCOD8O7GQan9bjsvLMsO5xiw6IhhIQ==",
 			"dev": true,
 			"requires": {
-				"lodash": "^4.17.15",
+				"lodash": "^4.17.21",
 				"postcss-media-query-parser": "^0.2.3",
 				"postcss-resolve-nested-selector": "^0.1.1",
-				"postcss-selector-parser": "^6.0.2",
+				"postcss-selector-parser": "^6.0.6",
 				"postcss-value-parser": "^4.1.0"
 			}
 		},
@@ -56681,39 +55658,6 @@
 			"version": "4.0.10",
 			"resolved": "https://registry.npmjs.org/stylis/-/stylis-4.0.10.tgz",
 			"integrity": "sha512-m3k+dk7QeJw660eIKRRn3xPF6uuvHs/FFzjX3HQ5ove0qYsiygoAhwn5a3IYKaZPo5LrYD0rfVmtv1gNY1uYwg=="
-		},
-		"sugarss": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/sugarss/-/sugarss-2.0.0.tgz",
-			"integrity": "sha512-WfxjozUk0UVA4jm+U1d736AUpzSrNsQcIbyOkoE364GrtWmIrFdk5lksEupgWMD4VaT/0kVx1dobpiDumSgmJQ==",
-			"dev": true,
-			"requires": {
-				"postcss": "^7.0.2"
-			},
-			"dependencies": {
-				"picocolors": {
-					"version": "0.2.1",
-					"resolved": "https://registry.npmjs.org/picocolors/-/picocolors-0.2.1.tgz",
-					"integrity": "sha512-cMlDqaLEqfSaW8Z7N5Jw+lyIW869EzT73/F5lhtY9cLGoVxSXznfgfXMO0Z5K0o0Q2TkTXq+0KFsdnSe3jDViA==",
-					"dev": true
-				},
-				"postcss": {
-					"version": "7.0.39",
-					"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.39.tgz",
-					"integrity": "sha512-yioayjNbHn6z1/Bywyb2Y4s3yvDAeXGOyxqD+LnVOinq6Mdmd++SW2wUNVzavyyHxd6+DxzWGIuosg6P1Rj8uA==",
-					"dev": true,
-					"requires": {
-						"picocolors": "^0.2.1",
-						"source-map": "^0.6.1"
-					}
-				},
-				"source-map": {
-					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-					"dev": true
-				}
-			}
 		},
 		"supports-color": {
 			"version": "5.5.0",
@@ -57093,14 +56037,6 @@
 				"acorn": "^8.5.0",
 				"commander": "^2.20.0",
 				"source-map-support": "~0.5.20"
-			},
-			"dependencies": {
-				"acorn": {
-					"version": "8.7.1",
-					"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.7.1.tgz",
-					"integrity": "sha512-Xx54uLJQZ19lKygFXOWsscKUbsBZW0CPykPhVQdhIeIwrbPmJzqeASDInc8nKBnp/JT6igTs82qPXz069H8I/A==",
-					"dev": true
-				}
 			}
 		},
 		"terser-webpack-plugin": {
@@ -57324,12 +56260,6 @@
 			"resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-3.0.1.tgz",
 			"integrity": "sha512-c1PTsA3tYrIsLGkJkzHF+w9F2EyxfXGo4UyJc4pFL++FMjnq0HJS69T3M7d//gKrFKwy429bouPescbjecU+Zw=="
 		},
-		"trough": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/trough/-/trough-1.0.5.tgz",
-			"integrity": "sha512-rvuRbTarPXmMb79SmzEp8aqXNKcK+y0XaB298IXueQ8I2PsrATcPBCSPyK/dDNa2iWOhKlfNnOjdAOTBU/nkFA==",
-			"dev": true
-		},
 		"ts-node": {
 			"version": "9.1.1",
 			"resolved": "https://registry.npmjs.org/ts-node/-/ts-node-9.1.1.tgz",
@@ -57443,13 +56373,13 @@
 			"optional": true
 		},
 		"unbox-primitive": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.1.tgz",
-			"integrity": "sha512-tZU/3NqK3dA5gpE1KtyiJUrEB0lxnGkMFHptJ7q6ewdZ8s12QrODwNbhIJStmJkd1QDXa1NRA8aF2A1zk/Ypyw==",
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.2.tgz",
+			"integrity": "sha512-61pPlCD9h51VoreyJ0BReideM3MDKMKnh6+V9L08331ipq6Q8OFXZYiqP6n/tbHx4s5I9uRhcye6BrbkizkBDw==",
 			"requires": {
-				"function-bind": "^1.1.1",
-				"has-bigints": "^1.0.1",
-				"has-symbols": "^1.0.2",
+				"call-bind": "^1.0.2",
+				"has-bigints": "^1.0.2",
+				"has-symbols": "^1.0.3",
 				"which-boxed-primitive": "^1.0.2"
 			}
 		},
@@ -57480,34 +56410,6 @@
 			"resolved": "https://registry.npmjs.org/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-2.0.0.tgz",
 			"integrity": "sha512-5Zfuy9q/DFr4tfO7ZPeVXb1aPoeQSdeFMLpYuFebehDAhbuevLs5yxSZmIFN1tP5F9Wl4IpJrYojg85/zgyZHQ==",
 			"dev": true
-		},
-		"unified": {
-			"version": "9.2.2",
-			"resolved": "https://registry.npmjs.org/unified/-/unified-9.2.2.tgz",
-			"integrity": "sha512-Sg7j110mtefBD+qunSLO1lqOEKdrwBFBrR6Qd8f4uwkhWNlbkaqwHse6e7QvD3AP/MNoJdEDLaf8OxYyoWgorQ==",
-			"dev": true,
-			"requires": {
-				"bail": "^1.0.0",
-				"extend": "^3.0.0",
-				"is-buffer": "^2.0.0",
-				"is-plain-obj": "^2.0.0",
-				"trough": "^1.0.0",
-				"vfile": "^4.0.0"
-			},
-			"dependencies": {
-				"is-buffer": {
-					"version": "2.0.5",
-					"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.5.tgz",
-					"integrity": "sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==",
-					"dev": true
-				},
-				"is-plain-obj": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
-					"integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
-					"dev": true
-				}
-			}
 		},
 		"union-value": {
 			"version": "1.0.1",
@@ -57558,30 +56460,6 @@
 			"dev": true,
 			"requires": {
 				"crypto-random-string": "^2.0.0"
-			}
-		},
-		"unist-util-find-all-after": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/unist-util-find-all-after/-/unist-util-find-all-after-3.0.2.tgz",
-			"integrity": "sha512-xaTC/AGZ0rIM2gM28YVRAFPIZpzbpDtU3dRmp7EXlNVA8ziQc4hY3H7BHXM1J49nEmiqc3svnqMReW+PGqbZKQ==",
-			"dev": true,
-			"requires": {
-				"unist-util-is": "^4.0.0"
-			}
-		},
-		"unist-util-is": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-4.1.0.tgz",
-			"integrity": "sha512-ZOQSsnce92GrxSqlnEEseX0gi7GH9zTJZ0p9dtu87WRb/37mMPO2Ilx1s/t9vBHrFhbgweUwb+t7cIn5dxPhZg==",
-			"dev": true
-		},
-		"unist-util-stringify-position": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-2.0.3.tgz",
-			"integrity": "sha512-3faScn5I+hy9VleOq/qNbAd6pAx7iH5jYBMS9I1HgQVijz/4mv5Bvw5iw1sC/90CODiKo81G/ps8AJrISn687g==",
-			"dev": true,
-			"requires": {
-				"@types/unist": "^2.0.2"
 			}
 		},
 		"universal-user-agent": {
@@ -57757,36 +56635,6 @@
 				"extsprintf": "^1.2.0"
 			}
 		},
-		"vfile": {
-			"version": "4.2.1",
-			"resolved": "https://registry.npmjs.org/vfile/-/vfile-4.2.1.tgz",
-			"integrity": "sha512-O6AE4OskCG5S1emQ/4gl8zK586RqA3srz3nfK/Viy0UPToBc5Trp9BVFb1u0CjsKrAWwnpr4ifM/KBXPWwJbCA==",
-			"dev": true,
-			"requires": {
-				"@types/unist": "^2.0.0",
-				"is-buffer": "^2.0.0",
-				"unist-util-stringify-position": "^2.0.0",
-				"vfile-message": "^2.0.0"
-			},
-			"dependencies": {
-				"is-buffer": {
-					"version": "2.0.5",
-					"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.5.tgz",
-					"integrity": "sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==",
-					"dev": true
-				}
-			}
-		},
-		"vfile-message": {
-			"version": "2.0.4",
-			"resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-2.0.4.tgz",
-			"integrity": "sha512-DjssxRGkMvifUOJre00juHoP9DPWuzjxKuMDrhNbk2TdaYYBNMStsNhEOt3idrtI12VQYM/1+iM0KOzXi4pxwQ==",
-			"dev": true,
-			"requires": {
-				"@types/unist": "^2.0.0",
-				"unist-util-stringify-position": "^2.0.0"
-			}
-		},
 		"w3c-hr-time": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/w3c-hr-time/-/w3c-hr-time-1.0.2.tgz",
@@ -57862,12 +56710,6 @@
 				"webpack-sources": "^3.2.2"
 			},
 			"dependencies": {
-				"acorn": {
-					"version": "8.6.0",
-					"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.6.0.tgz",
-					"integrity": "sha512-U1riIR+lBSNi3IbxtaHOIKdH8sLFv3NYfNv8sg7ZsNhcfl4HF2++BfqqrNAxoCLQW1iiylOj76ecnaUxz+z9yw==",
-					"dev": true
-				},
 				"webpack-sources": {
 					"version": "3.2.2",
 					"resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.2.2.tgz",
@@ -58305,12 +57147,6 @@
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
 			"integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="
-		},
-		"zwitch": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/zwitch/-/zwitch-1.0.5.tgz",
-			"integrity": "sha512-V50KMwwzqJV0NpZIZFwfOD5/lyny3WlSzRiXgA0G7VUnRlqttta1L6UQIHzd6EuBY/cHGfwTIck7w1yH6Q5zUw==",
-			"dev": true
 		}
 	}
 }

--- a/package.json
+++ b/package.json
@@ -15,8 +15,8 @@
 		"lint:js:staged": "eslint --ext .js,.jsx",
 		"lint:php": "./vendor/bin/phpcs .",
 		"lint:php:staged": "./vendor/bin/phpcs",
-		"lint:scss": "stylelint '**/*.scss' --syntax scss --config=./node_modules/newspack-scripts/config/stylelint.config.js",
-		"lint:scss:staged": "stylelint --syntax scss --config=./node_modules/newspack-scripts/config/stylelint.config.js",
+		"lint:scss": "stylelint '**/*.scss' --customSyntax postcss-scss --config=./node_modules/newspack-scripts/config/stylelint.config.js",
+		"lint:scss:staged": "stylelint --customSyntax postcss-scss --config=./node_modules/newspack-scripts/config/stylelint.config.js",
 		"format:js": "prettier 'src/**/*.{js,jsx}' --write",
 		"format:scss": "prettier --write 'src/**/*.scss'",
 		"format:php": "./vendor/bin/phpcbf .",
@@ -51,9 +51,10 @@
 		"@rushstack/eslint-patch": "^1.1.4",
 		"eslint": "^7.32.0",
 		"lint-staged": "^13.0.3",
-		"newspack-scripts": "^3.3.2",
+		"newspack-scripts": "^4.3.0",
 		"postcss": "^8.4.14",
-		"prettier": "npm:wp-prettier@^2.2.1-beta-1",
-		"stylelint": "^13.13.1"
+		"postcss-scss": "^4.0.4",
+		"prettier": "npm:wp-prettier@^2.6.2-beta-1",
+		"stylelint": "^14.9.1"
 	}
 }

--- a/src/blocks/subscribe/editor.scss
+++ b/src/blocks/subscribe/editor.scss
@@ -1,4 +1,4 @@
-@import './style.scss';
+@use 'style.scss';
 
 .newspack-newsletters-subscribe {
 	form {

--- a/src/components/init-modal/style.scss
+++ b/src/components/init-modal/style.scss
@@ -1,4 +1,4 @@
-@import '~@wordpress/base-styles/colors';
+@use '~@wordpress/base-styles/colors' as wp-colors;
 
 // Modal
 .newspack-newsletters-modal {
@@ -90,13 +90,13 @@
 		}
 
 		&__sidebar {
-			background: $gray-100;
-			border-bottom: 1px solid $gray-300;
+			background: wp-colors.$gray-100;
+			border-bottom: 1px solid wp-colors.$gray-300;
 			padding: 24px;
 
 			@media only screen and ( min-width: 600px ) {
 				border-bottom: none;
-				border-right: 1px solid $gray-300;
+				border-right: 1px solid wp-colors.$gray-300;
 			}
 
 			p {
@@ -161,13 +161,13 @@
 		}
 
 		.error {
-			color: $alert-red;
+			color: wp-colors.$alert-red;
 		}
 
 		.components-base-control {
 			&.has-error {
 				input[type='text'] {
-					border-color: $alert-red;
+					border-color: wp-colors.$alert-red;
 				}
 			}
 		}
@@ -224,7 +224,7 @@
 				&.is-active {
 					.newspack-newsletters-layouts__item-preview {
 						pointer-events: none;
-						border-color: currentColor;
+						border-color: currentcolor;
 						position: relative;
 
 						&::before {
@@ -245,7 +245,7 @@
 					margin: 0;
 					height: 20px;
 					&.is-destructive {
-						color: $alert-red;
+						color: wp-colors.$alert-red;
 						height: auto;
 					}
 				}
@@ -253,7 +253,7 @@
 
 			&__item-preview {
 				background: white;
-				border: 1px solid $gray-300;
+				border: 1px solid wp-colors.$gray-300;
 				border-radius: 2px;
 				overflow: hidden;
 				padding: 0 0 75%;
@@ -324,7 +324,7 @@
 		grid-row-end: 3;
 		align-items: center;
 		background: white;
-		border: 1px solid $gray-300;
+		border: 1px solid wp-colors.$gray-300;
 		border-top: none;
 		display: none;
 		justify-content: center;

--- a/src/editor/blocks/mailchimp-merge-tags/style.scss
+++ b/src/editor/blocks/mailchimp-merge-tags/style.scss
@@ -1,12 +1,12 @@
-@import '~@wordpress/base-styles/colors';
+@use '~@wordpress/base-styles/colors' as wp-colors;
 
 .newspack-completer-mc-merge-tags {
 	code {
-		color: $gray-900;
+		color: wp-colors.$gray-900;
 		display: inline-block;
 	}
 	p {
-		color: $gray-700;
+		color: wp-colors.$gray-700;
 		font-size: 12px;
 		margin: 8px 0 0;
 	}

--- a/src/editor/blocks/posts-inserter/index.js
+++ b/src/editor/blocks/posts-inserter/index.js
@@ -51,10 +51,10 @@ const PostsInserterBlock = ( {
 	const stringifiedPostList = JSON.stringify( postList );
 
 	// Stringify added to minimize flicker.
-	const templateBlocks = useMemo( () => getTemplateBlocks( postList, attributes ), [
-		stringifiedPostList,
-		attributes,
-	] );
+	const templateBlocks = useMemo(
+		() => getTemplateBlocks( postList, attributes ),
+		[ stringifiedPostList, attributes ]
+	);
 
 	const stringifiedTemplateBlocks = JSON.stringify( templateBlocks );
 
@@ -387,9 +387,8 @@ const PostsInserterBlockWithSelect = compose( [
 	} ),
 	withDispatch( ( dispatch, props ) => {
 		const { replaceBlocks } = dispatch( 'core/block-editor' );
-		const { setHandledPostsIds, setInsertedPostsIds, removeBlock } = dispatch(
-			POSTS_INSERTER_STORE_NAME
-		);
+		const { setHandledPostsIds, setInsertedPostsIds, removeBlock } =
+			dispatch( POSTS_INSERTER_STORE_NAME );
 		return {
 			replaceBlocks: blocks => {
 				replaceBlocks( props.selectedBlock.clientId, blocks );

--- a/src/editor/blocks/posts-inserter/style.scss
+++ b/src/editor/blocks/posts-inserter/style.scss
@@ -1,18 +1,18 @@
-@import '~@wordpress/base-styles/colors';
+@use '~@wordpress/base-styles/colors' as wp-colors;
 
 :root {
 	--newspack-post-inserter-width: 574px;
 }
 
 .newspack-posts-inserter {
-	border: 1px solid $gray-900;
+	border: 1px solid wp-colors.$gray-900;
 	border-radius: 2px;
 	padding: 0;
 
 	&__header {
 		align-items: center;
 		background: white;
-		border-bottom: 1px solid $gray-900;
+		border-bottom: 1px solid wp-colors.$gray-900;
 		display: flex;
 		padding: 1em;
 		position: relative;
@@ -26,7 +26,7 @@
 
 	&__footer {
 		background: white;
-		border-top: 1px solid $gray-900;
+		border-top: 1px solid wp-colors.$gray-900;
 		padding: 1em;
 	}
 

--- a/src/editor/blocks/visibility-attribute/style.scss
+++ b/src/editor/blocks/visibility-attribute/style.scss
@@ -1,4 +1,4 @@
-@import '~@wordpress/base-styles/colors';
+@use '~@wordpress/base-styles/colors' as wp-colors;
 
 :root {
 	/* stylelint-disable value-keyword-case */
@@ -20,7 +20,7 @@
 	&::before {
 		border-radius: 1px;
 		bottom: 1px;
-		box-shadow: 0 0 0 var( --wp-admin-border-width-focus ) $alert-yellow;
+		box-shadow: 0 0 0 var( --wp-admin-border-width-focus ) wp-colors.$alert-yellow;
 		content: '';
 		left: 1px;
 		pointer-events: none;
@@ -36,9 +36,9 @@
 	}
 
 	.newsletters-block-visibility-label {
-		background: $alert-yellow;
+		background: wp-colors.$alert-yellow;
 		border-radius: 2px;
-		color: $gray-900;
+		color: wp-colors.$gray-900;
 		display: flex;
 		font-family: var( --newspack-system-font );
 		font-size: 10px;
@@ -79,11 +79,11 @@
 	}
 	&.newsletters-block-error {
 		&::after {
-			box-shadow: 0 0 0 var( --wp-admin-border-width-focus ) $alert-red;
+			box-shadow: 0 0 0 var( --wp-admin-border-width-focus ) wp-colors.$alert-red;
 		}
 
 		> .newsletters-block-visibility-label {
-			background: $alert-red;
+			background: wp-colors.$alert-red;
 			color: white;
 		}
 	}

--- a/src/editor/style.scss
+++ b/src/editor/style.scss
@@ -205,7 +205,7 @@
 				position: relative;
 
 				&::before {
-					background: currentColor;
+					background: currentcolor;
 					bottom: 0;
 					content: '';
 					display: block;

--- a/src/newsletter-editor/editor/index.js
+++ b/src/newsletter-editor/editor/index.js
@@ -65,9 +65,8 @@ const Editor = compose( [
 		};
 	} ),
 	withDispatch( dispatch => {
-		const { lockPostAutosaving, lockPostSaving, unlockPostSaving, editPost } = dispatch(
-			'core/editor'
-		);
+		const { lockPostAutosaving, lockPostSaving, unlockPostSaving, editPost } =
+			dispatch( 'core/editor' );
 		const { createNotice, removeNotice } = dispatch( 'core/notices' );
 		return {
 			lockPostAutosaving,

--- a/src/newsletter-editor/layout/style.scss
+++ b/src/newsletter-editor/layout/style.scss
@@ -1,4 +1,4 @@
-@import '~@wordpress/base-styles/colors';
+@use '~@wordpress/base-styles/colors' as wp-colors;
 
 .newspack-newsletters-layouts {
 	&__spinner {
@@ -13,7 +13,7 @@
 
 	&__item-preview {
 		background: white;
-		border: 1px solid $gray-300;
+		border: 1px solid wp-colors.$gray-300;
 		border-radius: 2px;
 		overflow: hidden;
 		padding: 0 0 75%;

--- a/src/newsletter-editor/sidebar/style.scss
+++ b/src/newsletter-editor/sidebar/style.scss
@@ -1,10 +1,10 @@
-@import '~@wordpress/base-styles/colors';
+@use '~@wordpress/base-styles/colors' as wp-colors;
 
 .newspack-newsletters {
 	&__editor-block {
 		&__warning {
 			display: block;
-			color: $gray-900;
+			color: wp-colors.$gray-900;
 			ul {
 				margin: 0 !important;
 			}
@@ -42,7 +42,7 @@
 	}
 
 	&__error input.components-text-control__input {
-		border-color: $alert-red;
+		border-color: wp-colors.$alert-red;
 	}
 
 	&__label {

--- a/src/newsletter-editor/styling/style.scss
+++ b/src/newsletter-editor/styling/style.scss
@@ -1,4 +1,4 @@
-@import '~@wordpress/base-styles/colors';
+@use '~@wordpress/base-styles/colors' as wp-colors;
 
 .newspack-newsletters {
 	&__color-panel {
@@ -24,7 +24,7 @@
 
 	&__css-panel {
 		.CodeMirror {
-			border: 1px solid $gray-700;
+			border: 1px solid wp-colors.$gray-700;
 		}
 	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Similar to https://github.com/Automattic/newspack-theme/pull/1845 and https://github.com/Automattic/newspack-blocks/pull/1174, updates prettier, stylelint and Newspack scripts to the latest versions:

* `newspack-scripts@4.3.0` was installed
* `wp-prettier` (aliased to prettier) was updated
* styles were migrated with `npx sass-migrator module src/**/*.scss`
* styles were fixed with `npm run lint:scss -- --fix`
* JS was fixed with `npm run lint:js -- --fix`

For the formatting, I gave all the colours coming from `~@wordpress/base-styles/colors` the prefix `wp-colors` rather than the default `colors`, to go with how this was handled in the [Newspack Plugin](https://github.com/Automattic/newspack-plugin/pull/1713). Unlike the main Newspack plugin, this plugin doesn't include and Sass colour variables at all, so distinguishing between colours coming from WordPress vs. the plugin isn't necessary, but using the `wp-colors` prefix will make it consistent with other plugins.

(Please let me know if this seems like a bad idea, though!). 

As a precaution, I diffed the generated CSS and JS files before and after this change; the only change I noticed was expected (moving from `customColor` to `customcolor`).

### How to test the changes in this Pull Request:

1. Review the automated changes
2. Confirm all jobs pass in CI
3. Confirm `npm run build` runs without error.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
