### PR TITLE
Feat/contact add filter

### DIFF
--- a/includes/class-newspack-newsletters-subscription.php
+++ b/includes/class-newspack-newsletters-subscription.php
@@ -401,7 +401,7 @@ class Newspack_Newsletters_Subscription {
 	}
 
 	/**
-	 * Handle Newspack's reader registration – add contact to ESP.
+	 * Add a contact to ESP when a reader is registered.
 	 *
 	 * @param string         $email         Email address.
 	 * @param bool           $authenticate  Whether to authenticate after registering.

--- a/includes/class-newspack-newsletters-subscription.php
+++ b/includes/class-newspack-newsletters-subscription.php
@@ -308,6 +308,8 @@ class Newspack_Newsletters_Subscription {
 			return new WP_Error( 'newspack_newsletters_invalid_provider', __( 'Provider is not set.' ) );
 		}
 
+		$contact = apply_filters( 'newspack_newsletters_add_contact_data', $contact, $lists );
+
 		$errors = new WP_Error();
 
 		foreach ( $lists as $list_id ) {

--- a/includes/class-newspack-newsletters-subscription.php
+++ b/includes/class-newspack-newsletters-subscription.php
@@ -401,7 +401,7 @@ class Newspack_Newsletters_Subscription {
 	}
 
 	/**
-	 * Handle Newspack's reader registration – add contact to list.
+	 * Handle Newspack's reader registration – add contact to ESP.
 	 *
 	 * @param string         $email         Email address.
 	 * @param bool           $authenticate  Whether to authenticate after registering.
@@ -413,15 +413,17 @@ class Newspack_Newsletters_Subscription {
 		if ( isset( $metadata['lists'] ) && ! empty( $metadata['lists'] ) ) {
 			$lists = $metadata['lists'];
 			unset( $metadata['lists'] );
-			// Adding is actually upserting, so no need to check if the hook is called for an existing user.
-			self::add_contact(
-				[
-					'email'    => $email,
-					'metadata' => $metadata,
-				],
-				$lists
-			);
+		} else {
+			$lists = [];
 		}
+		// Adding is actually upserting, so no need to check if the hook is called for an existing user.
+		self::add_contact(
+			[
+				'email'    => $email,
+				'metadata' => $metadata,
+			],
+			$lists
+		);
 	}
 
 	/**

--- a/includes/class-newspack-newsletters-subscription.php
+++ b/includes/class-newspack-newsletters-subscription.php
@@ -290,7 +290,7 @@ class Newspack_Newsletters_Subscription {
 	 */
 	public static function existing_contact_data( $email_address ) {
 		if ( ! $email_address || empty( $email_address ) ) {
-			return new WP_Error( 'newspack_newsletters_invalid_email', __( 'No lists specified.' ) );
+			return new WP_Error( 'newspack_newsletters_invalid_email', __( 'Missing email address.' ) );
 		}
 
 		$provider = Newspack_Newsletters::get_service_provider();

--- a/includes/class-newspack-newsletters-subscription.php
+++ b/includes/class-newspack-newsletters-subscription.php
@@ -411,13 +411,15 @@ class Newspack_Newsletters_Subscription {
 	 */
 	public static function newspack_registered_reader( $email, $authenticate, $user_id, $existing_user, $metadata ) {
 		if ( isset( $metadata['lists'] ) && ! empty( $metadata['lists'] ) ) {
+			$lists = $metadata['lists'];
+			unset( $metadata['lists'] );
 			// Adding is actually upserting, so no need to check if the hook is called for an existing user.
 			self::add_contact(
 				[
-					'email'           => $email,
-					'passed_metadata' => $metadata,
+					'email'    => $email,
+					'metadata' => $metadata,
 				],
-				$metadata['lists']
+				$lists
 			);
 		}
 	}

--- a/includes/class-newspack-newsletters-subscription.php
+++ b/includes/class-newspack-newsletters-subscription.php
@@ -414,7 +414,8 @@ class Newspack_Newsletters_Subscription {
 			// Adding is actually upserting, so no need to check if the hook is called for an existing user.
 			self::add_contact(
 				[
-					'email' => $email,
+					'email'           => $email,
+					'passed_metadata' => $metadata,
 				],
 				$metadata['lists']
 			);

--- a/includes/class-newspack-newsletters-subscription.php
+++ b/includes/class-newspack-newsletters-subscription.php
@@ -288,7 +288,7 @@ class Newspack_Newsletters_Subscription {
 	 *
 	 * @return array|WP_Error Response or error.
 	 */
-	public static function existing_contact_data( $email_address ) {
+	public static function get_contact_data( $email_address ) {
 		if ( ! $email_address || empty( $email_address ) ) {
 			return new WP_Error( 'newspack_newsletters_invalid_email', __( 'Missing email address.' ) );
 		}
@@ -298,11 +298,11 @@ class Newspack_Newsletters_Subscription {
 			return new WP_Error( 'newspack_newsletters_invalid_provider', __( 'Provider is not set.' ) );
 		}
 
-		if ( ! method_exists( $provider, 'existing_contact_data' ) ) {
+		if ( ! method_exists( $provider, 'get_contact_data' ) ) {
 			return new WP_Error( 'newspack_newsletters_not_implemented', __( 'Provider does not handle the contact-exists check.' ) );
 		}
 
-		return $provider->existing_contact_data( $email_address );
+		return $provider->get_contact_data( $email_address );
 	}
 
 	/**

--- a/includes/class-newspack-newsletters-subscription.php
+++ b/includes/class-newspack-newsletters-subscription.php
@@ -145,7 +145,7 @@ class Newspack_Newsletters_Subscription {
 	/**
 	 * Get the lists available for subscription.
 	 *
-	 * @return array Lists.
+	 * @return array|WP_Error Lists or error.
 	 */
 	public static function get_lists() {
 		$provider = Newspack_Newsletters::get_service_provider();

--- a/includes/class-newspack-newsletters-subscription.php
+++ b/includes/class-newspack-newsletters-subscription.php
@@ -308,8 +308,6 @@ class Newspack_Newsletters_Subscription {
 			return new WP_Error( 'newspack_newsletters_invalid_provider', __( 'Provider is not set.' ) );
 		}
 
-		$contact = apply_filters( 'newspack_newsletters_add_contact_data', $contact, $lists );
-
 		$errors = new WP_Error();
 
 		foreach ( $lists as $list_id ) {

--- a/includes/class-newspack-newsletters-subscription.php
+++ b/includes/class-newspack-newsletters-subscription.php
@@ -308,6 +308,21 @@ class Newspack_Newsletters_Subscription {
 			return new WP_Error( 'newspack_newsletters_invalid_provider', __( 'Provider is not set.' ) );
 		}
 
+		/**
+		 * Filters the contact before passing on to the API.
+		 *
+		 * @param string        $provider The provider name.
+		 * @param array         $contact  {
+		 *    Contact information.
+		 *
+		 *    @type string   $email    Contact email address.
+		 *    @type string   $name     Contact name. Optional.
+		 *    @type string[] $metadata Contact additional metadata. Optional.
+		 * }
+		 * @param string[]      $lists    Array of list IDs to subscribe the contact to.
+		 */
+		$contact = apply_filters( 'newspack_newsletters_contact_data', $provider->service, $contact, $lists );
+
 		$errors = new WP_Error();
 
 		foreach ( $lists as $list_id ) {

--- a/includes/class-newspack-newsletters-subscription.php
+++ b/includes/class-newspack-newsletters-subscription.php
@@ -282,6 +282,30 @@ class Newspack_Newsletters_Subscription {
 	}
 
 	/**
+	 * Get contact data by email.
+	 *
+	 * @param string $email_address Email address.
+	 *
+	 * @return array|WP_Error Response or error.
+	 */
+	public static function existing_contact_data( $email_address ) {
+		if ( ! $email_address || empty( $email_address ) ) {
+			return new WP_Error( 'newspack_newsletters_invalid_email', __( 'No lists specified.' ) );
+		}
+
+		$provider = Newspack_Newsletters::get_service_provider();
+		if ( empty( $provider ) ) {
+			return new WP_Error( 'newspack_newsletters_invalid_provider', __( 'Provider is not set.' ) );
+		}
+
+		if ( ! method_exists( $provider, 'existing_contact_data' ) ) {
+			return new WP_Error( 'newspack_newsletters_not_implemented', __( 'Provider does not handle the contact-exists check.' ) );
+		}
+
+		return $provider->existing_contact_data( $email_address );
+	}
+
+	/**
 	 * Upserts a contact to lists.
 	 *
 	 * @param array    $contact {

--- a/includes/class-newspack-newsletters-subscription.php
+++ b/includes/class-newspack-newsletters-subscription.php
@@ -330,6 +330,21 @@ class Newspack_Newsletters_Subscription {
 		}
 
 		/**
+		 * Fires before a contact is added.
+		 *
+		 * @param string        $provider The provider name.
+		 * @param array         $contact  {
+		 *    Contact information.
+		 *
+		 *    @type string   $email    Contact email address.
+		 *    @type string   $name     Contact name. Optional.
+		 *    @type string[] $metadata Contact additional metadata. Optional.
+		 * }
+		 * @param string[]      $lists    Array of list IDs to subscribe the contact to.
+		 */
+		do_action( 'newspack_newsletters_before_add_contact', $provider->service, $contact, $lists );
+
+		/**
 		 * Filters the contact before passing on to the API.
 		 *
 		 * @param string        $provider The provider name.

--- a/includes/class-newspack-newsletters-subscription.php
+++ b/includes/class-newspack-newsletters-subscription.php
@@ -330,21 +330,6 @@ class Newspack_Newsletters_Subscription {
 		}
 
 		/**
-		 * Fires before a contact is added.
-		 *
-		 * @param string        $provider The provider name.
-		 * @param array         $contact  {
-		 *    Contact information.
-		 *
-		 *    @type string   $email    Contact email address.
-		 *    @type string   $name     Contact name. Optional.
-		 *    @type string[] $metadata Contact additional metadata. Optional.
-		 * }
-		 * @param string[]      $lists    Array of list IDs to subscribe the contact to.
-		 */
-		do_action( 'newspack_newsletters_before_add_contact', $provider->service, $contact, $lists );
-
-		/**
 		 * Filters the contact before passing on to the API.
 		 *
 		 * @param string        $provider The provider name.

--- a/includes/service-providers/active_campaign/class-newspack-newsletters-active-campaign.php
+++ b/includes/service-providers/active_campaign/class-newspack-newsletters-active-campaign.php
@@ -643,8 +643,9 @@ final class Newspack_Newsletters_Active_Campaign extends \Newspack_Newsletters_S
 		];
 		$existing_contact = $this->api_v1_request( 'contact_list', 'GET', [ 'query' => [ 'filters[email]' => $contact['email'] ] ] );
 		if ( ! is_wp_error( $existing_contact ) ) {
-			$action        = 'contact_edit';
-			$payload['id'] = $existing_contact[0]['id'];
+			$action               = 'contact_edit';
+			$payload['id']        = $existing_contact[0]['id'];
+			$payload['overwrite'] = 0;
 		}
 		if ( isset( $contact['name'] ) && ! empty( $contact['name'] ) ) {
 			$name_fragments = explode( ' ', $contact['name'], 2 );

--- a/includes/service-providers/active_campaign/class-newspack-newsletters-active-campaign.php
+++ b/includes/service-providers/active_campaign/class-newspack-newsletters-active-campaign.php
@@ -648,7 +648,7 @@ final class Newspack_Newsletters_Active_Campaign extends \Newspack_Newsletters_S
 		if ( $has_list_id ) {
 			$payload[ 'p[' . $list_id . ']' ] = $list_id;
 		}
-		$existing_contact = $this->existing_contact_data( $contact['email'] );
+		$existing_contact = $this->get_contact_data( $contact['email'] );
 		if ( is_wp_error( $existing_contact ) ) {
 			// Is a new contact.
 			$existing_contact = false;
@@ -735,7 +735,7 @@ final class Newspack_Newsletters_Active_Campaign extends \Newspack_Newsletters_S
 	 * @return true|WP_Error True if the contact was updated or error.
 	 */
 	public function update_contact_lists( $email, $lists_to_add = [], $lists_to_remove = [] ) {
-		$existing_contact = $this->existing_contact_data( $email );
+		$existing_contact = $this->get_contact_data( $email );
 		if ( is_wp_error( $existing_contact ) ) {
 			/** Create contact */
 			// Call Newspack_Newsletters_Subscription's method, so the appropriate hooks are called.
@@ -799,7 +799,7 @@ final class Newspack_Newsletters_Active_Campaign extends \Newspack_Newsletters_S
 	 *
 	 * @return array|WP_Error Response or error if contact was not found.
 	 */
-	public function existing_contact_data( $email_address ) {
+	public function get_contact_data( $email_address ) {
 		$results = $this->api_v1_request( 'contact_list', 'GET', [ 'query' => [ 'filters[email]' => $email_address ] ] );
 		if ( is_wp_error( $results ) ) {
 			return $results;

--- a/includes/service-providers/active_campaign/class-newspack-newsletters-active-campaign.php
+++ b/includes/service-providers/active_campaign/class-newspack-newsletters-active-campaign.php
@@ -673,17 +673,8 @@ final class Newspack_Newsletters_Active_Campaign extends \Newspack_Newsletters_S
 
 		/** Register metadata fields. */
 		if ( isset( $contact['metadata'] ) && is_array( $contact['metadata'] ) && ! empty( $contact['metadata'] ) ) {
-			$metadata_prefix = apply_filters( 'newspack_newsletters_active_campaign_metadata_prefix', '' );
 			foreach ( $contact['metadata'] as $field_title => $value ) {
-				if ( isset( $contact['_metadata_fields_active_campaign_map'], $contact['_metadata_fields_active_campaign_map'][ $field_title ] ) ) {
-					// Allow to override default title to pers. tag mapping.
-					$field_pers_tag = $contact['_metadata_fields_active_campaign_map'][ $field_title ];
-				} else {
-					$field_pers_tag = strtoupper( str_replace( '-', '_', sanitize_title( $field_title ) ) );
-				}
-
-				$field_title    = $metadata_prefix . $field_title;
-				$field_pers_tag = $metadata_prefix . $field_pers_tag;
+				$field_pers_tag = strtoupper( str_replace( '-', '_', sanitize_title( $field_title ) ) );
 
 				// Handle special fields.
 				if ( str_ends_with( $field_pers_tag, 'NEWSLETTER_SELECTION' ) ) {

--- a/includes/service-providers/active_campaign/class-newspack-newsletters-active-campaign.php
+++ b/includes/service-providers/active_campaign/class-newspack-newsletters-active-campaign.php
@@ -622,28 +622,32 @@ final class Newspack_Newsletters_Active_Campaign extends \Newspack_Newsletters_S
 	}
 
 	/**
-	 * Add contact to a list.
+	 * Add contact to a list or update an existing contact.
 	 *
-	 * @param array  $contact      {
-	 *    Contact data.
+	 * @param array        $contact      {
+	 *          Contact data.
 	 *
 	 *    @type string   $email    Contact email address.
 	 *    @type string   $name     Contact name. Optional.
 	 *    @type string[] $metadata Contact additional metadata. Optional.
 	 * }
-	 * @param string $list_id      List to add the contact to.
+	 * @param string|false $list_id      List to add the contact to.
 	 *
 	 * @return bool|WP_Error True if the contact was added or error if failed.
 	 */
-	public function add_contact( $contact, $list_id ) {
+	public function add_contact( $contact, $list_id = false ) {
 		if ( ! isset( $contact['metadata'] ) ) {
 			$contact['metadata'] = [];
 		}
-		$action           = 'contact_add';
-		$payload          = [
-			'p[' . $list_id . ']' => $list_id,
-			'email'               => $contact['email'],
+		$action      = 'contact_add';
+		$payload     = [
+			'email' => $contact['email'],
 		];
+
+		$has_list_id = false !== $list_id;
+		if ( $has_list_id ) {
+			$payload[ 'p[' . $list_id . ']' ] = $list_id;
+		}
 		$existing_contact = $this->api_v1_request( 'contact_list', 'GET', [ 'query' => [ 'filters[email]' => $contact['email'] ] ] );
 		if ( is_wp_error( $existing_contact ) ) {
 			// Is a new contact.
@@ -697,11 +701,11 @@ final class Newspack_Newsletters_Active_Campaign extends \Newspack_Newsletters_S
 					'POST',
 					[
 						'body' => [
-							'p[' . $list_id . ']' => $list_id,
-							'title'               => $field_title,
-							'req'                 => 0, // Whether it's a required field.
-							'type'                => 1, // 1 = Text field.
-							'perstag'             => $field_pers_tag,
+							'p[0]'    => 0, // Associate with all lists.
+							'title'   => $field_title,
+							'req'     => 0, // Whether it's a required field.
+							'type'    => 1, // 1 = Text field.
+							'perstag' => $field_pers_tag,
 						],
 					]
 				);

--- a/includes/service-providers/active_campaign/class-newspack-newsletters-active-campaign.php
+++ b/includes/service-providers/active_campaign/class-newspack-newsletters-active-campaign.php
@@ -658,8 +658,6 @@ final class Newspack_Newsletters_Active_Campaign extends \Newspack_Newsletters_S
 			$payload['overwrite'] = 0;
 		}
 
-		$contact = apply_filters( 'newspack_newsletters_active_campaign_add_contact_data', $contact, $list_id, $existing_contact );
-
 		if ( isset( $contact['name'] ) && ! empty( $contact['name'] ) ) {
 			$name_fragments = explode( ' ', $contact['name'], 2 );
 			$payload        = array_merge(
@@ -675,21 +673,6 @@ final class Newspack_Newsletters_Active_Campaign extends \Newspack_Newsletters_S
 		if ( isset( $contact['metadata'] ) && is_array( $contact['metadata'] ) && ! empty( $contact['metadata'] ) ) {
 			foreach ( $contact['metadata'] as $field_title => $value ) {
 				$field_pers_tag = strtoupper( str_replace( '-', '_', sanitize_title( $field_title ) ) );
-
-				// Handle special fields.
-				if ( str_ends_with( $field_pers_tag, 'NEWSLETTER_SELECTION' ) ) {
-					$lists_names = [];
-					$lists       = $this->get_lists();
-					foreach ( explode( ',', $value ) as $selected_list_id ) {
-						foreach ( $lists as $list ) {
-							if ( $list['id'] === $selected_list_id ) {
-								$lists_names[] = $list['name'];
-							}
-						}
-					}
-					$value = implode( ', ', $lists_names );
-				}
-
 				/** Optimistically add field. The API handles duplicates automatically. */
 				$this->api_v1_request(
 					'list_field_add',

--- a/includes/service-providers/active_campaign/class-newspack-newsletters-active-campaign.php
+++ b/includes/service-providers/active_campaign/class-newspack-newsletters-active-campaign.php
@@ -639,8 +639,8 @@ final class Newspack_Newsletters_Active_Campaign extends \Newspack_Newsletters_S
 		if ( ! isset( $contact['metadata'] ) ) {
 			$contact['metadata'] = [];
 		}
-		$action      = 'contact_add';
-		$payload     = [
+		$action  = 'contact_add';
+		$payload = [
 			'email' => $contact['email'],
 		];
 
@@ -651,12 +651,15 @@ final class Newspack_Newsletters_Active_Campaign extends \Newspack_Newsletters_S
 		$existing_contact = $this->api_v1_request( 'contact_list', 'GET', [ 'query' => [ 'filters[email]' => $contact['email'] ] ] );
 		if ( is_wp_error( $existing_contact ) ) {
 			// Is a new contact.
-			$contact['metadata']['Registered'] = gmdate( 'm/d/Y' );
+			$existing_contact = false;
 		} else {
 			$action               = 'contact_edit';
 			$payload['id']        = $existing_contact[0]['id'];
 			$payload['overwrite'] = 0;
 		}
+
+		$contact = apply_filters( 'newspack_newsletters_active_campaign_add_contact_data', $contact, $list_id, $existing_contact );
+
 		if ( isset( $contact['name'] ) && ! empty( $contact['name'] ) ) {
 			$name_fragments = explode( ' ', $contact['name'], 2 );
 			$payload        = array_merge(
@@ -667,6 +670,7 @@ final class Newspack_Newsletters_Active_Campaign extends \Newspack_Newsletters_S
 				]
 			);
 		}
+
 		/** Register metadata fields. */
 		if ( isset( $contact['metadata'] ) && is_array( $contact['metadata'] ) && ! empty( $contact['metadata'] ) ) {
 			$metadata_prefix = apply_filters( 'newspack_newsletters_active_campaign_metadata_prefix', '' );

--- a/includes/service-providers/active_campaign/class-newspack-newsletters-active-campaign.php
+++ b/includes/service-providers/active_campaign/class-newspack-newsletters-active-campaign.php
@@ -669,7 +669,7 @@ final class Newspack_Newsletters_Active_Campaign extends \Newspack_Newsletters_S
 		}
 		/** Register metadata fields. */
 		if ( isset( $contact['metadata'] ) && is_array( $contact['metadata'] ) && ! empty( $contact['metadata'] ) ) {
-			$metadata_prefix = 'NP_';
+			$metadata_prefix = apply_filters( 'newspack_newsletters_active_campaign_metadata_prefix', '' );
 			foreach ( $contact['metadata'] as $field_title => $value ) {
 				if ( isset( $contact['_metadata_fields_active_campaign_map'], $contact['_metadata_fields_active_campaign_map'][ $field_title ] ) ) {
 					// Allow to override default title to pers. tag mapping.

--- a/includes/service-providers/active_campaign/class-newspack-newsletters-active-campaign.php
+++ b/includes/service-providers/active_campaign/class-newspack-newsletters-active-campaign.php
@@ -648,13 +648,13 @@ final class Newspack_Newsletters_Active_Campaign extends \Newspack_Newsletters_S
 		if ( $has_list_id ) {
 			$payload[ 'p[' . $list_id . ']' ] = $list_id;
 		}
-		$existing_contact = $this->api_v1_request( 'contact_list', 'GET', [ 'query' => [ 'filters[email]' => $contact['email'] ] ] );
+		$existing_contact = $this->existing_contact_data( $contact['email'] );
 		if ( is_wp_error( $existing_contact ) ) {
 			// Is a new contact.
 			$existing_contact = false;
 		} else {
 			$action               = 'contact_edit';
-			$payload['id']        = $existing_contact[0]['id'];
+			$payload['id']        = $existing_contact['id'];
 			$payload['overwrite'] = 0;
 		}
 
@@ -803,5 +803,23 @@ final class Newspack_Newsletters_Active_Campaign extends \Newspack_Newsletters_S
 			}
 		}
 		return true;
+	}
+
+	/**
+	 * Get contact data by email.
+	 *
+	 * @param string $email_address Email address.
+	 *
+	 * @return array|WP_Error Response or error.
+	 */
+	public function existing_contact_data( $email_address ) {
+		$results = $this->api_v1_request( 'contact_list', 'GET', [ 'query' => [ 'filters[email]' => $email_address ] ] );
+		if ( is_wp_error( $results ) ) {
+			return $results;
+		}
+		if ( empty( $results ) ) {
+			return new WP_Error( 'newspack_newsletters', __( 'No contact data found.' ) );
+		}
+		return $results[0];
 	}
 }

--- a/includes/service-providers/active_campaign/class-newspack-newsletters-active-campaign.php
+++ b/includes/service-providers/active_campaign/class-newspack-newsletters-active-campaign.php
@@ -633,7 +633,7 @@ final class Newspack_Newsletters_Active_Campaign extends \Newspack_Newsletters_S
 	 * }
 	 * @param string|false $list_id      List to add the contact to.
 	 *
-	 * @return int|WP_Error Contact ID if the contact was added or error if failed.
+	 * @return array|WP_Error Contact data if the contact was added or error if failed.
 	 */
 	public function add_contact( $contact, $list_id = false ) {
 		if ( ! isset( $contact['metadata'] ) ) {
@@ -697,7 +697,7 @@ final class Newspack_Newsletters_Active_Campaign extends \Newspack_Newsletters_S
 				'body' => $payload,
 			]
 		);
-		return is_wp_error( $result ) ? $result : $result['subscriber_id'];
+		return is_wp_error( $result ) ? $result : [ 'id' => $result['subscriber_id'] ];
 	}
 
 	/**
@@ -740,10 +740,11 @@ final class Newspack_Newsletters_Active_Campaign extends \Newspack_Newsletters_S
 			/** Create contact */
 			// Call Newspack_Newsletters_Subscription's method (not the provider's directly),
 			// so the appropriate hooks are called.
-			$contact_id = Newspack_Newsletters_Subscription::add_contact( [ 'email' => $email ] );
-			if ( is_wp_error( $contact_id ) ) {
-				return $contact_id;
+			$contact_data = Newspack_Newsletters_Subscription::add_contact( [ 'email' => $email ] );
+			if ( is_wp_error( $contact_data ) ) {
+				return $contact_data;
 			}
+			$contact_id = $contact_data['id'];
 		} else {
 			$contact_id = $existing_contact['id'];
 			/** Set status to "2" (unsubscribed) for lists to remove. */

--- a/includes/service-providers/active_campaign/class-newspack-newsletters-active-campaign.php
+++ b/includes/service-providers/active_campaign/class-newspack-newsletters-active-campaign.php
@@ -657,8 +657,8 @@ final class Newspack_Newsletters_Active_Campaign extends \Newspack_Newsletters_S
 			);
 		}
 		/** Register metadata fields. */
-		if ( isset( $contact['metadata'] ) && is_array( $contact['metadata'] && ! empty( $contact['metadata'] ) ) ) {
-			foreach ( $metadata as $key => $value ) {
+		if ( isset( $contact['metadata'] ) && is_array( $contact['metadata'] ) && ! empty( $contact['metadata'] ) ) {
+			foreach ( $contact['metadata'] as $key => $value ) {
 				$key_tag = strtoupper( str_replace( '-', '_', sanitize_title( $key ) ) );
 				$value   = (string) $value;
 				/** Optimistically add field. The API handles duplicates automatically. */
@@ -675,7 +675,7 @@ final class Newspack_Newsletters_Active_Campaign extends \Newspack_Newsletters_S
 						],
 					]
 				);
-				$payload[ 'field[' . $key_tag . ',0]' ] = $value; // Per ESP documentation, "leave 0 as is".
+				$payload[ 'field[%' . $key_tag . '%,0]' ] = $value; // Per ESP documentation, "leave 0 as is".
 			}
 		}
 		$result = $this->api_v1_request(

--- a/includes/service-providers/campaign_monitor/class-newspack-newsletters-campaign-monitor.php
+++ b/includes/service-providers/campaign_monitor/class-newspack-newsletters-campaign-monitor.php
@@ -572,7 +572,7 @@ final class Newspack_Newsletters_Campaign_Monitor extends \Newspack_Newsletters_
 	 * }
 	 * @param string $list_id      List to add the contact to.
 	 *
-	 * @return bool|WP_Error True if the contact was added or error if failed.
+	 * @return array|WP_Error Contact data if it was added, or error otherwise.
 	 */
 	public function add_contact( $contact, $list_id ) {
 		try {
@@ -623,6 +623,7 @@ final class Newspack_Newsletters_Campaign_Monitor extends \Newspack_Newsletters_
 				} else {
 					$result = $cm_subscribers->add( $update_payload );
 				};
+				return $result;
 			}
 		} catch ( \Exception $e ) {
 			return new \WP_Error(

--- a/includes/service-providers/constant_contact/class-newspack-newsletters-constant-contact.php
+++ b/includes/service-providers/constant_contact/class-newspack-newsletters-constant-contact.php
@@ -703,7 +703,7 @@ final class Newspack_Newsletters_Constant_Contact extends \Newspack_Newsletters_
 	 * Add contact to a list.
 	 *
 	 * @param array  $contact Contact data.
-	 * @param strine $list_id List ID.
+	 * @param string $list_id List ID.
 	 * @throws Exception Error message.
 	 */
 	public function add_contact( $contact, $list_id ) {

--- a/includes/service-providers/interface-newspack-newsletters-esp-service.php
+++ b/includes/service-providers/interface-newspack-newsletters-esp-service.php
@@ -99,7 +99,7 @@ interface Newspack_Newsletters_ESP_API_Interface {
 	 * }
 	 * @param string $list_id      List to add the contact to.
 	 *
-	 * @return bool|WP_Error True if the contact was added or error if failed.
+	 * @return array|WP_Error Contact data if it was added, or error otherwise.
 	 */
 	public function add_contact( $contact, $list_id );
 

--- a/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp.php
+++ b/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp.php
@@ -798,9 +798,12 @@ final class Newspack_Newsletters_Mailchimp extends \Newspack_Newsletters_Service
 	 * }
 	 * @param string $list_id      List to add the contact to.
 	 *
-	 * @return bool|WP_Error True if the contact was added or error if failed.
+	 * @return array|WP_Error Contact data if it was added, or error otherwise.
 	 */
-	public function add_contact( $contact, $list_id ) {
+	public function add_contact( $contact, $list_id = false ) {
+		if ( false === $list_id ) {
+			return new WP_Error( 'newspack_newsletters_mailchimp_list_id', __( 'Missing list id.' ) );
+		}
 		try {
 			$mc             = new Mailchimp( $this->api_key() );
 			$email_address  = $contact['email'];
@@ -881,6 +884,6 @@ final class Newspack_Newsletters_Mailchimp extends \Newspack_Newsletters_Service
 				$e->getMessage()
 			);
 		}
-		return true;
+		return $result;
 	}
 }

--- a/src/blocks/subscribe/index.php
+++ b/src/blocks/subscribe/index.php
@@ -248,7 +248,7 @@ function process_form() {
 	 * Fires after subscribing a user to a list.
 	 *
 	 * @param string         $email  Email address of the reader.
-	 * @param bool|\WP_Error $result Whether the contact was added or error.
+	 * @return array|WP_Error Contact data if it was added, or error otherwise.
 	 */
 	\do_action( 'newspack_newsletters_subscribe_form_processed', $email, $result );
 

--- a/src/blocks/subscribe/index.php
+++ b/src/blocks/subscribe/index.php
@@ -219,7 +219,7 @@ function send_form_response( $data ) {
 }
 
 /**
- * Process registration form.
+ * Process newsletter signup form.
  */
 function process_form() {
 	if ( ! isset( $_REQUEST[ FORM_ACTION ] ) || ! \wp_verify_nonce( \sanitize_text_field( $_REQUEST[ FORM_ACTION ] ), FORM_ACTION ) ) {
@@ -246,6 +246,10 @@ function process_form() {
 		],
 		$lists
 	);
+
+	if ( ! \is_user_logged_in() && \class_exists( '\Newspack\Reader_Activation' ) && \Newspack\Reader_Activation::is_enabled() ) {
+		\Newspack\Reader_Activation::register_reader( $email );
+	}
 
 	/**
 	 * Fires after subscribing a user to a list.

--- a/src/blocks/subscribe/index.php
+++ b/src/blocks/subscribe/index.php
@@ -239,7 +239,10 @@ function process_form() {
 
 	$result = \Newspack_Newsletters_Subscription::add_contact(
 		[
-			'email' => $email,
+			'email'    => $email,
+			'metadata' => [
+				'current_page_url' => home_url( add_query_arg( array(), \wp_get_referer() ) ),
+			],
 		],
 		$lists
 	);


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes and refactors how ActiveCampaign ESP contact upsertion (`add_contact` method) works, and adds a filter to modify the contact data prior to sending.

Enables contact adding without lists assigned.

### How to test the changes in this Pull Request:

_Follow instructions in https://github.com/Automattic/newspack-plugin/pull/1793_

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->