### PR TITLE
feat: enable contact adding w/out lists, as opposed to w/ empty lists

### DIFF
--- a/includes/class-newspack-newsletters-subscription.php
+++ b/includes/class-newspack-newsletters-subscription.php
@@ -308,19 +308,19 @@ class Newspack_Newsletters_Subscription {
 	/**
 	 * Upserts a contact to lists.
 	 *
-	 * @param array    $contact {
-	 *    Contact information.
+	 * @param array          $contact {
+	 *          Contact information.
 	 *
 	 *    @type string   $email    Contact email address.
 	 *    @type string   $name     Contact name. Optional.
 	 *    @type string[] $metadata Contact additional metadata. Optional.
 	 * }
-	 * @param string[] $lists   Array of list IDs to subscribe the contact to. If empty, contact will be created but not subscribed to any lists.
+	 * @param string[]|false $lists   Array of list IDs to subscribe the contact to. If empty or false, contact will be created but not subscribed to any lists.
 	 *
 	 * @return array|WP_Error Contact data if it was added, or error otherwise.
 	 */
-	public static function add_contact( $contact, $lists = [] ) {
-		if ( ! is_array( $lists ) ) {
+	public static function add_contact( $contact, $lists = false ) {
+		if ( ! is_array( $lists ) && false !== $lists ) {
 			$lists = [ $lists ];
 		}
 
@@ -340,7 +340,7 @@ class Newspack_Newsletters_Subscription {
 		 *    @type string   $name     Contact name. Optional.
 		 *    @type string[] $metadata Contact additional metadata. Optional.
 		 * }
-		 * @param string[]      $lists    Array of list IDs to subscribe the contact to.
+		 * @param string[]|false      $lists    Array of list IDs to subscribe the contact to.
 		 */
 		$contact = apply_filters( 'newspack_newsletters_contact_data', $provider->service, $contact, $lists );
 
@@ -350,14 +350,14 @@ class Newspack_Newsletters_Subscription {
 			try {
 				$result = $provider->add_contact( $contact );
 			} catch ( \Exception $e ) {
-				$errors->add( 'newspack_newsletters_add_contact', $e->getMessage() );
+				$errors->add( 'newspack_newsletters_subscription_add_contact', $e->getMessage() );
 			}
 		} else {
 			foreach ( $lists as $list_id ) {
 				try {
 					$result = $provider->add_contact( $contact, $list_id );
 				} catch ( \Exception $e ) {
-					$errors->add( 'newspack_newsletters_add_contact', $e->getMessage() );
+					$errors->add( 'newspack_newsletters_subscription_add_contact', $e->getMessage() );
 				}
 			}
 		}
@@ -377,7 +377,7 @@ class Newspack_Newsletters_Subscription {
 		 *    @type string   $name     Contact name. Optional.
 		 *    @type string[] $metadata Contact additional metadata. Optional.
 		 * }
-		 * @param string[]      $lists    Array of list IDs to subscribe the contact to.
+		 * @param string[]|false      $lists    Array of list IDs to subscribe the contact to.
 		 * @param bool|WP_Error $result   True if the contact was added or error if failed.
 		 */
 		do_action( 'newspack_newsletters_add_contact', $provider->service, $contact, $lists, $result );
@@ -399,7 +399,7 @@ class Newspack_Newsletters_Subscription {
 			$lists = $metadata['lists'];
 			unset( $metadata['lists'] );
 		} else {
-			$lists = [];
+			$lists = false;
 		}
 		// Adding is actually upserting, so no need to check if the hook is called for an existing user.
 		self::add_contact(

--- a/includes/class-newspack-newsletters-subscription.php
+++ b/includes/class-newspack-newsletters-subscription.php
@@ -369,8 +369,8 @@ class Newspack_Newsletters_Subscription {
 		/**
 		 * Fires after a contact is added.
 		 *
-		 * @param string        $provider The provider name.
-		 * @param array         $contact  {
+		 * @param string              $provider The provider name.
+		 * @param array               $contact  {
 		 *    Contact information.
 		 *
 		 *    @type string   $email    Contact email address.
@@ -378,7 +378,7 @@ class Newspack_Newsletters_Subscription {
 		 *    @type string[] $metadata Contact additional metadata. Optional.
 		 * }
 		 * @param string[]|false      $lists    Array of list IDs to subscribe the contact to.
-		 * @param bool|WP_Error $result   True if the contact was added or error if failed.
+		 * @param bool|WP_Error       $result   True if the contact was added or error if failed.
 		 */
 		do_action( 'newspack_newsletters_add_contact', $provider->service, $contact, $lists, $result );
 

--- a/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp.php
+++ b/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp.php
@@ -880,7 +880,7 @@ final class Newspack_Newsletters_Mailchimp extends \Newspack_Newsletters_Service
 			}
 		} catch ( \Exception $e ) {
 			return new \WP_Error(
-				'newspack_add_contact',
+				'newspack_newsletters_mailchimp_add_contact_failed',
 				$e->getMessage()
 			);
 		}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Enables signalling that the contact should be upserted without any change in list selection. Before, the list selection was an empty array by default, implicitly meaning that the upserted contact should not be subscribed to any list in the absence of this parameter. 

With this change, when an empty array of lists is supplied, it means the contact is unsubscribed from any lists. When a `false` value of the list ids parameter means that the contact has no change in lists selection.

### How to test the changes in this Pull Request:

_Follow instructions in https://github.com/Automattic/newspack-plugin/pull/1816_

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->