### PR TITLE
feat: filter contact lists and small fixes

### DIFF
--- a/includes/class-newspack-newsletters-subscription.php
+++ b/includes/class-newspack-newsletters-subscription.php
@@ -330,22 +330,41 @@ class Newspack_Newsletters_Subscription {
 			return new WP_Error( 'newspack_newsletters_invalid_provider', __( 'Provider is not set.' ) );
 		}
 
-		Newspack_Newsletters_Logger::log( 'Adding contact to list(s): ' . implode( ', ', $lists ) . '. Provider is ' . $provider->service . '.' );
+		if ( false !== $lists ) {
+			Newspack_Newsletters_Logger::log( 'Adding contact to list(s): ' . implode( ', ', $lists ) . '. Provider is ' . $provider->service . '.' );
+		} else {
+			Newspack_Newsletters_Logger::log( 'Adding contact without lists. Provider is ' . $provider->service . '.' );
+		}
 
 		/**
 		 * Filters the contact before passing on to the API.
 		 *
-		 * @param string        $provider The provider name.
-		 * @param array         $contact  {
-		 *    Contact information.
+	 * @param array          $contact           {
+	 *          Contact information.
+	 *
+	 *    @type string   $email    Contact email address.
+	 *    @type string   $name     Contact name. Optional.
+	 *    @type string[] $metadata Contact additional metadata. Optional.
+	 * }
+	 * @param string[]|false $selected_list_ids Array of list IDs the contact will be subscribed to, or false.
+	 * @param string         $provider          The provider name.
+		 */
+		$contact = apply_filters( 'newspack_newsletters_contact_data', $contact, $lists, $provider->service );
+
+		/**
+		 * Filters the contact selected lists before passing on to the API.
+		 *
+		 * @param string[]|false $lists    Array of list IDs the contact will be subscribed to, or false.
+		 * @param array          $contact  {
+		 *          Contact information.
 		 *
 		 *    @type string   $email    Contact email address.
 		 *    @type string   $name     Contact name. Optional.
 		 *    @type string[] $metadata Contact additional metadata. Optional.
 		 * }
-		 * @param string[]|false      $lists    Array of list IDs to subscribe the contact to.
+		 * @param string         $provider          The provider name.
 		 */
-		$contact = apply_filters( 'newspack_newsletters_contact_data', $provider->service, $contact, $lists );
+		$lists = apply_filters( 'newspack_newsletters_contact_lists', $lists, $contact, $provider->service );
 
 		$errors = new WP_Error();
 

--- a/includes/class-newspack-newsletters-subscription.php
+++ b/includes/class-newspack-newsletters-subscription.php
@@ -339,15 +339,15 @@ class Newspack_Newsletters_Subscription {
 		/**
 		 * Filters the contact before passing on to the API.
 		 *
-	 * @param array          $contact           {
-	 *          Contact information.
-	 *
-	 *    @type string   $email    Contact email address.
-	 *    @type string   $name     Contact name. Optional.
-	 *    @type string[] $metadata Contact additional metadata. Optional.
-	 * }
-	 * @param string[]|false $selected_list_ids Array of list IDs the contact will be subscribed to, or false.
-	 * @param string         $provider          The provider name.
+		 * @param array          $contact           {
+		 *          Contact information.
+		 *
+		 *    @type string   $email    Contact email address.
+		 *    @type string   $name     Contact name. Optional.
+		 *    @type string[] $metadata Contact additional metadata. Optional.
+		 * }
+		 * @param string[]|false $selected_list_ids Array of list IDs the contact will be subscribed to, or false.
+		 * @param string         $provider          The provider name.
 		 */
 		$contact = apply_filters( 'newspack_newsletters_contact_data', $contact, $lists, $provider->service );
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR introduces filters for `add_contact()` lists and a few fixes:

 - The contact data filter should have `$contact` as initial argument, otherwise it'll be replaced with the provider name when no filters are applied
 - The logger was producing a warning for attempting to `implode()` a `$lists` set to `false`

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->
Closes #896 

### How to test the changes in this Pull Request:

Instructions at https://github.com/Automattic/newspack-plugin/pull/1818

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
