### PR TITLE
fix: updating a list member

### DIFF
--- a/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp.php
+++ b/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp.php
@@ -862,7 +862,7 @@ final class Newspack_Newsletters_Mailchimp extends \Newspack_Newsletters_Service
 				$result = $mc->post( "lists/$list_id/members", $update_payload );
 			} else {
 				$member_id = $found_subscribers[0]['id'];
-				$result    = $mc->patch( "lists/$list_id/members/$member_id", $update_payload );
+				$result    = $mc->put( "lists/$list_id/members/$member_id", $update_payload );
 			}
 			if (
 				! $result ||

--- a/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp.php
+++ b/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp.php
@@ -852,16 +852,11 @@ final class Newspack_Newsletters_Mailchimp extends \Newspack_Newsletters_Service
 			}
 
 			// Create or update a list member.
-			$found_subscribers = $mc->get(
-				'search-members',
-				[
-					'query' => $email_address,
-				]
-			)['exact_matches']['members'];
-			if ( empty( $found_subscribers ) ) {
+			$existing_contact = self::get_contact_data( $email_address );
+			if ( is_wp_error( $existing_contact ) ) {
 				$result = $mc->post( "lists/$list_id/members", $update_payload );
 			} else {
-				$member_id = $found_subscribers[0]['id'];
+				$member_id = $existing_contact['id'];
 				$result    = $mc->put( "lists/$list_id/members/$member_id", $update_payload );
 			}
 			if (
@@ -971,7 +966,7 @@ final class Newspack_Newsletters_Mailchimp extends \Newspack_Newsletters_Service
 		if ( empty( $found ) ) {
 			return new WP_Error( 'newspack_newsletters_mailchimp_contact_not_found', __( 'Contact not found', 'newspack-newsletters' ) );
 		}
-		$keys = [ 'full_name', 'email_address' ];
+		$keys = [ 'full_name', 'email_address', 'id' ];
 		$data = [ 'lists' => [] ];
 		foreach ( $found as $contact ) {
 			foreach ( $keys as $key ) {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes a bug. `PATCH` will only update, but `PUT` [will update or create](https://mailchimp.com/developer/marketing/api/list-merges/).

### How to test the changes in this Pull Request:

1. Set up MC w/ two audiences
2. Using Reader Activation, register and subscribe to both lists
3. On `master`, the reader will be subscribed to only the first list, on this branch to both

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->