### PR TITLE
feat: pass existing contact data to the add_contact hooks

### DIFF
--- a/includes/class-newspack-newsletters-subscription.php
+++ b/includes/class-newspack-newsletters-subscription.php
@@ -336,15 +336,19 @@ class Newspack_Newsletters_Subscription {
 			Newspack_Newsletters_Logger::log( 'Adding contact without lists. Provider is ' . $provider->service . '.' );
 		}
 
+		$existing_contact                 = self::get_contact_data( $contact['email'] );
+		$contact['existing_contact_data'] = \is_wp_error( $existing_contact ) ? false : $existing_contact;
+
 		/**
 		 * Filters the contact before passing on to the API.
 		 *
 		 * @param array          $contact           {
 		 *          Contact information.
 		 *
-		 *    @type string   $email    Contact email address.
-		 *    @type string   $name     Contact name. Optional.
-		 *    @type string[] $metadata Contact additional metadata. Optional.
+		 *    @type string   $email                 Contact email address.
+		 *    @type string   $name                  Contact name. Optional.
+		 *    @type string   $existing_contact_data Existing contact data, if updating a contact. The hook will be also called when
+		 *    @type string[] $metadata              Contact additional metadata. Optional.
 		 * }
 		 * @param string[]|false $selected_list_ids Array of list IDs the contact will be subscribed to, or false.
 		 * @param string         $provider          The provider name.


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Adds existing subsriber data for hooks triggered in `add_contact`. 

### How to test the changes in this Pull Request:

_Testing steps in https://github.com/Automattic/newspack-plugin/pull/1828_

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->