### PR TITLE
fix: urlencode email addresses passed as URL params to ActiveCampaign API

### DIFF
--- a/includes/service-providers/active_campaign/class-newspack-newsletters-active-campaign.php
+++ b/includes/service-providers/active_campaign/class-newspack-newsletters-active-campaign.php
@@ -736,7 +736,6 @@ final class Newspack_Newsletters_Active_Campaign extends \Newspack_Newsletters_S
 	 */
 	public function update_contact_lists( $email, $lists_to_add = [], $lists_to_remove = [] ) {
 		$existing_contact = $this->get_contact_data( $email );
-
 		if ( is_wp_error( $existing_contact ) ) {
 			/** Create contact */
 			// Call Newspack_Newsletters_Subscription's method (not the provider's directly),

--- a/includes/service-providers/active_campaign/class-newspack-newsletters-active-campaign.php
+++ b/includes/service-providers/active_campaign/class-newspack-newsletters-active-campaign.php
@@ -736,6 +736,9 @@ final class Newspack_Newsletters_Active_Campaign extends \Newspack_Newsletters_S
 	 */
 	public function update_contact_lists( $email, $lists_to_add = [], $lists_to_remove = [] ) {
 		$existing_contact = $this->get_contact_data( $email );
+
+		error_log( print_r( $existing_contact, true ) );
+
 		if ( is_wp_error( $existing_contact ) ) {
 			/** Create contact */
 			// Call Newspack_Newsletters_Subscription's method (not the provider's directly),
@@ -803,7 +806,7 @@ final class Newspack_Newsletters_Active_Campaign extends \Newspack_Newsletters_S
 	 * @return array|WP_Error Response or error if contact was not found.
 	 */
 	public function get_contact_data( $email, $return_details = false ) {
-		$result = $this->api_v3_request( 'contacts', 'GET', [ 'query' => [ 'email' => $email ] ] );
+		$result = $this->api_v3_request( 'contacts', 'GET', [ 'query' => [ 'email' => urlencode( $email ) ] ] );
 		if ( is_wp_error( $result ) ) {
 			return $result;
 		}

--- a/includes/service-providers/active_campaign/class-newspack-newsletters-active-campaign.php
+++ b/includes/service-providers/active_campaign/class-newspack-newsletters-active-campaign.php
@@ -737,8 +737,6 @@ final class Newspack_Newsletters_Active_Campaign extends \Newspack_Newsletters_S
 	public function update_contact_lists( $email, $lists_to_add = [], $lists_to_remove = [] ) {
 		$existing_contact = $this->get_contact_data( $email );
 
-		error_log( print_r( $existing_contact, true ) );
-
 		if ( is_wp_error( $existing_contact ) ) {
 			/** Create contact */
 			// Call Newspack_Newsletters_Subscription's method (not the provider's directly),


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Because arguments are passed as URL parameters in ActiveCampaign's API, email addresses need to be passed through `urlencode` before they hit the API.

### How to test the changes in this Pull Request:

1. On a site connected to ActiveCampaign, subscribe via the Register or Subscribe blocks with an email address containing a `+` character.
2. On `master`, go to My Account and update your newsletter preferences. Observe an error message: `You selected a list that does not allow duplicates. The email <email address> is in the system already, please edit that contact instead.`.
3. Check out this branch and repeat step 2. Confirm that you're able to update list subscriptions as expected.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
