### PR TITLE
feat: send verification email upon new account registration

### DIFF
--- a/includes/class-newspack-newsletters-subscription.php
+++ b/includes/class-newspack-newsletters-subscription.php
@@ -12,7 +12,12 @@ defined( 'ABSPATH' ) || exit;
  */
 class Newspack_Newsletters_Subscription {
 
-	const API_NAMESPACE       = 'newspack-newsletters/v1';
+	const API_NAMESPACE = 'newspack-newsletters/v1';
+
+	const EMAIL_VERIFIED_META    = 'newspack_newsletters_email_verified';
+	const EMAIL_VERIFIED_REQUEST = 'newspack_newsletters_email_verification_request';
+	const EMAIL_VERIFIED_CONFIRM = 'newspack_newsletters_email_verification';
+
 	const WC_ENDPOINT         = 'newsletters';
 	const SUBSCRIPTION_UPDATE = 'newspack_newsletters_subscription';
 
@@ -22,6 +27,15 @@ class Newspack_Newsletters_Subscription {
 	public static function init() {
 		add_action( 'rest_api_init', [ __CLASS__, 'register_api_endpoints' ] );
 		add_action( 'newspack_registered_reader', [ __CLASS__, 'newspack_registered_reader' ], 10, 5 );
+
+		/** User email verification for subscription management. */
+		add_action( 'resetpass_form', [ __CLASS__, 'set_current_user_email_verified' ] );
+		add_action( 'password_reset', [ __CLASS__, 'set_current_user_email_verified' ] );
+		add_action( 'newspack_magic_link_authenticated', [ __CLASS__, 'set_current_user_email_verified' ] );
+		add_action( 'newspack_reader_verified', [ __CLASS__, 'set_user_email_verified' ] );
+		add_action( 'template_redirect', [ __CLASS__, 'process_email_verification_request' ] );
+		add_action( 'template_redirect', [ __CLASS__, 'process_email_verification' ] );
+		add_action( 'newspack_registered_reader', [ __CLASS__, 'send_verification_email_on_registration' ], 10, 4 );
 
 		/** Subscription management through WC's "My Account".  */
 		add_action( 'wp_enqueue_scripts', [ __CLASS__, 'enqueue_scripts' ] );
@@ -426,18 +440,6 @@ class Newspack_Newsletters_Subscription {
 	}
 
 	/**
-	 * Enqueue subscription lists scripts and styles.
-	 */
-	public static function enqueue_scripts() {
-		wp_enqueue_style(
-			'newspack-newsletters-subscriptions',
-			plugins_url( '../dist/subscriptions.css', __FILE__ ),
-			[],
-			filemtime( NEWSPACK_NEWSLETTERS_PLUGIN_FILE . 'dist/subscriptions.css' )
-		);
-	}
-
-	/**
 	 * Update a contact lists subscription.
 	 *
 	 * This method will remove the contact from all subscription lists and add
@@ -501,6 +503,259 @@ class Newspack_Newsletters_Subscription {
 	}
 
 	/**
+	 * Whether the current user has its email verified in order to manage their
+	 * newletters subscriptions.
+	 *
+	 * @param int    $user_id User ID. Default is the current user ID.
+	 * @param string $email   Email address being verified. Default is the current user email.
+	 *
+	 * @return bool
+	 */
+	public static function is_email_verified( $user_id = 0, $email = '' ) {
+		if ( empty( $user_id ) ) {
+			$user_id = get_current_user_id();
+		}
+		if ( ! $user_id ) {
+			return false;
+		}
+
+		$user = get_user_by( 'id', $user_id );
+		if ( ! $user ) {
+			return false;
+		}
+
+		if ( empty( $email ) ) {
+			$email = $user->user_email;
+		}
+
+		$verified_emails = get_user_meta( $user_id, self::EMAIL_VERIFIED_META, true );
+		if ( ! is_array( $verified_emails ) ) {
+			$verified_emails = [];
+		}
+
+		$verified = in_array( $email, $verified_emails, true );
+
+		/**
+		 * Filters whether the current user has its email verified.
+		 *
+		 * @param bool    $verified Whether the current user has its email verified.
+		 * @param WP_User $user     User object.
+		 * @param string  $email    Email address being verified.
+		 */
+		return (bool) apply_filters( 'newspack_newsletters_is_email_verified', $verified, $user, $email );
+	}
+
+	/**
+	 * Set email as verified for a user.
+	 *
+	 * @param int    $user_id User ID.
+	 * @param string $email   Email address being verified. Default is the current user's email.
+	 *
+	 * @return bool Wether the email was marked as verified successfully.
+	 */
+	public static function set_email_verified( $user_id, $email = '' ) {
+		$verified_emails = get_user_meta( $user_id, self::EMAIL_VERIFIED_META, true );
+		if ( ! is_array( $verified_emails ) ) {
+			$verified_emails = [];
+		}
+		if ( empty( $email ) ) {
+			$email = get_user_by( 'id', $user_id )->user_email;
+		}
+		if ( ! in_array( $email, $verified_emails, true ) ) {
+			$verified_emails[] = $email;
+			return update_user_meta( $user_id, self::EMAIL_VERIFIED_META, $verified_emails );
+		}
+		return false;
+	}
+
+	/**
+	 * Set the user's email as verified.
+	 *
+	 * @param WP_User $user User.
+	 */
+	public static function set_user_email_verified( $user ) {
+		if ( ! $user instanceof WP_User ) {
+			return;
+		}
+		self::set_email_verified( $user->ID, $user->user_email );
+	}
+
+	/**
+	 * Set current user's email as verified.
+	 */
+	public static function set_current_user_email_verified() {
+		if ( ! is_user_logged_in() ) {
+			return;
+		}
+		self::set_user_email_verified( wp_get_current_user() );
+	}
+
+	/**
+	 * Get current user email verification transient key.
+	 *
+	 * @param string $email Email address being verified. Default is the current user's email.
+	 */
+	private static function get_email_verification_transient_key( $email = '' ) {
+		$user_id = get_current_user_id();
+		if ( empty( $email ) ) {
+			$email = get_user_by( 'id', $user_id )->user_email;
+		}
+		return sprintf( 'newspack_newsletters_email_verification_%s_%s', $user_id, wp_hash( $email ) );
+	}
+
+	/**
+	 * Process request to verify a user's email.
+	 *
+	 * @param boolean $direct_request If calling this method directly from the server, no need to verify nonce.
+	 *
+	 * A 1-day transient will hold a token to verify the email.
+	 */
+	public static function process_email_verification_request( $direct_request = false ) {
+		if (
+			! $direct_request &&
+			( ! isset( $_GET[ self::EMAIL_VERIFIED_REQUEST ] ) || ! wp_verify_nonce( sanitize_text_field( $_GET[ self::EMAIL_VERIFIED_REQUEST ] ), self::EMAIL_VERIFIED_REQUEST ) )
+		) {
+			return;
+		}
+
+		if ( ! is_user_logged_in() ) {
+			wp_die( esc_html( __( 'Invalid request.', 'newspack-newsletters' ) ) );
+		}
+
+		$user               = wp_get_current_user();
+		$transient_key      = self::get_email_verification_transient_key();
+		$token              = \wp_generate_password( 43, false, false );
+		$verification_nonce = wp_create_nonce( self::EMAIL_VERIFIED_CONFIRM );
+
+		$url = home_url();
+		if ( function_exists( 'wc_get_account_endpoint_url' ) ) {
+			$url = wc_get_account_endpoint_url( '/' );
+		}
+		$url = add_query_arg(
+			[
+				self::EMAIL_VERIFIED_CONFIRM => $verification_nonce,
+				'token'                      => $token,
+			],
+			$url
+		);
+
+		set_transient( $transient_key, $token, DAY_IN_SECONDS );
+
+		$blogname = wp_specialchars_decode( get_option( 'blogname' ), ENT_QUOTES );
+
+		$switched_locale = switch_to_locale( get_user_locale( $user ) );
+
+		/* translators: %s: User display name. */
+		$message  = sprintf( __( 'Welcome, %s! Thank you for registering an account.', 'newspack-newsletters' ), $user->display_name ) . "\r\n\r\n";
+		$message .= __( 'To manage your account details, please verify your email address by visiting the following URL:', 'newspack-newsletters' ) . "\r\n\r\n";
+		$message .= $url . "\r\n";
+
+		$email = [
+			'to'      => $user->user_email,
+			/* translators: %s Site title. */
+			'subject' => __( '[%s] Verify your email', 'newspack' ),
+			'message' => $message,
+			'headers' => '',
+		];
+
+		/**
+		 * Filters the email verification email.
+		 *
+		 * @param array    $email          Email arguments. {
+		 *   Used to build wp_mail().
+		 *
+		 *   @type string $to      The intended recipient - New user email address.
+		 *   @type string $subject The subject of the email.
+		 *   @type string $message The body of the email.
+		 *   @type string $headers The headers of the email.
+		 * }
+		 * @param \WP_User $user           User to send the magic link to.
+		 * @param string   $magic_link_url Magic link url.
+		 */
+		$email = \apply_filters( 'newspack_newsletters_email_verification_email', $email, $user, $url );
+
+		// phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.wp_mail_wp_mail
+		$sent = \wp_mail(
+			$email['to'],
+			\wp_specialchars_decode( sprintf( $email['subject'], $blogname ) ),
+			$email['message'],
+			$email['headers']
+		);
+
+		if ( $switched_locale ) {
+			\restore_previous_locale();
+		}
+
+		if ( ! $direct_request ) {
+			if ( function_exists( 'wc_add_notice' ) ) {
+				wc_add_notice( __( 'Check your email address for a verification link.', 'newspack-newsletters' ), 'success' );
+			}
+			wp_safe_redirect( add_query_arg( [ 'verification_sent' => 1 ], remove_query_arg( self::EMAIL_VERIFIED_REQUEST, wp_get_referer() ) ) );
+			exit;
+		}
+	}
+
+	/**
+	 * Process email verification.
+	 */
+	public static function process_email_verification() {
+		if ( ! isset( $_GET[ self::EMAIL_VERIFIED_CONFIRM ] ) || ! wp_verify_nonce( sanitize_text_field( $_GET[ self::EMAIL_VERIFIED_CONFIRM ] ), self::EMAIL_VERIFIED_CONFIRM ) ) {
+			return;
+		}
+		if ( ! is_user_logged_in() ) {
+			wp_die( esc_html( __( 'You\'re not logged in.', 'newspack-newsletters' ) ) );
+		}
+		$transient_key = self::get_email_verification_transient_key();
+		$token         = get_transient( $transient_key );
+		if ( ! $token ) {
+			wp_die( esc_html( __( 'Invalid request.', 'newspack-newsletters' ) ) );
+		}
+		if ( ! isset( $_GET['token'] ) || sanitize_text_field( $_GET['token'] ) !== $token ) {
+			wp_die( esc_html( __( 'Invalid request.', 'newspack-newsletters' ) ) );
+		}
+
+		self::set_email_verified( get_current_user_id() );
+
+		delete_transient( $transient_key );
+
+		if ( function_exists( 'wc_add_notice' ) ) {
+			wc_add_notice( __( 'Your email has been verified.', 'newspack-newsletters' ), 'success' );
+		}
+		wp_safe_redirect( remove_query_arg( [ self::EMAIL_VERIFIED_CONFIRM, 'token' ] ) );
+		exit;
+	}
+
+	/**
+	 * Upon new reader registration, send a verification email.
+	 *
+	 * @param string         $email         Email address.
+	 * @param bool           $authenticate  Whether to authenticate after registering.
+	 * @param false|int      $user_id       The created user id.
+	 * @param false|\WP_User $existing_user The existing user object.
+	 */
+	public static function send_verification_email_on_registration( $email, $authenticate, $user_id, $existing_user ) {
+		// Only send for new, unverified users.
+		if ( false !== $existing_user || self::is_email_verified( $user_id, $email ) ) {
+			return;
+		}
+
+		self::process_email_verification_request( true );
+		Newspack_Newsletters_Logger::log( 'New reader account registered. Sending verification email to ' . $email . '.' );
+	}
+
+	/**
+	 * Enqueue subscription lists scripts and styles.
+	 */
+	public static function enqueue_scripts() {
+		wp_enqueue_style(
+			'newspack-newsletters-subscriptions',
+			plugins_url( '../dist/subscriptions.css', __FILE__ ),
+			[],
+			filemtime( NEWSPACK_NEWSLETTERS_PLUGIN_FILE . 'dist/subscriptions.css' )
+		);
+	}
+
+	/**
 	 * Add query var
 	 *
 	 * @param array $vars Query var.
@@ -548,7 +803,7 @@ class Newspack_Newsletters_Subscription {
 		}
 		$user_id  = get_current_user_id();
 		$email    = get_userdata( $user_id )->user_email;
-		$verified = method_exists( '\Newspack\Reader_Activation', 'is_email_verified' ) ? \Newspack\Reader_Activation::is_email_verified( $user_id, $email ) : true;
+		$verified = self::is_email_verified();
 		?>
 		<div class="newspack-newsletters__user-subscription">
 			<?php if ( ! $verified && ! isset( $_GET['verification_sent'] ) ) : // phpcs:ignore WordPress.Security.NonceVerification.Recommended ?>
@@ -556,7 +811,7 @@ class Newspack_Newsletters_Subscription {
 					<?php esc_html_e( 'Please verify your email address before managing your newsletters subscriptions.', 'newspack-newsletters' ); ?>
 				</p>
 				<p>
-					<a href="<?php echo esc_url( wp_nonce_url( remove_query_arg( \Newspack\Reader_Activation::EMAIL_VERIFIED_REQUEST ), \Newspack\Reader_Activation::EMAIL_VERIFIED_REQUEST, \Newspack\Reader_Activation::EMAIL_VERIFIED_REQUEST ) ); ?>" class="button button-primary">
+					<a href="<?php echo esc_url( wp_nonce_url( remove_query_arg( self::EMAIL_VERIFIED_REQUEST ), self::EMAIL_VERIFIED_REQUEST, self::EMAIL_VERIFIED_REQUEST ) ); ?>" class="button button-primary">
 						<?php esc_html_e( 'Verify Email', 'newspack-newsletters' ); ?>
 					</a>
 				</p>

--- a/includes/class-newspack-newsletters-subscription.php
+++ b/includes/class-newspack-newsletters-subscription.php
@@ -12,12 +12,7 @@ defined( 'ABSPATH' ) || exit;
  */
 class Newspack_Newsletters_Subscription {
 
-	const API_NAMESPACE = 'newspack-newsletters/v1';
-
-	const EMAIL_VERIFIED_META    = 'newspack_newsletters_email_verified';
-	const EMAIL_VERIFIED_REQUEST = 'newspack_newsletters_email_verification_request';
-	const EMAIL_VERIFIED_CONFIRM = 'newspack_newsletters_email_verification';
-
+	const API_NAMESPACE       = 'newspack-newsletters/v1';
 	const WC_ENDPOINT         = 'newsletters';
 	const SUBSCRIPTION_UPDATE = 'newspack_newsletters_subscription';
 
@@ -27,15 +22,6 @@ class Newspack_Newsletters_Subscription {
 	public static function init() {
 		add_action( 'rest_api_init', [ __CLASS__, 'register_api_endpoints' ] );
 		add_action( 'newspack_registered_reader', [ __CLASS__, 'newspack_registered_reader' ], 10, 5 );
-
-		/** User email verification for subscription management. */
-		add_action( 'resetpass_form', [ __CLASS__, 'set_current_user_email_verified' ] );
-		add_action( 'password_reset', [ __CLASS__, 'set_current_user_email_verified' ] );
-		add_action( 'newspack_magic_link_authenticated', [ __CLASS__, 'set_current_user_email_verified' ] );
-		add_action( 'newspack_reader_verified', [ __CLASS__, 'set_user_email_verified' ] );
-		add_action( 'template_redirect', [ __CLASS__, 'process_email_verification_request' ] );
-		add_action( 'template_redirect', [ __CLASS__, 'process_email_verification' ] );
-		add_action( 'newspack_registered_reader', [ __CLASS__, 'send_verification_email_on_registration' ], 10, 4 );
 
 		/** Subscription management through WC's "My Account".  */
 		add_action( 'wp_enqueue_scripts', [ __CLASS__, 'enqueue_scripts' ] );
@@ -440,6 +426,18 @@ class Newspack_Newsletters_Subscription {
 	}
 
 	/**
+	 * Enqueue subscription lists scripts and styles.
+	 */
+	public static function enqueue_scripts() {
+		wp_enqueue_style(
+			'newspack-newsletters-subscriptions',
+			plugins_url( '../dist/subscriptions.css', __FILE__ ),
+			[],
+			filemtime( NEWSPACK_NEWSLETTERS_PLUGIN_FILE . 'dist/subscriptions.css' )
+		);
+	}
+
+	/**
 	 * Update a contact lists subscription.
 	 *
 	 * This method will remove the contact from all subscription lists and add
@@ -503,259 +501,6 @@ class Newspack_Newsletters_Subscription {
 	}
 
 	/**
-	 * Whether the current user has its email verified in order to manage their
-	 * newletters subscriptions.
-	 *
-	 * @param int    $user_id User ID. Default is the current user ID.
-	 * @param string $email   Email address being verified. Default is the current user email.
-	 *
-	 * @return bool
-	 */
-	public static function is_email_verified( $user_id = 0, $email = '' ) {
-		if ( empty( $user_id ) ) {
-			$user_id = get_current_user_id();
-		}
-		if ( ! $user_id ) {
-			return false;
-		}
-
-		$user = get_user_by( 'id', $user_id );
-		if ( ! $user ) {
-			return false;
-		}
-
-		if ( empty( $email ) ) {
-			$email = $user->user_email;
-		}
-
-		$verified_emails = get_user_meta( $user_id, self::EMAIL_VERIFIED_META, true );
-		if ( ! is_array( $verified_emails ) ) {
-			$verified_emails = [];
-		}
-
-		$verified = in_array( $email, $verified_emails, true );
-
-		/**
-		 * Filters whether the current user has its email verified.
-		 *
-		 * @param bool    $verified Whether the current user has its email verified.
-		 * @param WP_User $user     User object.
-		 * @param string  $email    Email address being verified.
-		 */
-		return (bool) apply_filters( 'newspack_newsletters_is_email_verified', $verified, $user, $email );
-	}
-
-	/**
-	 * Set email as verified for a user.
-	 *
-	 * @param int    $user_id User ID.
-	 * @param string $email   Email address being verified. Default is the current user's email.
-	 *
-	 * @return bool Wether the email was marked as verified successfully.
-	 */
-	public static function set_email_verified( $user_id, $email = '' ) {
-		$verified_emails = get_user_meta( $user_id, self::EMAIL_VERIFIED_META, true );
-		if ( ! is_array( $verified_emails ) ) {
-			$verified_emails = [];
-		}
-		if ( empty( $email ) ) {
-			$email = get_user_by( 'id', $user_id )->user_email;
-		}
-		if ( ! in_array( $email, $verified_emails, true ) ) {
-			$verified_emails[] = $email;
-			return update_user_meta( $user_id, self::EMAIL_VERIFIED_META, $verified_emails );
-		}
-		return false;
-	}
-
-	/**
-	 * Set the user's email as verified.
-	 *
-	 * @param WP_User $user User.
-	 */
-	public static function set_user_email_verified( $user ) {
-		if ( ! $user instanceof WP_User ) {
-			return;
-		}
-		self::set_email_verified( $user->ID, $user->user_email );
-	}
-
-	/**
-	 * Set current user's email as verified.
-	 */
-	public static function set_current_user_email_verified() {
-		if ( ! is_user_logged_in() ) {
-			return;
-		}
-		self::set_user_email_verified( wp_get_current_user() );
-	}
-
-	/**
-	 * Get current user email verification transient key.
-	 *
-	 * @param string $email Email address being verified. Default is the current user's email.
-	 */
-	private static function get_email_verification_transient_key( $email = '' ) {
-		$user_id = get_current_user_id();
-		if ( empty( $email ) ) {
-			$email = get_user_by( 'id', $user_id )->user_email;
-		}
-		return sprintf( 'newspack_newsletters_email_verification_%s_%s', $user_id, wp_hash( $email ) );
-	}
-
-	/**
-	 * Process request to verify a user's email.
-	 *
-	 * @param boolean $direct_request If calling this method directly from the server, no need to verify nonce.
-	 *
-	 * A 1-day transient will hold a token to verify the email.
-	 */
-	public static function process_email_verification_request( $direct_request = false ) {
-		if (
-			! $direct_request &&
-			( ! isset( $_GET[ self::EMAIL_VERIFIED_REQUEST ] ) || ! wp_verify_nonce( sanitize_text_field( $_GET[ self::EMAIL_VERIFIED_REQUEST ] ), self::EMAIL_VERIFIED_REQUEST ) )
-		) {
-			return;
-		}
-
-		if ( ! is_user_logged_in() ) {
-			wp_die( esc_html( __( 'Invalid request.', 'newspack-newsletters' ) ) );
-		}
-
-		$user               = wp_get_current_user();
-		$transient_key      = self::get_email_verification_transient_key();
-		$token              = \wp_generate_password( 43, false, false );
-		$verification_nonce = wp_create_nonce( self::EMAIL_VERIFIED_CONFIRM );
-
-		$url = home_url();
-		if ( function_exists( 'wc_get_account_endpoint_url' ) ) {
-			$url = wc_get_account_endpoint_url( '/' );
-		}
-		$url = add_query_arg(
-			[
-				self::EMAIL_VERIFIED_CONFIRM => $verification_nonce,
-				'token'                      => $token,
-			],
-			$url
-		);
-
-		set_transient( $transient_key, $token, DAY_IN_SECONDS );
-
-		$blogname = wp_specialchars_decode( get_option( 'blogname' ), ENT_QUOTES );
-
-		$switched_locale = switch_to_locale( get_user_locale( $user ) );
-
-		/* translators: %s: User display name. */
-		$message  = sprintf( __( 'Welcome, %s! Thank you for registering an account.', 'newspack-newsletters' ), $user->display_name ) . "\r\n\r\n";
-		$message .= __( 'To manage your account details, please verify your email address by visiting the following URL:', 'newspack-newsletters' ) . "\r\n\r\n";
-		$message .= $url . "\r\n";
-
-		$email = [
-			'to'      => $user->user_email,
-			/* translators: %s Site title. */
-			'subject' => __( '[%s] Verify your email', 'newspack' ),
-			'message' => $message,
-			'headers' => '',
-		];
-
-		/**
-		 * Filters the email verification email.
-		 *
-		 * @param array    $email          Email arguments. {
-		 *   Used to build wp_mail().
-		 *
-		 *   @type string $to      The intended recipient - New user email address.
-		 *   @type string $subject The subject of the email.
-		 *   @type string $message The body of the email.
-		 *   @type string $headers The headers of the email.
-		 * }
-		 * @param \WP_User $user           User to send the magic link to.
-		 * @param string   $magic_link_url Magic link url.
-		 */
-		$email = \apply_filters( 'newspack_newsletters_email_verification_email', $email, $user, $url );
-
-		// phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.wp_mail_wp_mail
-		$sent = \wp_mail(
-			$email['to'],
-			\wp_specialchars_decode( sprintf( $email['subject'], $blogname ) ),
-			$email['message'],
-			$email['headers']
-		);
-
-		if ( $switched_locale ) {
-			\restore_previous_locale();
-		}
-
-		if ( ! $direct_request ) {
-			if ( function_exists( 'wc_add_notice' ) ) {
-				wc_add_notice( __( 'Check your email address for a verification link.', 'newspack-newsletters' ), 'success' );
-			}
-			wp_safe_redirect( add_query_arg( [ 'verification_sent' => 1 ], remove_query_arg( self::EMAIL_VERIFIED_REQUEST, wp_get_referer() ) ) );
-			exit;
-		}
-	}
-
-	/**
-	 * Process email verification.
-	 */
-	public static function process_email_verification() {
-		if ( ! isset( $_GET[ self::EMAIL_VERIFIED_CONFIRM ] ) || ! wp_verify_nonce( sanitize_text_field( $_GET[ self::EMAIL_VERIFIED_CONFIRM ] ), self::EMAIL_VERIFIED_CONFIRM ) ) {
-			return;
-		}
-		if ( ! is_user_logged_in() ) {
-			wp_die( esc_html( __( 'You\'re not logged in.', 'newspack-newsletters' ) ) );
-		}
-		$transient_key = self::get_email_verification_transient_key();
-		$token         = get_transient( $transient_key );
-		if ( ! $token ) {
-			wp_die( esc_html( __( 'Invalid request.', 'newspack-newsletters' ) ) );
-		}
-		if ( ! isset( $_GET['token'] ) || sanitize_text_field( $_GET['token'] ) !== $token ) {
-			wp_die( esc_html( __( 'Invalid request.', 'newspack-newsletters' ) ) );
-		}
-
-		self::set_email_verified( get_current_user_id() );
-
-		delete_transient( $transient_key );
-
-		if ( function_exists( 'wc_add_notice' ) ) {
-			wc_add_notice( __( 'Your email has been verified.', 'newspack-newsletters' ), 'success' );
-		}
-		wp_safe_redirect( remove_query_arg( [ self::EMAIL_VERIFIED_CONFIRM, 'token' ] ) );
-		exit;
-	}
-
-	/**
-	 * Upon new reader registration, send a verification email.
-	 *
-	 * @param string         $email         Email address.
-	 * @param bool           $authenticate  Whether to authenticate after registering.
-	 * @param false|int      $user_id       The created user id.
-	 * @param false|\WP_User $existing_user The existing user object.
-	 */
-	public static function send_verification_email_on_registration( $email, $authenticate, $user_id, $existing_user ) {
-		// Only send for new, unverified users.
-		if ( false !== $existing_user || self::is_email_verified( $user_id, $email ) ) {
-			return;
-		}
-
-		self::process_email_verification_request( true );
-		Newspack_Newsletters_Logger::log( 'New reader account registered. Sending verification email to ' . $email . '.' );
-	}
-
-	/**
-	 * Enqueue subscription lists scripts and styles.
-	 */
-	public static function enqueue_scripts() {
-		wp_enqueue_style(
-			'newspack-newsletters-subscriptions',
-			plugins_url( '../dist/subscriptions.css', __FILE__ ),
-			[],
-			filemtime( NEWSPACK_NEWSLETTERS_PLUGIN_FILE . 'dist/subscriptions.css' )
-		);
-	}
-
-	/**
 	 * Add query var
 	 *
 	 * @param array $vars Query var.
@@ -803,7 +548,7 @@ class Newspack_Newsletters_Subscription {
 		}
 		$user_id  = get_current_user_id();
 		$email    = get_userdata( $user_id )->user_email;
-		$verified = self::is_email_verified();
+		$verified = method_exists( '\Newspack\Reader_Activation', 'is_email_verified' ) ? \Newspack\Reader_Activation::is_email_verified( $user_id, $email ) : true;
 		?>
 		<div class="newspack-newsletters__user-subscription">
 			<?php if ( ! $verified && ! isset( $_GET['verification_sent'] ) ) : // phpcs:ignore WordPress.Security.NonceVerification.Recommended ?>
@@ -811,7 +556,7 @@ class Newspack_Newsletters_Subscription {
 					<?php esc_html_e( 'Please verify your email address before managing your newsletters subscriptions.', 'newspack-newsletters' ); ?>
 				</p>
 				<p>
-					<a href="<?php echo esc_url( wp_nonce_url( remove_query_arg( self::EMAIL_VERIFIED_REQUEST ), self::EMAIL_VERIFIED_REQUEST, self::EMAIL_VERIFIED_REQUEST ) ); ?>" class="button button-primary">
+					<a href="<?php echo esc_url( wp_nonce_url( remove_query_arg( \Newspack\Reader_Activation::EMAIL_VERIFIED_REQUEST ), \Newspack\Reader_Activation::EMAIL_VERIFIED_REQUEST, \Newspack\Reader_Activation::EMAIL_VERIFIED_REQUEST ) ); ?>" class="button button-primary">
 						<?php esc_html_e( 'Verify Email', 'newspack-newsletters' ); ?>
 					</a>
 				</p>

--- a/includes/class-newspack-newsletters-subscription.php
+++ b/includes/class-newspack-newsletters-subscription.php
@@ -614,7 +614,7 @@ class Newspack_Newsletters_Subscription {
 		if (
 			! $direct_request &&
 			( ! isset( $_GET[ self::EMAIL_VERIFIED_REQUEST ] ) || ! wp_verify_nonce( sanitize_text_field( $_GET[ self::EMAIL_VERIFIED_REQUEST ] ), self::EMAIL_VERIFIED_REQUEST ) )
-		 ) {
+		) {
 			return;
 		}
 
@@ -629,7 +629,7 @@ class Newspack_Newsletters_Subscription {
 
 		$url = home_url();
 		if ( function_exists( 'wc_get_account_endpoint_url' ) ) {
-			$url = wc_get_account_endpoint_url( 'newsletters' );
+			$url = wc_get_account_endpoint_url( '/' );
 		}
 		$url = add_query_arg(
 			[


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Along with https://github.com/Automattic/newspack-plugin/pull/1876, sends a verification email instead of the standard WooCommerce "welcome" email to readers who register a new account via direct email input.

Will not send a verification email to readers who register via SSO, which is considered a secure login method and doesn't require verification.

Closes https://github.com/Automattic/newspack-plugin/issues/1872.

### How to test the changes in this Pull Request:

1. Check out this branch and https://github.com/Automattic/newspack-plugin/pull/1876.
2. Register a new email address via the Register block (via direct email input, not SSO) and confirm that you receive a verification email (with slightly tweaked language) instead of WooCommerce's "Your Newspack account has been created!" email.
3. Visit the verification URL in the same session where you registered the email address and confirm that you're redirected to the main My Account dashboard page with a message that your email has been verified. Also confirm that you're able to manage newsletter subscriptions at this point.
4. In a new session, register a new account via SSO and confirm that you do not receive a verification email, and that you're immediately able to manage newsletter subscriptions in My Account > Newsletters.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
