### PR TITLE
fix(activecampaign): resubscribe on adding contact

### DIFF
--- a/includes/service-providers/active_campaign/class-newspack-newsletters-active-campaign.php
+++ b/includes/service-providers/active_campaign/class-newspack-newsletters-active-campaign.php
@@ -676,7 +676,8 @@ final class Newspack_Newsletters_Active_Campaign extends \Newspack_Newsletters_S
 
 		$has_list_id = false !== $list_id;
 		if ( $has_list_id ) {
-			$payload[ 'p[' . $list_id . ']' ] = $list_id;
+			$payload[ 'p[' . $list_id . ']' ]      = $list_id;
+			$payload[ 'status[' . $list_id . ']' ] = 1;
 		}
 		$existing_contact = $this->get_contact_data( $contact['email'] );
 		if ( is_wp_error( $existing_contact ) ) {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Ensure that adding a contact to a list makes them subscribed to it on ActiveCampaign.

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes #923

### How to test the changes in this Pull Request:

1. With reader activation and AC as your ESP, register a new account subscribed to all newsletters
2. Visit "My Account -> Newsletters" and unsubscribe to all newsletters
3. Log out and use the same email subscribing to all newsletters on a Registration Block
4. Sign in with the magic link you've received and confirm you're resubscribed to all newsletters

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
