### PR TITLE
feat: use Reader Activation custom sender info for verification emails

### DIFF
--- a/includes/class-newspack-newsletters-subscription.php
+++ b/includes/class-newspack-newsletters-subscription.php
@@ -643,13 +643,24 @@ class Newspack_Newsletters_Subscription {
 		$message  = sprintf( __( 'Hello, %s!', 'newspack-newsletters' ), $user->display_name ) . "\r\n\r\n";
 		$message .= __( 'Verify your email address by visiting the following address:', 'newspack-newsletters' ) . "\r\n\r\n";
 		$message .= $url . "\r\n";
+		$headers  = '';
+
+		if ( method_exists( '\Newspack\Reader_Activation', 'get_from_email' ) && method_exists( '\Newspack\Reader_Activation', 'get_from_name' ) ) {
+			$headers = [
+				sprintf(
+					'From: %1$s <%2$s>',
+					\Newspack\Reader_Activation::get_from_name(),
+					\Newspack\Reader_Activation::get_from_email()
+				),
+			];
+		}
 
 		$email = [
 			'to'      => $user->user_email,
 			/* translators: %s Site title. */
 			'subject' => __( '[%s] Verify your email', 'newspack' ),
 			'message' => $message,
-			'headers' => '',
+			'headers' => $headers,
 		];
 
 		/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Uses new methods established in https://github.com/Automattic/newspack-plugin/pull/1880 to set the from email address and name for transactional emails (for this plugin, just the verification emails).

Since the standalone verification flow is locked when Reader Activation is active, this probably won't have any major effects, but it's just for completion's sake and/or in case we decide to handle the Newsletters area of My Account separately in the future.

### How to test the changes in this Pull Request:

1. Check out https://github.com/Automattic/newspack-plugin/pull/1880 and this branch.
2. With Reader Activation features active, register a new email address and sign up for at least one newsletter.
3. Temporarily disable Reader Activation features (otherwise you can't access the standalone verification flow in this plugin).
4. Go to My Account > Newsletters and click on the button to verify your email address.
5. Confirm that the email gets sent with the RAS custom scheme: `Site Name <no-reply@sitedomain.com>`

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
