### PR TITLE
feat: delete contact on reader account deletion

### DIFF
--- a/includes/class-newspack-newsletters-subscription.php
+++ b/includes/class-newspack-newsletters-subscription.php
@@ -43,6 +43,7 @@ class Newspack_Newsletters_Subscription {
 		add_action( 'woocommerce_account_newsletters_endpoint', [ __CLASS__, 'endpoint_content' ] );
 		add_action( 'template_redirect', [ __CLASS__, 'process_subscription_update' ] );
 		add_action( 'init', [ __CLASS__, 'flush_rewrite_rules' ] );
+		add_action( 'newspack_reader_before_delete', [ __CLASS__, 'delete_user_subscription' ], 10, 2 );
 	}
 
 	/**
@@ -410,6 +411,29 @@ class Newspack_Newsletters_Subscription {
 		do_action( 'newspack_newsletters_add_contact', $provider->service, $contact, $lists, $result );
 
 		return $result;
+	}
+
+	/**
+	 * Permanently delete a user subscription.
+	 *
+	 * @param int     $user_id User ID.
+	 * @param WP_User $user    User object.
+	 *
+	 * @return bool|WP_Error Whether the contact was deleted or error.
+	 */
+	public static function delete_user_subscription( $user_id, $user ) {
+		/** Only delete if email ownership is verified. */
+		if ( ! self::is_email_verified( $user_id ) ) {
+			return new \WP_Error( 'newspack_newsletters_email_not_verified', __( 'Email ownership is not verified.' ) );
+		}
+		$provider = Newspack_Newsletters::get_service_provider();
+		if ( empty( $provider ) ) {
+			return new WP_Error( 'newspack_newsletters_invalid_provider', __( 'Provider is not set.' ) );
+		}
+		if ( ! method_exists( $provider, 'delete_contact' ) ) {
+			return new WP_Error( 'newspack_newsletters_invalid_provider_method', __( 'Provider does not support deleting user subscriptions.' ) );
+		}
+		return $provider->delete_contact( $user->user_email );
 	}
 
 	/**

--- a/includes/class-newspack-newsletters-subscription.php
+++ b/includes/class-newspack-newsletters-subscription.php
@@ -27,7 +27,7 @@ class Newspack_Newsletters_Subscription {
 	public static function init() {
 		add_action( 'rest_api_init', [ __CLASS__, 'register_api_endpoints' ] );
 		add_action( 'newspack_registered_reader', [ __CLASS__, 'newspack_registered_reader' ], 10, 5 );
-		add_action( 'newspack_reader_before_delete', [ __CLASS__, 'reader_before_delete' ] );
+		add_action( 'delete_user', [ __CLASS__, 'delete_user' ], 10, 3 );
 
 		/** User email verification for subscription management. */
 		add_action( 'resetpass_form', [ __CLASS__, 'set_current_user_email_verified' ] );
@@ -473,11 +473,17 @@ class Newspack_Newsletters_Subscription {
 	/**
 	 * Delete a contact from ESP when a reader is deleted.
 	 *
-	 * @param int $user_id The user ID.
+	 * @param int      $user_id  ID of the user to delete.
+	 * @param int|null $reassign ID of the user to reassign posts and links to.
+	 *                           Default null, for no reassignment.
+	 * @param WP_User  $user     WP_User object of the user to delete.
 	 *
 	 * @return bool|WP_Error Whether the contact was deleted or error.
 	 */
-	public static function reader_before_delete( $user_id ) {
+	public static function delete_user( $user_id, $reassign, $user ) {
+		if ( ! \Newspack\Reader_Activation::is_user_reader( $user ) ) {
+			return;
+		}
 		$sync = \Newspack\Reader_Activation::get_setting( 'sync_esp' );
 		if ( ! $sync ) {
 			return;

--- a/includes/class-newspack-newsletters-subscription.php
+++ b/includes/class-newspack-newsletters-subscription.php
@@ -449,15 +449,16 @@ class Newspack_Newsletters_Subscription {
 	 * @param array          $metadata      Metadata.
 	 */
 	public static function newspack_registered_reader( $email, $authenticate, $user_id, $existing_user, $metadata ) {
-		$sync = \Newspack\Reader_Activation::get_setting( 'sync_esp' );
-		if ( ! $sync ) {
-			return;
-		}
 		if ( isset( $metadata['lists'] ) && ! empty( $metadata['lists'] ) ) {
 			$lists = $metadata['lists'];
 			unset( $metadata['lists'] );
 		} else {
 			$lists = false;
+		}
+		/** Don't add contact if reader sync is disabled and there are no lists to subscribe to. */
+		$sync = \Newspack\Reader_Activation::get_setting( 'sync_esp' );
+		if ( ! $sync && empty( $lists ) ) {
+			return;
 		}
 		// Adding is actually upserting, so no need to check if the hook is called for an existing user.
 		self::add_contact(

--- a/includes/service-providers/active_campaign/class-newspack-newsletters-active-campaign.php
+++ b/includes/service-providers/active_campaign/class-newspack-newsletters-active-campaign.php
@@ -781,6 +781,22 @@ final class Newspack_Newsletters_Active_Campaign extends \Newspack_Newsletters_S
 	}
 
 	/**
+	 * Delete contact from all lists given its email.
+	 *
+	 * @param string $email Email address.
+	 *
+	 * @return bool|WP_Error True if the contact was deleted, error if failed.
+	 */
+	public function delete_contact( $email ) {
+		$contact = $this->get_contact_data( $email );
+		if ( is_wp_error( $contact ) ) {
+			return $contact;
+		}
+		$result = $this->api_v1_request( 'contact_delete', 'GET', [ 'query' => [ 'id' => $contact['id'] ] ] );
+		return is_wp_error( $result ) ? $result : true;
+	}
+
+	/**
 	 * Get the lists a contact is subscribed to.
 	 *
 	 * @param string $email The contact email.

--- a/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp.php
+++ b/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp.php
@@ -883,6 +883,33 @@ final class Newspack_Newsletters_Mailchimp extends \Newspack_Newsletters_Service
 	}
 
 	/**
+	 * Delete contact from all lists given its email.
+	 *
+	 * @param string $email Email address.
+	 *
+	 * @return bool|WP_Error True if the contact was deleted, error if failed.
+	 */
+	public function delete_contact( $email ) {
+		$contact = $this->get_contact_data( $email );
+		if ( is_wp_error( $contact ) ) {
+			return $contact;
+		}
+		foreach ( $contact['lists'] as $list_id => $list ) {
+			try {
+				$member_id = $list['id'];
+				$mc        = new Mailchimp( $this->api_key() );
+				$result    = $mc->post( "lists/$list_id/members/$member_id/actions/delete-permanent" );
+			} catch ( \Exception $e ) {
+				return new \WP_Error(
+					'newspack_newsletters_mailchimp_delete_contact_failed',
+					$e->getMessage()
+				);
+			}
+		}
+		return true;
+	}
+
+	/**
 	 * Get the lists a contact is subscribed to.
 	 *
 	 * @param string $email The contact email.
@@ -975,6 +1002,7 @@ final class Newspack_Newsletters_Mailchimp extends \Newspack_Newsletters_Service
 				}
 			}
 			$data['lists'][ $contact['list_id'] ] = [
+				'id'         => $contact['id'], // md5 hash of email.
 				'contact_id' => $contact['contact_id'],
 				'status'     => $contact['status'],
 			];

--- a/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp.php
+++ b/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp.php
@@ -898,7 +898,7 @@ final class Newspack_Newsletters_Mailchimp extends \Newspack_Newsletters_Service
 			try {
 				$member_id = $list['id'];
 				$mc        = new Mailchimp( $this->api_key() );
-				$result    = $mc->post( "lists/$list_id/members/$member_id/actions/delete-permanent" );
+				$mc->delete( "lists/$list_id/members/$member_id" );
 			} catch ( \Exception $e ) {
 				return new \WP_Error(
 					'newspack_newsletters_mailchimp_delete_contact_failed',


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Implements contact deletion methods for ActiveCampaign and Mailchimp and delete on reader deletion according to the config.

### How to test the changes in this Pull Request:

Further details and testing instructions at https://github.com/Automattic/newspack-plugin/pull/1884

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
