### PR TITLE
feat: honeypot field for Subscribe block form

### DIFF
--- a/src/blocks/subscribe/index.php
+++ b/src/blocks/subscribe/index.php
@@ -87,8 +87,8 @@ function render_block( $attrs ) {
 		if ( isset( $_REQUEST['message'] ) ) {
 			$message = \sanitize_text_field( $_REQUEST['message'] );
 		}
-		if ( isset( $_REQUEST['email'] ) ) {
-			$email = \sanitize_text_field( $_REQUEST['email'] );
+		if ( isset( $_REQUEST['npe'] ) ) {
+			$email = \sanitize_text_field( $_REQUEST['npe'] );
 		}
 		if ( isset( $_REQUEST['lists'] ) && is_array( $_REQUEST['lists'] ) ) {
 			$list_map = array_flip( array_map( 'sanitize_text_field', $_REQUEST['lists'] ) );
@@ -105,6 +105,16 @@ function render_block( $attrs ) {
 				<?php \wp_nonce_field( FORM_ACTION, FORM_ACTION ); ?>
 				<div class="newspack-newsletters-email-input">
 					<input
+						type="email"
+						name="npe"
+						autocomplete="email"
+						placeholder="<?php echo \esc_attr( $attrs['placeholder'] ); ?>"
+						value="<?php echo esc_attr( $email ); ?>"
+					/>
+					<input
+						class="nphp"
+						tabindex="-1"
+						aria-hidden="true"
 						type="email"
 						name="email"
 						autocomplete="email"
@@ -226,7 +236,12 @@ function process_form() {
 		return;
 	}
 
-	if ( ! isset( $_REQUEST['email'] ) || empty( $_REQUEST['email'] ) ) {
+	// Honeypot trap.
+	if ( ! empty( $_REQUEST['email'] ) ) {
+		return send_form_response( new \WP_Error( 'invalid_request', __( 'Invalid request.', 'newspack-newsletters' ) ) );
+	}
+
+	if ( ! isset( $_REQUEST['npe'] ) || empty( $_REQUEST['npe'] ) ) {
 		return send_form_response( new \WP_Error( 'invalid_email', __( 'You must enter a valid email address.', 'newspack-newsletters' ) ) );
 	}
 
@@ -234,7 +249,7 @@ function process_form() {
 		return send_form_response( new \WP_Error( 'no_lists', __( 'You must select a list.', 'newspack-newsletters' ) ) );
 	}
 
-	$email = \sanitize_email( $_REQUEST['email'] );
+	$email = \sanitize_email( $_REQUEST['npe'] );
 	$lists = array_map( 'sanitize_text_field', $_REQUEST['lists'] );
 
 	$result = \Newspack_Newsletters_Subscription::add_contact(

--- a/src/blocks/subscribe/index.php
+++ b/src/blocks/subscribe/index.php
@@ -238,7 +238,7 @@ function process_form() {
 
 	// Honeypot trap.
 	if ( ! empty( $_REQUEST['email'] ) ) {
-		return send_form_response( new \WP_Error( 'invalid_request', __( 'Invalid request.', 'newspack-newsletters' ) ) );
+		return send_form_response( [ 'email' => \sanitize_email( $_REQUEST['email'] ) ] );
 	}
 
 	if ( ! isset( $_REQUEST['npe'] ) || empty( $_REQUEST['npe'] ) ) {

--- a/src/blocks/subscribe/index.php
+++ b/src/blocks/subscribe/index.php
@@ -249,6 +249,7 @@ function process_form() {
 		return send_form_response( new \WP_Error( 'no_lists', __( 'You must select a list.', 'newspack-newsletters' ) ) );
 	}
 
+	// The "true" email address field is called `npe` due to the honeypot strategy.
 	$email = \sanitize_email( $_REQUEST['npe'] );
 	$lists = array_map( 'sanitize_text_field', $_REQUEST['lists'] );
 

--- a/src/blocks/subscribe/style.scss
+++ b/src/blocks/subscribe/style.scss
@@ -55,4 +55,16 @@
 			margin-right: 0;
 		}
 	}
+	.nphp {
+		border: 0;
+		clip: rect( 1px, 1px, 1px, 1px );
+		clip-path: inset( 50% );
+		height: 1px;
+		margin: -1px;
+		overflow: hidden;
+		padding: 0;
+		position: absolute !important;
+		width: 1px;
+		word-wrap: normal !important;
+	}
 }

--- a/src/blocks/subscribe/view.js
+++ b/src/blocks/subscribe/view.js
@@ -18,7 +18,7 @@ import './style.scss';
 			form.addEventListener( 'submit', ev => {
 				ev.preventDefault();
 				const body = new FormData( form );
-				if ( ! body.has( 'email' ) || ! body.get( 'email' ) ) {
+				if ( ! body.has( 'npe' ) || ! body.get( 'npe' ) ) {
 					return;
 				}
 				emailInput.disabled = true;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Similar to https://github.com/Automattic/newspack-plugin/pull/1896, implements a honeypot trap field for the Subscribe block's form. This is implemented fully in this plugin so that it has no dependencies on the main plugin.

### How to test the changes in this Pull Request:

1. Check out this branch. Confirm that the Subscribe block looks and functions as normal.
2. Temporarily comment out or delete [this SCSS block](https://github.com/Automattic/newspack-newsletters/pull/932/files#diff-bb09ed8cb7e0f6604c1d72c36e6bfb866010cc2e5d8dc319c3c1c8238af7e6f3R58-R69) to unhide the honeypot field.
3. Refresh the Subscribe block and confirm there's a new email input field alongside the usual one.
4. Rebusmit the form, this time filling out both email inputs, and confirm that the form resolves with a success message.
5. Confirm that no subscription event happens with the ESP on the back-end.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
