### PR TITLE
fix: ensure main query post type is an array

### DIFF
--- a/includes/class-newspack-newsletters.php
+++ b/includes/class-newspack-newsletters.php
@@ -1222,6 +1222,9 @@ final class Newspack_Newsletters {
 			if ( empty( $post_type ) ) {
 				$post_type = [ 'post' ];
 			}
+			if ( ! is_array( $post_type ) ) {
+				$post_type = [ $post_type ];
+			}
 			$post_type[] = self::NEWSPACK_NEWSLETTERS_CPT;
 			$query->set( 'post_type', $post_type );
 		}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Although it is standard for the main query to have the `post_type` set as an array, a hook may change it to a string ( `'post'`, instead of `array( 'post' )`)

This PR ensures that a string `post_type` is transformed to array before adding the newsletters post type to it.

### How to test the changes in this Pull Request:

Public newsletters should continue to be displayed in archives.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
