### PR TITLE
feat: handle reCAPTCHA on Subscribe form

### DIFF
--- a/src/blocks/subscribe/index.php
+++ b/src/blocks/subscribe/index.php
@@ -36,10 +36,10 @@ function enqueue_scripts() {
 		filemtime( NEWSPACK_NEWSLETTERS_PLUGIN_FILE . 'dist/subscribeBlock.css' )
 	);
 
-	$use_captcha  = method_exists( '\Newspack\Reader_Activation', 'can_use_captcha' ) && \Newspack\Reader_Activation::can_use_captcha();
+	$use_captcha  = method_exists( '\Newspack\Recaptcha', 'can_use_captcha' ) && \Newspack\Recaptcha::can_use_captcha();
 	$dependencies = [ 'wp-polyfill', 'wp-i18n' ];
 	if ( $use_captcha ) {
-		$dependencies[] = \Newspack\Reader_Activation::RECAPTCHA_SCRIPT_HANDLE;
+		$dependencies[] = \Newspack\Recaptcha::RECAPTCHA_SCRIPT_HANDLE;
 	}
 
 	\wp_enqueue_script(
@@ -249,9 +249,9 @@ function process_form() {
 	}
 
 	// reCAPTCHA test.
-	if ( ! empty( $_REQUEST['captcha_token'] ) && method_exists( '\Newspack\Reader_Activation', 'verify_captcha' ) ) {
-		$captcha_token  = \sanitize_text_field( $_REQUEST['captcha_token'] );
-		$captcha_result = \Newspack\Reader_Activation::verify_captcha( $captcha_token );
+	if ( method_exists( '\Newspack\Recaptcha', 'can_use_captcha' ) && \Newspack\Recaptcha::can_use_captcha() ) {
+		$captcha_token  = isset( $_REQUEST['captcha_token'] ) ? \sanitize_text_field( $_REQUEST['captcha_token'] ) : '';
+		$captcha_result = \Newspack\Recaptcha::verify_captcha( $captcha_token );
 		if ( \is_wp_error( $captcha_result ) ) {
 			return send_form_response( $captcha_result );
 		}

--- a/src/blocks/subscribe/index.php
+++ b/src/blocks/subscribe/index.php
@@ -239,7 +239,6 @@ function send_form_response( $data ) {
  * Process newsletter signup form.
  */
 function process_form() {
-	error_log( print_r( $_REQUEST, true ) );
 	if ( ! isset( $_REQUEST[ FORM_ACTION ] ) || ! \wp_verify_nonce( \sanitize_text_field( $_REQUEST[ FORM_ACTION ] ), FORM_ACTION ) ) {
 		return;
 	}
@@ -253,7 +252,6 @@ function process_form() {
 	if ( ! empty( $_REQUEST['captcha_token'] ) && method_exists( '\Newspack\Reader_Activation', 'verify_captcha' ) ) {
 		$captcha_token  = \sanitize_text_field( $_REQUEST['captcha_token'] );
 		$captcha_result = \Newspack\Reader_Activation::verify_captcha( $captcha_token );
-		error_log( print_r( $captcha_result, true ) );
 		if ( \is_wp_error( $captcha_result ) ) {
 			return send_form_response( $captcha_result );
 		}

--- a/src/blocks/subscribe/index.php
+++ b/src/blocks/subscribe/index.php
@@ -35,10 +35,17 @@ function enqueue_scripts() {
 		[],
 		filemtime( NEWSPACK_NEWSLETTERS_PLUGIN_FILE . 'dist/subscribeBlock.css' )
 	);
+
+	$use_captcha  = method_exists( '\Newspack\Reader_Activation', 'can_use_captcha' ) && \Newspack\Reader_Activation::can_use_captcha();
+	$dependencies = [ 'wp-polyfill', 'wp-i18n' ];
+	if ( $use_captcha ) {
+		$dependencies[] = \Newspack\Reader_Activation::RECAPTCHA_SCRIPT_HANDLE;
+	}
+
 	\wp_enqueue_script(
 		$handle,
 		plugins_url( '../../../dist/subscribeBlock.js', __FILE__ ),
-		[ 'wp-polyfill' ],
+		$dependencies,
 		filemtime( NEWSPACK_NEWSLETTERS_PLUGIN_FILE . 'dist/subscribeBlock.js' ),
 		true
 	);
@@ -119,7 +126,7 @@ function render_block( $attrs ) {
 						name="email"
 						autocomplete="email"
 						placeholder="<?php echo \esc_attr( $attrs['placeholder'] ); ?>"
-						value="<?php echo esc_attr( $email ); ?>"
+						value=""
 					/>
 				</div>
 				<?php if ( 1 < count( $available_lists ) ) : ?>
@@ -232,6 +239,7 @@ function send_form_response( $data ) {
  * Process newsletter signup form.
  */
 function process_form() {
+	error_log( print_r( $_REQUEST, true ) );
 	if ( ! isset( $_REQUEST[ FORM_ACTION ] ) || ! \wp_verify_nonce( \sanitize_text_field( $_REQUEST[ FORM_ACTION ] ), FORM_ACTION ) ) {
 		return;
 	}
@@ -239,6 +247,16 @@ function process_form() {
 	// Honeypot trap.
 	if ( ! empty( $_REQUEST['email'] ) ) {
 		return send_form_response( [ 'email' => \sanitize_email( $_REQUEST['email'] ) ] );
+	}
+
+	// reCAPTCHA test.
+	if ( ! empty( $_REQUEST['captcha_token'] ) && method_exists( '\Newspack\Reader_Activation', 'verify_captcha' ) ) {
+		$captcha_token  = \sanitize_text_field( $_REQUEST['captcha_token'] );
+		$captcha_result = \Newspack\Reader_Activation::verify_captcha( $captcha_token );
+		error_log( print_r( $captcha_result, true ) );
+		if ( \is_wp_error( $captcha_result ) ) {
+			return send_form_response( $captcha_result );
+		}
 	}
 
 	if ( ! isset( $_REQUEST['npe'] ) || empty( $_REQUEST['npe'] ) ) {

--- a/src/blocks/subscribe/index.php
+++ b/src/blocks/subscribe/index.php
@@ -39,7 +39,7 @@ function enqueue_scripts() {
 	$use_captcha  = method_exists( '\Newspack\Recaptcha', 'can_use_captcha' ) && \Newspack\Recaptcha::can_use_captcha();
 	$dependencies = [ 'wp-polyfill', 'wp-i18n' ];
 	if ( $use_captcha ) {
-		$dependencies[] = \Newspack\Recaptcha::RECAPTCHA_SCRIPT_HANDLE;
+		$dependencies[] = \Newspack\Recaptcha::SCRIPT_HANDLE;
 	}
 
 	\wp_enqueue_script(

--- a/src/blocks/subscribe/style.scss
+++ b/src/blocks/subscribe/style.scss
@@ -16,6 +16,9 @@
 	input[type='submit'] {
 		background-color: #d33;
 	}
+	input[disabled] {
+		opacity: 0.5;
+	}
 	.newspack-newsletters-lists {
 		list-style: none;
 		margin: 1rem 0 0;
@@ -48,7 +51,7 @@
 	.newspack-newsletters-subscribe-response {
 		margin: 0.5rem 0;
 		font-size: 0.8rem;
-		color: #777;
+		color: #cc1818;
 	}
 	&.multiple-lists {
 		form {

--- a/src/blocks/subscribe/view.js
+++ b/src/blocks/subscribe/view.js
@@ -15,7 +15,7 @@ import './style.scss';
 			const messageContainer = container.querySelector(
 				'.newspack-newsletters-subscribe-response'
 			);
-			const getCaptchaToken = async () => {
+			const getCaptchaToken = () => {
 				return new Promise( ( res, rej ) => {
 					const reCaptchaScript = document.getElementById( 'newspack-recaptcha-js' );
 					if ( ! reCaptchaScript ) {
@@ -33,12 +33,10 @@ import './style.scss';
 					}
 
 					grecaptcha.ready( async () => {
-						try {
-							const token = await grecaptcha.execute( captchaSiteKey, { action: 'submit' } );
-							return res( token );
-						} catch ( e ) {
-							rej( e );
-						}
+						const token = await grecaptcha
+							.execute( captchaSiteKey, { action: 'submit' } )
+							.then( () => res( token ) )
+							.catch( e => rej( e ) );
 					} );
 				} );
 			};
@@ -56,42 +54,47 @@ import './style.scss';
 					messageContainer.appendChild( messageNode );
 				}
 			};
-			form.addEventListener( 'submit', async ev => {
+			form.addEventListener( 'submit', ev => {
 				ev.preventDefault();
-				try {
-					const captchaToken = await getCaptchaToken();
-					if ( captchaToken ) {
+
+				getCaptchaToken()
+					.then( captchaToken => {
+						if ( ! captchaToken ) {
+							return;
+						}
 						const tokenField = document.createElement( 'input' );
 						tokenField.setAttribute( 'type', 'hidden' );
 						tokenField.setAttribute( 'name', 'captcha_token' );
 						tokenField.value = captchaToken;
 						form.appendChild( tokenField );
-					}
-				} catch ( e ) {
-					form.endFlow( e, 400 );
-				}
-				const body = new FormData( form );
-				if ( ! body.has( 'npe' ) || ! body.get( 'npe' ) ) {
-					return;
-				}
-				emailInput.disabled = true;
-				submit.disabled = true;
-				messageContainer.innerHTML = '';
-				emailInput.setAttribute( 'disabled', 'true' );
-				submit.setAttribute( 'disabled', 'true' );
-				fetch( form.getAttribute( 'action' ) || window.location.pathname, {
-					method: 'POST',
-					headers: {
-						Accept: 'application/json',
-					},
-					body,
-				} ).then( res => {
-					emailInput.disabled = false;
-					submit.disabled = false;
-					res.json().then( ( { message } ) => {
-						form.endFlow( message, res.status );
+					} )
+					.catch( e => {
+						form.endFlow( e, 400 );
+					} )
+					.finally( () => {
+						const body = new FormData( form );
+						if ( ! body.has( 'npe' ) || ! body.get( 'npe' ) ) {
+							return;
+						}
+						emailInput.disabled = true;
+						submit.disabled = true;
+						messageContainer.innerHTML = '';
+						emailInput.setAttribute( 'disabled', 'true' );
+						submit.setAttribute( 'disabled', 'true' );
+						fetch( form.getAttribute( 'action' ) || window.location.pathname, {
+							method: 'POST',
+							headers: {
+								Accept: 'application/json',
+							},
+							body,
+						} ).then( res => {
+							emailInput.disabled = false;
+							submit.disabled = false;
+							res.json().then( ( { message } ) => {
+								form.endFlow( message, res.status );
+							} );
+						} );
 					} );
-				} );
 			} );
 		} );
 	};

--- a/src/blocks/subscribe/view.js
+++ b/src/blocks/subscribe/view.js
@@ -32,10 +32,10 @@ import './style.scss';
 						rej( __( 'Error loading the reCaptcha library.', 'newspack-newsletters' ) );
 					}
 
-					grecaptcha.ready( async () => {
-						const token = await grecaptcha
+					grecaptcha.ready( () => {
+						grecaptcha
 							.execute( captchaSiteKey, { action: 'submit' } )
-							.then( () => res( token ) )
+							.then( token => res( token ) )
 							.catch( e => rej( e ) );
 					} );
 				} );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Adds reCAPTCHA to Subscribe form submissions as implemented in https://github.com/Automattic/newspack-plugin/pull/1910, if available.

Also fixes a bug from #932 where the honeypot field is prefilled with an email address if one is known, which causes the form to always trigger the honeypot trap.

### How to test the changes in this Pull Request:

See testing instructions in https://github.com/Automattic/newspack-plugin/pull/1910.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
