### PR TITLE
style: red button for Subscribe block form

### DIFF
--- a/src/blocks/subscribe/style.scss
+++ b/src/blocks/subscribe/style.scss
@@ -13,6 +13,9 @@
 		width: 100%;
 		margin-right: 1rem;
 	}
+	input[type='submit'] {
+		background-color: #d33;
+	}
 	.newspack-newsletters-lists {
 		list-style: none;
 		margin: 1rem 0 0;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Makes the submit button for the Subscribe block form the same #d33 red color as default CTA buttons in the Newspack theme.

### How to test the changes in this Pull Request:

1. Check out this branch.
2. Confirm the button color (static and hover/focus) for the Subscribe block form.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
