### PR TITLE
feat: give each subscribe form a unique ID

### DIFF
--- a/src/blocks/subscribe/index.php
+++ b/src/blocks/subscribe/index.php
@@ -55,7 +55,7 @@ function enqueue_scripts() {
 add_action( 'wp_enqueue_scripts', __NAMESPACE__ . '\\enqueue_scripts' );
 
 /**
- * Generate a unique ID for each registration form.
+ * Generate a unique ID for each subscription form.
  *
  * The ID for each form instance is unique only for each page render.
  * The main intent is to be able to pass this ID to analytics so we

--- a/src/blocks/subscribe/index.php
+++ b/src/blocks/subscribe/index.php
@@ -55,6 +55,15 @@ function enqueue_scripts() {
 add_action( 'wp_enqueue_scripts', __NAMESPACE__ . '\\enqueue_scripts' );
 
 /**
+ * Generate a unique ID for each registration form.
+ *
+ * @return string A unique ID string to identify the form.
+ */
+function get_form_id() {
+	return \wp_unique_id( 'newspack-subscribe-' );
+}
+
+/**
  * Render Registration Block.
  *
  * @param array[] $attrs Block attributes.
@@ -108,7 +117,7 @@ function render_block( $attrs ) {
 		<?php if ( $subscribed ) : ?>
 			<p class="message"><?php echo \esc_html( $message ); ?></p>
 		<?php else : ?>
-			<form>
+			<form id="<?php echo esc_attr( get_form_id() ); ?>">
 				<?php \wp_nonce_field( FORM_ACTION, FORM_ACTION ); ?>
 				<div class="newspack-newsletters-email-input">
 					<input

--- a/src/blocks/subscribe/index.php
+++ b/src/blocks/subscribe/index.php
@@ -57,6 +57,11 @@ add_action( 'wp_enqueue_scripts', __NAMESPACE__ . '\\enqueue_scripts' );
 /**
  * Generate a unique ID for each registration form.
  *
+ * The ID for each form instance is unique only for each page render.
+ * The main intent is to be able to pass this ID to analytics so we
+ * can identify what type of form it is, so the ID doesn't need to be
+ * predictable nor consistent across page renders.
+ *
  * @return string A unique ID string to identify the form.
  */
 function get_form_id() {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

This gives each subscribe form a unique ID that can be picked up by Google Analytics to identify the form while firing submission events. Required for https://github.com/Automattic/newspack-popups/pull/951.

### How to test the changes in this Pull Request:

Instructions in https://github.com/Automattic/newspack-popups/pull/951.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
