### PR TITLE
chore: remove deprecated add_contact method of Newspack_Newsletters

### DIFF
--- a/includes/class-newspack-newsletters.php
+++ b/includes/class-newspack-newsletters.php
@@ -1140,28 +1140,6 @@ final class Newspack_Newsletters {
 	}
 
 	/**
-	 * Add contact to a mailing list of the configured ESP.
-	 *
-	 * This method is soon to be deprecated.
-	 * Use Newspack_Newsletters_Subscription::add_contact() instead.
-	 *
-	 * @param array  $contact The contact to add to the list.
-	 * @param string $list_id ID of the list to add the contact to.
-	 */
-	public static function add_contact( $contact, $list_id ) {
-		if ( self::is_service_provider_configured() ) {
-			try {
-				return self::$provider->add_contact( $contact, $list_id );
-			} catch ( \Exception $e ) {
-				return new WP_Error(
-					'newspack_newsletters_get_lists',
-					$e->getMessage()
-				);
-			}
-		}
-	}
-
-	/**
 	 * Mark newsletter as sent.
 	 *
 	 * @param int $post_id Post ID.


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

It's been two months since `Newspack_Newsletters::add_contact` method has bee marked for deprecation, in favour of `Newspack_Newsletters_Subscription::add_contact`. This PR removes the deprecated method, so there's no confusion. Our code does not use the deprecated method anywhere. 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->