### PR TITLE
Subscribe block's horizontal scroll; AC errors

### DIFF
--- a/includes/service-providers/active_campaign/class-newspack-newsletters-active-campaign.php
+++ b/includes/service-providers/active_campaign/class-newspack-newsletters-active-campaign.php
@@ -929,8 +929,11 @@ final class Newspack_Newsletters_Active_Campaign extends \Newspack_Newsletters_S
 		}
 		$contact_data = $result['contacts'][0];
 		if ( $return_details ) {
-			$fields_result            = $this->api_v3_request( 'fields', 'GET' );
-			$fields                   = array_reduce(
+			$fields_result = $this->api_v3_request( 'fields', 'GET' );
+			if ( \is_wp_error( $fields_result ) ) {
+				return $fields_result;
+			}
+			$fields         = array_reduce(
 				$fields_result['fields'],
 				function( $acc, $field ) {
 					$acc[ $field['id'] ] = $field['perstag'];
@@ -938,7 +941,10 @@ final class Newspack_Newsletters_Active_Campaign extends \Newspack_Newsletters_S
 				},
 				[]
 			);
-			$contact_result           = $this->api_v3_request( 'contacts/' . $contact_data['id'], 'GET' );
+			$contact_result = $this->api_v3_request( 'contacts/' . $contact_data['id'], 'GET' );
+			if ( \is_wp_error( $contact_result ) ) {
+				return $contact_result;
+			}
 			$contact_fields           = array_reduce(
 				$contact_result['fieldValues'],
 				function( $acc, $field ) use ( $fields ) {

--- a/src/blocks/subscribe/style.scss
+++ b/src/blocks/subscribe/style.scss
@@ -21,6 +21,9 @@
 		@media ( min-width: 782px ) {
 			margin-right: 1rem;
 		}
+		&[aria-hidden='true'] {
+			width: 0;
+		}
 	}
 	input[type='submit'] {
 		background-color: #d33;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Two small issues:

- removing horizontal overflow on the Subscribe block (caused by the honeypot field)
- handling errors when fetching AC's data

### How to test the changes in this Pull Request:

1. Insert a Subscribe block as the single element on a page
2. Notice that on `master`, it overflows horizontally, causing side-scroll
3. Verify that it does not on this branch
4. The AC errors are hard to reproduce, must've been a network error when I've encountered them. A smoke check will suffice.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->