### PR TITLE
fix(constant-contact): update api for oauth2

### DIFF
--- a/includes/service-providers/constant_contact/class-newspack-newsletters-constant-contact-sdk.php
+++ b/includes/service-providers/constant_contact/class-newspack-newsletters-constant-contact-sdk.php
@@ -74,7 +74,7 @@ final class Newspack_Newsletters_Constant_Contact_SDK {
 	 */
 	private function request( $method, $path, $options = [] ) {
 		$url = $this->base_uri . $path;
-		if ( $options['query'] ) {
+		if ( isset( $options['query'] ) ) {
 			$url = add_query_arg( $options['query'], $url );
 			unset( $options['query'] );
 		}

--- a/includes/service-providers/constant_contact/class-newspack-newsletters-constant-contact-sdk.php
+++ b/includes/service-providers/constant_contact/class-newspack-newsletters-constant-contact-sdk.php
@@ -20,11 +20,18 @@ final class Newspack_Newsletters_Constant_Contact_SDK {
 	private $base_uri = 'https://api.cc.email/v3/';
 
 	/**
+	 * Authorization request URL.
+	 *
+	 * @var string
+	 */
+	private $authorization_url = 'https://authz.constantcontact.com/oauth2/default/v1/authorize';
+
+	/**
 	 * Base URI for Token requests.
 	 *
 	 * @var string
 	 */
-	private $token_base_uri = 'https://idfed.constantcontact.com/as/token.oauth2';
+	private $token_base_uri = 'https://authz.constantcontact.com/oauth2/default/v1/token';
 
 	/**
 	 * Scope for API requests.
@@ -84,7 +91,17 @@ final class Newspack_Newsletters_Constant_Contact_SDK {
 			if ( is_wp_error( $response ) ) {
 				throw new Exception( $response->get_error_message() );
 			}
-			return json_decode( $response['body'] );
+			$body = json_decode( $response['body'] );
+			if ( 200 !== wp_remote_retrieve_response_code( $response ) ) {
+				if ( is_array( $body ) && isset( $body[0], $body[0]->error_message ) ) {
+					throw new Exception( $body[0]->error_message );
+				} elseif ( is_object( $body ) && isset( $body->error_message ) ) {
+					throw new Exception( $body->error_message );
+				} else {
+					throw new Exception( wp_remote_retrieve_response_message( $response ) );
+				}
+			}
+			return $body;
 		} catch ( Exception $e ) {
 			throw new Exception( 'Constant Contact: ' . $e->getMessage() );
 		}
@@ -117,12 +134,22 @@ final class Newspack_Newsletters_Constant_Contact_SDK {
 	/**
 	 * Get authorization code url
 	 *
+	 * @param string $nonce        Nonce.
 	 * @param string $redirect_uri Redirect URI.
 	 *
 	 * @return string
 	 */
-	public function get_auth_code_url( $redirect_uri = '' ) {
-		return $this->base_uri . 'idfed?client_id=' . $this->api_key . '&scope=' . implode( '+', $this->scope ) . '&response_type=code&redirect_uri=' . urlencode( $redirect_uri );
+	public function get_auth_code_url( $nonce, $redirect_uri = '' ) {
+		return add_query_arg(
+			[
+				'response_type' => 'code',
+				'state'         => $nonce,
+				'client_id'     => $this->api_key,
+				'redirect_uri'  => $redirect_uri,
+				'scope'         => implode( ' ', $this->scope ),
+			],
+			$this->authorization_url
+		);
 	}
 
 	/**
@@ -132,6 +159,25 @@ final class Newspack_Newsletters_Constant_Contact_SDK {
 	 */
 	public function set_access_token( $access_token ) {
 		$this->access_token = $access_token;
+	}
+
+	/**
+	 * Parse JWT.
+	 *
+	 * @param string $jwt JWT.
+	 *
+	 * @return array Containing JWT payload.
+	 */
+	private static function parse_jwt( $jwt ) {
+		$segments = explode( '.', $jwt );
+		if ( count( $segments ) !== 3 ) {
+			return false;
+		}
+		$data = json_decode( base64_decode( $segments[1] ), true );
+		if ( ! $data ) {
+			return false;
+		}
+		return $data;
 	}
 
 	/**
@@ -146,16 +192,11 @@ final class Newspack_Newsletters_Constant_Contact_SDK {
 		if ( ! $access_token ) {
 			return false;
 		}
-		try {
-			$response = $this->request(
-				'POST',
-				'token_info',
-				[ 'body' => wp_json_encode( [ 'token' => $access_token ] ) ]
-			);
-			return [] === array_diff( $this->scope, $response->scopes ?? [] );
-		} catch ( Exception $e ) {
+		$data = self::parse_jwt( $access_token );
+		if ( $data['exp'] < time() ) {
 			return false;
 		}
+		return [] === array_diff( $this->scope, $data['scp'] ?? [] );
 	}
 
 	/**
@@ -177,7 +218,7 @@ final class Newspack_Newsletters_Constant_Contact_SDK {
 		];
 		$args        = [
 			'headers' => [
-				'Content-Type'  => 'application/json',
+				'Content-Type'  => 'application/x-www-form-urlencoded',
 				'Accept'        => 'application/json',
 				'Authorization' => 'Basic ' . $credentials,
 			],
@@ -210,7 +251,7 @@ final class Newspack_Newsletters_Constant_Contact_SDK {
 		];
 		$args        = [
 			'headers' => [
-				'Content-Type'  => 'application/json',
+				'Content-Type'  => 'application/x-www-form-urlencoded',
 				'Accept'        => 'application/json',
 				'Authorization' => 'Basic ' . $credentials,
 			],
@@ -247,8 +288,7 @@ final class Newspack_Newsletters_Constant_Contact_SDK {
 	public function get_email_addresses() {
 		return $this->request( 'GET', 'account/emails' );
 	}
-	
-	
+
 	/**
 	 * Get Contact Lists
 	 *

--- a/includes/service-providers/constant_contact/class-newspack-newsletters-constant-contact.php
+++ b/includes/service-providers/constant_contact/class-newspack-newsletters-constant-contact.php
@@ -61,21 +61,21 @@ final class Newspack_Newsletters_Constant_Contact extends \Newspack_Newsletters_
 	public function verify_token( $refresh = true ) {
 		$credentials  = $this->api_credentials();
 		$redirect_uri = $this->get_oauth_redirect_uri();
-		$cc           = new Newspack_Newsletters_Constant_Contact_SDK( $credentials['api_key'], $credentials['api_secret'] );
-
-		if ( ! empty( $credentials['access_token'] ) ) {
-			$cc->set_access_token( $credentials['access_token'] );
-		}
+		$cc           = new Newspack_Newsletters_Constant_Contact_SDK(
+			$credentials['api_key'],
+			$credentials['api_secret'],
+			$credentials['access_token']
+		);
 
 		$response = [
 			'error'    => null,
 			'valid'    => false,
-			'auth_url' => $cc->get_auth_code_url( $redirect_uri ),
+			'auth_url' => $cc->get_auth_code_url( wp_create_nonce( 'constant_contact_oauth2' ), $redirect_uri ),
 		];
 
 		try {
 			// If we have a valid access token, we're connected.
-			if ( ! empty( $credentials['access_token'] ) && $cc->validate_token() ) {
+			if ( $cc->validate_token() ) {
 				$response['valid'] = true;
 				return $response;
 			}
@@ -103,14 +103,12 @@ final class Newspack_Newsletters_Constant_Contact extends \Newspack_Newsletters_
 	/**
 	 * Get OAuth Redirect URI.
 	 *
-	 * @param string $nonce Optional nonce used for URI identity validation.
-	 *
 	 * @return string OAuth Redirect URI.
 	 */
-	private function get_oauth_redirect_uri( $nonce = '' ) {
+	private function get_oauth_redirect_uri() {
 		return add_query_arg(
-			'cc_oauth2callback',
-			empty( $nonce ) ? wp_create_nonce( 'newspack_newsletters_oauth_nonce' ) : $nonce,
+			'cc_oauth2',
+			1,
 			admin_url( 'index.php' )
 		);
 	}
@@ -122,15 +120,22 @@ final class Newspack_Newsletters_Constant_Contact extends \Newspack_Newsletters_
 		if ( ! current_user_can( 'edit_others_posts' ) ) {
 			return;
 		}
+		if ( ! isset( $_GET['cc_oauth2'] ) ) {
+			return;
+		}
 		if (
-			! isset( $_GET['cc_oauth2callback'] ) ||
-			! wp_verify_nonce( sanitize_text_field( $_GET['cc_oauth2callback'] ), 'newspack_newsletters_oauth_nonce' ) ||
+			! isset( $_GET['state'] ) ||
+			! wp_verify_nonce( sanitize_text_field( $_GET['state'] ), 'constant_contact_oauth2' ) ||
 			! isset( $_GET['code'] )
 		) {
 			return;
 		}
 
-		$redirect_uri = $this->get_oauth_redirect_uri( sanitize_text_field( $_GET['cc_oauth2callback'] ) );
+		if ( isset( $_GET['error_description'] ) ) {
+			wp_die( esc_html( sanitize_text_field( $_GET['error_description'] ) ) );
+		}
+
+		$redirect_uri = $this->get_oauth_redirect_uri();
 		$code         = sanitize_text_field( $_GET['code'] );
 
 		$this->connect( $redirect_uri, $code );
@@ -156,7 +161,10 @@ final class Newspack_Newsletters_Constant_Contact extends \Newspack_Newsletters_
 	private function connect( $redirect_uri, $code ) {
 		$cc    = new Newspack_Newsletters_Constant_Contact_SDK( $this->api_key(), $this->api_secret() );
 		$token = $cc->get_access_token( $redirect_uri, $code );
-		return $this->set_access_token( $token->access_token, $token->refresh_token );
+		return $this->set_access_token(
+			$token->access_token,
+			isset( $token->refresh_token ) ? $token->refresh_token : ''
+		);
 	}
 
 	/**
@@ -233,14 +241,14 @@ final class Newspack_Newsletters_Constant_Contact extends \Newspack_Newsletters_
 	 * @throws Exception Error message.
 	 */
 	private function set_access_token( $access_token = '', $refresh_token = '' ) {
-		if ( empty( $access_token ) || empty( $refresh_token ) ) {
+		if ( empty( $access_token ) ) {
 			throw new Exception(
-				__( 'Access and refresh tokens are required.', 'newspack-newsletter' )
+				__( 'Access token is required.', 'newspack-newsletter' )
 			);
 		}
 		$update_access_token  = update_option( 'newspack_newsletters_constant_contact_api_access_token', $access_token );
 		$update_refresh_token = update_option( 'newspack_newsletters_constant_contact_api_refresh_token', $refresh_token );
-		return $update_access_token && $update_refresh_token;
+		return $update_access_token;
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR fixes the OAuth2 API integration and improves error handling. The refresh token is now optional because the request for an access token wasn't always returning a refresh token value.

Closes #802.

### How to test the changes in this Pull Request:

#### Updating the app

You might have to update your app to the new OAuth2 API, follow instructions from this page: https://developer.constantcontact.com/api_guide/auth_update_apps.html

On the app settings, change the redirect URI to: `https://yoursite.com/wp-admin/index.php?cc_oauth2=1`

1. Check out this branch and connect to a valid and reviewed* Constant Contact account
2. Create a draft newsletter and attempt to send a test email
3. If you have a free account, you might see the error message: "Constant Contact: Your current plan does not allow the use of Test Send."
4. If you have access to the test email feature you should see a success message. Confirm you've received the email
5. Select a list and send the campaign
6. Confirm the campaign is sent

*Accounts can be under "compliance review" and must be approved before using some functionality.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
