### PR TITLE
fix: adding contact w/out lists handling

### DIFF
--- a/includes/class-newspack-newsletters-subscription.php
+++ b/includes/class-newspack-newsletters-subscription.php
@@ -377,7 +377,7 @@ class Newspack_Newsletters_Subscription {
 		$lists = apply_filters( 'newspack_newsletters_contact_lists', $lists, $contact, $provider->service );
 
 		$errors = new WP_Error();
-		$result = true;
+		$result = [];
 
 		if ( empty( $lists ) ) {
 			try {

--- a/includes/class-newspack-newsletters-subscription.php
+++ b/includes/class-newspack-newsletters-subscription.php
@@ -377,6 +377,7 @@ class Newspack_Newsletters_Subscription {
 		$lists = apply_filters( 'newspack_newsletters_contact_lists', $lists, $contact, $provider->service );
 
 		$errors = new WP_Error();
+		$result = true;
 
 		if ( empty( $lists ) ) {
 			try {

--- a/includes/service-providers/campaign_monitor/class-newspack-newsletters-campaign-monitor.php
+++ b/includes/service-providers/campaign_monitor/class-newspack-newsletters-campaign-monitor.php
@@ -574,7 +574,10 @@ final class Newspack_Newsletters_Campaign_Monitor extends \Newspack_Newsletters_
 	 *
 	 * @return array|WP_Error Contact data if it was added, or error otherwise.
 	 */
-	public function add_contact( $contact, $list_id ) {
+	public function add_contact( $contact, $list_id = false ) {
+		if ( false === $list_id ) {
+			return new WP_Error( 'newspack_newsletters_constant_contact_list_id', __( 'Missing list id.' ) );
+		}
 		try {
 			$api_key   = $this->api_key();
 			$client_id = $this->client_id();

--- a/includes/service-providers/constant_contact/class-newspack-newsletters-constant-contact.php
+++ b/includes/service-providers/constant_contact/class-newspack-newsletters-constant-contact.php
@@ -706,7 +706,7 @@ final class Newspack_Newsletters_Constant_Contact extends \Newspack_Newsletters_
 	 * @param string $list_id List ID.
 	 * @throws Exception Error message.
 	 */
-	public function add_contact( $contact, $list_id ) {
+	public function add_contact( $contact, $list_id = false ) {
 		throw new Exception(
 			__( 'Adding contacts not implemented for Constant Contact.', 'newspack-newsletters' )
 		);

--- a/includes/service-providers/interface-newspack-newsletters-esp-service.php
+++ b/includes/service-providers/interface-newspack-newsletters-esp-service.php
@@ -101,7 +101,7 @@ interface Newspack_Newsletters_ESP_API_Interface {
 	 *
 	 * @return array|WP_Error Contact data if it was added, or error otherwise.
 	 */
-	public function add_contact( $contact, $list_id );
+	public function add_contact( $contact, $list_id = false );
 
 	/**
 	 * Update a contact lists subscription.

--- a/includes/service-providers/letterhead/class-newspack-newsletters-letterhead.php
+++ b/includes/service-providers/letterhead/class-newspack-newsletters-letterhead.php
@@ -28,7 +28,7 @@ final class Newspack_Newsletters_Letterhead extends \Newspack_Newsletters_Servic
 	 * @param string $list_id List identifier.
 	 * @return object|void|null API Response or error
 	 */
-	public function add_contact( $contact, $list_id ) {
+	public function add_contact( $contact, $list_id = false ) {
 		// TODO: Implement add_contact() method.
 	}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Reader Activation introduces adding contact w/out lists. This PR ensures this is handled gracefully by all ESPs.

### How to test the changes in this Pull Request:

1. Enable Reader Activation
2. Set the ESP to Constanct Contact 
3. On `master`, observe the post-donation webhook callback errors out, if it won't pass a list ID to `add_contact`
4. Observe it handled gracefully on this branch

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->