### PR TITLE
Remove newsletter subs. on WP account deletion

### DIFF
--- a/includes/class-newspack-newsletters-subscription.php
+++ b/includes/class-newspack-newsletters-subscription.php
@@ -44,6 +44,8 @@ class Newspack_Newsletters_Subscription {
 		add_action( 'woocommerce_account_newsletters_endpoint', [ __CLASS__, 'endpoint_content' ] );
 		add_action( 'template_redirect', [ __CLASS__, 'process_subscription_update' ] );
 		add_action( 'init', [ __CLASS__, 'flush_rewrite_rules' ] );
+
+		add_action( 'delete_user', [ __CLASS__, 'unsubscribe_deleted_user' ] );
 	}
 
 	/**
@@ -934,6 +936,19 @@ class Newspack_Newsletters_Subscription {
 			} else {
 				wc_add_notice( __( 'Your subscriptions were updated.', 'newspack-newsletters' ), 'success' );
 			}
+		}
+	}
+
+	/**
+	 * Unsubscribe user from all newsletters.
+	 *
+	 * @param int $user_id User ID.
+	 */
+	public static function unsubscribe_deleted_user( $user_id ) {
+		$user = get_userdata( $user_id );
+		if ( $user ) {
+			Newspack_Newsletters_Logger::log( 'User ' . $user_id . ' is deleted. Unsubscribing them from all lists.' );
+			self::update_contact_lists( $user->user_email, [] );
 		}
 	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Removes the newsletter subscriptions when a user deletes their account. 

### How to test the changes in this Pull Request:

_Follow instructions on https://github.com/Automattic/newspack-plugin/pull/2021_

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->