### PR TITLE
feat(post-inserter): post type selection

### DIFF
--- a/src/editor/blocks/posts-inserter/block.json
+++ b/src/editor/blocks/posts-inserter/block.json
@@ -1,10 +1,8 @@
 {
-  "name": "newspack-newsletters/posts-inserter",
-  "category": "widgets",
-  "supports": [
-    "align"
-  ],
-  "attributes": {
+	"name": "newspack-newsletters/posts-inserter",
+	"category": "widgets",
+	"supports": [ "align" ],
+	"attributes": {
 		"areBlocksInserted": {
 			"type": "boolean",
 			"default": false
@@ -75,6 +73,10 @@
 		"subHeadingColor": {
 			"type": "string"
 		},
+		"postType": {
+			"type": "string",
+			"default": "post"
+		},
 		"tags": {
 			"type": "array",
 			"default": []
@@ -91,5 +93,5 @@
 			"type": "array",
 			"default": []
 		}
-  }
+	}
 }

--- a/src/editor/blocks/posts-inserter/index.js
+++ b/src/editor/blocks/posts-inserter/index.js
@@ -316,6 +316,7 @@ const PostsInserterBlockWithSelect = compose( [
 			postsToShow,
 			order,
 			orderBy,
+			postType,
 			categories,
 			isDisplayingSpecificPosts,
 			specificPosts,
@@ -353,7 +354,7 @@ const PostsInserterBlockWithSelect = compose( [
 						value => ! isUndefined( value )
 				  );
 
-			posts = getEntityRecords( 'postType', 'post', postListQuery ) || [];
+			posts = getEntityRecords( 'postType', postType, postListQuery ) || [];
 		}
 
 		// Order posts in the order as they appear in the input

--- a/src/editor/blocks/posts-inserter/query-controls.js
+++ b/src/editor/blocks/posts-inserter/query-controls.js
@@ -215,9 +215,7 @@ const QueryControlsSettings = ( { attributes, setAttributes } ) => {
 				label={ __( 'Post type', 'newspack-newsletters' ) }
 				options={ postTypesList }
 				value={ attributes.postType }
-				onChange={ postType => {
-					setAttributes( { postType } );
-				} }
+				onChange={ postType => setAttributes( { postType } ) }
 			/>
 			<ToggleControl
 				label={ __( 'Display specific posts', 'newspack-newsletters' ) }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Add post type selection to the Post Inserter block.

<img width="279" alt="image" src="https://user-images.githubusercontent.com/820752/191362288-5692f295-d588-44b0-8270-80409d1af266.png">

Closes #843

### How to test the changes in this Pull Request:

1. Check out this branch and start a newsletter draft with the "Post Inserter" block
2. Edit the block and confirm you see the post type dropdown as pictured above
3. Select a custom post type and confirm the posts are updated
4. Toggle "Display specific posts"
5. Search for content inside the selected post type and confirm it works as expected
6. Insert the posts and confirm they are rendered correctly

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
