### PR TITLE
Add filter for enhancing/modifying data when doing ActiveCampaign contact sync

### DIFF
--- a/includes/service-providers/active_campaign/class-newspack-newsletters-active-campaign.php
+++ b/includes/service-providers/active_campaign/class-newspack-newsletters-active-campaign.php
@@ -731,6 +731,9 @@ final class Newspack_Newsletters_Active_Campaign extends \Newspack_Newsletters_S
 		if ( ! isset( $contact['metadata'] ) ) {
 			$contact['metadata'] = [];
 		}
+
+		$contact = apply_filters( 'newspack_activecampaign_add_contact', $contact );
+
 		$action  = 'contact_add';
 		$payload = [
 			'email' => $contact['email'],


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

This PR adds a filter for modifying the contact data before it gets sent to ActiveCampaign. The main purpose of this filter is for supporting legacy AC workflows by re-mapping or adding extra metadata to the contact. 

I'm not a huge fan of using a filter here because it means more custom code floating around out there, but that seems like the most straightforward way to support legacy workflows without adding a whole UI for mapping and managing contact fields. If you have a better suggestion that wouldn't require adding custom code to sites, please share. :)

Here's a small plugin you can use to test this feature:

```
<?php
/**
 * Plugin Name: Enhance ActiveCampaign Data Sync
 * Description: Enhance ActiveCampaign Data Sync
 * Version: 1.0.0
 * Author: Automattic
 * Author URI: https://newspack.pub/
 * License: GPL2
 * Text Domain: newspack
 * Domain Path: /languages/
 */

defined( 'ABSPATH' ) || exit;

function newspack_enhance_activecampaign_data_sync( $contact ) {
	if ( empty( $contact['metadata'] ) ) {
		return $contact;
	}

	if ( ! empty( $contact['metadata']['NP_Registration Date'] ) ) {
		$contact['metadata']['Date Opt-In'] = $contact['metadata']['NP_Registration Date'];
	}

	if ( ! empty( $contact['metadata']['NP_Last Payment Date'] ) ) {
		$contact['metadata']['Last Gift Date'] = $contact['metadata']['NP_Last Payment Date'];
	}

	if ( ! empty( $contact['metadata']['NP_Last Payment Amount'] ) ) {
		$contact['metadata']['Last Gift Amount'] = $contact['metadata']['NP_Last Payment Amount'];
	}

	if ( ! empty( $contact['metadata']['NP_Billing Cycle'] ) && 'month' === $contact['metadata']['NP_Billing Cycle'] || 'year' === $contact['metadata']['NP_Billing Cycle'] ) {
		$contact['metadata']['Last Gift Type'] = 'month' === $contact['metadata']['NP_Billing Cycle'] ? 'Monthly' : 'Annual';
	}

	return $contact;
}
add_filter( 'newspack_activecampaign_add_contact', 'newspack_enhance_activecampaign_data_sync' );

```

### How to test the changes in this Pull Request:

1.  Set up RAS with ActiveCampaign. Install and activate the above plugin.
2. Make a Monthly donation or some other donation using the simplified donate block.
3. In AC, verify that the `Date Opt-In`,  `Last Gift Date`, `Last Gift Amount`, and `Last Gift Type` fields populate with the same data as their Newspack counterpart fields.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
