### PR TITLE
feat: update subscribe block design to match reader registration

### DIFF
--- a/src/blocks/subscribe/edit.js
+++ b/src/blocks/subscribe/edit.js
@@ -116,36 +116,38 @@ export default function SubscribeEdit( {
 						} ) }
 					>
 						<form onSubmit={ ev => ev.preventDefault() }>
+							{ lists.length > 1 && (
+								<div className="newspack-newsletters-lists">
+									<ul>
+										{ lists.map( listId => (
+											<li key={ listId }>
+												<span className="list-checkbox">
+													<input
+														id={ getListCheckboxId( listId ) }
+														type="checkbox"
+														checked
+														readOnly
+													/>
+												</span>
+												<span className="list-details">
+													<label htmlFor={ getListCheckboxId( listId ) }>
+														<span className="list-title">{ listConfig[ listId ]?.title }</span>
+														{ displayDescription && (
+															<span className="list-description">
+																{ listConfig[ listId ]?.description }
+															</span>
+														) }
+													</label>
+												</span>
+											</li>
+										) ) }
+									</ul>
+								</div>
+							) }
 							<div className="newspack-newsletters-email-input">
 								<input type="email" placeholder={ placeholder } />
+								<input type="submit" value={ label } />
 							</div>
-							{ lists.length > 1 && (
-								<ul className="newspack-newsletters-lists">
-									{ lists.map( listId => (
-										<li key={ listId }>
-											<span className="list-checkbox">
-												<input
-													id={ getListCheckboxId( listId ) }
-													type="checkbox"
-													checked
-													readOnly
-												/>
-											</span>
-											<span className="list-details">
-												<label htmlFor={ getListCheckboxId( listId ) }>
-													<span className="list-title">{ listConfig[ listId ]?.title }</span>
-													{ displayDescription && (
-														<span className="list-description">
-															{ listConfig[ listId ]?.description }
-														</span>
-													) }
-												</label>
-											</span>
-										</li>
-									) ) }
-								</ul>
-							) }
-							<input type="submit" value={ label } />
 						</form>
 					</div>
 				) }

--- a/src/blocks/subscribe/editor.scss
+++ b/src/blocks/subscribe/editor.scss
@@ -11,10 +11,11 @@
 			-webkit-appearance: none;
 			outline-offset: 0;
 			border-radius: 0;
+			font-size: 1rem;
 		}
 		input[type='submit'] {
 			transition: background 150ms ease-in-out;
-			background: #555;
+			background: #d33;
 			border: none;
 			border-radius: 5px;
 			box-sizing: border-box;
@@ -22,7 +23,7 @@
 			color: #fff;
 			font-family: -apple-system, blinkmacsystemfont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell,
 				'Fira Sans', 'Droid Sans', 'Helvetica Neue', sans-serif;
-			font-size: 0.8em;
+			font-size: 0.8rem;
 			font-weight: 700;
 			line-height: 1.2;
 			outline: none;

--- a/src/blocks/subscribe/index.php
+++ b/src/blocks/subscribe/index.php
@@ -124,27 +124,9 @@ function render_block( $attrs ) {
 		<?php else : ?>
 			<form id="<?php echo esc_attr( get_form_id() ); ?>">
 				<?php \wp_nonce_field( FORM_ACTION, FORM_ACTION ); ?>
-				<div class="newspack-newsletters-email-input">
-					<input
-						type="email"
-						name="npe"
-						autocomplete="email"
-						placeholder="<?php echo \esc_attr( $attrs['placeholder'] ); ?>"
-						value="<?php echo esc_attr( $email ); ?>"
-					/>
-					<input
-						class="nphp"
-						tabindex="-1"
-						aria-hidden="true"
-						type="email"
-						name="email"
-						autocomplete="email"
-						placeholder="<?php echo \esc_attr( $attrs['placeholder'] ); ?>"
-						value=""
-					/>
-				</div>
 				<?php if ( 1 < count( $available_lists ) ) : ?>
-					<ul class="newspack-newsletters-lists">
+					<div class="newspack-newsletters-lists">
+						<ul>
 						<?php
 						foreach ( $available_lists as $list_id ) :
 							if ( ! isset( $list_config[ $list_id ] ) ) {
@@ -176,10 +158,30 @@ function render_block( $attrs ) {
 							</li>
 						<?php endforeach; ?>
 					</ul>
+					</div>
 				<?php else : ?>
 					<input type="hidden" name="lists[]" value="<?php echo \esc_attr( $available_lists[0] ); ?>" />
 				<?php endif; ?>
-				<input type="submit" value="<?php echo \esc_attr( $attrs['label'] ); ?>" />
+				<div class="newspack-newsletters-email-input">
+					<input
+						type="email"
+						name="npe"
+						autocomplete="email"
+						placeholder="<?php echo \esc_attr( $attrs['placeholder'] ); ?>"
+						value="<?php echo esc_attr( $email ); ?>"
+					/>
+					<input
+						class="nphp"
+						tabindex="-1"
+						aria-hidden="true"
+						type="email"
+						name="email"
+						autocomplete="email"
+						placeholder="<?php echo \esc_attr( $attrs['placeholder'] ); ?>"
+						value=""
+					/>
+					<input type="submit" value="<?php echo \esc_attr( $attrs['label'] ); ?>" />
+				</div>
 			</form>
 			<div class="newspack-newsletters-subscribe-response">
 				<?php if ( ! empty( $message ) ) : ?>

--- a/src/blocks/subscribe/style.scss
+++ b/src/blocks/subscribe/style.scss
@@ -1,3 +1,5 @@
+@use '~@wordpress/base-styles/colors' as wp-colors;
+
 .newspack-newsletters-subscribe {
 	form {
 		width: 100%;
@@ -9,68 +11,121 @@
 		}
 	}
 	.newspack-newsletters-email-input {
+		display: flex;
 		flex: 1 1 100%;
+		flex-wrap: wrap;
+		gap: 0.5rem;
 
 		@media ( min-width: 782px ) {
-			margin-right: 1rem;
+			gap: 0.4rem;
 		}
 	}
 	input[type='email'] {
-		width: 100%;
+		flex: 1 1 100%;
 
 		@media ( min-width: 782px ) {
-			margin-right: 1rem;
+			flex-basis: auto;
 		}
+
 		&[aria-hidden='true'] {
 			width: 0;
 		}
 	}
 	input[type='submit'] {
 		background-color: #d33;
-		color: #fff;
-		margin: 0.5rem 0;
-		width: 100%;
+		color: white;
+		flex: 1 1 100%;
 
 		@media ( min-width: 782px ) {
-			width: auto;
+			flex: 0 0 auto;
 		}
 	}
 	input[disabled] {
 		opacity: 0.5;
 	}
+	// .newspack-newsletters-lists {
+	// 	list-style: none;
+	// 	margin: 0 0 0.8rem;
+	// 	padding: 0;
+	// 	display: flex;
+	// 	font-size: 0.8rem;
+	// 	flex-wrap: wrap;
+	// 	li {
+	// 		flex: 1 1 33.3333%;
+	// 		display: flex;
+	// 		min-width: 200px;
+	// 		box-sizing: border-box;
+	// 		margin: 0;
+	// 		padding: 0 1.4rem 1rem 0;
+	// 	}
+	// 	.list-checkbox {
+	// 		flex: 0 0 auto;
+	// 		margin: 0 0.5rem 0 0;
+	// 	}
+	// 	.list-title {
+	// 		display: block;
+	// 	}
+	// 	.list-description {
+	// 		display: block;
+	// 		font-size: 0.8rem;
+	// 		color: wp-colors.$gray-700;
+	// 		margin: 0;
+	// 	}
+	// }
+
 	.newspack-newsletters-lists {
-		list-style: none;
-		margin: 1rem 0 0;
-		padding: 0;
-		display: flex;
+		border: 1px solid wp-colors.$gray-200;
+		border-radius: 2px;
+		box-sizing: border-box;
+		flex: 1 1 100%;
 		font-size: 0.8rem;
-		flex-wrap: wrap;
-		li {
-			flex: 1 1 33.3333%;
-			display: flex;
-			min-width: 200px;
-			box-sizing: border-box;
+		margin-bottom: 0.8rem;
+		padding: 0.5em;
+
+		ul {
+			list-style: none;
 			margin: 0;
-			padding: 0 1.4rem 1rem 0;
+			padding: 0;
+			display: flex;
+			flex-wrap: wrap;
+			min-width: 100%;
+			li {
+				flex: 1 1 33.3333%;
+				display: flex;
+				min-width: 142px;
+				box-sizing: border-box;
+				margin: 0.5em;
+				padding: 0;
+			}
 		}
+
 		.list-checkbox {
+			align-items: center;
+			display: flex;
 			flex: 0 0 auto;
+			height: 1.6em;
 			margin: 0 0.5rem 0 0;
 		}
+
 		.list-title {
 			display: block;
 		}
+
 		.list-description {
 			display: block;
 			font-size: 0.8rem;
-			color: #777;
+			color: wp-colors.$gray-700;
 			margin: 0;
 		}
 	}
+
 	.newspack-newsletters-subscribe-response {
-		margin: 0.5rem 0;
 		font-size: 0.8rem;
-		color: #cc1818;
+		color: wp-colors.$alert-red;
+
+		p {
+			margin: 0.5rem 0 0;
+		}
 	}
 	&.multiple-lists {
 		form {

--- a/src/blocks/subscribe/style.scss
+++ b/src/blocks/subscribe/style.scss
@@ -43,36 +43,6 @@
 	input[disabled] {
 		opacity: 0.5;
 	}
-	// .newspack-newsletters-lists {
-	// 	list-style: none;
-	// 	margin: 0 0 0.8rem;
-	// 	padding: 0;
-	// 	display: flex;
-	// 	font-size: 0.8rem;
-	// 	flex-wrap: wrap;
-	// 	li {
-	// 		flex: 1 1 33.3333%;
-	// 		display: flex;
-	// 		min-width: 200px;
-	// 		box-sizing: border-box;
-	// 		margin: 0;
-	// 		padding: 0 1.4rem 1rem 0;
-	// 	}
-	// 	.list-checkbox {
-	// 		flex: 0 0 auto;
-	// 		margin: 0 0.5rem 0 0;
-	// 	}
-	// 	.list-title {
-	// 		display: block;
-	// 	}
-	// 	.list-description {
-	// 		display: block;
-	// 		font-size: 0.8rem;
-	// 		color: wp-colors.$gray-700;
-	// 		margin: 0;
-	// 	}
-	// }
-
 	.newspack-newsletters-lists {
 		border: 1px solid wp-colors.$gray-200;
 		border-radius: 2px;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Make sure the Reader Registration block and the Newsletter Subscription Form block share the same design.

![1 desktop](https://user-images.githubusercontent.com/177929/193528203-5d5577dd-ba9a-4e31-b147-86cc21a7029a.png)
![2 mobile](https://user-images.githubusercontent.com/177929/193528205-7d363fe6-733e-4454-991b-83ae9b2508bb.png)

### How to test the changes in this Pull Request:

1. Add to a page a Reader Registration block and a Newsletter Subscription Form block (to compare)
2. Publish
3. Notice how different they look
4. Switch to this branch
5. Refresh page

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
