### PR TITLE
feat: name fields options for the subscription block

### DIFF
--- a/src/blocks/subscribe/block.json
+++ b/src/blocks/subscribe/block.json
@@ -9,7 +9,23 @@
 	"attributes": {
 		"placeholder": {
 			"type": "string",
-			"default": "Enter your email address"
+			"default": "Email Address"
+		},
+		"displayNameField": {
+			"type": "boolean",
+			"default": false
+		},
+		"displayLastNameField": {
+			"type": "boolean",
+			"default": false
+		},
+		"namePlaceholder": {
+			"type": "string",
+			"default": ""
+		},
+		"lastNamePlaceholder": {
+			"type": "string",
+			"default": "Last Name"
 		},
 		"label": {
 			"type": "string",

--- a/src/blocks/subscribe/edit.js
+++ b/src/blocks/subscribe/edit.js
@@ -26,7 +26,16 @@ const settingsUrl = window.newspack_newsletters_blocks.settings_url;
 
 export default function SubscribeEdit( {
 	setAttributes,
-	attributes: { placeholder, label, lists, displayDescription },
+	attributes: {
+		placeholder,
+		displayNameField,
+		displayLastNameField,
+		namePlaceholder,
+		lastNamePlaceholder,
+		label,
+		lists,
+		displayDescription,
+	},
 } ) {
 	const blockProps = useBlockProps();
 	const [ inFlight, setInFlight ] = useState( false );
@@ -46,6 +55,15 @@ export default function SubscribeEdit( {
 			setAttributes( { lists: [ Object.keys( listConfig )[ 0 ] ] } );
 		}
 	}, [ listConfig ] );
+	const getNameFieldPlaceholder = () => {
+		if ( namePlaceholder ) {
+			return namePlaceholder;
+		}
+		if ( displayLastNameField ) {
+			return __( 'First Name', 'newspack-newsletters' );
+		}
+		return __( 'Name', 'newspack-newsletters' );
+	};
 	return (
 		<>
 			<InspectorControls>
@@ -55,6 +73,33 @@ export default function SubscribeEdit( {
 						value={ placeholder }
 						onChange={ value => setAttributes( { placeholder: value } ) }
 					/>
+					<ToggleControl
+						label={ __( 'Display name field', 'newspack-newsletters' ) }
+						checked={ displayNameField }
+						onChange={ value => setAttributes( { displayNameField: value } ) }
+					/>
+					{ displayNameField && (
+						<>
+							<TextControl
+								label={ __( 'Name field placeholder', 'newspack-newsletters' ) }
+								value={ namePlaceholder }
+								placeholder={ getNameFieldPlaceholder() }
+								onChange={ value => setAttributes( { namePlaceholder: value } ) }
+							/>
+							<ToggleControl
+								label={ __( 'Display "Last Name" field', 'newspack-newsletters' ) }
+								checked={ displayLastNameField }
+								onChange={ value => setAttributes( { displayLastNameField: value } ) }
+							/>
+							{ displayLastNameField && (
+								<TextControl
+									label={ __( '"Last Name" field placeholder', 'newspack-newsletters' ) }
+									value={ lastNamePlaceholder }
+									onChange={ value => setAttributes( { lastNamePlaceholder: value } ) }
+								/>
+							) }
+						</>
+					) }
 					<TextControl
 						label={ __( 'Button label', 'newspack-newsletters' ) }
 						value={ label }
@@ -142,6 +187,14 @@ export default function SubscribeEdit( {
 											</li>
 										) ) }
 									</ul>
+								</div>
+							) }
+							{ displayNameField && (
+								<div className="newspack-newsletters-name-input">
+									<input type="text" placeholder={ getNameFieldPlaceholder() } />
+									{ displayLastNameField && (
+										<input type="text" placeholder={ lastNamePlaceholder } />
+									) }
 								</div>
 							) }
 							<div className="newspack-newsletters-email-input">

--- a/src/blocks/subscribe/edit.js
+++ b/src/blocks/subscribe/edit.js
@@ -69,7 +69,7 @@ export default function SubscribeEdit( {
 			<InspectorControls>
 				<PanelBody title={ __( 'Form settings', 'newspack-newsletters' ) }>
 					<TextControl
-						label={ __( 'Input placeholder', 'newspack-newsletters' ) }
+						label={ __( 'Email placeholder', 'newspack-newsletters' ) }
 						value={ placeholder }
 						onChange={ value => setAttributes( { placeholder: value } ) }
 					/>
@@ -81,7 +81,7 @@ export default function SubscribeEdit( {
 					{ displayNameField && (
 						<>
 							<TextControl
-								label={ __( 'Name field placeholder', 'newspack-newsletters' ) }
+								label={ __( 'Name placeholder', 'newspack-newsletters' ) }
 								value={ namePlaceholder }
 								placeholder={ getNameFieldPlaceholder() }
 								onChange={ value => setAttributes( { namePlaceholder: value } ) }
@@ -93,7 +93,7 @@ export default function SubscribeEdit( {
 							/>
 							{ displayLastNameField && (
 								<TextControl
-									label={ __( '"Last Name" field placeholder', 'newspack-newsletters' ) }
+									label={ __( '"Last Name" placeholder', 'newspack-newsletters' ) }
 									value={ lastNamePlaceholder }
 									onChange={ value => setAttributes( { lastNamePlaceholder: value } ) }
 								/>

--- a/src/blocks/subscribe/editor.scss
+++ b/src/blocks/subscribe/editor.scss
@@ -2,6 +2,7 @@
 
 .newspack-newsletters-subscribe {
 	form {
+		input[type='text'],
 		input[type='email'] {
 			background: #fff;
 			border: solid 1px #ccc;

--- a/src/blocks/subscribe/index.php
+++ b/src/blocks/subscribe/index.php
@@ -162,6 +162,22 @@ function render_block( $attrs ) {
 				<?php else : ?>
 					<input type="hidden" name="lists[]" value="<?php echo \esc_attr( $available_lists[0] ); ?>" />
 				<?php endif; ?>
+				<?php
+				if ( $attrs['displayNameField'] ) :
+					$name_placeholder      = $attrs['namePlaceholder'];
+					$last_name_placeholder = $attrs['lastNamePlaceholder'];
+					$display_last_name     = $attrs['displayLastNameField'];
+					if ( empty( $name_placeholder ) ) {
+						$name_placeholder = $display_last_name ? __( 'First Name', 'newspack-newsletters' ) : __( 'Name', 'newspack-newsletters' );
+					}
+					?>
+					<div class="newspack-newsletters-name-input">
+						<input type="text" name="name" placeholder="<?php echo \esc_attr( $name_placeholder ); ?>" />
+						<?php if ( $display_last_name ) : ?>
+							<input type="text" name="last_name" placeholder="<?php echo \esc_attr( $last_name_placeholder ); ?>" />
+						<?php endif; ?>
+					</div>
+				<?php endif; ?>
 				<div class="newspack-newsletters-email-input">
 					<input
 						type="email"
@@ -282,11 +298,20 @@ function process_form() {
 	}
 
 	// The "true" email address field is called `npe` due to the honeypot strategy.
-	$email = \sanitize_email( $_REQUEST['npe'] );
-	$lists = array_map( 'sanitize_text_field', $_REQUEST['lists'] );
+	$last_name = isset( $_REQUEST['last_name'] ) ? \sanitize_text_field( $_REQUEST['last_name'] ) : '';
+	$name      = trim(
+		sprintf(
+			'%s %s',
+			isset( $_REQUEST['name'] ) ? \sanitize_text_field( $_REQUEST['name'] ) : '',
+			$last_name
+		)
+	);
+	$email     = \sanitize_email( $_REQUEST['npe'] );
+	$lists     = array_map( 'sanitize_text_field', $_REQUEST['lists'] );
 
 	$result = \Newspack_Newsletters_Subscription::add_contact(
 		[
+			'name'     => $name ?? null,
 			'email'    => $email,
 			'metadata' => [
 				'current_page_url' => home_url( add_query_arg( array(), \wp_get_referer() ) ),

--- a/src/blocks/subscribe/style.scss
+++ b/src/blocks/subscribe/style.scss
@@ -5,11 +5,15 @@
 		width: 100%;
 		align-items: center;
 		margin: 0;
+		display: flex;
+		flex-wrap: wrap;
+		gap: 0.5rem;
 
 		@media ( min-width: 782px ) {
-			display: flex;
+			gap: 0.4rem;
 		}
 	}
+	.newspack-newsletters-name-input,
 	.newspack-newsletters-email-input {
 		display: flex;
 		flex: 1 1 100%;
@@ -20,6 +24,7 @@
 			gap: 0.4rem;
 		}
 	}
+	input[type='text'],
 	input[type='email'] {
 		flex: 1 1 100%;
 
@@ -49,7 +54,6 @@
 		box-sizing: border-box;
 		flex: 1 1 100%;
 		font-size: 0.8rem;
-		margin-bottom: 0.8rem;
 		padding: 0.5em;
 
 		ul {
@@ -95,14 +99,6 @@
 
 		p {
 			margin: 0.5rem 0 0;
-		}
-	}
-	&.multiple-lists {
-		form {
-			display: block;
-		}
-		.newspack-newsletters-email-input {
-			margin-right: 0;
 		}
 	}
 	.nphp {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Implements name fields options for the subscription block:

<img width="288" alt="image" src="https://user-images.githubusercontent.com/820752/195431780-a63965bd-2952-4a89-bfdc-c60e50682e50.png">

<img width="859" alt="image" src="https://user-images.githubusercontent.com/820752/195429624-1bc092b0-8491-4be6-ab04-f16fc9bac64a.png">

<img width="853" alt="image" src="https://user-images.githubusercontent.com/820752/195429580-bed9ebb9-7e30-4da7-8cfd-e9d1a7388959.png">

Stacked inputs on mobile:

<img width="429" alt="image" src="https://user-images.githubusercontent.com/820752/195430904-af3715a6-fe52-4a8c-933d-239dbbf1dcc6.png">

This PR also adjusts the form elements styling for a more consistent responsive grid using flexboxes and `gap` for spacing.

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes #983

### How to test the changes in this Pull Request:

1. Check out this branch and confirm you're connected to a Mailchimp or ActiveCampaign account
2. Draft a "Newsletter Subscription Form" block
3. Confirm you see the new block options
4. Save with the default options (without name field), subscribe and confirm the contact is stored
5. Toggle the name field, apply a custom placeholder, and save
6. Visit the page and confirm the custom placeholder is rendered
7. Subscribe using the block and confirm the name is stored in the contact
8. Toggle the last name field, apply a custom placeholder and save
9. Visit the page and confirm the custom placeholder is rendered
10. Change your viewport to mobile and confirm the inputs stack appropriately
11. Subscribe using the block and confirm the name and last name are stored in the contact

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
