### PR TITLE
fix: standardize api error status code

### DIFF
--- a/includes/service-providers/active_campaign/class-newspack-newsletters-active-campaign-controller.php
+++ b/includes/service-providers/active_campaign/class-newspack-newsletters-active-campaign-controller.php
@@ -150,6 +150,9 @@ class Newspack_Newsletters_Active_Campaign_Controller extends Newspack_Newslette
 	 */
 	public function api_retrieve( $request ) {
 		$response = $this->service_provider->retrieve( $request['id'], true );
+		if ( is_wp_error( $response ) ) {
+			$response->add_data( [ 'status' => 400 ] );
+		}
 		return \rest_ensure_response( $response );
 	}
 
@@ -169,6 +172,9 @@ class Newspack_Newsletters_Active_Campaign_Controller extends Newspack_Newslette
 			$request['id'],
 			$emails
 		);
+		if ( is_wp_error( $response ) ) {
+			$response->add_data( [ 'status' => 400 ] );
+		}
 		return \rest_ensure_response( $response );
 	}
 

--- a/includes/service-providers/active_campaign/class-newspack-newsletters-active-campaign-controller.php
+++ b/includes/service-providers/active_campaign/class-newspack-newsletters-active-campaign-controller.php
@@ -150,10 +150,7 @@ class Newspack_Newsletters_Active_Campaign_Controller extends Newspack_Newslette
 	 */
 	public function api_retrieve( $request ) {
 		$response = $this->service_provider->retrieve( $request['id'], true );
-		if ( is_wp_error( $response ) ) {
-			$response->add_data( [ 'status' => 400 ] );
-		}
-		return \rest_ensure_response( $response );
+		return self::get_api_response( $response );
 	}
 
 	/**
@@ -172,10 +169,7 @@ class Newspack_Newsletters_Active_Campaign_Controller extends Newspack_Newslette
 			$request['id'],
 			$emails
 		);
-		if ( is_wp_error( $response ) ) {
-			$response->add_data( [ 'status' => 400 ] );
-		}
-		return \rest_ensure_response( $response );
+		return self::get_api_response( $response );
 	}
 
 	/**

--- a/includes/service-providers/campaign_monitor/class-newspack-newsletters-campaign-monitor-controller.php
+++ b/includes/service-providers/campaign_monitor/class-newspack-newsletters-campaign-monitor-controller.php
@@ -180,10 +180,7 @@ class Newspack_Newsletters_Campaign_Monitor_Controller extends Newspack_Newslett
 	 */
 	public function api_retrieve( $request ) {
 		$response = $this->service_provider->retrieve( $request['id'], true );
-		if ( is_wp_error( $response ) ) {
-			$response->add_data( [ 'status' => 400 ] );
-		}
-		return \rest_ensure_response( $response );
+		return self::get_api_response( $response );
 	}
 
 	/**
@@ -202,10 +199,7 @@ class Newspack_Newsletters_Campaign_Monitor_Controller extends Newspack_Newslett
 			$request['id'],
 			$emails
 		);
-		if ( is_wp_error( $response ) ) {
-			$response->add_data( [ 'status' => 400 ] );
-		}
-		return \rest_ensure_response( $response );
+		return self::get_api_response( $response );
 	}
 
 	/**

--- a/includes/service-providers/campaign_monitor/class-newspack-newsletters-campaign-monitor-controller.php
+++ b/includes/service-providers/campaign_monitor/class-newspack-newsletters-campaign-monitor-controller.php
@@ -180,6 +180,9 @@ class Newspack_Newsletters_Campaign_Monitor_Controller extends Newspack_Newslett
 	 */
 	public function api_retrieve( $request ) {
 		$response = $this->service_provider->retrieve( $request['id'], true );
+		if ( is_wp_error( $response ) ) {
+			$response->add_data( [ 'status' => 400 ] );
+		}
 		return \rest_ensure_response( $response );
 	}
 
@@ -199,6 +202,9 @@ class Newspack_Newsletters_Campaign_Monitor_Controller extends Newspack_Newslett
 			$request['id'],
 			$emails
 		);
+		if ( is_wp_error( $response ) ) {
+			$response->add_data( [ 'status' => 400 ] );
+		}
 		return \rest_ensure_response( $response );
 	}
 

--- a/includes/service-providers/class-newspack-newsletters-service-provider-controller.php
+++ b/includes/service-providers/class-newspack-newsletters-service-provider-controller.php
@@ -36,8 +36,20 @@ abstract class Newspack_Newsletters_Service_Provider_Controller extends \WP_REST
 	}
 
 	/**
+	 * Prepare and return the API response.
+	 *
+	 * @param array|WP_Error|mixed $response Data to return.
+	 */
+	public static function get_api_response( $response ) {
+		if ( is_wp_error( $response ) ) {
+			$response->add_data( [ 'status' => 400 ] );
+		}
+		return \rest_ensure_response( $response );
+	}
+
+	/**
 	 * Update user's default email addresses for test email
-	 * 
+	 *
 	 * @param array $emails Email addresses.
 	 * @return bool Whether the value has been updated or not
 	 */

--- a/includes/service-providers/class-newspack-newsletters-service-provider.php
+++ b/includes/service-providers/class-newspack-newsletters-service-provider.php
@@ -114,7 +114,7 @@ abstract class Newspack_Newsletters_Service_Provider implements Newspack_Newslet
 
 		// Prevent status change from the controlled status if newsletter has been sent.
 		if ( ! in_array( $new_status, self::$controlled_statuses, true ) && $old_status !== $new_status && $sent ) {
-			$error = new WP_Error( 'newspack_newsletters_error', __( 'You cannot change a sent newsletter status.', 'newspack-newsletters' ) );
+			$error = new WP_Error( 'newspack_newsletters_error', __( 'You cannot change a sent newsletter status.', 'newspack-newsletters' ), [ 'status' => 403 ] );
 			wp_die( $error ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 		}
 
@@ -296,7 +296,7 @@ abstract class Newspack_Newsletters_Service_Provider implements Newspack_Newslet
 		try {
 			$result = $this->send( $post );
 		} catch ( Exception $e ) {
-			$result = new WP_Error( 'newspack_newsletter_error', $e->getMessage() );
+			$result = new WP_Error( 'newspack_newsletter_error', $e->getMessage(), [ 'status' => 400 ] );
 		}
 
 		if ( true === $result ) {
@@ -316,6 +316,6 @@ abstract class Newspack_Newsletters_Service_Provider implements Newspack_Newslet
 	 * @return true|WP_Error True if the contact was updated or error.
 	 */
 	public function update_contact_lists( $email, $lists_to_add = [], $lists_to_remove = [] ) {
-		return new WP_Error( 'newspack_newsletters_not_implemented', __( 'Not implemented', 'newspack-newsletters' ) );
+		return new WP_Error( 'newspack_newsletters_not_implemented', __( 'Not implemented', 'newspack-newsletters' ), [ 'status' => 400 ] );
 	}
 }

--- a/includes/service-providers/constant_contact/class-newspack-newsletters-constant-contact-controller.php
+++ b/includes/service-providers/constant_contact/class-newspack-newsletters-constant-contact-controller.php
@@ -156,10 +156,7 @@ class Newspack_Newsletters_Constant_Contact_Controller extends Newspack_Newslett
 	 */
 	public function verify_token() {
 		$response = $this->service_provider->verify_token();
-		if ( is_wp_error( $response ) ) {
-			$response->add_data( [ 'status' => 400 ] );
-		}
-		return \rest_ensure_response( $response );
+		return self::get_api_response( $response );
 	}
 
 	/**
@@ -170,10 +167,7 @@ class Newspack_Newsletters_Constant_Contact_Controller extends Newspack_Newslett
 	 */
 	public function api_retrieve( $request ) {
 		$response = $this->service_provider->retrieve( $request['id'] );
-		if ( is_wp_error( $response ) ) {
-			$response->add_data( [ 'status' => 400 ] );
-		}
-		return \rest_ensure_response( $response );
+		return self::get_api_response( $response );
 	}
 
 	/**
@@ -192,10 +186,7 @@ class Newspack_Newsletters_Constant_Contact_Controller extends Newspack_Newslett
 			$request['id'],
 			$emails
 		);
-		if ( is_wp_error( $response ) ) {
-			$response->add_data( [ 'status' => 400 ] );
-		}
-		return \rest_ensure_response( $response );
+		return self::get_api_response( $response );
 	}
 
 	/**
@@ -210,10 +201,7 @@ class Newspack_Newsletters_Constant_Contact_Controller extends Newspack_Newslett
 			$request['from_name'],
 			$request['reply_to']
 		);
-		if ( is_wp_error( $response ) ) {
-			$response->add_data( [ 'status' => 400 ] );
-		}
-		return \rest_ensure_response( $response );
+		return self::get_api_response( $response );
 	}
 
 	/**
@@ -234,9 +222,6 @@ class Newspack_Newsletters_Constant_Contact_Controller extends Newspack_Newslett
 				$request['list_id']
 			);
 		}
-		if ( is_wp_error( $response ) ) {
-			$response->add_data( [ 'status' => 400 ] );
-		}
-		return \rest_ensure_response( $response );
+		return self::get_api_response( $response );
 	}
 }

--- a/includes/service-providers/constant_contact/class-newspack-newsletters-constant-contact-controller.php
+++ b/includes/service-providers/constant_contact/class-newspack-newsletters-constant-contact-controller.php
@@ -151,11 +151,14 @@ class Newspack_Newsletters_Constant_Contact_Controller extends Newspack_Newslett
 
 	/**
 	 * Verify connection
-	 * 
+	 *
 	 * @return WP_REST_Response|mixed API response or error.
 	 */
 	public function verify_token() {
 		$response = $this->service_provider->verify_token();
+		if ( is_wp_error( $response ) ) {
+			$response->add_data( [ 'status' => 400 ] );
+		}
 		return \rest_ensure_response( $response );
 	}
 
@@ -167,6 +170,9 @@ class Newspack_Newsletters_Constant_Contact_Controller extends Newspack_Newslett
 	 */
 	public function api_retrieve( $request ) {
 		$response = $this->service_provider->retrieve( $request['id'] );
+		if ( is_wp_error( $response ) ) {
+			$response->add_data( [ 'status' => 400 ] );
+		}
 		return \rest_ensure_response( $response );
 	}
 
@@ -186,6 +192,9 @@ class Newspack_Newsletters_Constant_Contact_Controller extends Newspack_Newslett
 			$request['id'],
 			$emails
 		);
+		if ( is_wp_error( $response ) ) {
+			$response->add_data( [ 'status' => 400 ] );
+		}
 		return \rest_ensure_response( $response );
 	}
 
@@ -201,6 +210,9 @@ class Newspack_Newsletters_Constant_Contact_Controller extends Newspack_Newslett
 			$request['from_name'],
 			$request['reply_to']
 		);
+		if ( is_wp_error( $response ) ) {
+			$response->add_data( [ 'status' => 400 ] );
+		}
 		return \rest_ensure_response( $response );
 	}
 
@@ -221,6 +233,9 @@ class Newspack_Newsletters_Constant_Contact_Controller extends Newspack_Newslett
 				$request['id'],
 				$request['list_id']
 			);
+		}
+		if ( is_wp_error( $response ) ) {
+			$response->add_data( [ 'status' => 400 ] );
 		}
 		return \rest_ensure_response( $response );
 	}

--- a/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp-controller.php
+++ b/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp-controller.php
@@ -165,6 +165,9 @@ class Newspack_Newsletters_Mailchimp_Controller extends Newspack_Newsletters_Ser
 	 */
 	public function api_retrieve( $request ) {
 		$response = $this->service_provider->retrieve( $request['id'] );
+		if ( is_wp_error( $response ) ) {
+			$response->add_data( [ 'status' => 400 ] );
+		}
 		return \rest_ensure_response( $response );
 	}
 
@@ -184,6 +187,9 @@ class Newspack_Newsletters_Mailchimp_Controller extends Newspack_Newsletters_Ser
 			$request['id'],
 			$emails
 		);
+		if ( is_wp_error( $response ) ) {
+			$response->add_data( [ 'status' => 400 ] );
+		}
 		return \rest_ensure_response( $response );
 	}
 
@@ -199,6 +205,9 @@ class Newspack_Newsletters_Mailchimp_Controller extends Newspack_Newsletters_Ser
 			$request['from_name'],
 			$request['reply_to']
 		);
+		if ( is_wp_error( $response ) ) {
+			$response->add_data( [ 'status' => 400 ] );
+		}
 		return \rest_ensure_response( $response );
 	}
 
@@ -213,6 +222,9 @@ class Newspack_Newsletters_Mailchimp_Controller extends Newspack_Newsletters_Ser
 			$request['id'],
 			$request['list_id']
 		);
+		if ( is_wp_error( $response ) ) {
+			$response->add_data( [ 'status' => 400 ] );
+		}
 		return \rest_ensure_response( $response );
 	}
 
@@ -227,6 +239,9 @@ class Newspack_Newsletters_Mailchimp_Controller extends Newspack_Newsletters_Ser
 			$request['id'],
 			$request['target_id']
 		);
+		if ( is_wp_error( $response ) ) {
+			$response->add_data( [ 'status' => 400 ] );
+		}
 		return \rest_ensure_response( $response );
 	}
 }

--- a/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp-controller.php
+++ b/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp-controller.php
@@ -165,10 +165,7 @@ class Newspack_Newsletters_Mailchimp_Controller extends Newspack_Newsletters_Ser
 	 */
 	public function api_retrieve( $request ) {
 		$response = $this->service_provider->retrieve( $request['id'] );
-		if ( is_wp_error( $response ) ) {
-			$response->add_data( [ 'status' => 400 ] );
-		}
-		return \rest_ensure_response( $response );
+		return self::get_api_response( $response );
 	}
 
 	/**
@@ -187,10 +184,7 @@ class Newspack_Newsletters_Mailchimp_Controller extends Newspack_Newsletters_Ser
 			$request['id'],
 			$emails
 		);
-		if ( is_wp_error( $response ) ) {
-			$response->add_data( [ 'status' => 400 ] );
-		}
-		return \rest_ensure_response( $response );
+		return self::get_api_response( $response );
 	}
 
 	/**
@@ -205,10 +199,7 @@ class Newspack_Newsletters_Mailchimp_Controller extends Newspack_Newsletters_Ser
 			$request['from_name'],
 			$request['reply_to']
 		);
-		if ( is_wp_error( $response ) ) {
-			$response->add_data( [ 'status' => 400 ] );
-		}
-		return \rest_ensure_response( $response );
+		return self::get_api_response( $response );
 	}
 
 	/**
@@ -222,10 +213,7 @@ class Newspack_Newsletters_Mailchimp_Controller extends Newspack_Newsletters_Ser
 			$request['id'],
 			$request['list_id']
 		);
-		if ( is_wp_error( $response ) ) {
-			$response->add_data( [ 'status' => 400 ] );
-		}
-		return \rest_ensure_response( $response );
+		return self::get_api_response( $response );
 	}
 
 	/**
@@ -239,9 +227,6 @@ class Newspack_Newsletters_Mailchimp_Controller extends Newspack_Newsletters_Ser
 			$request['id'],
 			$request['target_id']
 		);
-		if ( is_wp_error( $response ) ) {
-			$response->add_data( [ 'status' => 400 ] );
-		}
-		return \rest_ensure_response( $response );
+		return self::get_api_response( $response );
 	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

The default status code for REST API responses when returning a `WP_Error` is `500`. This in combination with the [PWA](https://wordpress.org/plugins/pwa/) plugin triggers the service worker's cached template, which is HTML content instead of the standard JSON response.

The returned HTML is not parseable, resulting in the error seen in #964.

This error is intermittent because it only occurs if the PWA's service worker is installed and active, which is most of the time.

This PR updates the error response of API requests to change the status to `400`, ensuring that the SW cached template doesn't take over.

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes #964

### How to test the changes in this Pull Request:

1. Make sure you have [PWA](https://wordpress.org/plugins/pwa/) plugin installed
2. Setup Newsletters with ActiveCampaign
3. Modify line `167` of `includes/service-providers/active_campaign/class-newspack-newsletters-active-campaign-controller.php` to: `return new \WP_Error( 'test_error', 'This is a test error' );` to ensure that an attempt to send a test campaign will return an error
4. Start a new newsletter draft, open devtools and send a test
5. Confirm the request is handled by the service worker and the error message is displayed correctly
6. In case the service worker did not handle the request, refresh the page without cache clearing and attempt to send a test again:

<img width="1344" alt="image" src="https://user-images.githubusercontent.com/820752/197257917-9cddf8c9-91ca-4e05-9f58-52081b27b92a.png">


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
