### PR TITLE
fix: lists and list item blocks in WP 6.1

### DIFF
--- a/includes/class-newspack-newsletters-editor.php
+++ b/includes/class-newspack-newsletters-editor.php
@@ -244,6 +244,7 @@ final class Newspack_Newsletters_Editor {
 			'core/image',
 			'core/separator',
 			'core/list',
+			'core/list-item',
 			'core/quote',
 			'core/site-logo',
 			'core/site-tagline',

--- a/includes/class-newspack-newsletters-renderer.php
+++ b/includes/class-newspack-newsletters-renderer.php
@@ -332,10 +332,11 @@ final class Newspack_Newsletters_Renderer {
 	 * @return string MJML component.
 	 */
 	public static function render_mjml_component( $block, $is_in_column = false, $is_in_group = false, $default_attrs = [] ) {
-		$block_name   = $block['blockName'];
-		$attrs        = $block['attrs'];
-		$inner_blocks = $block['innerBlocks'];
-		$inner_html   = $block['innerHTML'];
+		$block_name    = $block['blockName'];
+		$attrs         = $block['attrs'];
+		$inner_blocks  = $block['innerBlocks'];
+		$inner_content = $block['innerContent'];
+		$inner_html    = $block['innerHTML'];
 
 		if ( ! isset( $attrs['innerBlocksToInsert'] ) && self::is_empty_block( $block ) ) {
 			return '';
@@ -376,7 +377,6 @@ final class Newspack_Newsletters_Renderer {
 			 * Text-based blocks.
 			 */
 			case 'core/paragraph':
-			case 'core/list':
 			case 'core/heading':
 			case 'core/quote':
 			case 'core/site-title':
@@ -712,6 +712,27 @@ final class Newspack_Newsletters_Renderer {
 					$markup .= self::render_mjml_component( $block );
 				}
 				$block_mjml_markup = $markup;
+				break;
+
+			/**
+			 * List block.
+			 */
+			case 'core/list':
+				$text_attrs = array_merge(
+					array(
+						'padding'     => '0',
+						'line-height' => '1.5',
+						'font-size'   => '16px',
+						'font-family' => $font_family,
+					),
+					$attrs
+				);
+
+				$markup = '<mj-text ' . self::array_to_attributes( $text_attrs ) . '>' . $inner_content[0];
+				foreach ( $inner_blocks as $block ) {
+					$markup .= $block['innerHTML'];
+				}
+				$block_mjml_markup = $markup . $inner_content[ count( $inner_content ) - 1 ] . '</mj-text>';
 				break;
 
 			/**

--- a/includes/class-newspack-newsletters-renderer.php
+++ b/includes/class-newspack-newsletters-renderer.php
@@ -728,11 +728,14 @@ final class Newspack_Newsletters_Renderer {
 					$attrs
 				);
 
-				$markup = '<mj-text ' . self::array_to_attributes( $text_attrs ) . '>' . $inner_content[0];
-				foreach ( $inner_blocks as $block ) {
-					$markup .= $block['innerHTML'];
+				$block_mjml_markup = '<mj-text ' . self::array_to_attributes( $text_attrs ) . '>' . $inner_content[0];
+				if ( ! empty( $inner_blocks ) && 1 < count( $inner_content ) ) {
+					foreach ( $inner_blocks as $block ) {
+						$block_mjml_markup .= $block['innerHTML'];
+					}
+					$block_mjml_markup .= $inner_content[ count( $inner_content ) - 1 ];
 				}
-				$block_mjml_markup = $markup . $inner_content[ count( $inner_content ) - 1 ] . '</mj-text>';
+				$block_mjml_markup .= '</mj-text>';
 				break;
 
 			/**

--- a/tests/test-controlled-statuses.php
+++ b/tests/test-controlled-statuses.php
@@ -22,7 +22,7 @@ class Newsletter_Controlled_Statuses_Test extends WP_UnitTestCase {
 	 */
 	public function test_publish_private_newsletter() {
 		// Create draft.
-		$post_id = $this->factory->post->create(
+		$post_id = self::factory()->post->create(
 			[
 				'post_type'   => \Newspack_Newsletters::NEWSPACK_NEWSLETTERS_CPT,
 				'post_status' => 'draft',
@@ -47,7 +47,7 @@ class Newsletter_Controlled_Statuses_Test extends WP_UnitTestCase {
 	 */
 	public function test_publish_public_newsletter() {
 		// Create draft.
-		$post_id = $this->factory->post->create(
+		$post_id = self::factory()->post->create(
 			[
 				'post_type'   => \Newspack_Newsletters::NEWSPACK_NEWSLETTERS_CPT,
 				'post_status' => 'draft',

--- a/tests/test-renderer.php
+++ b/tests/test-renderer.php
@@ -22,10 +22,11 @@ class Newsletters_Renderer_Test extends WP_UnitTestCase {
 		$this->assertEquals(
 			Newspack_Newsletters_Renderer::render_mjml_component(
 				[
-					'blockName'   => 'core/paragraph',
-					'attrs'       => [],
-					'innerBlocks' => [],
-					'innerHTML'   => $inner_html,
+					'blockName'    => 'core/paragraph',
+					'attrs'        => [],
+					'innerBlocks'  => [],
+					'innerContent' => [],
+					'innerHTML'    => $inner_html,
 				]
 			),
 			'<mj-section padding="0"><mj-column padding="12px" width="100%"><mj-text padding="0" line-height="1.5" font-size="16px" >' . $inner_html . '</mj-text></mj-column></mj-section>',
@@ -35,8 +36,8 @@ class Newsletters_Renderer_Test extends WP_UnitTestCase {
 		$this->assertEquals(
 			Newspack_Newsletters_Renderer::render_mjml_component(
 				[
-					'blockName'   => 'core/paragraph',
-					'attrs'       => [
+					'blockName'    => 'core/paragraph',
+					'attrs'        => [
 						'textColor' => 'vivid-purple',
 						'fontSize'  => 'normal',
 						'style'     => [
@@ -45,8 +46,9 @@ class Newsletters_Renderer_Test extends WP_UnitTestCase {
 							],
 						],
 					],
-					'innerBlocks' => [],
-					'innerHTML'   => $inner_html,
+					'innerBlocks'  => [],
+					'innerContent' => [],
+					'innerHTML'    => $inner_html,
 				]
 			),
 			'<mj-section textColor="vivid-purple" color="#db18e6 !important" background-color="#4aadd7 !important" font-size="16px" padding="0"><mj-column padding="12px" width="100%"><mj-text padding="0" line-height="1.5" font-size="16px"  textColor="vivid-purple" color="#db18e6 !important" container-background-color="#4aadd7 !important">' . $inner_html . '</mj-text></mj-column></mj-section>',
@@ -63,12 +65,13 @@ class Newsletters_Renderer_Test extends WP_UnitTestCase {
 		$this->assertEquals(
 			Newspack_Newsletters_Renderer::render_mjml_component(
 				[
-					'blockName'   => 'core/embed',
-					'attrs'       => [
+					'blockName'    => 'core/embed',
+					'attrs'        => [
 						'url' => 'https://www.youtube.com/watch?v=aIRgcb3cQ1Q',
 					],
-					'innerBlocks' => [],
-					'innerHTML'   => $inner_html,
+					'innerBlocks'  => [],
+					'innerContent' => [],
+					'innerHTML'    => $inner_html,
 				]
 			),
 			'<mj-section url="https://www.youtube.com/watch?v=aIRgcb3cQ1Q" padding="0"><mj-column padding="12px" width="100%"><mj-image padding="0" src="https://i.ytimg.com/vi/aIRgcb3cQ1Q/hqdefault.jpg" width="480px" height="360px" href="https://www.youtube.com/watch?v=aIRgcb3cQ1Q" /><mj-text align="center" color="#555d66" line-height="1.56" font-size="13px" >How to use the Newspack Newsletter plugin - YouTube</mj-text></mj-column></mj-section>',
@@ -80,12 +83,13 @@ class Newsletters_Renderer_Test extends WP_UnitTestCase {
 		$this->assertEquals(
 			Newspack_Newsletters_Renderer::render_mjml_component(
 				[
-					'blockName'   => 'core/embed',
-					'attrs'       => [
+					'blockName'    => 'core/embed',
+					'attrs'        => [
 						'url' => 'https://flickr.com/photos/thomashawk/9274246246',
 					],
-					'innerBlocks' => [],
-					'innerHTML'   => $inner_html,
+					'innerBlocks'  => [],
+					'innerContent' => [],
+					'innerHTML'    => $inner_html,
 				]
 			),
 			'<mj-section url="https://flickr.com/photos/thomashawk/9274246246" padding="0"><mj-column padding="12px" width="100%"><mj-image src="https://live.staticflickr.com/7357/9274246246_201d71cf9a.jpg" alt="Automattic" width="500" height="333" href="https://flickr.com/photos/thomashawk/9274246246" /><mj-text align="center" color="#555d66" line-height="1.56" font-size="13px" >Automattic - Flickr</mj-text></mj-column></mj-section>',
@@ -97,12 +101,13 @@ class Newsletters_Renderer_Test extends WP_UnitTestCase {
 		$this->assertEquals(
 			Newspack_Newsletters_Renderer::render_mjml_component(
 				[
-					'blockName'   => 'core/embed',
-					'attrs'       => [
+					'blockName'    => 'core/embed',
+					'attrs'        => [
 						'url' => 'https://twitter.com/automattic/status/1395447061336711181',
 					],
-					'innerBlocks' => [],
-					'innerHTML'   => $inner_html,
+					'innerBlocks'  => [],
+					'innerContent' => [],
+					'innerHTML'    => $inner_html,
 				]
 			),
 			"<mj-section url=\"https://twitter.com/automattic/status/1395447061336711181\" padding=\"0\"><mj-column padding=\"12px\" width=\"100%\"><mj-text padding=\"0\" line-height=\"1.5\" font-size=\"16px\" ><blockquote>We&#039;re Hiring! We are continuing to grow and have some exciting open positions available, including in Engineering, Product, Marketing, Business Development, HR, Customer Support, and more. Work with us, from anywhere. <a href=\"https://t.co/EZST4WBsy2\">https://t.co/EZST4WBsy2</a> <a href=\"https://t.co/z8bKfCgn14\">pic.twitter.com/z8bKfCgn14</a>&mdash; Automattic (@automattic) <a href=\"https://twitter.com/automattic/status/1395447061336711181?ref_src=twsrc%5Etfw\">May 20, 2021</a></blockquote>\n\n</mj-text></mj-column></mj-section>",
@@ -114,12 +119,13 @@ class Newsletters_Renderer_Test extends WP_UnitTestCase {
 		$this->assertEquals(
 			Newspack_Newsletters_Renderer::render_mjml_component(
 				[
-					'blockName'   => 'core/embed',
-					'attrs'       => [
+					'blockName'    => 'core/embed',
+					'attrs'        => [
 						'url' => 'https://www.amazon.com/Learning-PHP-MySQL-JavaScript-Javascript/dp/1491978910',
 					],
-					'innerBlocks' => [],
-					'innerHTML'   => $inner_html,
+					'innerBlocks'  => [],
+					'innerContent' => [],
+					'innerHTML'    => $inner_html,
 				]
 			),
 			'<mj-section url="https://www.amazon.com/Learning-PHP-MySQL-JavaScript-Javascript/dp/1491978910" padding="0"><mj-column padding="12px" width="100%"><mj-text padding="0" line-height="1.5" font-size="16px" ><a href="https://www.amazon.com/Learning-PHP-MySQL-JavaScript-Javascript/dp/1491978910">Learning PHP, MySQL &amp; JavaScript: With jQuery, CSS &amp; HTML5 (Learning PHP, MYSQL, Javascript, CSS &amp; HTML5)</a></mj-text></mj-column></mj-section>',


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

WP 6.1 introduced the concept of sortable list items. This, however, broke our MJML renderer's implementation of lists, causing them to not be rendered at all in the final email HTML. The fact that list items are now inner blocks of List blocks also means that we need to whitelist `core/list-item` as an allowed block in the Newsletter editor, or it's not possible to add list items to any list.

### How to test the changes in this Pull Request:

1. On a site with WP 6.1, on `master`, create a newsletter containing two List blocks: one bulleted and the other numbered. Try to add some list items and observe that you can't.
2. Check out this branch and refresh the editor. Confirm that you can now add list items to each List block.
3. Send a test email. Confirm that the lists are rendered as expected.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
