### PR TITLE
fix: update CI orb newspack-scripts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  newspack: adekbadek/newspack@1.4.1
+  newspack: adekbadek/newspack@1.4.2
 
 jobs:
   release_wporg:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  newspack: adekbadek/newspack@1.4.2
+  newspack: adekbadek/newspack@1.4.3
 
 jobs:
   release_wporg:

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
 				"@rushstack/eslint-patch": "^1.2.0",
 				"eslint": "^7.32.0",
 				"lint-staged": "^13.0.3",
-				"newspack-scripts": "^4.3.7",
+				"newspack-scripts": "^4.3.8",
 				"postcss": "^8.4.18",
 				"postcss-scss": "^4.0.5",
 				"prettier": "npm:wp-prettier@^2.6.2-beta-1",
@@ -204,6 +204,7 @@
 			"version": "7.16.4",
 			"resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.16.4.tgz",
 			"integrity": "sha512-1o/jo7D+kC9ZjHX5v+EHrdjl3PhxMrLSOTGsOdHJ+KL8HCaEK6ehrVL2RS6oHDZp+L7xLirLrPmQtEng769J/Q==",
+			"dev": true,
 			"engines": {
 				"node": ">=6.9.0"
 			}
@@ -212,6 +213,7 @@
 			"version": "7.16.0",
 			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.16.0.tgz",
 			"integrity": "sha512-mYZEvshBRHGsIAiyH5PzCFTCfbWfoYbO/jcSdXQSUQu1/pW0xDZAUP7KEc32heqWTAfAHhV9j1vH8Sav7l+JNQ==",
+			"dev": true,
 			"dependencies": {
 				"@babel/code-frame": "^7.16.0",
 				"@babel/generator": "^7.16.0",
@@ -242,6 +244,7 @@
 			"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
 			"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
 			"deprecated": "Debug versions >=3.2.0 <3.2.7 || >=4 <4.3.1 have a low-severity ReDos regression when used in a Node.js environment. It is recommended you upgrade to 3.2.7 or 4.3.1. (https://github.com/visionmedia/debug/issues/797)",
+			"dev": true,
 			"dependencies": {
 				"ms": "^2.1.1"
 			}
@@ -250,6 +253,7 @@
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/json5/-/json5-2.1.2.tgz",
 			"integrity": "sha512-MoUOQ4WdiN3yxhm7NEVJSJrieAo5hNSLQ5sj05OTRHPL9HOBy8u4Bu88jsC1jvqAdN+E1bJmsUcZH+1HQxliqQ==",
+			"dev": true,
 			"dependencies": {
 				"minimist": "^1.2.5"
 			},
@@ -263,12 +267,14 @@
 		"node_modules/@babel/core/node_modules/ms": {
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+			"dev": true
 		},
 		"node_modules/@babel/core/node_modules/semver": {
 			"version": "6.3.0",
 			"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
 			"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+			"dev": true,
 			"bin": {
 				"semver": "bin/semver.js"
 			}
@@ -277,6 +283,7 @@
 			"version": "7.18.9",
 			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.18.9.tgz",
 			"integrity": "sha512-wt5Naw6lJrL1/SGkipMiFxJjtyczUWTP38deiP1PO60HsBjDeKk08CGC3S8iVuvf0FmTdgKwU1KIXzSKL1G0Ug==",
+			"dev": true,
 			"dependencies": {
 				"@babel/types": "^7.18.9",
 				"@jridgewell/gen-mapping": "^0.3.2",
@@ -315,6 +322,7 @@
 			"version": "7.16.3",
 			"resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.16.3.tgz",
 			"integrity": "sha512-vKsoSQAyBmxS35JUOOt+07cLc6Nk/2ljLIHwmq2/NM6hdioUaqEXq/S+nXvbvXbZkNDlWOymPanJGOc4CBjSJA==",
+			"dev": true,
 			"dependencies": {
 				"@babel/compat-data": "^7.16.0",
 				"@babel/helper-validator-option": "^7.14.5",
@@ -332,6 +340,7 @@
 			"version": "6.3.0",
 			"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
 			"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+			"dev": true,
 			"bin": {
 				"semver": "bin/semver.js"
 			}
@@ -428,6 +437,7 @@
 			"version": "7.18.9",
 			"resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.18.9.tgz",
 			"integrity": "sha512-3r/aACDJ3fhQ/EVgFy0hpj8oHyHpQc+LPtJoY9SzTThAsStm4Ptegq92vqKoE3vD706ZVFWITnMnxucw+S9Ipg==",
+			"dev": true,
 			"engines": {
 				"node": ">=6.9.0"
 			}
@@ -448,6 +458,7 @@
 			"version": "7.18.9",
 			"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.18.9.tgz",
 			"integrity": "sha512-fJgWlZt7nxGksJS9a0XdSaI4XvpExnNIgRP+rVefWh5U7BL8pPuir6SJUmFKRfjWQ51OtWSzwOxhaH/EBWWc0A==",
+			"dev": true,
 			"dependencies": {
 				"@babel/template": "^7.18.6",
 				"@babel/types": "^7.18.9"
@@ -460,6 +471,7 @@
 			"version": "7.18.6",
 			"resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.18.6.tgz",
 			"integrity": "sha512-UlJQPkFqFULIcyW5sbzgbkxn2FKRgwWiRexcuaR8RNJRy8+LLveqPjwZV/bwrLZCN0eUHD/x8D0heK1ozuoo6Q==",
+			"dev": true,
 			"dependencies": {
 				"@babel/types": "^7.18.6"
 			},
@@ -471,6 +483,7 @@
 			"version": "7.18.9",
 			"resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.18.9.tgz",
 			"integrity": "sha512-RxifAh2ZoVU67PyKIO4AMi1wTenGfMR/O/ae0CCRqwgBAt5v7xjdtRw7UoSbsreKrQn5t7r89eruK/9JjYHuDg==",
+			"dev": true,
 			"dependencies": {
 				"@babel/types": "^7.18.9"
 			},
@@ -493,6 +506,7 @@
 			"version": "7.16.0",
 			"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.16.0.tgz",
 			"integrity": "sha512-My4cr9ATcaBbmaEa8M0dZNA74cfI6gitvUAskgDtAFmAqyFKDSHQo5YstxPbN+lzHl2D9l/YOEFqb2mtUh4gfA==",
+			"dev": true,
 			"dependencies": {
 				"@babel/helper-module-imports": "^7.16.0",
 				"@babel/helper-replace-supers": "^7.16.0",
@@ -511,6 +525,7 @@
 			"version": "7.18.6",
 			"resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.18.6.tgz",
 			"integrity": "sha512-HP59oD9/fEHQkdcbgFCnbmgH5vIQTJbxh2yf+CdM89/glUNnuzr87Q8GIjGEnOktTROemO0Pe0iPAYbqZuOUiA==",
+			"dev": true,
 			"dependencies": {
 				"@babel/types": "^7.18.6"
 			},
@@ -544,6 +559,7 @@
 			"version": "7.18.9",
 			"resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.18.9.tgz",
 			"integrity": "sha512-dNsWibVI4lNT6HiuOIBr1oyxo40HvIVmbwPUm3XZ7wMh4k2WxrxTqZwSqw/eEmXDS9np0ey5M2bz9tBmO9c+YQ==",
+			"dev": true,
 			"dependencies": {
 				"@babel/helper-environment-visitor": "^7.18.9",
 				"@babel/helper-member-expression-to-functions": "^7.18.9",
@@ -559,6 +575,7 @@
 			"version": "7.16.0",
 			"resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.16.0.tgz",
 			"integrity": "sha512-o1rjBT/gppAqKsYfUdfHq5Rk03lMQrkPHG1OWzHWpLgVXRH4HnMM9Et9CVdIqwkCQlobnGHEJMsgWP/jE1zUiw==",
+			"dev": true,
 			"dependencies": {
 				"@babel/types": "^7.16.0"
 			},
@@ -582,6 +599,7 @@
 			"version": "7.18.6",
 			"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.18.6.tgz",
 			"integrity": "sha512-bde1etTx6ZyTmobl9LLMMQsaizFVZrquTEHOqKeQESMKo4PlObf+8+JA25ZsIpZhT/WEd39+vOdLXAFG/nELpA==",
+			"dev": true,
 			"dependencies": {
 				"@babel/types": "^7.18.6"
 			},
@@ -601,6 +619,7 @@
 			"version": "7.18.6",
 			"resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.18.6.tgz",
 			"integrity": "sha512-XO7gESt5ouv/LRJdrVjkShckw6STTaB7l9BrpBaAHDeF5YZT+01PCwmR0SJHnkW6i8OwW/EVWRShfi4j2x+KQw==",
+			"dev": true,
 			"engines": {
 				"node": ">=6.9.0"
 			}
@@ -624,6 +643,7 @@
 			"version": "7.16.3",
 			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.16.3.tgz",
 			"integrity": "sha512-Xn8IhDlBPhvYTvgewPKawhADichOsbkZuzN7qz2BusOM0brChsyXMDJvldWaYMMUNiCQdQzNEioXTp3sC8Nt8w==",
+			"dev": true,
 			"dependencies": {
 				"@babel/template": "^7.16.0",
 				"@babel/traverse": "^7.16.3",
@@ -650,6 +670,7 @@
 			"version": "7.18.9",
 			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.18.9.tgz",
 			"integrity": "sha512-9uJveS9eY9DJ0t64YbIBZICtJy8a5QrDEVdiLCG97fVLpDTpGX7t8mMSb6OWw6Lrnjqj4O8zwjELX3dhoMgiBg==",
+			"dev": true,
 			"bin": {
 				"parser": "bin/babel-parser.js"
 			},
@@ -1960,6 +1981,7 @@
 			"version": "7.18.6",
 			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.18.6.tgz",
 			"integrity": "sha512-JoDWzPe+wgBsTTgdnIma3iHNFC7YVJoPssVBDjiHfNlyt4YcunDtcDOUmfVDfCK5MfdsaIoX9PkijPhjH3nYUw==",
+			"dev": true,
 			"dependencies": {
 				"@babel/code-frame": "^7.18.6",
 				"@babel/parser": "^7.18.6",
@@ -1973,6 +1995,7 @@
 			"version": "7.18.9",
 			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.18.9.tgz",
 			"integrity": "sha512-LcPAnujXGwBgv3/WHv01pHtb2tihcyW1XuL9wd7jqh1Z8AQkTd+QVjMrMijrln0T7ED3UXLIy36P9Ao7W75rYg==",
+			"dev": true,
 			"dependencies": {
 				"@babel/code-frame": "^7.18.6",
 				"@babel/generator": "^7.18.9",
@@ -1994,6 +2017,7 @@
 			"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
 			"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
 			"deprecated": "Debug versions >=3.2.0 <3.2.7 || >=4 <4.3.1 have a low-severity ReDos regression when used in a Node.js environment. It is recommended you upgrade to 3.2.7 or 4.3.1. (https://github.com/visionmedia/debug/issues/797)",
+			"dev": true,
 			"dependencies": {
 				"ms": "^2.1.1"
 			}
@@ -2001,7 +2025,8 @@
 		"node_modules/@babel/traverse/node_modules/ms": {
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+			"dev": true
 		},
 		"node_modules/@babel/types": {
 			"version": "7.18.9",
@@ -4106,6 +4131,7 @@
 			"version": "0.3.2",
 			"resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.2.tgz",
 			"integrity": "sha512-mh65xKQAzI6iBcFzwv28KVWSmCkdRBWoOh+bYQGW3+6OZvbbN3TqMGo5hqYxQniRcH9F2VZIoJCm4pa3BPDK/A==",
+			"dev": true,
 			"dependencies": {
 				"@jridgewell/set-array": "^1.0.1",
 				"@jridgewell/sourcemap-codec": "^1.4.10",
@@ -4127,6 +4153,7 @@
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.1.2.tgz",
 			"integrity": "sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw==",
+			"dev": true,
 			"engines": {
 				"node": ">=6.0.0"
 			}
@@ -10678,26 +10705,6 @@
 				"node": ">=0.10.0"
 			}
 		},
-		"node_modules/array.prototype.filter": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/array.prototype.filter/-/array.prototype.filter-1.0.2.tgz",
-			"integrity": "sha512-us+UrmGOilqttSOgoWZTpOvHu68vZT2YCjc/H4vhu56vzZpaDFBhB+Se2UwqWzMKbDv7Myq5M5pcZLAtUvTQdQ==",
-			"dev": true,
-			"peer": true,
-			"dependencies": {
-				"call-bind": "^1.0.2",
-				"define-properties": "^1.1.4",
-				"es-abstract": "^1.20.4",
-				"es-array-method-boxes-properly": "^1.0.0",
-				"is-string": "^1.0.7"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
 		"node_modules/array.prototype.find": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/array.prototype.find/-/array.prototype.find-2.1.1.tgz",
@@ -11407,6 +11414,7 @@
 			"version": "4.19.1",
 			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.19.1.tgz",
 			"integrity": "sha512-u2tbbG5PdKRTUoctO3NBD8FQ5HdPh1ZXPHzp1rwaa5jTc+RV9/+RlWiAIKmjRPQF+xbGM9Kklj5bZQFa2s/38A==",
+			"dev": true,
 			"dependencies": {
 				"caniuse-lite": "^1.0.30001286",
 				"electron-to-chromium": "^1.4.17",
@@ -11661,6 +11669,7 @@
 			"version": "1.0.30001301",
 			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001301.tgz",
 			"integrity": "sha512-csfD/GpHMqgEL3V3uIgosvh+SVIQvCh43SNu9HRbP1lnxkKm1kjDG4f32PP571JplkLjfS+mg2p1gxR7MYrrIA==",
+			"dev": true,
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/browserslist"
@@ -11763,171 +11772,6 @@
 			"resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
 			"integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
 			"dev": true
-		},
-		"node_modules/cheerio": {
-			"version": "1.0.0-rc.12",
-			"resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.0.0-rc.12.tgz",
-			"integrity": "sha512-VqR8m68vM46BNnuZ5NtnGBKIE/DfN0cRIzg9n40EIq9NOv90ayxLBXA8fXC5gquFRGJSTRqBq25Jt2ECLR431Q==",
-			"dev": true,
-			"peer": true,
-			"dependencies": {
-				"cheerio-select": "^2.1.0",
-				"dom-serializer": "^2.0.0",
-				"domhandler": "^5.0.3",
-				"domutils": "^3.0.1",
-				"htmlparser2": "^8.0.1",
-				"parse5": "^7.0.0",
-				"parse5-htmlparser2-tree-adapter": "^7.0.0"
-			},
-			"engines": {
-				"node": ">= 6"
-			},
-			"funding": {
-				"url": "https://github.com/cheeriojs/cheerio?sponsor=1"
-			}
-		},
-		"node_modules/cheerio-select": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/cheerio-select/-/cheerio-select-2.1.0.tgz",
-			"integrity": "sha512-9v9kG0LvzrlcungtnJtpGNxY+fzECQKhK4EGJX2vByejiMX84MFNQw4UxPJl3bFbTMw+Dfs37XaIkCwTZfLh4g==",
-			"dev": true,
-			"peer": true,
-			"dependencies": {
-				"boolbase": "^1.0.0",
-				"css-select": "^5.1.0",
-				"css-what": "^6.1.0",
-				"domelementtype": "^2.3.0",
-				"domhandler": "^5.0.3",
-				"domutils": "^3.0.1"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/fb55"
-			}
-		},
-		"node_modules/cheerio-select/node_modules/dom-serializer": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
-			"integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
-			"dev": true,
-			"peer": true,
-			"dependencies": {
-				"domelementtype": "^2.3.0",
-				"domhandler": "^5.0.2",
-				"entities": "^4.2.0"
-			},
-			"funding": {
-				"url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
-			}
-		},
-		"node_modules/cheerio-select/node_modules/domelementtype": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
-			"integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
-			"dev": true,
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/fb55"
-				}
-			],
-			"peer": true
-		},
-		"node_modules/cheerio-select/node_modules/domutils": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/domutils/-/domutils-3.0.1.tgz",
-			"integrity": "sha512-z08c1l761iKhDFtfXO04C7kTdPBLi41zwOZl00WS8b5eiaebNpY00HKbztwBq+e3vyqWNwWF3mP9YLUeqIrF+Q==",
-			"dev": true,
-			"peer": true,
-			"dependencies": {
-				"dom-serializer": "^2.0.0",
-				"domelementtype": "^2.3.0",
-				"domhandler": "^5.0.1"
-			},
-			"funding": {
-				"url": "https://github.com/fb55/domutils?sponsor=1"
-			}
-		},
-		"node_modules/cheerio-select/node_modules/entities": {
-			"version": "4.4.0",
-			"resolved": "https://registry.npmjs.org/entities/-/entities-4.4.0.tgz",
-			"integrity": "sha512-oYp7156SP8LkeGD0GF85ad1X9Ai79WtRsZ2gxJqtBuzH+98YUV6jkHEKlZkMbcrjJjIVJNIDP/3WL9wQkoPbWA==",
-			"dev": true,
-			"peer": true,
-			"engines": {
-				"node": ">=0.12"
-			},
-			"funding": {
-				"url": "https://github.com/fb55/entities?sponsor=1"
-			}
-		},
-		"node_modules/cheerio/node_modules/dom-serializer": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
-			"integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
-			"dev": true,
-			"peer": true,
-			"dependencies": {
-				"domelementtype": "^2.3.0",
-				"domhandler": "^5.0.2",
-				"entities": "^4.2.0"
-			},
-			"funding": {
-				"url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
-			}
-		},
-		"node_modules/cheerio/node_modules/domelementtype": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
-			"integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
-			"dev": true,
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/fb55"
-				}
-			],
-			"peer": true
-		},
-		"node_modules/cheerio/node_modules/domutils": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/domutils/-/domutils-3.0.1.tgz",
-			"integrity": "sha512-z08c1l761iKhDFtfXO04C7kTdPBLi41zwOZl00WS8b5eiaebNpY00HKbztwBq+e3vyqWNwWF3mP9YLUeqIrF+Q==",
-			"dev": true,
-			"peer": true,
-			"dependencies": {
-				"dom-serializer": "^2.0.0",
-				"domelementtype": "^2.3.0",
-				"domhandler": "^5.0.1"
-			},
-			"funding": {
-				"url": "https://github.com/fb55/domutils?sponsor=1"
-			}
-		},
-		"node_modules/cheerio/node_modules/entities": {
-			"version": "4.4.0",
-			"resolved": "https://registry.npmjs.org/entities/-/entities-4.4.0.tgz",
-			"integrity": "sha512-oYp7156SP8LkeGD0GF85ad1X9Ai79WtRsZ2gxJqtBuzH+98YUV6jkHEKlZkMbcrjJjIVJNIDP/3WL9wQkoPbWA==",
-			"dev": true,
-			"peer": true,
-			"engines": {
-				"node": ">=0.12"
-			},
-			"funding": {
-				"url": "https://github.com/fb55/entities?sponsor=1"
-			}
-		},
-		"node_modules/cheerio/node_modules/parse5": {
-			"version": "7.1.1",
-			"resolved": "https://registry.npmjs.org/parse5/-/parse5-7.1.1.tgz",
-			"integrity": "sha512-kwpuwzB+px5WUg9pyK0IcK/shltJN5/OVhQagxhCQNtT9Y9QRZqNY2e1cmbu/paRh5LMnz/oVTVLBpjFmMZhSg==",
-			"dev": true,
-			"peer": true,
-			"dependencies": {
-				"entities": "^4.4.0"
-			},
-			"funding": {
-				"url": "https://github.com/inikulin/parse5?sponsor=1"
-			}
 		},
 		"node_modules/chokidar": {
 			"version": "3.5.2",
@@ -13002,84 +12846,11 @@
 				"source-map": "~0.6.1"
 			}
 		},
-		"node_modules/css-select": {
-			"version": "5.1.0",
-			"resolved": "https://registry.npmjs.org/css-select/-/css-select-5.1.0.tgz",
-			"integrity": "sha512-nwoRF1rvRRnnCqqY7updORDsuqKzqYJ28+oSMaJMMgOauh3fvwHqMS7EZpIPqK8GL+g9mKxF1vP/ZjSeNjEVHg==",
-			"dev": true,
-			"peer": true,
-			"dependencies": {
-				"boolbase": "^1.0.0",
-				"css-what": "^6.1.0",
-				"domhandler": "^5.0.2",
-				"domutils": "^3.0.1",
-				"nth-check": "^2.0.1"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/fb55"
-			}
-		},
 		"node_modules/css-select-base-adapter": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/css-select-base-adapter/-/css-select-base-adapter-0.1.1.tgz",
 			"integrity": "sha512-jQVeeRG70QI08vSTwf1jHxp74JoZsr2XSgETae8/xC8ovSnL2WF87GTLO86Sbwdt2lK4Umg4HnnwMO4YF3Ce7w==",
 			"dev": true
-		},
-		"node_modules/css-select/node_modules/dom-serializer": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
-			"integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
-			"dev": true,
-			"peer": true,
-			"dependencies": {
-				"domelementtype": "^2.3.0",
-				"domhandler": "^5.0.2",
-				"entities": "^4.2.0"
-			},
-			"funding": {
-				"url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
-			}
-		},
-		"node_modules/css-select/node_modules/domelementtype": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
-			"integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
-			"dev": true,
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/fb55"
-				}
-			],
-			"peer": true
-		},
-		"node_modules/css-select/node_modules/domutils": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/domutils/-/domutils-3.0.1.tgz",
-			"integrity": "sha512-z08c1l761iKhDFtfXO04C7kTdPBLi41zwOZl00WS8b5eiaebNpY00HKbztwBq+e3vyqWNwWF3mP9YLUeqIrF+Q==",
-			"dev": true,
-			"peer": true,
-			"dependencies": {
-				"dom-serializer": "^2.0.0",
-				"domelementtype": "^2.3.0",
-				"domhandler": "^5.0.1"
-			},
-			"funding": {
-				"url": "https://github.com/fb55/domutils?sponsor=1"
-			}
-		},
-		"node_modules/css-select/node_modules/entities": {
-			"version": "4.4.0",
-			"resolved": "https://registry.npmjs.org/entities/-/entities-4.4.0.tgz",
-			"integrity": "sha512-oYp7156SP8LkeGD0GF85ad1X9Ai79WtRsZ2gxJqtBuzH+98YUV6jkHEKlZkMbcrjJjIVJNIDP/3WL9wQkoPbWA==",
-			"dev": true,
-			"peer": true,
-			"engines": {
-				"node": ">=0.12"
-			},
-			"funding": {
-				"url": "https://github.com/fb55/entities?sponsor=1"
-			}
 		},
 		"node_modules/css-tree": {
 			"version": "1.0.0-alpha.37",
@@ -13101,19 +12872,6 @@
 			"dev": true,
 			"engines": {
 				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/css-what": {
-			"version": "6.1.0",
-			"resolved": "https://registry.npmjs.org/css-what/-/css-what-6.1.0.tgz",
-			"integrity": "sha512-HTUrgRJ7r4dsZKU6GjmpfRK1O76h97Z8MfS1G0FozR+oF2kG6Vfe8JE6zwrkbxigziPHinCJ+gCPjA9EaBDtRw==",
-			"dev": true,
-			"peer": true,
-			"engines": {
-				"node": ">= 6"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/fb55"
 			}
 		},
 		"node_modules/css.escape": {
@@ -13865,13 +13623,6 @@
 				"url": "https://github.com/sponsors/wooorm"
 			}
 		},
-		"node_modules/discontinuous-range": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/discontinuous-range/-/discontinuous-range-1.0.0.tgz",
-			"integrity": "sha512-c68LpLbO+7kP/b1Hr1qs8/BJ09F5khZGTxqxZuhzxpmwJKOgRFHJWIb9/KmqnqHhLdO55aOxFH/EGBvUQbL/RQ==",
-			"dev": true,
-			"peer": true
-		},
 		"node_modules/doctrine": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
@@ -13939,35 +13690,6 @@
 			"engines": {
 				"node": ">=8"
 			}
-		},
-		"node_modules/domhandler": {
-			"version": "5.0.3",
-			"resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
-			"integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
-			"dev": true,
-			"peer": true,
-			"dependencies": {
-				"domelementtype": "^2.3.0"
-			},
-			"engines": {
-				"node": ">= 4"
-			},
-			"funding": {
-				"url": "https://github.com/fb55/domhandler?sponsor=1"
-			}
-		},
-		"node_modules/domhandler/node_modules/domelementtype": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
-			"integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
-			"dev": true,
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/fb55"
-				}
-			],
-			"peer": true
 		},
 		"node_modules/domutils": {
 			"version": "1.7.0",
@@ -14063,7 +13785,8 @@
 		"node_modules/electron-to-chromium": {
 			"version": "1.4.51",
 			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.51.tgz",
-			"integrity": "sha512-JNEmcYl3mk1tGQmy0EvL5eik/CKSBuzAyGP0QFdG6LIgxQe3II0BL1m2zKc2MZMf3uGqHWE1TFddJML0RpjSHQ=="
+			"integrity": "sha512-JNEmcYl3mk1tGQmy0EvL5eik/CKSBuzAyGP0QFdG6LIgxQe3II0BL1m2zKc2MZMf3uGqHWE1TFddJML0RpjSHQ==",
+			"dev": true
 		},
 		"node_modules/emitter-mixin": {
 			"version": "0.0.3",
@@ -14289,40 +14012,6 @@
 				"node": ">=4"
 			}
 		},
-		"node_modules/enzyme": {
-			"version": "3.11.0",
-			"resolved": "https://registry.npmjs.org/enzyme/-/enzyme-3.11.0.tgz",
-			"integrity": "sha512-Dw8/Gs4vRjxY6/6i9wU0V+utmQO9kvh9XLnz3LIudviOnVYDEe2ec+0k+NQoMamn1VrjKgCUOWj5jG/5M5M0Qw==",
-			"dev": true,
-			"peer": true,
-			"dependencies": {
-				"array.prototype.flat": "^1.2.3",
-				"cheerio": "^1.0.0-rc.3",
-				"enzyme-shallow-equal": "^1.0.1",
-				"function.prototype.name": "^1.1.2",
-				"has": "^1.0.3",
-				"html-element-map": "^1.2.0",
-				"is-boolean-object": "^1.0.1",
-				"is-callable": "^1.1.5",
-				"is-number-object": "^1.0.4",
-				"is-regex": "^1.0.5",
-				"is-string": "^1.0.5",
-				"is-subset": "^0.1.1",
-				"lodash.escape": "^4.0.1",
-				"lodash.isequal": "^4.5.0",
-				"object-inspect": "^1.7.0",
-				"object-is": "^1.0.2",
-				"object.assign": "^4.1.0",
-				"object.entries": "^1.1.1",
-				"object.values": "^1.1.1",
-				"raf": "^3.4.1",
-				"rst-selector-parser": "^2.2.3",
-				"string.prototype.trim": "^1.2.1"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
 		"node_modules/enzyme-matchers": {
 			"version": "7.1.2",
 			"resolved": "https://registry.npmjs.org/enzyme-matchers/-/enzyme-matchers-7.1.2.tgz",
@@ -14427,13 +14116,6 @@
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
 			}
-		},
-		"node_modules/es-array-method-boxes-properly": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/es-array-method-boxes-properly/-/es-array-method-boxes-properly-1.0.0.tgz",
-			"integrity": "sha512-wd6JXUmyHmt8T5a2xreUwKcGPq6f1f+WwIJkijUqiGcJz1qqnZgP6XIK+QyIWU5lT7imeNxUll48bziG+TSYcA==",
-			"dev": true,
-			"peer": true
 		},
 		"node_modules/es-module-lexer": {
 			"version": "0.9.3",
@@ -16136,6 +15818,7 @@
 			"version": "1.0.0-beta.2",
 			"resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
 			"integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+			"dev": true,
 			"engines": {
 				"node": ">=6.9.0"
 			}
@@ -16394,6 +16077,7 @@
 			"version": "11.12.0",
 			"resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
 			"integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
+			"dev": true,
 			"engines": {
 				"node": ">=4"
 			}
@@ -16730,20 +16414,6 @@
 			"integrity": "sha1-wc56MWjIxmFAM6S194d/OyJfnDg=",
 			"dev": true
 		},
-		"node_modules/html-element-map": {
-			"version": "1.3.1",
-			"resolved": "https://registry.npmjs.org/html-element-map/-/html-element-map-1.3.1.tgz",
-			"integrity": "sha512-6XMlxrAFX4UEEGxctfFnmrFaaZFNf9i5fNuV5wZ3WWQ4FVaNP1aX1LkX9j2mfEx1NpjeE/rL3nmgEn23GdFmrg==",
-			"dev": true,
-			"peer": true,
-			"dependencies": {
-				"array.prototype.filter": "^1.0.0",
-				"call-bind": "^1.0.2"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
 		"node_modules/html-encoding-sniffer": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-2.0.1.tgz",
@@ -16772,82 +16442,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/htmlparser2": {
-			"version": "8.0.1",
-			"resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-8.0.1.tgz",
-			"integrity": "sha512-4lVbmc1diZC7GUJQtRQ5yBAeUCL1exyMwmForWkRLnwyzWBFxN633SALPMGYaWZvKe9j1pRZJpauvmxENSp/EA==",
-			"dev": true,
-			"funding": [
-				"https://github.com/fb55/htmlparser2?sponsor=1",
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/fb55"
-				}
-			],
-			"peer": true,
-			"dependencies": {
-				"domelementtype": "^2.3.0",
-				"domhandler": "^5.0.2",
-				"domutils": "^3.0.1",
-				"entities": "^4.3.0"
-			}
-		},
-		"node_modules/htmlparser2/node_modules/dom-serializer": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
-			"integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
-			"dev": true,
-			"peer": true,
-			"dependencies": {
-				"domelementtype": "^2.3.0",
-				"domhandler": "^5.0.2",
-				"entities": "^4.2.0"
-			},
-			"funding": {
-				"url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
-			}
-		},
-		"node_modules/htmlparser2/node_modules/domelementtype": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
-			"integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
-			"dev": true,
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/fb55"
-				}
-			],
-			"peer": true
-		},
-		"node_modules/htmlparser2/node_modules/domutils": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/domutils/-/domutils-3.0.1.tgz",
-			"integrity": "sha512-z08c1l761iKhDFtfXO04C7kTdPBLi41zwOZl00WS8b5eiaebNpY00HKbztwBq+e3vyqWNwWF3mP9YLUeqIrF+Q==",
-			"dev": true,
-			"peer": true,
-			"dependencies": {
-				"dom-serializer": "^2.0.0",
-				"domelementtype": "^2.3.0",
-				"domhandler": "^5.0.1"
-			},
-			"funding": {
-				"url": "https://github.com/fb55/domutils?sponsor=1"
-			}
-		},
-		"node_modules/htmlparser2/node_modules/entities": {
-			"version": "4.4.0",
-			"resolved": "https://registry.npmjs.org/entities/-/entities-4.4.0.tgz",
-			"integrity": "sha512-oYp7156SP8LkeGD0GF85ad1X9Ai79WtRsZ2gxJqtBuzH+98YUV6jkHEKlZkMbcrjJjIVJNIDP/3WL9wQkoPbWA==",
-			"dev": true,
-			"peer": true,
-			"engines": {
-				"node": ">=0.12"
-			},
-			"funding": {
-				"url": "https://github.com/fb55/entities?sponsor=1"
 			}
 		},
 		"node_modules/http-proxy-agent": {
@@ -17716,13 +17310,6 @@
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
 			}
-		},
-		"node_modules/is-subset": {
-			"version": "0.1.1",
-			"resolved": "https://registry.npmjs.org/is-subset/-/is-subset-0.1.1.tgz",
-			"integrity": "sha512-6Ybun0IkarhmEqxXCNw/C0bna6Zb/TkfUX9UbwJtK6ObwAVCxmAP308WWTHviM/zAqXk05cdhYsUsZeGQh99iw==",
-			"dev": true,
-			"peer": true
 		},
 		"node_modules/is-symbol": {
 			"version": "1.0.3",
@@ -20980,6 +20567,7 @@
 			"version": "2.5.2",
 			"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
 			"integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
+			"dev": true,
 			"bin": {
 				"jsesc": "bin/jsesc"
 			},
@@ -21725,25 +21313,11 @@
 			"integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168=",
 			"dev": true
 		},
-		"node_modules/lodash.escape": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-4.0.1.tgz",
-			"integrity": "sha512-nXEOnb/jK9g0DYMr1/Xvq6l5xMD7GDG55+GSYIYmS0G4tBk/hURD4JR9WCavs04t33WmJx9kCyp9vJ+mr4BOUw==",
-			"dev": true,
-			"peer": true
-		},
 		"node_modules/lodash.escaperegexp": {
 			"version": "4.1.2",
 			"resolved": "https://registry.npmjs.org/lodash.escaperegexp/-/lodash.escaperegexp-4.1.2.tgz",
 			"integrity": "sha512-TM9YBvyC84ZxE3rgfefxUWiQKLilstD6k7PTGt6wfbtXF8ixIJLOL3VYyV/z+ZiPLsVxAsKAFVwWlWeb2Y8Yyw==",
 			"dev": true
-		},
-		"node_modules/lodash.flattendeep": {
-			"version": "4.4.0",
-			"resolved": "https://registry.npmjs.org/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz",
-			"integrity": "sha512-uHaJFihxmJcEX3kT4I23ABqKKalJ/zDrDg0lsFtc1h+3uw49SIJ5beyhx5ExVRti3AvKoOJngIj7xz3oylPdWQ==",
-			"dev": true,
-			"peer": true
 		},
 		"node_modules/lodash.isarguments": {
 			"version": "3.1.0",
@@ -21756,13 +21330,6 @@
 			"resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
 			"integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U=",
 			"dev": true
-		},
-		"node_modules/lodash.isequal": {
-			"version": "4.5.0",
-			"resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
-			"integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==",
-			"dev": true,
-			"peer": true
 		},
 		"node_modules/lodash.ismatch": {
 			"version": "4.4.0",
@@ -22662,13 +22229,6 @@
 				"node": "*"
 			}
 		},
-		"node_modules/moo": {
-			"version": "0.5.2",
-			"resolved": "https://registry.npmjs.org/moo/-/moo-0.5.2.tgz",
-			"integrity": "sha512-iSAJLHYKnX41mKcJKjqvnAN9sf0LMDTXDEvFv+ffuRR9a1MIuXLjMNL6EsnDHSkKLTWNqQQ5uo61P4EbU4NU+Q==",
-			"dev": true,
-			"peer": true
-		},
 		"node_modules/mousetrap": {
 			"version": "1.6.5",
 			"resolved": "https://registry.npmjs.org/mousetrap/-/mousetrap-1.6.5.tgz",
@@ -22733,29 +22293,6 @@
 			"integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
 			"dev": true
 		},
-		"node_modules/nearley": {
-			"version": "2.20.1",
-			"resolved": "https://registry.npmjs.org/nearley/-/nearley-2.20.1.tgz",
-			"integrity": "sha512-+Mc8UaAebFzgV+KpI5n7DasuuQCHA89dmwm7JXw3TV43ukfNQ9DnBH3Mdb2g/I4Fdxc26pwimBWvjIw0UAILSQ==",
-			"dev": true,
-			"peer": true,
-			"dependencies": {
-				"commander": "^2.19.0",
-				"moo": "^0.5.0",
-				"railroad-diagrams": "^1.0.0",
-				"randexp": "0.4.6"
-			},
-			"bin": {
-				"nearley-railroad": "bin/nearley-railroad.js",
-				"nearley-test": "bin/nearley-test.js",
-				"nearley-unparse": "bin/nearley-unparse.js",
-				"nearleyc": "bin/nearleyc.js"
-			},
-			"funding": {
-				"type": "individual",
-				"url": "https://nearley.js.org/#give-to-nearley"
-			}
-		},
 		"node_modules/neo-async": {
 			"version": "2.6.2",
 			"resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
@@ -22799,20 +22336,6 @@
 				"node": ">=12"
 			}
 		},
-		"node_modules/newspack-components/node_modules/react": {
-			"version": "16.14.0",
-			"resolved": "https://registry.npmjs.org/react/-/react-16.14.0.tgz",
-			"integrity": "sha512-0X2CImDkJGApiAlcf0ODKIneSwBPhqJawOa5wCtKbu7ZECrmS26NvtSILynQ66cgkT/RJ4LidJOc3bUESwmU8g==",
-			"peer": true,
-			"dependencies": {
-				"loose-envify": "^1.1.0",
-				"object-assign": "^4.1.1",
-				"prop-types": "^15.6.2"
-			},
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
 		"node_modules/newspack-components/node_modules/react-daterange-picker": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/react-daterange-picker/-/react-daterange-picker-2.0.1.tgz",
@@ -22835,35 +22358,10 @@
 				"react-dom": "0.14.x || 15.x.x || 16.x.x"
 			}
 		},
-		"node_modules/newspack-components/node_modules/react-dom": {
-			"version": "16.14.0",
-			"resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.14.0.tgz",
-			"integrity": "sha512-1gCeQXDLoIqMgqD3IO2Ah9bnf0w9kzhwN5q4FGnHZ67hBm9yePzB5JJAIQCc8x3pFnNlwFq4RidZggNAAkzWWw==",
-			"peer": true,
-			"dependencies": {
-				"loose-envify": "^1.1.0",
-				"object-assign": "^4.1.1",
-				"prop-types": "^15.6.2",
-				"scheduler": "^0.19.1"
-			},
-			"peerDependencies": {
-				"react": "^16.14.0"
-			}
-		},
-		"node_modules/newspack-components/node_modules/scheduler": {
-			"version": "0.19.1",
-			"resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.19.1.tgz",
-			"integrity": "sha512-n/zwRWRYSUj0/3g/otKDRPMh6qv2SYMWNq85IEa8iZyAv8od9zDYpGSnpBEjNgcMNq6Scbu5KfIPxNF72R/2EA==",
-			"peer": true,
-			"dependencies": {
-				"loose-envify": "^1.1.0",
-				"object-assign": "^4.1.1"
-			}
-		},
 		"node_modules/newspack-scripts": {
-			"version": "4.3.7",
-			"resolved": "https://registry.npmjs.org/newspack-scripts/-/newspack-scripts-4.3.7.tgz",
-			"integrity": "sha512-twxZz9tRnxCIAUlfdppxaFiClt7WJIOoQv57+d4GU5sPQk6zOdXNtqZkWXoptRICWbgzsLzDxoSilKCvV7Ivtw==",
+			"version": "4.3.8",
+			"resolved": "https://registry.npmjs.org/newspack-scripts/-/newspack-scripts-4.3.8.tgz",
+			"integrity": "sha512-3nK3HKSLUjjkC+wP83DGfc9DKf7uLSN5zYhn6138oL0KEmwn8roP+DUY+ePuywV9MocT8X8sBP7hxvMqInlDHA==",
 			"dev": true,
 			"dependencies": {
 				"@automattic/calypso-build": "^10.0.0",
@@ -24453,7 +23951,8 @@
 		"node_modules/node-releases": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.1.tgz",
-			"integrity": "sha512-CqyzN6z7Q6aMeF/ktcMVTzhAHCEpf8SOarwpzpf8pNBY2k5/oM34UHldUwp8VKI7uxct2HxSRdJjBaZeESzcxA=="
+			"integrity": "sha512-CqyzN6z7Q6aMeF/ktcMVTzhAHCEpf8SOarwpzpf8pNBY2k5/oM34UHldUwp8VKI7uxct2HxSRdJjBaZeESzcxA==",
+			"dev": true
 		},
 		"node_modules/normalize-package-data": {
 			"version": "2.5.0",
@@ -27077,19 +26576,6 @@
 			"inBundle": true,
 			"license": "ISC"
 		},
-		"node_modules/nth-check": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
-			"integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
-			"dev": true,
-			"peer": true,
-			"dependencies": {
-				"boolbase": "^1.0.0"
-			},
-			"funding": {
-				"url": "https://github.com/fb55/nth-check?sponsor=1"
-			}
-		},
 		"node_modules/nwsapi": {
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.0.tgz",
@@ -27612,46 +27098,6 @@
 			"integrity": "sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw==",
 			"dev": true
 		},
-		"node_modules/parse5-htmlparser2-tree-adapter": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/parse5-htmlparser2-tree-adapter/-/parse5-htmlparser2-tree-adapter-7.0.0.tgz",
-			"integrity": "sha512-B77tOZrqqfUfnVcOrUvfdLbz4pu4RopLD/4vmu3HUPswwTA8OH0EMW9BlWR2B0RCoiZRAHEUu7IxeP1Pd1UU+g==",
-			"dev": true,
-			"peer": true,
-			"dependencies": {
-				"domhandler": "^5.0.2",
-				"parse5": "^7.0.0"
-			},
-			"funding": {
-				"url": "https://github.com/inikulin/parse5?sponsor=1"
-			}
-		},
-		"node_modules/parse5-htmlparser2-tree-adapter/node_modules/entities": {
-			"version": "4.4.0",
-			"resolved": "https://registry.npmjs.org/entities/-/entities-4.4.0.tgz",
-			"integrity": "sha512-oYp7156SP8LkeGD0GF85ad1X9Ai79WtRsZ2gxJqtBuzH+98YUV6jkHEKlZkMbcrjJjIVJNIDP/3WL9wQkoPbWA==",
-			"dev": true,
-			"peer": true,
-			"engines": {
-				"node": ">=0.12"
-			},
-			"funding": {
-				"url": "https://github.com/fb55/entities?sponsor=1"
-			}
-		},
-		"node_modules/parse5-htmlparser2-tree-adapter/node_modules/parse5": {
-			"version": "7.1.1",
-			"resolved": "https://registry.npmjs.org/parse5/-/parse5-7.1.1.tgz",
-			"integrity": "sha512-kwpuwzB+px5WUg9pyK0IcK/shltJN5/OVhQagxhCQNtT9Y9QRZqNY2e1cmbu/paRh5LMnz/oVTVLBpjFmMZhSg==",
-			"dev": true,
-			"peer": true,
-			"dependencies": {
-				"entities": "^4.4.0"
-			},
-			"funding": {
-				"url": "https://github.com/inikulin/parse5?sponsor=1"
-			}
-		},
 		"node_modules/parserlib": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/parserlib/-/parserlib-1.1.1.tgz",
@@ -27775,7 +27221,8 @@
 		"node_modules/picocolors": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
-			"integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ=="
+			"integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==",
+			"dev": true
 		},
 		"node_modules/picomatch": {
 			"version": "2.3.1",
@@ -29797,27 +29244,6 @@
 				"performance-now": "^2.1.0"
 			}
 		},
-		"node_modules/railroad-diagrams": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/railroad-diagrams/-/railroad-diagrams-1.0.0.tgz",
-			"integrity": "sha512-cz93DjNeLY0idrCNOH6PviZGRN9GJhsdm9hpn1YCS879fj4W+x5IFJhhkRZcwVgMmFF7R82UA/7Oh+R8lLZg6A==",
-			"dev": true,
-			"peer": true
-		},
-		"node_modules/randexp": {
-			"version": "0.4.6",
-			"resolved": "https://registry.npmjs.org/randexp/-/randexp-0.4.6.tgz",
-			"integrity": "sha512-80WNmd9DA0tmZrw9qQa62GPPWfuXJknrmVmLcxvq4uZBdYqb1wYoKTmnlGUchvVWe0XiLupYkBoXVOxz3C8DYQ==",
-			"dev": true,
-			"peer": true,
-			"dependencies": {
-				"discontinuous-range": "1.0.0",
-				"ret": "~0.1.10"
-			},
-			"engines": {
-				"node": ">=0.12"
-			}
-		},
 		"node_modules/randombytes": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
@@ -30866,17 +30292,6 @@
 			},
 			"bin": {
 				"rimraf": "bin.js"
-			}
-		},
-		"node_modules/rst-selector-parser": {
-			"version": "2.2.3",
-			"resolved": "https://registry.npmjs.org/rst-selector-parser/-/rst-selector-parser-2.2.3.tgz",
-			"integrity": "sha512-nDG1rZeP6oFTLN6yNDV/uiAvs1+FS/KlrEwh7+y7dpuApDBy6bI2HTBcc0/V8lv9OTqfyD34eF7au2pm8aBbhA==",
-			"dev": true,
-			"peer": true,
-			"dependencies": {
-				"lodash.flattendeep": "^4.4.0",
-				"nearley": "^2.7.10"
 			}
 		},
 		"node_modules/rsvp": {
@@ -32291,24 +31706,6 @@
 				"internal-slot": "^1.0.3",
 				"regexp.prototype.flags": "^1.3.1",
 				"side-channel": "^1.0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/string.prototype.trim": {
-			"version": "1.2.6",
-			"resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.6.tgz",
-			"integrity": "sha512-8lMR2m+U0VJTPp6JjvJTtGyc4FIGq9CdRt7O9p6T0e6K4vjU+OP+SQJpbe/SBmRcCUIvNUnjsbmY6lnMp8MhsQ==",
-			"dev": true,
-			"peer": true,
-			"dependencies": {
-				"call-bind": "^1.0.2",
-				"define-properties": "^1.1.4",
-				"es-abstract": "^1.19.5"
-			},
-			"engines": {
-				"node": ">= 0.4"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
@@ -34939,12 +34336,14 @@
 		"@babel/compat-data": {
 			"version": "7.16.4",
 			"resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.16.4.tgz",
-			"integrity": "sha512-1o/jo7D+kC9ZjHX5v+EHrdjl3PhxMrLSOTGsOdHJ+KL8HCaEK6ehrVL2RS6oHDZp+L7xLirLrPmQtEng769J/Q=="
+			"integrity": "sha512-1o/jo7D+kC9ZjHX5v+EHrdjl3PhxMrLSOTGsOdHJ+KL8HCaEK6ehrVL2RS6oHDZp+L7xLirLrPmQtEng769J/Q==",
+			"dev": true
 		},
 		"@babel/core": {
 			"version": "7.16.0",
 			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.16.0.tgz",
 			"integrity": "sha512-mYZEvshBRHGsIAiyH5PzCFTCfbWfoYbO/jcSdXQSUQu1/pW0xDZAUP7KEc32heqWTAfAHhV9j1vH8Sav7l+JNQ==",
+			"dev": true,
 			"requires": {
 				"@babel/code-frame": "^7.16.0",
 				"@babel/generator": "^7.16.0",
@@ -34967,6 +34366,7 @@
 					"version": "4.1.1",
 					"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
 					"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+					"dev": true,
 					"requires": {
 						"ms": "^2.1.1"
 					}
@@ -34975,6 +34375,7 @@
 					"version": "2.1.2",
 					"resolved": "https://registry.npmjs.org/json5/-/json5-2.1.2.tgz",
 					"integrity": "sha512-MoUOQ4WdiN3yxhm7NEVJSJrieAo5hNSLQ5sj05OTRHPL9HOBy8u4Bu88jsC1jvqAdN+E1bJmsUcZH+1HQxliqQ==",
+					"dev": true,
 					"requires": {
 						"minimist": "^1.2.5"
 					}
@@ -34982,12 +34383,14 @@
 				"ms": {
 					"version": "2.1.2",
 					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+					"dev": true
 				},
 				"semver": {
 					"version": "6.3.0",
 					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
+					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+					"dev": true
 				}
 			}
 		},
@@ -34995,6 +34398,7 @@
 			"version": "7.18.9",
 			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.18.9.tgz",
 			"integrity": "sha512-wt5Naw6lJrL1/SGkipMiFxJjtyczUWTP38deiP1PO60HsBjDeKk08CGC3S8iVuvf0FmTdgKwU1KIXzSKL1G0Ug==",
+			"dev": true,
 			"requires": {
 				"@babel/types": "^7.18.9",
 				"@jridgewell/gen-mapping": "^0.3.2",
@@ -35024,6 +34428,7 @@
 			"version": "7.16.3",
 			"resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.16.3.tgz",
 			"integrity": "sha512-vKsoSQAyBmxS35JUOOt+07cLc6Nk/2ljLIHwmq2/NM6hdioUaqEXq/S+nXvbvXbZkNDlWOymPanJGOc4CBjSJA==",
+			"dev": true,
 			"requires": {
 				"@babel/compat-data": "^7.16.0",
 				"@babel/helper-validator-option": "^7.14.5",
@@ -35034,7 +34439,8 @@
 				"semver": {
 					"version": "6.3.0",
 					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
+					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+					"dev": true
 				}
 			}
 		},
@@ -35105,7 +34511,8 @@
 		"@babel/helper-environment-visitor": {
 			"version": "7.18.9",
 			"resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.18.9.tgz",
-			"integrity": "sha512-3r/aACDJ3fhQ/EVgFy0hpj8oHyHpQc+LPtJoY9SzTThAsStm4Ptegq92vqKoE3vD706ZVFWITnMnxucw+S9Ipg=="
+			"integrity": "sha512-3r/aACDJ3fhQ/EVgFy0hpj8oHyHpQc+LPtJoY9SzTThAsStm4Ptegq92vqKoE3vD706ZVFWITnMnxucw+S9Ipg==",
+			"dev": true
 		},
 		"@babel/helper-explode-assignable-expression": {
 			"version": "7.16.0",
@@ -35120,6 +34527,7 @@
 			"version": "7.18.9",
 			"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.18.9.tgz",
 			"integrity": "sha512-fJgWlZt7nxGksJS9a0XdSaI4XvpExnNIgRP+rVefWh5U7BL8pPuir6SJUmFKRfjWQ51OtWSzwOxhaH/EBWWc0A==",
+			"dev": true,
 			"requires": {
 				"@babel/template": "^7.18.6",
 				"@babel/types": "^7.18.9"
@@ -35129,6 +34537,7 @@
 			"version": "7.18.6",
 			"resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.18.6.tgz",
 			"integrity": "sha512-UlJQPkFqFULIcyW5sbzgbkxn2FKRgwWiRexcuaR8RNJRy8+LLveqPjwZV/bwrLZCN0eUHD/x8D0heK1ozuoo6Q==",
+			"dev": true,
 			"requires": {
 				"@babel/types": "^7.18.6"
 			}
@@ -35137,6 +34546,7 @@
 			"version": "7.18.9",
 			"resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.18.9.tgz",
 			"integrity": "sha512-RxifAh2ZoVU67PyKIO4AMi1wTenGfMR/O/ae0CCRqwgBAt5v7xjdtRw7UoSbsreKrQn5t7r89eruK/9JjYHuDg==",
+			"dev": true,
 			"requires": {
 				"@babel/types": "^7.18.9"
 			}
@@ -35153,6 +34563,7 @@
 			"version": "7.16.0",
 			"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.16.0.tgz",
 			"integrity": "sha512-My4cr9ATcaBbmaEa8M0dZNA74cfI6gitvUAskgDtAFmAqyFKDSHQo5YstxPbN+lzHl2D9l/YOEFqb2mtUh4gfA==",
+			"dev": true,
 			"requires": {
 				"@babel/helper-module-imports": "^7.16.0",
 				"@babel/helper-replace-supers": "^7.16.0",
@@ -35168,6 +34579,7 @@
 			"version": "7.18.6",
 			"resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.18.6.tgz",
 			"integrity": "sha512-HP59oD9/fEHQkdcbgFCnbmgH5vIQTJbxh2yf+CdM89/glUNnuzr87Q8GIjGEnOktTROemO0Pe0iPAYbqZuOUiA==",
+			"dev": true,
 			"requires": {
 				"@babel/types": "^7.18.6"
 			}
@@ -35192,6 +34604,7 @@
 			"version": "7.18.9",
 			"resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.18.9.tgz",
 			"integrity": "sha512-dNsWibVI4lNT6HiuOIBr1oyxo40HvIVmbwPUm3XZ7wMh4k2WxrxTqZwSqw/eEmXDS9np0ey5M2bz9tBmO9c+YQ==",
+			"dev": true,
 			"requires": {
 				"@babel/helper-environment-visitor": "^7.18.9",
 				"@babel/helper-member-expression-to-functions": "^7.18.9",
@@ -35204,6 +34617,7 @@
 			"version": "7.16.0",
 			"resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.16.0.tgz",
 			"integrity": "sha512-o1rjBT/gppAqKsYfUdfHq5Rk03lMQrkPHG1OWzHWpLgVXRH4HnMM9Et9CVdIqwkCQlobnGHEJMsgWP/jE1zUiw==",
+			"dev": true,
 			"requires": {
 				"@babel/types": "^7.16.0"
 			}
@@ -35221,6 +34635,7 @@
 			"version": "7.18.6",
 			"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.18.6.tgz",
 			"integrity": "sha512-bde1etTx6ZyTmobl9LLMMQsaizFVZrquTEHOqKeQESMKo4PlObf+8+JA25ZsIpZhT/WEd39+vOdLXAFG/nELpA==",
+			"dev": true,
 			"requires": {
 				"@babel/types": "^7.18.6"
 			}
@@ -35233,7 +34648,8 @@
 		"@babel/helper-validator-option": {
 			"version": "7.18.6",
 			"resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.18.6.tgz",
-			"integrity": "sha512-XO7gESt5ouv/LRJdrVjkShckw6STTaB7l9BrpBaAHDeF5YZT+01PCwmR0SJHnkW6i8OwW/EVWRShfi4j2x+KQw=="
+			"integrity": "sha512-XO7gESt5ouv/LRJdrVjkShckw6STTaB7l9BrpBaAHDeF5YZT+01PCwmR0SJHnkW6i8OwW/EVWRShfi4j2x+KQw==",
+			"dev": true
 		},
 		"@babel/helper-wrap-function": {
 			"version": "7.16.0",
@@ -35251,6 +34667,7 @@
 			"version": "7.16.3",
 			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.16.3.tgz",
 			"integrity": "sha512-Xn8IhDlBPhvYTvgewPKawhADichOsbkZuzN7qz2BusOM0brChsyXMDJvldWaYMMUNiCQdQzNEioXTp3sC8Nt8w==",
+			"dev": true,
 			"requires": {
 				"@babel/template": "^7.16.0",
 				"@babel/traverse": "^7.16.3",
@@ -35270,7 +34687,8 @@
 		"@babel/parser": {
 			"version": "7.18.9",
 			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.18.9.tgz",
-			"integrity": "sha512-9uJveS9eY9DJ0t64YbIBZICtJy8a5QrDEVdiLCG97fVLpDTpGX7t8mMSb6OWw6Lrnjqj4O8zwjELX3dhoMgiBg=="
+			"integrity": "sha512-9uJveS9eY9DJ0t64YbIBZICtJy8a5QrDEVdiLCG97fVLpDTpGX7t8mMSb6OWw6Lrnjqj4O8zwjELX3dhoMgiBg==",
+			"dev": true
 		},
 		"@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": {
 			"version": "7.16.2",
@@ -36147,6 +35565,7 @@
 			"version": "7.18.6",
 			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.18.6.tgz",
 			"integrity": "sha512-JoDWzPe+wgBsTTgdnIma3iHNFC7YVJoPssVBDjiHfNlyt4YcunDtcDOUmfVDfCK5MfdsaIoX9PkijPhjH3nYUw==",
+			"dev": true,
 			"requires": {
 				"@babel/code-frame": "^7.18.6",
 				"@babel/parser": "^7.18.6",
@@ -36157,6 +35576,7 @@
 			"version": "7.18.9",
 			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.18.9.tgz",
 			"integrity": "sha512-LcPAnujXGwBgv3/WHv01pHtb2tihcyW1XuL9wd7jqh1Z8AQkTd+QVjMrMijrln0T7ED3UXLIy36P9Ao7W75rYg==",
+			"dev": true,
 			"requires": {
 				"@babel/code-frame": "^7.18.6",
 				"@babel/generator": "^7.18.9",
@@ -36174,6 +35594,7 @@
 					"version": "4.1.1",
 					"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
 					"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+					"dev": true,
 					"requires": {
 						"ms": "^2.1.1"
 					}
@@ -36181,7 +35602,8 @@
 				"ms": {
 					"version": "2.1.2",
 					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+					"dev": true
 				}
 			}
 		},
@@ -36782,8 +36204,7 @@
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/@csstools/selector-specificity/-/selector-specificity-2.0.2.tgz",
 			"integrity": "sha512-IkpVW/ehM1hWKln4fCA3NzJU8KwD+kIOvPZA4cqxoJHtE21CCzjyp+Kxbu0i5I4tBNOlXPL9mjwnWlL0VEG4Fg==",
-			"dev": true,
-			"requires": {}
+			"dev": true
 		},
 		"@discoveryjs/json-ext": {
 			"version": "0.5.5",
@@ -36954,8 +36375,7 @@
 		"@emotion/use-insertion-effect-with-fallbacks": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/@emotion/use-insertion-effect-with-fallbacks/-/use-insertion-effect-with-fallbacks-1.0.0.tgz",
-			"integrity": "sha512-1eEgUGmkaljiBnRMTdksDV1W4kUnmwgp7X9G8B++9GYwl1lUdqSndSriIrTJ0N7LQaoauY9JJ2yhiOYK5+NI4A==",
-			"requires": {}
+			"integrity": "sha512-1eEgUGmkaljiBnRMTdksDV1W4kUnmwgp7X9G8B++9GYwl1lUdqSndSriIrTJ0N7LQaoauY9JJ2yhiOYK5+NI4A=="
 		},
 		"@emotion/utils": {
 			"version": "1.0.0",
@@ -37745,6 +37165,7 @@
 			"version": "0.3.2",
 			"resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.2.tgz",
 			"integrity": "sha512-mh65xKQAzI6iBcFzwv28KVWSmCkdRBWoOh+bYQGW3+6OZvbbN3TqMGo5hqYxQniRcH9F2VZIoJCm4pa3BPDK/A==",
+			"dev": true,
 			"requires": {
 				"@jridgewell/set-array": "^1.0.1",
 				"@jridgewell/sourcemap-codec": "^1.4.10",
@@ -37759,7 +37180,8 @@
 		"@jridgewell/set-array": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.1.2.tgz",
-			"integrity": "sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw=="
+			"integrity": "sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw==",
+			"dev": true
 		},
 		"@jridgewell/source-map": {
 			"version": "0.3.2",
@@ -38043,8 +37465,7 @@
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/@octokit/plugin-request-log/-/plugin-request-log-1.0.4.tgz",
 			"integrity": "sha512-mLUsMkgP7K/cnFEw07kWqXGF5LKrOkD+lhCrKvPHXWDywAwuDUeDwWBpc69XK3pNX0uKiVt8g5z96PJ6z9xCFA==",
-			"dev": true,
-			"requires": {}
+			"dev": true
 		},
 		"@octokit/plugin-rest-endpoint-methods": {
 			"version": "6.7.0",
@@ -39854,8 +39275,7 @@
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/@webpack-cli/configtest/-/configtest-1.1.0.tgz",
 			"integrity": "sha512-ttOkEkoalEHa7RaFYpM0ErK1xc4twg3Am9hfHhL7MVqlHebnkYd2wuI/ZqTDj0cVzZho6PdinY0phFZV3O0Mzg==",
-			"dev": true,
-			"requires": {}
+			"dev": true
 		},
 		"@webpack-cli/info": {
 			"version": "1.4.0",
@@ -39870,8 +39290,7 @@
 			"version": "1.6.0",
 			"resolved": "https://registry.npmjs.org/@webpack-cli/serve/-/serve-1.6.0.tgz",
 			"integrity": "sha512-ZkVeqEmRpBV2GHvjjUZqEai2PpUbuq8Bqd//vEYsp63J8WyexI8ppCqVS3Zs0QADf6aWuPdU+0XsPI647PVlQA==",
-			"dev": true,
-			"requires": {}
+			"dev": true
 		},
 		"@wojtekmaj/enzyme-adapter-react-17": {
 			"version": "0.6.5",
@@ -39944,8 +39363,7 @@
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/@wordpress/babel-plugin-import-jsx-pragma/-/babel-plugin-import-jsx-pragma-3.1.0.tgz",
 			"integrity": "sha512-518mL3goaSeXtJCQcPK9OYHUUiA0sjXuoGWHBwRalkyTIQZZy5ZZzlwrlSc9ESZcOw9BZ+Uo8CJRjV2OWnx+Zw==",
-			"dev": true,
-			"requires": {}
+			"dev": true
 		},
 		"@wordpress/babel-preset-default": {
 			"version": "6.5.0",
@@ -42791,15 +42209,13 @@
 			"version": "1.8.0",
 			"resolved": "https://registry.npmjs.org/acorn-import-assertions/-/acorn-import-assertions-1.8.0.tgz",
 			"integrity": "sha512-m7VZ3jwz4eK6A4Vtt8Ew1/mNbP24u0FhdyfA7fSvnJR6LMdfOYnmuIrrJAgrYfYJ10F/otaHTtrtrtmHdMNzEw==",
-			"dev": true,
-			"requires": {}
+			"dev": true
 		},
 		"acorn-jsx": {
 			"version": "5.3.2",
 			"resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
 			"integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
-			"dev": true,
-			"requires": {}
+			"dev": true
 		},
 		"acorn-walk": {
 			"version": "7.2.0",
@@ -42876,8 +42292,7 @@
 			"version": "3.5.2",
 			"resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
 			"integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
-			"dev": true,
-			"requires": {}
+			"dev": true
 		},
 		"alphanum-sort": {
 			"version": "1.0.2",
@@ -43042,20 +42457,6 @@
 			"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
 			"integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
 			"dev": true
-		},
-		"array.prototype.filter": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/array.prototype.filter/-/array.prototype.filter-1.0.2.tgz",
-			"integrity": "sha512-us+UrmGOilqttSOgoWZTpOvHu68vZT2YCjc/H4vhu56vzZpaDFBhB+Se2UwqWzMKbDv7Myq5M5pcZLAtUvTQdQ==",
-			"dev": true,
-			"peer": true,
-			"requires": {
-				"call-bind": "^1.0.2",
-				"define-properties": "^1.1.4",
-				"es-abstract": "^1.20.4",
-				"es-array-method-boxes-properly": "^1.0.0",
-				"is-string": "^1.0.7"
-			}
 		},
 		"array.prototype.find": {
 			"version": "2.1.1",
@@ -43608,6 +43009,7 @@
 			"version": "4.19.1",
 			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.19.1.tgz",
 			"integrity": "sha512-u2tbbG5PdKRTUoctO3NBD8FQ5HdPh1ZXPHzp1rwaa5jTc+RV9/+RlWiAIKmjRPQF+xbGM9Kklj5bZQFa2s/38A==",
+			"dev": true,
 			"requires": {
 				"caniuse-lite": "^1.0.30001286",
 				"electron-to-chromium": "^1.4.17",
@@ -43798,7 +43200,8 @@
 		"caniuse-lite": {
 			"version": "1.0.30001301",
 			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001301.tgz",
-			"integrity": "sha512-csfD/GpHMqgEL3V3uIgosvh+SVIQvCh43SNu9HRbP1lnxkKm1kjDG4f32PP571JplkLjfS+mg2p1gxR7MYrrIA=="
+			"integrity": "sha512-csfD/GpHMqgEL3V3uIgosvh+SVIQvCh43SNu9HRbP1lnxkKm1kjDG4f32PP571JplkLjfS+mg2p1gxR7MYrrIA==",
+			"dev": true
 		},
 		"capital-case": {
 			"version": "1.0.4",
@@ -43889,127 +43292,6 @@
 			"resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
 			"integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
 			"dev": true
-		},
-		"cheerio": {
-			"version": "1.0.0-rc.12",
-			"resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.0.0-rc.12.tgz",
-			"integrity": "sha512-VqR8m68vM46BNnuZ5NtnGBKIE/DfN0cRIzg9n40EIq9NOv90ayxLBXA8fXC5gquFRGJSTRqBq25Jt2ECLR431Q==",
-			"dev": true,
-			"peer": true,
-			"requires": {
-				"cheerio-select": "^2.1.0",
-				"dom-serializer": "^2.0.0",
-				"domhandler": "^5.0.3",
-				"domutils": "^3.0.1",
-				"htmlparser2": "^8.0.1",
-				"parse5": "^7.0.0",
-				"parse5-htmlparser2-tree-adapter": "^7.0.0"
-			},
-			"dependencies": {
-				"dom-serializer": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
-					"integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
-					"dev": true,
-					"peer": true,
-					"requires": {
-						"domelementtype": "^2.3.0",
-						"domhandler": "^5.0.2",
-						"entities": "^4.2.0"
-					}
-				},
-				"domelementtype": {
-					"version": "2.3.0",
-					"resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
-					"integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
-					"dev": true,
-					"peer": true
-				},
-				"domutils": {
-					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/domutils/-/domutils-3.0.1.tgz",
-					"integrity": "sha512-z08c1l761iKhDFtfXO04C7kTdPBLi41zwOZl00WS8b5eiaebNpY00HKbztwBq+e3vyqWNwWF3mP9YLUeqIrF+Q==",
-					"dev": true,
-					"peer": true,
-					"requires": {
-						"dom-serializer": "^2.0.0",
-						"domelementtype": "^2.3.0",
-						"domhandler": "^5.0.1"
-					}
-				},
-				"entities": {
-					"version": "4.4.0",
-					"resolved": "https://registry.npmjs.org/entities/-/entities-4.4.0.tgz",
-					"integrity": "sha512-oYp7156SP8LkeGD0GF85ad1X9Ai79WtRsZ2gxJqtBuzH+98YUV6jkHEKlZkMbcrjJjIVJNIDP/3WL9wQkoPbWA==",
-					"dev": true,
-					"peer": true
-				},
-				"parse5": {
-					"version": "7.1.1",
-					"resolved": "https://registry.npmjs.org/parse5/-/parse5-7.1.1.tgz",
-					"integrity": "sha512-kwpuwzB+px5WUg9pyK0IcK/shltJN5/OVhQagxhCQNtT9Y9QRZqNY2e1cmbu/paRh5LMnz/oVTVLBpjFmMZhSg==",
-					"dev": true,
-					"peer": true,
-					"requires": {
-						"entities": "^4.4.0"
-					}
-				}
-			}
-		},
-		"cheerio-select": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/cheerio-select/-/cheerio-select-2.1.0.tgz",
-			"integrity": "sha512-9v9kG0LvzrlcungtnJtpGNxY+fzECQKhK4EGJX2vByejiMX84MFNQw4UxPJl3bFbTMw+Dfs37XaIkCwTZfLh4g==",
-			"dev": true,
-			"peer": true,
-			"requires": {
-				"boolbase": "^1.0.0",
-				"css-select": "^5.1.0",
-				"css-what": "^6.1.0",
-				"domelementtype": "^2.3.0",
-				"domhandler": "^5.0.3",
-				"domutils": "^3.0.1"
-			},
-			"dependencies": {
-				"dom-serializer": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
-					"integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
-					"dev": true,
-					"peer": true,
-					"requires": {
-						"domelementtype": "^2.3.0",
-						"domhandler": "^5.0.2",
-						"entities": "^4.2.0"
-					}
-				},
-				"domelementtype": {
-					"version": "2.3.0",
-					"resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
-					"integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
-					"dev": true,
-					"peer": true
-				},
-				"domutils": {
-					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/domutils/-/domutils-3.0.1.tgz",
-					"integrity": "sha512-z08c1l761iKhDFtfXO04C7kTdPBLi41zwOZl00WS8b5eiaebNpY00HKbztwBq+e3vyqWNwWF3mP9YLUeqIrF+Q==",
-					"dev": true,
-					"peer": true,
-					"requires": {
-						"dom-serializer": "^2.0.0",
-						"domelementtype": "^2.3.0",
-						"domhandler": "^5.0.1"
-					}
-				},
-				"entities": {
-					"version": "4.4.0",
-					"resolved": "https://registry.npmjs.org/entities/-/entities-4.4.0.tgz",
-					"integrity": "sha512-oYp7156SP8LkeGD0GF85ad1X9Ai79WtRsZ2gxJqtBuzH+98YUV6jkHEKlZkMbcrjJjIVJNIDP/3WL9wQkoPbWA==",
-					"dev": true,
-					"peer": true
-				}
-			}
 		},
 		"chokidar": {
 			"version": "3.5.2",
@@ -44623,8 +43905,7 @@
 		"cosmiconfig-typescript-loader": {
 			"version": "4.2.0",
 			"resolved": "https://registry.npmjs.org/cosmiconfig-typescript-loader/-/cosmiconfig-typescript-loader-4.2.0.tgz",
-			"integrity": "sha512-NkANeMnaHrlaSSlpKGyvn2R4rqUDeE/9E5YHx+b4nwo0R8dZyAqcih8/gxpCZvqWP9Vf6xuLpMSzSgdVEIM78g==",
-			"requires": {}
+			"integrity": "sha512-NkANeMnaHrlaSSlpKGyvn2R4rqUDeE/9E5YHx+b4nwo0R8dZyAqcih8/gxpCZvqWP9Vf6xuLpMSzSgdVEIM78g=="
 		},
 		"create-react-class": {
 			"version": "15.7.0",
@@ -44853,60 +44134,6 @@
 				}
 			}
 		},
-		"css-select": {
-			"version": "5.1.0",
-			"resolved": "https://registry.npmjs.org/css-select/-/css-select-5.1.0.tgz",
-			"integrity": "sha512-nwoRF1rvRRnnCqqY7updORDsuqKzqYJ28+oSMaJMMgOauh3fvwHqMS7EZpIPqK8GL+g9mKxF1vP/ZjSeNjEVHg==",
-			"dev": true,
-			"peer": true,
-			"requires": {
-				"boolbase": "^1.0.0",
-				"css-what": "^6.1.0",
-				"domhandler": "^5.0.2",
-				"domutils": "^3.0.1",
-				"nth-check": "^2.0.1"
-			},
-			"dependencies": {
-				"dom-serializer": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
-					"integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
-					"dev": true,
-					"peer": true,
-					"requires": {
-						"domelementtype": "^2.3.0",
-						"domhandler": "^5.0.2",
-						"entities": "^4.2.0"
-					}
-				},
-				"domelementtype": {
-					"version": "2.3.0",
-					"resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
-					"integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
-					"dev": true,
-					"peer": true
-				},
-				"domutils": {
-					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/domutils/-/domutils-3.0.1.tgz",
-					"integrity": "sha512-z08c1l761iKhDFtfXO04C7kTdPBLi41zwOZl00WS8b5eiaebNpY00HKbztwBq+e3vyqWNwWF3mP9YLUeqIrF+Q==",
-					"dev": true,
-					"peer": true,
-					"requires": {
-						"dom-serializer": "^2.0.0",
-						"domelementtype": "^2.3.0",
-						"domhandler": "^5.0.1"
-					}
-				},
-				"entities": {
-					"version": "4.4.0",
-					"resolved": "https://registry.npmjs.org/entities/-/entities-4.4.0.tgz",
-					"integrity": "sha512-oYp7156SP8LkeGD0GF85ad1X9Ai79WtRsZ2gxJqtBuzH+98YUV6jkHEKlZkMbcrjJjIVJNIDP/3WL9wQkoPbWA==",
-					"dev": true,
-					"peer": true
-				}
-			}
-		},
 		"css-select-base-adapter": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/css-select-base-adapter/-/css-select-base-adapter-0.1.1.tgz",
@@ -44930,13 +44157,6 @@
 					"dev": true
 				}
 			}
-		},
-		"css-what": {
-			"version": "6.1.0",
-			"resolved": "https://registry.npmjs.org/css-what/-/css-what-6.1.0.tgz",
-			"integrity": "sha512-HTUrgRJ7r4dsZKU6GjmpfRK1O76h97Z8MfS1G0FozR+oF2kG6Vfe8JE6zwrkbxigziPHinCJ+gCPjA9EaBDtRw==",
-			"dev": true,
-			"peer": true
 		},
 		"css.escape": {
 			"version": "1.5.1",
@@ -45508,13 +44728,6 @@
 			"resolved": "https://registry.npmjs.org/direction/-/direction-1.0.4.tgz",
 			"integrity": "sha512-GYqKi1aH7PJXxdhTeZBFrg8vUBeKXi+cNprXsC1kpJcbcVnV9wBsrOu1cQEdG0WeQwlfHiy3XvnKfIrJ2R0NzQ=="
 		},
-		"discontinuous-range": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/discontinuous-range/-/discontinuous-range-1.0.0.tgz",
-			"integrity": "sha512-c68LpLbO+7kP/b1Hr1qs8/BJ09F5khZGTxqxZuhzxpmwJKOgRFHJWIb9/KmqnqHhLdO55aOxFH/EGBvUQbL/RQ==",
-			"dev": true,
-			"peer": true
-		},
 		"doctrine": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
@@ -45573,25 +44786,6 @@
 					"resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-5.0.0.tgz",
 					"integrity": "sha512-VlZwKPCkYKxQgeSbH5EyngOmRp7Ww7I9rQLERETtf5ofd9pGeswWiOtogpEO850jziPRarreGxn5QIiTqpb2wA==",
 					"dev": true
-				}
-			}
-		},
-		"domhandler": {
-			"version": "5.0.3",
-			"resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
-			"integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
-			"dev": true,
-			"peer": true,
-			"requires": {
-				"domelementtype": "^2.3.0"
-			},
-			"dependencies": {
-				"domelementtype": {
-					"version": "2.3.0",
-					"resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
-					"integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
-					"dev": true,
-					"peer": true
 				}
 			}
 		},
@@ -45687,7 +44881,8 @@
 		"electron-to-chromium": {
 			"version": "1.4.51",
 			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.51.tgz",
-			"integrity": "sha512-JNEmcYl3mk1tGQmy0EvL5eik/CKSBuzAyGP0QFdG6LIgxQe3II0BL1m2zKc2MZMf3uGqHWE1TFddJML0RpjSHQ=="
+			"integrity": "sha512-JNEmcYl3mk1tGQmy0EvL5eik/CKSBuzAyGP0QFdG6LIgxQe3II0BL1m2zKc2MZMf3uGqHWE1TFddJML0RpjSHQ==",
+			"dev": true
 		},
 		"emitter-mixin": {
 			"version": "0.0.3",
@@ -45852,37 +45047,6 @@
 			"integrity": "sha512-/o+BXHmB7ocbHEAs6F2EnG0ogybVVUdkRunTT2glZU9XAaGmhqskrvKwqXuDfNjEO0LZKWdejEEpnq8aM0tOaw==",
 			"dev": true
 		},
-		"enzyme": {
-			"version": "3.11.0",
-			"resolved": "https://registry.npmjs.org/enzyme/-/enzyme-3.11.0.tgz",
-			"integrity": "sha512-Dw8/Gs4vRjxY6/6i9wU0V+utmQO9kvh9XLnz3LIudviOnVYDEe2ec+0k+NQoMamn1VrjKgCUOWj5jG/5M5M0Qw==",
-			"dev": true,
-			"peer": true,
-			"requires": {
-				"array.prototype.flat": "^1.2.3",
-				"cheerio": "^1.0.0-rc.3",
-				"enzyme-shallow-equal": "^1.0.1",
-				"function.prototype.name": "^1.1.2",
-				"has": "^1.0.3",
-				"html-element-map": "^1.2.0",
-				"is-boolean-object": "^1.0.1",
-				"is-callable": "^1.1.5",
-				"is-number-object": "^1.0.4",
-				"is-regex": "^1.0.5",
-				"is-string": "^1.0.5",
-				"is-subset": "^0.1.1",
-				"lodash.escape": "^4.0.1",
-				"lodash.isequal": "^4.5.0",
-				"object-inspect": "^1.7.0",
-				"object-is": "^1.0.2",
-				"object.assign": "^4.1.0",
-				"object.entries": "^1.1.1",
-				"object.values": "^1.1.1",
-				"raf": "^3.4.1",
-				"rst-selector-parser": "^2.2.3",
-				"string.prototype.trim": "^1.2.1"
-			}
-		},
 		"enzyme-matchers": {
 			"version": "7.1.2",
 			"resolved": "https://registry.npmjs.org/enzyme-matchers/-/enzyme-matchers-7.1.2.tgz",
@@ -45966,13 +45130,6 @@
 				"string.prototype.trimstart": "^1.0.5",
 				"unbox-primitive": "^1.0.2"
 			}
-		},
-		"es-array-method-boxes-properly": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/es-array-method-boxes-properly/-/es-array-method-boxes-properly-1.0.0.tgz",
-			"integrity": "sha512-wd6JXUmyHmt8T5a2xreUwKcGPq6f1f+WwIJkijUqiGcJz1qqnZgP6XIK+QyIWU5lT7imeNxUll48bziG+TSYcA==",
-			"dev": true,
-			"peer": true
 		},
 		"es-module-lexer": {
 			"version": "0.9.3",
@@ -46306,8 +45463,7 @@
 			"version": "8.3.0",
 			"resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.3.0.tgz",
 			"integrity": "sha512-BgZuLUSeKzvlL/VUjx/Yb787VQ26RU3gGjA3iiFvdsp/2bMfVIWUVP7tjxtjS0e+HP409cPlPvNkQloz8C91ew==",
-			"dev": true,
-			"requires": {}
+			"dev": true
 		},
 		"eslint-import-resolver-node": {
 			"version": "0.3.6",
@@ -47291,7 +46447,8 @@
 		"gensync": {
 			"version": "1.0.0-beta.2",
 			"resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
-			"integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg=="
+			"integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+			"dev": true
 		},
 		"get-caller-file": {
 			"version": "2.0.5",
@@ -47493,7 +46650,8 @@
 		"globals": {
 			"version": "11.12.0",
 			"resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
-			"integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA=="
+			"integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
+			"dev": true
 		},
 		"globby": {
 			"version": "5.0.0",
@@ -47762,17 +46920,6 @@
 			"integrity": "sha1-wc56MWjIxmFAM6S194d/OyJfnDg=",
 			"dev": true
 		},
-		"html-element-map": {
-			"version": "1.3.1",
-			"resolved": "https://registry.npmjs.org/html-element-map/-/html-element-map-1.3.1.tgz",
-			"integrity": "sha512-6XMlxrAFX4UEEGxctfFnmrFaaZFNf9i5fNuV5wZ3WWQ4FVaNP1aX1LkX9j2mfEx1NpjeE/rL3nmgEn23GdFmrg==",
-			"dev": true,
-			"peer": true,
-			"requires": {
-				"array.prototype.filter": "^1.0.0",
-				"call-bind": "^1.0.2"
-			}
-		},
 		"html-encoding-sniffer": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-2.0.1.tgz",
@@ -47793,59 +46940,6 @@
 			"resolved": "https://registry.npmjs.org/html-tags/-/html-tags-3.2.0.tgz",
 			"integrity": "sha512-vy7ClnArOZwCnqZgvv+ddgHgJiAFXe3Ge9ML5/mBctVJoUoYPCdxVucOywjDARn6CVoh3dRSFdPHy2sX80L0Wg==",
 			"dev": true
-		},
-		"htmlparser2": {
-			"version": "8.0.1",
-			"resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-8.0.1.tgz",
-			"integrity": "sha512-4lVbmc1diZC7GUJQtRQ5yBAeUCL1exyMwmForWkRLnwyzWBFxN633SALPMGYaWZvKe9j1pRZJpauvmxENSp/EA==",
-			"dev": true,
-			"peer": true,
-			"requires": {
-				"domelementtype": "^2.3.0",
-				"domhandler": "^5.0.2",
-				"domutils": "^3.0.1",
-				"entities": "^4.3.0"
-			},
-			"dependencies": {
-				"dom-serializer": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
-					"integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
-					"dev": true,
-					"peer": true,
-					"requires": {
-						"domelementtype": "^2.3.0",
-						"domhandler": "^5.0.2",
-						"entities": "^4.2.0"
-					}
-				},
-				"domelementtype": {
-					"version": "2.3.0",
-					"resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
-					"integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
-					"dev": true,
-					"peer": true
-				},
-				"domutils": {
-					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/domutils/-/domutils-3.0.1.tgz",
-					"integrity": "sha512-z08c1l761iKhDFtfXO04C7kTdPBLi41zwOZl00WS8b5eiaebNpY00HKbztwBq+e3vyqWNwWF3mP9YLUeqIrF+Q==",
-					"dev": true,
-					"peer": true,
-					"requires": {
-						"dom-serializer": "^2.0.0",
-						"domelementtype": "^2.3.0",
-						"domhandler": "^5.0.1"
-					}
-				},
-				"entities": {
-					"version": "4.4.0",
-					"resolved": "https://registry.npmjs.org/entities/-/entities-4.4.0.tgz",
-					"integrity": "sha512-oYp7156SP8LkeGD0GF85ad1X9Ai79WtRsZ2gxJqtBuzH+98YUV6jkHEKlZkMbcrjJjIVJNIDP/3WL9wQkoPbWA==",
-					"dev": true,
-					"peer": true
-				}
-			}
 		},
 		"http-proxy-agent": {
 			"version": "4.0.1",
@@ -47930,8 +47024,7 @@
 			"version": "5.1.0",
 			"resolved": "https://registry.npmjs.org/icss-utils/-/icss-utils-5.1.0.tgz",
 			"integrity": "sha512-soFhflCVWLfRNOPU3iv5Z9VUdT44xFRbzjLsEzSr5AQmgqPMTHdU3PMT1Cf1ssx8fLNJDA1juftYl+PUcv3MqA==",
-			"dev": true,
-			"requires": {}
+			"dev": true
 		},
 		"ieee754": {
 			"version": "1.2.1",
@@ -48484,13 +47577,6 @@
 			"requires": {
 				"has-tostringtag": "^1.0.0"
 			}
-		},
-		"is-subset": {
-			"version": "0.1.1",
-			"resolved": "https://registry.npmjs.org/is-subset/-/is-subset-0.1.1.tgz",
-			"integrity": "sha512-6Ybun0IkarhmEqxXCNw/C0bna6Zb/TkfUX9UbwJtK6ObwAVCxmAP308WWTHviM/zAqXk05cdhYsUsZeGQh99iw==",
-			"dev": true,
-			"peer": true
 		},
 		"is-symbol": {
 			"version": "1.0.3",
@@ -50181,8 +49267,7 @@
 			"version": "1.2.2",
 			"resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.2.tgz",
 			"integrity": "sha512-olV41bKSMm8BdnuMsewT4jqlZ8+3TCARAXjZGT9jcoSnrfUnRCqnMoF9XEeoWjbzObpqF9dRhHQj0Xb9QdF6/w==",
-			"dev": true,
-			"requires": {}
+			"dev": true
 		},
 		"jest-regex-util": {
 			"version": "27.4.0",
@@ -50966,7 +50051,8 @@
 		"jsesc": {
 			"version": "2.5.2",
 			"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
-			"integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA=="
+			"integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
+			"dev": true
 		},
 		"json-parse-better-errors": {
 			"version": "1.0.2",
@@ -51518,25 +50604,11 @@
 			"integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168=",
 			"dev": true
 		},
-		"lodash.escape": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-4.0.1.tgz",
-			"integrity": "sha512-nXEOnb/jK9g0DYMr1/Xvq6l5xMD7GDG55+GSYIYmS0G4tBk/hURD4JR9WCavs04t33WmJx9kCyp9vJ+mr4BOUw==",
-			"dev": true,
-			"peer": true
-		},
 		"lodash.escaperegexp": {
 			"version": "4.1.2",
 			"resolved": "https://registry.npmjs.org/lodash.escaperegexp/-/lodash.escaperegexp-4.1.2.tgz",
 			"integrity": "sha512-TM9YBvyC84ZxE3rgfefxUWiQKLilstD6k7PTGt6wfbtXF8ixIJLOL3VYyV/z+ZiPLsVxAsKAFVwWlWeb2Y8Yyw==",
 			"dev": true
-		},
-		"lodash.flattendeep": {
-			"version": "4.4.0",
-			"resolved": "https://registry.npmjs.org/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz",
-			"integrity": "sha512-uHaJFihxmJcEX3kT4I23ABqKKalJ/zDrDg0lsFtc1h+3uw49SIJ5beyhx5ExVRti3AvKoOJngIj7xz3oylPdWQ==",
-			"dev": true,
-			"peer": true
 		},
 		"lodash.isarguments": {
 			"version": "3.1.0",
@@ -51549,13 +50621,6 @@
 			"resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
 			"integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U=",
 			"dev": true
-		},
-		"lodash.isequal": {
-			"version": "4.5.0",
-			"resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
-			"integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==",
-			"dev": true,
-			"peer": true
 		},
 		"lodash.ismatch": {
 			"version": "4.4.0",
@@ -52231,13 +51296,6 @@
 				"moment": ">= 2.9.0"
 			}
 		},
-		"moo": {
-			"version": "0.5.2",
-			"resolved": "https://registry.npmjs.org/moo/-/moo-0.5.2.tgz",
-			"integrity": "sha512-iSAJLHYKnX41mKcJKjqvnAN9sf0LMDTXDEvFv+ffuRR9a1MIuXLjMNL6EsnDHSkKLTWNqQQ5uo61P4EbU4NU+Q==",
-			"dev": true,
-			"peer": true
-		},
 		"mousetrap": {
 			"version": "1.6.5",
 			"resolved": "https://registry.npmjs.org/mousetrap/-/mousetrap-1.6.5.tgz",
@@ -52293,19 +51351,6 @@
 			"integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
 			"dev": true
 		},
-		"nearley": {
-			"version": "2.20.1",
-			"resolved": "https://registry.npmjs.org/nearley/-/nearley-2.20.1.tgz",
-			"integrity": "sha512-+Mc8UaAebFzgV+KpI5n7DasuuQCHA89dmwm7JXw3TV43ukfNQ9DnBH3Mdb2g/I4Fdxc26pwimBWvjIw0UAILSQ==",
-			"dev": true,
-			"peer": true,
-			"requires": {
-				"commander": "^2.19.0",
-				"moo": "^0.5.0",
-				"railroad-diagrams": "^1.0.0",
-				"randexp": "0.4.6"
-			}
-		},
 		"neo-async": {
 			"version": "2.6.2",
 			"resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
@@ -52346,17 +51391,6 @@
 						"@wordpress/primitives": "^3.1.1"
 					}
 				},
-				"react": {
-					"version": "16.14.0",
-					"resolved": "https://registry.npmjs.org/react/-/react-16.14.0.tgz",
-					"integrity": "sha512-0X2CImDkJGApiAlcf0ODKIneSwBPhqJawOa5wCtKbu7ZECrmS26NvtSILynQ66cgkT/RJ4LidJOc3bUESwmU8g==",
-					"peer": true,
-					"requires": {
-						"loose-envify": "^1.1.0",
-						"object-assign": "^4.1.1",
-						"prop-types": "^15.6.2"
-					}
-				},
 				"react-daterange-picker": {
 					"version": "2.0.1",
 					"resolved": "https://registry.npmjs.org/react-daterange-picker/-/react-daterange-picker-2.0.1.tgz",
@@ -52369,35 +51403,13 @@
 						"prop-types": "^15.6.0",
 						"react-addons-pure-render-mixin": "^15.6.2"
 					}
-				},
-				"react-dom": {
-					"version": "16.14.0",
-					"resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.14.0.tgz",
-					"integrity": "sha512-1gCeQXDLoIqMgqD3IO2Ah9bnf0w9kzhwN5q4FGnHZ67hBm9yePzB5JJAIQCc8x3pFnNlwFq4RidZggNAAkzWWw==",
-					"peer": true,
-					"requires": {
-						"loose-envify": "^1.1.0",
-						"object-assign": "^4.1.1",
-						"prop-types": "^15.6.2",
-						"scheduler": "^0.19.1"
-					}
-				},
-				"scheduler": {
-					"version": "0.19.1",
-					"resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.19.1.tgz",
-					"integrity": "sha512-n/zwRWRYSUj0/3g/otKDRPMh6qv2SYMWNq85IEa8iZyAv8od9zDYpGSnpBEjNgcMNq6Scbu5KfIPxNF72R/2EA==",
-					"peer": true,
-					"requires": {
-						"loose-envify": "^1.1.0",
-						"object-assign": "^4.1.1"
-					}
 				}
 			}
 		},
 		"newspack-scripts": {
-			"version": "4.3.7",
-			"resolved": "https://registry.npmjs.org/newspack-scripts/-/newspack-scripts-4.3.7.tgz",
-			"integrity": "sha512-twxZz9tRnxCIAUlfdppxaFiClt7WJIOoQv57+d4GU5sPQk6zOdXNtqZkWXoptRICWbgzsLzDxoSilKCvV7Ivtw==",
+			"version": "4.3.8",
+			"resolved": "https://registry.npmjs.org/newspack-scripts/-/newspack-scripts-4.3.8.tgz",
+			"integrity": "sha512-3nK3HKSLUjjkC+wP83DGfc9DKf7uLSN5zYhn6138oL0KEmwn8roP+DUY+ePuywV9MocT8X8sBP7hxvMqInlDHA==",
 			"dev": true,
 			"requires": {
 				"@automattic/calypso-build": "^10.0.0",
@@ -53142,8 +52154,7 @@
 					"version": "4.3.0",
 					"resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.3.0.tgz",
 					"integrity": "sha512-XslZy0LnMn+84NEG9jSGR6eGqaZB3133L8xewQo3fQagbQuGt7a63gf+P1NGKZavEYEC3UXaWEAA/AqDkuN6xA==",
-					"dev": true,
-					"requires": {}
+					"dev": true
 				},
 				"eslint-utils": {
 					"version": "3.0.0",
@@ -53594,7 +52605,8 @@
 		"node-releases": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.1.tgz",
-			"integrity": "sha512-CqyzN6z7Q6aMeF/ktcMVTzhAHCEpf8SOarwpzpf8pNBY2k5/oM34UHldUwp8VKI7uxct2HxSRdJjBaZeESzcxA=="
+			"integrity": "sha512-CqyzN6z7Q6aMeF/ktcMVTzhAHCEpf8SOarwpzpf8pNBY2k5/oM34UHldUwp8VKI7uxct2HxSRdJjBaZeESzcxA==",
+			"dev": true
 		},
 		"normalize-package-data": {
 			"version": "2.5.0",
@@ -55429,16 +54441,6 @@
 				"path-key": "^2.0.0"
 			}
 		},
-		"nth-check": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
-			"integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
-			"dev": true,
-			"peer": true,
-			"requires": {
-				"boolbase": "^1.0.0"
-			}
-		},
 		"nwsapi": {
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.0.tgz",
@@ -55816,36 +54818,6 @@
 			"integrity": "sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw==",
 			"dev": true
 		},
-		"parse5-htmlparser2-tree-adapter": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/parse5-htmlparser2-tree-adapter/-/parse5-htmlparser2-tree-adapter-7.0.0.tgz",
-			"integrity": "sha512-B77tOZrqqfUfnVcOrUvfdLbz4pu4RopLD/4vmu3HUPswwTA8OH0EMW9BlWR2B0RCoiZRAHEUu7IxeP1Pd1UU+g==",
-			"dev": true,
-			"peer": true,
-			"requires": {
-				"domhandler": "^5.0.2",
-				"parse5": "^7.0.0"
-			},
-			"dependencies": {
-				"entities": {
-					"version": "4.4.0",
-					"resolved": "https://registry.npmjs.org/entities/-/entities-4.4.0.tgz",
-					"integrity": "sha512-oYp7156SP8LkeGD0GF85ad1X9Ai79WtRsZ2gxJqtBuzH+98YUV6jkHEKlZkMbcrjJjIVJNIDP/3WL9wQkoPbWA==",
-					"dev": true,
-					"peer": true
-				},
-				"parse5": {
-					"version": "7.1.1",
-					"resolved": "https://registry.npmjs.org/parse5/-/parse5-7.1.1.tgz",
-					"integrity": "sha512-kwpuwzB+px5WUg9pyK0IcK/shltJN5/OVhQagxhCQNtT9Y9QRZqNY2e1cmbu/paRh5LMnz/oVTVLBpjFmMZhSg==",
-					"dev": true,
-					"peer": true,
-					"requires": {
-						"entities": "^4.4.0"
-					}
-				}
-			}
-		},
 		"parserlib": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/parserlib/-/parserlib-1.1.1.tgz",
@@ -55959,7 +54931,8 @@
 		"picocolors": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
-			"integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ=="
+			"integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==",
+			"dev": true
 		},
 		"picomatch": {
 			"version": "2.3.1",
@@ -56651,8 +55624,7 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/postcss-modules-extract-imports/-/postcss-modules-extract-imports-3.0.0.tgz",
 			"integrity": "sha512-bdHleFnP3kZ4NYDhuGlVK+CMrQ/pqUm8bx/oGL93K6gVwiclvX5x0n76fYMKuIGKzlABOy13zsvqjb0f92TEXw==",
-			"dev": true,
-			"requires": {}
+			"dev": true
 		},
 		"postcss-modules-local-by-default": {
 			"version": "4.0.0",
@@ -57175,15 +56147,13 @@
 			"version": "6.0.0",
 			"resolved": "https://registry.npmjs.org/postcss-safe-parser/-/postcss-safe-parser-6.0.0.tgz",
 			"integrity": "sha512-FARHN8pwH+WiS2OPCxJI8FuRJpTVnn6ZNFiqAM2aeW2LwTHWWmWgIyKC6cUo0L8aeKiF/14MNvnpls6R2PBeMQ==",
-			"dev": true,
-			"requires": {}
+			"dev": true
 		},
 		"postcss-scss": {
 			"version": "4.0.5",
 			"resolved": "https://registry.npmjs.org/postcss-scss/-/postcss-scss-4.0.5.tgz",
 			"integrity": "sha512-F7xpB6TrXyqUh3GKdyB4Gkp3QL3DDW1+uI+gxx/oJnUt/qXI4trj5OGlp9rOKdoABGULuqtqeG+3HEVQk4DjmA==",
-			"dev": true,
-			"requires": {}
+			"dev": true
 		},
 		"postcss-selector-parser": {
 			"version": "6.0.10",
@@ -57486,24 +56456,6 @@
 				"performance-now": "^2.1.0"
 			}
 		},
-		"railroad-diagrams": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/railroad-diagrams/-/railroad-diagrams-1.0.0.tgz",
-			"integrity": "sha512-cz93DjNeLY0idrCNOH6PviZGRN9GJhsdm9hpn1YCS879fj4W+x5IFJhhkRZcwVgMmFF7R82UA/7Oh+R8lLZg6A==",
-			"dev": true,
-			"peer": true
-		},
-		"randexp": {
-			"version": "0.4.6",
-			"resolved": "https://registry.npmjs.org/randexp/-/randexp-0.4.6.tgz",
-			"integrity": "sha512-80WNmd9DA0tmZrw9qQa62GPPWfuXJknrmVmLcxvq4uZBdYqb1wYoKTmnlGUchvVWe0XiLupYkBoXVOxz3C8DYQ==",
-			"dev": true,
-			"peer": true,
-			"requires": {
-				"discontinuous-range": "1.0.0",
-				"ret": "~0.1.10"
-			}
-		},
 		"randombytes": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
@@ -57581,8 +56533,7 @@
 		"react-colorful": {
 			"version": "5.5.1",
 			"resolved": "https://registry.npmjs.org/react-colorful/-/react-colorful-5.5.1.tgz",
-			"integrity": "sha512-M1TJH2X3RXEt12sWkpa6hLc/bbYS0H6F4rIqjQZ+RxNBstpY67d9TrFXtqdZwhpmBXcCwEi7stKqFue3ZRkiOg==",
-			"requires": {}
+			"integrity": "sha512-M1TJH2X3RXEt12sWkpa6hLc/bbYS0H6F4rIqjQZ+RxNBstpY67d9TrFXtqdZwhpmBXcCwEi7stKqFue3ZRkiOg=="
 		},
 		"react-dates": {
 			"version": "17.2.0",
@@ -57668,8 +56619,7 @@
 		"react-resize-aware": {
 			"version": "3.1.1",
 			"resolved": "https://registry.npmjs.org/react-resize-aware/-/react-resize-aware-3.1.1.tgz",
-			"integrity": "sha512-M8IyVLBN8D6tEUss+bxQlWte3ZYtNEGhg7rBxtCVG8yEBjUlZwUo5EFLq6tnvTZXcgAbCLjsQn+NCoTJKumRYg==",
-			"requires": {}
+			"integrity": "sha512-M8IyVLBN8D6tEUss+bxQlWte3ZYtNEGhg7rBxtCVG8yEBjUlZwUo5EFLq6tnvTZXcgAbCLjsQn+NCoTJKumRYg=="
 		},
 		"react-router": {
 			"version": "5.2.1",
@@ -57735,8 +56685,7 @@
 		"react-use-gesture": {
 			"version": "9.1.3",
 			"resolved": "https://registry.npmjs.org/react-use-gesture/-/react-use-gesture-9.1.3.tgz",
-			"integrity": "sha512-CdqA2SmS/fj3kkS2W8ZU8wjTbVBAIwDWaRprX7OKaj7HlGwBasGEFggmk5qNklknqk9zK/h8D355bEJFTpqEMg==",
-			"requires": {}
+			"integrity": "sha512-CdqA2SmS/fj3kkS2W8ZU8wjTbVBAIwDWaRprX7OKaj7HlGwBasGEFggmk5qNklknqk9zK/h8D355bEJFTpqEMg=="
 		},
 		"react-with-direction": {
 			"version": "1.3.1",
@@ -57902,8 +56851,7 @@
 		"reakit-utils": {
 			"version": "0.15.2",
 			"resolved": "https://registry.npmjs.org/reakit-utils/-/reakit-utils-0.15.2.tgz",
-			"integrity": "sha512-i/RYkq+W6hvfFmXw5QW7zvfJJT/K8a4qZ0hjA79T61JAFPGt23DsfxwyBbyK91GZrJ9HMrXFVXWMovsKBc1qEQ==",
-			"requires": {}
+			"integrity": "sha512-i/RYkq+W6hvfFmXw5QW7zvfJJT/K8a4qZ0hjA79T61JAFPGt23DsfxwyBbyK91GZrJ9HMrXFVXWMovsKBc1qEQ=="
 		},
 		"reakit-warning": {
 			"version": "0.6.2",
@@ -58328,17 +57276,6 @@
 			"dev": true,
 			"requires": {
 				"glob": "^7.1.3"
-			}
-		},
-		"rst-selector-parser": {
-			"version": "2.2.3",
-			"resolved": "https://registry.npmjs.org/rst-selector-parser/-/rst-selector-parser-2.2.3.tgz",
-			"integrity": "sha512-nDG1rZeP6oFTLN6yNDV/uiAvs1+FS/KlrEwh7+y7dpuApDBy6bI2HTBcc0/V8lv9OTqfyD34eF7au2pm8aBbhA==",
-			"dev": true,
-			"peer": true,
-			"requires": {
-				"lodash.flattendeep": "^4.4.0",
-				"nearley": "^2.7.10"
 			}
 		},
 		"rsvp": {
@@ -59453,18 +58390,6 @@
 				"side-channel": "^1.0.4"
 			}
 		},
-		"string.prototype.trim": {
-			"version": "1.2.6",
-			"resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.6.tgz",
-			"integrity": "sha512-8lMR2m+U0VJTPp6JjvJTtGyc4FIGq9CdRt7O9p6T0e6K4vjU+OP+SQJpbe/SBmRcCUIvNUnjsbmY6lnMp8MhsQ==",
-			"dev": true,
-			"peer": true,
-			"requires": {
-				"call-bind": "^1.0.2",
-				"define-properties": "^1.1.4",
-				"es-abstract": "^1.19.5"
-			}
-		},
 		"string.prototype.trimend": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.5.tgz",
@@ -59814,15 +58739,13 @@
 			"version": "9.0.3",
 			"resolved": "https://registry.npmjs.org/stylelint-config-prettier/-/stylelint-config-prettier-9.0.3.tgz",
 			"integrity": "sha512-5n9gUDp/n5tTMCq1GLqSpA30w2sqWITSSEiAWQlpxkKGAUbjcemQ0nbkRvRUa0B1LgD3+hCvdL7B1eTxy1QHJg==",
-			"dev": true,
-			"requires": {}
+			"dev": true
 		},
 		"stylelint-config-recommended": {
 			"version": "6.0.0",
 			"resolved": "https://registry.npmjs.org/stylelint-config-recommended/-/stylelint-config-recommended-6.0.0.tgz",
 			"integrity": "sha512-ZorSSdyMcxWpROYUvLEMm0vSZud2uB7tX1hzBZwvVY9SV/uly4AvvJPPhCcymZL3fcQhEQG5AELmrxWqtmzacw==",
-			"dev": true,
-			"requires": {}
+			"dev": true
 		},
 		"stylelint-config-recommended-scss": {
 			"version": "5.0.2",
@@ -60741,8 +59664,7 @@
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/use-isomorphic-layout-effect/-/use-isomorphic-layout-effect-1.1.2.tgz",
 			"integrity": "sha512-49L8yCO3iGT/ZF9QttjwLF/ZD9Iwto5LnH5LmEdk/6cFmXddqi2ulF0edxTwjj+7mqvpVVGQWvbXZdn32wRSHA==",
-			"dev": true,
-			"requires": {}
+			"dev": true
 		},
 		"use-lilius": {
 			"version": "2.0.3",
@@ -60756,15 +59678,13 @@
 		"use-memo-one": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/use-memo-one/-/use-memo-one-1.1.1.tgz",
-			"integrity": "sha512-oFfsyun+bP7RX8X2AskHNTxu+R3QdE/RC5IefMbqptmACAA/gfol1KDD5KRzPsGMa62sWxGZw+Ui43u6x4ddoQ==",
-			"requires": {}
+			"integrity": "sha512-oFfsyun+bP7RX8X2AskHNTxu+R3QdE/RC5IefMbqptmACAA/gfol1KDD5KRzPsGMa62sWxGZw+Ui43u6x4ddoQ=="
 		},
 		"use-sync-external-store": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz",
 			"integrity": "sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==",
-			"dev": true,
-			"requires": {}
+			"dev": true
 		},
 		"util-deprecate": {
 			"version": "1.0.2",
@@ -61239,8 +60159,7 @@
 			"version": "7.5.0",
 			"resolved": "https://registry.npmjs.org/ws/-/ws-7.5.0.tgz",
 			"integrity": "sha512-6ezXvzOZupqKj4jUqbQ9tXuJNo+BR2gU8fFRk3XCP3e0G6WT414u5ELe6Y0vtp7kmSJ3F7YWObSNr1ESsgi4vw==",
-			"dev": true,
-			"requires": {}
+			"dev": true
 		},
 		"xml-name-validator": {
 			"version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
 		"@rushstack/eslint-patch": "^1.2.0",
 		"eslint": "^7.32.0",
 		"lint-staged": "^13.0.3",
-		"newspack-scripts": "^4.3.7",
+		"newspack-scripts": "^4.3.8",
 		"postcss": "^8.4.18",
 		"postcss-scss": "^4.0.5",
 		"prettier": "npm:wp-prettier@^2.6.2-beta-1",


### PR DESCRIPTION
Update `newspack-scripts` and CI orb. The latest version combo will handle building JS files on CI better:

- version `1.4.2` of the orb adds setting node version according to the project's `.nvmrc` file prior to installing npm modules and building the JS files
- version `4.3.8` of `newspack-scripts` removes a hacky partial fix for issues caused by node version mismatch