### PR TITLE
fix: nested list items and quote blocks in email

### DIFF
--- a/includes/class-newspack-newsletters-renderer.php
+++ b/includes/class-newspack-newsletters-renderer.php
@@ -335,8 +335,8 @@ final class Newspack_Newsletters_Renderer {
 		$block_name    = $block['blockName'];
 		$attrs         = $block['attrs'];
 		$inner_blocks  = $block['innerBlocks'];
-		$inner_content = $block['innerContent'];
 		$inner_html    = $block['innerHTML'];
+		$inner_content = isset( $block['innerContent'] ) ? $block['innerContent'] : [ $inner_html ];
 
 		if ( ! isset( $attrs['innerBlocksToInsert'] ) && self::is_empty_block( $block ) ) {
 			return '';
@@ -378,7 +378,6 @@ final class Newspack_Newsletters_Renderer {
 			 */
 			case 'core/paragraph':
 			case 'core/heading':
-			case 'core/quote':
 			case 'core/site-title':
 			case 'core/site-tagline':
 			case 'newspack-newsletters/share':
@@ -715,9 +714,12 @@ final class Newspack_Newsletters_Renderer {
 				break;
 
 			/**
-			 * List block.
+			 * List, list item, and quote blocks.
+			 * These blocks may or may not contain innerBlocks with their actual content.
 			 */
 			case 'core/list':
+			case 'core/list-item':
+			case 'core/quote':
 				$text_attrs = array_merge(
 					array(
 						'padding'     => '0',
@@ -730,8 +732,8 @@ final class Newspack_Newsletters_Renderer {
 
 				$block_mjml_markup = '<mj-text ' . self::array_to_attributes( $text_attrs ) . '>' . $inner_content[0];
 				if ( ! empty( $inner_blocks ) && 1 < count( $inner_content ) ) {
-					foreach ( $inner_blocks as $block ) {
-						$block_mjml_markup .= $block['innerHTML'];
+					foreach ( $inner_blocks as $inner_block ) {
+						$block_mjml_markup .= self::render_mjml_component( $inner_block );
 					}
 					$block_mjml_markup .= $inner_content[ count( $inner_content ) - 1 ];
 				}

--- a/includes/class-newspack-newsletters-renderer.php
+++ b/includes/class-newspack-newsletters-renderer.php
@@ -329,9 +329,10 @@ final class Newspack_Newsletters_Renderer {
 	 * @param bool     $is_in_column Whether the component is a child of a column component.
 	 * @param bool     $is_in_group Whether the component is a child of a group component.
 	 * @param array    $default_attrs Default attributes for the component.
+	 * @param bool     $is_in_list_or_quote Whether the component is a child of a list or quote block.
 	 * @return string MJML component.
 	 */
-	public static function render_mjml_component( $block, $is_in_column = false, $is_in_group = false, $default_attrs = [] ) {
+	public static function render_mjml_component( $block, $is_in_column = false, $is_in_group = false, $default_attrs = [], $is_in_list_or_quote = false ) {
 		$block_name    = $block['blockName'];
 		$attrs         = $block['attrs'];
 		$inner_blocks  = $block['innerBlocks'];
@@ -731,19 +732,19 @@ final class Newspack_Newsletters_Renderer {
 				);
 
 				// If a wrapper block, wrap in mj-text.
-				if ( ! $is_in_group ) {
+				if ( ! $is_in_list_or_quote ) {
 					$block_mjml_markup = '<mj-text ' . self::array_to_attributes( $text_attrs ) . '>';
 				}
 
 				$block_mjml_markup .= $inner_content[0];
 				if ( ! empty( $inner_blocks ) && 1 < count( $inner_content ) ) {
 					foreach ( $inner_blocks as $inner_block ) {
-						$block_mjml_markup .= self::render_mjml_component( $inner_block, false, true );
+						$block_mjml_markup .= self::render_mjml_component( $inner_block, false, false, [], true );
 					}
 					$block_mjml_markup .= $inner_content[ count( $inner_content ) - 1 ];
 				}
 
-				if ( ! $is_in_group ) {
+				if ( ! $is_in_list_or_quote ) {
 					$block_mjml_markup .= '</mj-text>';
 				}
 
@@ -865,7 +866,7 @@ final class Newspack_Newsletters_Renderer {
 
 		if (
 			! $is_in_column &&
-			! $is_in_group &&
+			! $is_in_list_or_quote &&
 			! $is_grouped_block &&
 			'core/columns' != $block_name &&
 			'core/column' != $block_name &&
@@ -876,7 +877,7 @@ final class Newspack_Newsletters_Renderer {
 			$column_attrs['width'] = '100%';
 			$block_mjml_markup     = '<mj-column ' . self::array_to_attributes( $column_attrs ) . '>' . $block_mjml_markup . '</mj-column>';
 		}
-		if ( $is_in_column || $is_in_group || $is_posts_inserter_block ) {
+		if ( $is_in_column || $is_in_list_or_quote || $is_posts_inserter_block ) {
 			// Render a nested block without a wrapping section.
 			return $block_mjml_markup;
 		} else {

--- a/includes/class-newspack-newsletters-renderer.php
+++ b/includes/class-newspack-newsletters-renderer.php
@@ -730,14 +730,23 @@ final class Newspack_Newsletters_Renderer {
 					$attrs
 				);
 
-				$block_mjml_markup = '<mj-text ' . self::array_to_attributes( $text_attrs ) . '>' . $inner_content[0];
+				// If a wrapper block, wrap in mj-text.
+				if ( ! $is_in_group ) {
+					$block_mjml_markup = '<mj-text ' . self::array_to_attributes( $text_attrs ) . '>';
+				}
+
+				$block_mjml_markup .= $inner_content[0];
 				if ( ! empty( $inner_blocks ) && 1 < count( $inner_content ) ) {
 					foreach ( $inner_blocks as $inner_block ) {
-						$block_mjml_markup .= self::render_mjml_component( $inner_block );
+						$block_mjml_markup .= self::render_mjml_component( $inner_block, false, true );
 					}
 					$block_mjml_markup .= $inner_content[ count( $inner_content ) - 1 ];
 				}
-				$block_mjml_markup .= '</mj-text>';
+
+				if ( ! $is_in_group ) {
+					$block_mjml_markup .= '</mj-text>';
+				}
+
 				break;
 
 			/**
@@ -852,11 +861,12 @@ final class Newspack_Newsletters_Renderer {
 		}
 
 		$is_posts_inserter_block = 'newspack-newsletters/posts-inserter' == $block_name;
-		$is_group_block          = 'core/group' == $block_name;
+		$is_grouped_block        = in_array( $block_name, [ 'core/group', 'core/list', 'core/list-item', 'core/quote' ], true );
 
 		if (
 			! $is_in_column &&
-			! $is_group_block &&
+			! $is_in_group &&
+			! $is_grouped_block &&
 			'core/columns' != $block_name &&
 			'core/column' != $block_name &&
 			'core/buttons' != $block_name &&
@@ -866,7 +876,7 @@ final class Newspack_Newsletters_Renderer {
 			$column_attrs['width'] = '100%';
 			$block_mjml_markup     = '<mj-column ' . self::array_to_attributes( $column_attrs ) . '>' . $block_mjml_markup . '</mj-column>';
 		}
-		if ( $is_in_column || $is_group_block || $is_posts_inserter_block ) {
+		if ( $is_in_column || $is_in_group || $is_posts_inserter_block ) {
 			// Render a nested block without a wrapping section.
 			return $block_mjml_markup;
 		} else {

--- a/includes/class-newspack-newsletters-renderer.php
+++ b/includes/class-newspack-newsletters-renderer.php
@@ -425,7 +425,8 @@ final class Newspack_Newsletters_Renderer {
 					unset( $text_attrs['background-color'] );
 				}
 
-				$block_mjml_markup = '<mj-text ' . self::array_to_attributes( $text_attrs ) . '>' . $inner_html . '</mj-text>';
+				// Avoid wrapping markup in `mj-text` if the block is an inner block.
+				$block_mjml_markup = $is_in_list_or_quote ? $inner_html : '<mj-text ' . self::array_to_attributes( $text_attrs ) . '>' . $inner_html . '</mj-text>';
 				break;
 
 			/**
@@ -733,7 +734,7 @@ final class Newspack_Newsletters_Renderer {
 
 				// If a wrapper block, wrap in mj-text.
 				if ( ! $is_in_list_or_quote ) {
-					$block_mjml_markup = '<mj-text ' . self::array_to_attributes( $text_attrs ) . '>';
+					$block_mjml_markup .= '<mj-text ' . self::array_to_attributes( $text_attrs ) . '>';
 				}
 
 				$block_mjml_markup .= $inner_content[0];
@@ -1231,6 +1232,7 @@ final class Newspack_Newsletters_Renderer {
 		if ( ! $background_color ) {
 			$background_color = '#ffffff';
 		}
+
 		ob_start();
 		include dirname( __FILE__ ) . '/email-template.mjml.php';
 		return ob_get_clean();


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes missing nested list items and Quote blocks from rendered emails. Asana reference: `/0/1200550061930446/1203326737036715`

### How to test the changes in this Pull Request:

1. Add a Quote block and a List block and then indent some of the list items like so:

<img width="349" alt="Screen Shot 2022-11-10 at 12 00 01 PM" src="https://user-images.githubusercontent.com/2230142/201183092-a6249c97-f0fe-4a9e-b157-e4c7511ba6a8.png">

2. On `master`, send a test email and observe that the Quote block and the nested list items are dropped.
3. On this branch, send another test and confirm that all items are rendered.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
