### PR TITLE
Tags support/add provider attributes

### DIFF
--- a/includes/class-subscription-lists.php
+++ b/includes/class-subscription-lists.php
@@ -51,7 +51,7 @@ class Subscription_Lists {
 		}
 		
 		// If Service Provider is not configured yet.
-		if ( ! Newspack_Newsletters::is_service_provider_configured() ) {
+		if ( 'manual' === Newspack_Newsletters::service_provider() || ! Newspack_Newsletters::is_service_provider_configured() ) {
 			return false;
 		}
 

--- a/includes/class-subscription-lists.php
+++ b/includes/class-subscription-lists.php
@@ -7,6 +7,8 @@
 
 namespace Newspack\Newsletters;
 
+use Newspack_Newsletters;
+
 defined( 'ABSPATH' ) || exit;
 
 /**
@@ -29,9 +31,35 @@ class Subscription_Lists {
 	 * @return void
 	 */
 	public static function init() {
+		if ( ! self::should_initialize_lists() ) {
+			return;
+		}
 		add_action( 'init', [ __CLASS__, 'register_post_type' ] );
 		add_action( 'admin_menu', [ __CLASS__, 'add_submenu_item' ] );
 		add_filter( 'wp_editor_settings', [ __CLASS__, 'filter_editor_settings' ], 10, 2 );
+	}
+
+	/**
+	 * Check if we should initialize the Subscription lists
+	 *
+	 * @return boolean
+	 */
+	public static function should_initialize_lists() {
+		// We only need this on admin.
+		if ( ! is_admin() ) {
+			return false;
+		}
+		
+		// If Service Provider is not configured yet.
+		if ( ! Newspack_Newsletters::is_service_provider_configured() ) {
+			return false;
+		}
+
+		$provider = Newspack_Newsletters::get_service_provider();
+
+		// Only init if current provider supports tags.
+		return $provider::$support_tags;
+
 	}
 
 	/**
@@ -56,7 +84,7 @@ class Subscription_Lists {
 	 */
 	public static function add_submenu_item() {
 		add_submenu_page(
-			'edit.php?post_type=' . \Newspack_Newsletters::NEWSPACK_NEWSLETTERS_CPT,
+			'edit.php?post_type=' . Newspack_Newsletters::NEWSPACK_NEWSLETTERS_CPT,
 			__( 'Lists', 'newspack-newsletters' ),
 			__( 'Lists', 'newspack-newsletters' ),
 			'edit_others_posts',

--- a/includes/service-providers/active_campaign/class-newspack-newsletters-active-campaign.php
+++ b/includes/service-providers/active_campaign/class-newspack-newsletters-active-campaign.php
@@ -34,6 +34,13 @@ final class Newspack_Newsletters_Active_Campaign extends \Newspack_Newsletters_S
 	private $contact_data = [];
 
 	/**
+	 * Whether the provider has support to tags and tags based Subscription Lists.
+	 *
+	 * @var boolean
+	 */
+	public static $support_tags = true;
+
+	/**
 	 * Class constructor.
 	 */
 	public function __construct() {
@@ -1233,5 +1240,21 @@ final class Newspack_Newsletters_Active_Campaign extends \Newspack_Newsletters_S
 		if ( isset( $this->contact_data[ $email ] ) ) {
 			unset( $this->contact_data[ $email ] );
 		}
+	}
+
+	/**
+	 * Get the provider specific labels
+	 *
+	 * This allows us to make reference to provider specific features in the way the user is used to see them in the provider's UI
+	 *
+	 * @return array
+	 */
+	public static function get_labels() {
+		return array_merge(
+			parent::get_labels(),
+			[
+				'name' => 'Active Campaign',
+			]
+		);
 	}
 }

--- a/includes/service-providers/campaign_monitor/class-newspack-newsletters-campaign-monitor.php
+++ b/includes/service-providers/campaign_monitor/class-newspack-newsletters-campaign-monitor.php
@@ -635,4 +635,20 @@ final class Newspack_Newsletters_Campaign_Monitor extends \Newspack_Newsletters_
 			);
 		}
 	}
+
+	/**
+	 * Get the provider specific labels
+	 *
+	 * This allows us to make reference to provider specific features in the way the user is used to see them in the provider's UI
+	 *
+	 * @return array
+	 */
+	public static function get_labels() {
+		return array_merge(
+			parent::get_labels(),
+			[
+				'name' => 'Campaign Monitor',
+			]
+		);
+	}
 }

--- a/includes/service-providers/class-newspack-newsletters-service-provider.php
+++ b/includes/service-providers/class-newspack-newsletters-service-provider.php
@@ -43,6 +43,13 @@ abstract class Newspack_Newsletters_Service_Provider implements Newspack_Newslet
 	protected static $controlled_statuses = [ 'publish', 'private' ];
 
 	/**
+	 * Whether the provider has support to tags and tags based Subscription Lists.
+	 *
+	 * @var boolean
+	 */
+	public static $support_tags = false;
+
+	/**
 	 * Class constructor.
 	 */
 	public function __construct() {
@@ -317,5 +324,33 @@ abstract class Newspack_Newsletters_Service_Provider implements Newspack_Newslet
 	 */
 	public function update_contact_lists( $email, $lists_to_add = [], $lists_to_remove = [] ) {
 		return new WP_Error( 'newspack_newsletters_not_implemented', __( 'Not implemented', 'newspack-newsletters' ), [ 'status' => 400 ] );
+	}
+
+	/**
+	 * Get the provider specific labels
+	 *
+	 * This allows us to make reference to provider specific features in the way the user is used to see them in the provider's UI
+	 *
+	 * @return array
+	 */
+	public static function get_labels() {
+		return [
+			'name'  => '', // The provider name.
+			'list'  => __( 'list', 'newspack-newsletters' ), // "list" in lower case singular format.
+			'lists' => __( 'lists', 'newspack-newsletters' ), // "list" in lower case plural format.
+			'List'  => __( 'List', 'newspack-newsletters' ), // "list" in uppercase case singular format.
+			'Lists' => __( 'Lists', 'newspack-newsletters' ), // "list" in uppercase case plural format.
+		];
+	}
+
+	/**
+	 * Get one specific label for the current provider
+	 *
+	 * @param string $key The label key.
+	 * @return string Empty string in case the label is not found.
+	 */
+	public static function label( $key ) {
+		$labels = static::get_labels();
+		return $labels[ $key ] ?? '';
 	}
 }

--- a/includes/service-providers/constant_contact/class-newspack-newsletters-constant-contact.php
+++ b/includes/service-providers/constant_contact/class-newspack-newsletters-constant-contact.php
@@ -802,4 +802,20 @@ final class Newspack_Newsletters_Constant_Contact extends \Newspack_Newsletters_
 		return get_object_vars( $contact );
 	}
 
+	/**
+	 * Get the provider specific labels
+	 *
+	 * This allows us to make reference to provider specific features in the way the user is used to see them in the provider's UI
+	 *
+	 * @return array
+	 */
+	public static function get_labels() {
+		return array_merge(
+			parent::get_labels(),
+			[
+				'name' => 'Constant Contact',
+			]
+		);
+	}
+
 }

--- a/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp.php
+++ b/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp.php
@@ -15,6 +15,13 @@ use \DrewM\MailChimp\MailChimp;
 final class Newspack_Newsletters_Mailchimp extends \Newspack_Newsletters_Service_Provider {
 
 	/**
+	 * Whether the provider has support to tags and tags based Subscription Lists.
+	 *
+	 * @var boolean
+	 */
+	public static $support_tags = true;
+
+	/**
 	 * Class constructor.
 	 */
 	public function __construct() {
@@ -1060,5 +1067,22 @@ final class Newspack_Newsletters_Mailchimp extends \Newspack_Newsletters_Service
 			];
 		}
 		return $data;
+	}
+
+	/**
+	 * Get the provider specific labels
+	 *
+	 * This allows us to make reference to provider specific features in the way the user is used to see them in the provider's UI
+	 *
+	 * @return array
+	 */
+	public static function get_labels() {
+		return [
+			'name'  => 'Mailchimp', // The provider name.
+			'list'  => __( 'audience', 'newspack-newsletters' ), // "list" in lower case singular format.
+			'lists' => __( 'audiences', 'newspack-newsletters' ), // "list" in lower case plural format.
+			'List'  => __( 'Audience', 'newspack-newsletters' ), // "list" in uppercase case singular format.
+			'Lists' => __( 'Audiences', 'newspack-newsletters' ), // "list" in uppercase case plural format.
+		];
 	}
 }

--- a/newspack-newsletters.php
+++ b/newspack-newsletters.php
@@ -56,4 +56,5 @@ require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/class-newspack-newsle
 require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/class-newspack-newsletters-embed.php';
 require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/class-newspack-newsletters.php';
 
+// This MUST be initialized after Newspack_Newsletter class.
 \Newspack\Newsletters\Subscription_Lists::init();

--- a/tests/test-labels.php
+++ b/tests/test-labels.php
@@ -1,0 +1,73 @@
+<?php
+/**
+ * Class Newsletters Test provider labels
+ *
+ * @package Newspack_Newsletters
+ */
+
+/**
+ * Newsletters Renderer Test.
+ */
+class Newsletters_Labels_Test extends WP_UnitTestCase {
+
+	/**
+	 * Test the labels inheritance
+	 */
+	public function test_labels_inheritance() {
+		$ac_labels = Newspack_Newsletters_Active_Campaign::get_labels();
+		$this->assertSame( 'Active Campaign', $ac_labels['name'] );
+		$this->assertSame( 'list', $ac_labels['list'] );
+
+		$ac_labels = Newspack_Newsletters_Campaign_Monitor::get_labels();
+		$this->assertSame( 'Campaign Monitor', $ac_labels['name'] );
+		$this->assertSame( 'list', $ac_labels['list'] );
+
+		$ac_labels = Newspack_Newsletters_Constant_Contact::get_labels();
+		$this->assertSame( 'Constant Contact', $ac_labels['name'] );
+		$this->assertSame( 'list', $ac_labels['list'] );
+	}
+
+	/**
+	 * Data provider for test_get_label
+	 *
+	 * @return array
+	 */
+	public function get_label_provider() {
+		return [
+			'AC list'        => [
+				'Newspack_Newsletters_Active_Campaign',
+				'list',
+				'list',
+			],
+			'AC invalid'     => [
+				'Newspack_Newsletters_Active_Campaign',
+				'invalid',
+				'',
+			],
+			'mailchimp list' => [
+				'Newspack_Newsletters_Mailchimp',
+				'list',
+				'audience',
+			],
+			'mailchimp name' => [
+				'Newspack_Newsletters_Mailchimp',
+				'name',
+				'Mailchimp',
+			],
+		];
+	}
+
+	/**
+	 * Test label method
+	 *
+	 * @param string $provider The provider class name.
+	 * @param string $key The label key.
+	 * @param string $expected The expected value.
+	 * @return void
+	 * @dataProvider get_label_provider
+	 */
+	public function test_get_label( $provider, $key, $expected ) {
+		$this->assertSame( $expected, $provider::label( $key ) );
+	}
+
+}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR adds new attributes to the providers classes
* labels that will be used in the UI
* a flag indicating whether the provider supports Tag

It also adds a condition and only loads the Lists CPT if the provider is set and support tags.

### How to test the changes in this Pull Request:

1. Make sure tests pass
2. Configure Constant Contact as a provider
3. Confirm that the Newsletters > Lists submenu is not added
4. Try to access `wp-admin/edit.php?post_type=newspack_nl_list` and make sure you get the "Invalid post type" message
5. Configure Mailchimp or Active Campaing as a provider
6. Confirm you now see and are able to use the Newsletters > Lists post type

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
