### PR TITLE
Tags support/add metabox

### DIFF
--- a/includes/class-newspack-newsletters.php
+++ b/includes/class-newspack-newsletters.php
@@ -34,6 +34,18 @@ final class Newspack_Newsletters {
 	];
 
 	/**
+	 * List of the implemented Servide providers. Keys are providers slugs and values the providers class names
+	 *
+	 * @var array
+	 */
+	const REGISTERED_PROVIDERS = [
+		'mailchimp'        => 'Newspack_Newsletters_Mailchimp',
+		'constant_contact' => 'Newspack_Newsletters_Constant_Contact',
+		'campaign_monitor' => 'Newspack_Newsletters_Campaign_Monitor',
+		'active_campaign'  => 'Newspack_Newsletters_Active_Campaign',
+	];
+
+	/**
 	 * The single instance of the class.
 	 *
 	 * @var Newspack_Newsletters
@@ -100,20 +112,20 @@ final class Newspack_Newsletters {
 	 */
 	public static function set_service_provider( $service_provider ) {
 		update_option( 'newspack_newsletters_service_provider', $service_provider );
-		switch ( $service_provider ) {
-			case 'mailchimp':
-				self::$provider = Newspack_Newsletters_Mailchimp::instance();
-				break;
-			case 'constant_contact':
-				self::$provider = Newspack_Newsletters_Constant_Contact::instance();
-				break;
-			case 'campaign_monitor':
-				self::$provider = Newspack_Newsletters_Campaign_Monitor::instance();
-				break;
-			case 'active_campaign':
-				self::$provider = Newspack_Newsletters_Active_Campaign::instance();
-				break;
+		self::$provider = self::get_service_provider_instance( $service_provider );
+	}
+
+	/**
+	 * Gets the Service provider instance
+	 *
+	 * @param string $provider_slug The provider slug.
+	 * @return ?Newspack_Newsletters_Service_Provider
+	 */
+	public static function get_service_provider_instance( $provider_slug ) {
+		if ( empty( self::REGISTERED_PROVIDERS[ $provider_slug ] ) ) {
+			return null;
 		}
+		return self::REGISTERED_PROVIDERS[ $provider_slug ]::instance();
 	}
 
 	/**

--- a/includes/class-subscription-list.php
+++ b/includes/class-subscription-list.php
@@ -1,0 +1,183 @@
+<?php
+/**
+ * Newspack Newsletters Subscriptio List
+ *
+ * @package Newspack
+ */
+
+namespace Newspack\Newsletters;
+
+use Newspack_Newsletters;
+use WP_Post;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class used to represent one Subscription List
+ */
+class Subscription_List {
+
+	/**
+	 * Hold the WP_Post object associated with this List.
+	 *
+	 * @var WP_Post
+	 */
+	protected $post;
+
+	/**
+	 * The meta key where the settings are stored.
+	 */
+	const META_KEY = 'newspack_nl_provider_settings';
+
+	/**
+	 * Initializes a new Subscription List
+	 *
+	 * @param WP_Post|int $post_or_id The post object or ID.
+	 * @throws \InvalidArgumentException In case the post is not found.
+	 */
+	public function __construct( $post_or_id ) {
+		if ( ! $post_or_id instanceof WP_Post ) {
+			$post_or_id = get_post( (int) $post_or_id );
+			if ( ! $post_or_id instanceof WP_Post ) {
+				throw new \InvalidArgumentException( 'Post not found' );
+			}
+		}
+		$this->post = $post_or_id;
+	}
+
+	/**
+	 * Gets the List ID
+	 *
+	 * @return int
+	 */
+	public function get_id() {
+		return $this->post->ID;
+	}
+
+	/**
+	 * Gets the List title
+	 *
+	 * @return string
+	 */
+	public function get_title() {
+		return $this->post->post_title;
+	}
+
+	/**
+	 * Gets the List description
+	 *
+	 * @return string
+	 */
+	public function get_description() {
+		return $this->post->post_content;
+	}
+
+	/**
+	 * Returns the settings stored for a provider
+	 *
+	 * @param string $provider_slug The provider slug.
+	 * @return ?array
+	 */
+	public function get_provider_settings( $provider_slug ) {
+		$meta = $this->get_all_providers_settings();
+		if ( ! empty( $provider_slug ) && is_array( $meta ) && ! empty( $meta[ $provider_slug ] ) ) {
+			return $meta[ $provider_slug ];
+		}
+		return null;
+	}
+
+	/**
+	 * Returns the settings stored for the current service provicer
+	 *
+	 * @return ?array
+	 */
+	public function get_current_provider_settings() {
+		return $this->get_provider_settings( Newspack_Newsletters::service_provider() );
+	}
+
+	/**
+	 * Gets all the settings stored for all providers
+	 *
+	 * @return array
+	 */
+	public function get_all_providers_settings() {
+		$settings = get_post_meta( $this->get_id(), self::META_KEY, true );
+		return is_array( $settings ) ? $settings : [];
+	}
+
+	/**
+	 * Gets a list of all providers slugs this List has configuration for
+	 *
+	 * @return array
+	 */
+	public function get_configured_providers() {
+		return array_keys( $this->get_all_providers_settings() );
+	}
+
+	/**
+	 * Gets a list of all providers slugs this List has configuration for, excluding the current active provider
+	 *
+	 * @return array
+	 */
+	public function get_other_configured_providers() {
+		$providers = array_keys( $this->get_all_providers_settings() );
+		return array_diff( $providers, [ Newspack_Newsletters::service_provider() ] );
+	}
+
+	/**
+	 * Gets a list of all providers names this List has configuration for
+	 *
+	 * @param boolean $ignore_current Whether to ignore the current provider or not.
+	 * @return array
+	 */
+	public function get_configured_providers_names( $ignore_current = false ) {
+		$providers = $ignore_current ? $this->get_other_configured_providers() : $this->get_configured_providers();
+		$names     = [];
+		foreach ( $providers as $provider_slug ) {
+			$provider = Newspack_Newsletters::get_service_provider_instance( $provider_slug );
+			if ( is_object( $provider ) ) {
+				$names[] = $provider::label( 'name' );
+			}
+		}
+		return $names;
+	}
+
+	/**
+	 * Gets a list of all providers names this List has configuration for, excluding the current active provider
+	 *
+	 * @return array
+	 */
+	public function get_other_configured_providers_names() {
+		return $this->get_configured_providers_names( true );
+	}
+
+	/**
+	 * Checks if this List has any other providers configured other than the current active provider
+	 *
+	 * @return boolean
+	 */
+	public function has_other_providers_configured() {
+		return ! empty( $this->get_other_configured_providers() );
+
+	}
+
+	/**
+	 * Updates the settings of a provider
+	 *
+	 * @param string $list The list ID readers will be added to when they signup for this List.
+	 * @param string $tag The Tag that will be added readers who signup to this List.
+	 * @return int|bool Meta ID if the key didn't exist, true on successful update, false on failure or if the value passed to the function is the same as the one that is already in the database.
+	 */
+	public function update_current_provider_settings( $list, $tag ) {
+		if ( empty( $list ) ) {
+			return false;
+		}
+		$settings = $this->get_all_providers_settings();
+		$settings[ Newspack_Newsletters::service_provider() ] = [
+			'list' => $list,
+			'tag'  => $tag,
+		];
+		return update_post_meta( $this->get_id(), self::META_KEY, $settings );
+	}
+
+}

--- a/includes/class-subscription-list.php
+++ b/includes/class-subscription-list.php
@@ -121,7 +121,7 @@ class Subscription_List {
 	 */
 	public function get_other_configured_providers() {
 		$providers = array_keys( $this->get_all_providers_settings() );
-		return array_diff( $providers, [ Newspack_Newsletters::service_provider() ] );
+		return array_values( array_diff( $providers, [ Newspack_Newsletters::service_provider() ] ) );
 	}
 
 	/**

--- a/includes/class-subscription-lists.php
+++ b/includes/class-subscription-lists.php
@@ -211,26 +211,32 @@ class Subscription_Lists {
 		</div>
 
 		<div class="misc-pub-section">
-			<label for="newspack_newsletter_tags">
+			<label for="newspack_newsletters_tag">
 				<?php esc_html_e( 'Tag', 'newspack-newsletters' ); ?>:
 			</label>
-			<input type="text" name="newspack_newsletter_tags" id="newspack_newsletter_tags" style="width: 100%" value="<?php echo esc_attr( $current_settings['tag'] ); ?>" />
+			<input type="text" name="newspack_newsletters_tag" id="newspack_newsletters_tag" style="width: 100%" value="<?php echo esc_attr( $current_settings['tag'] ); ?>" />
 		</div>
 		<?php
 	}
 
-	public static function save_post() {
+	/**
+	 * Save post callback
+	 *
+	 * @param int $post_id The ID of the post being saved.
+	 * @return void
+	 */
+	public static function save_post( $post_id ) {
 
-		$post_type = sanitize_text_field( $_POST['post_type'] );
+		$post_type = sanitize_text_field( $_POST['post_type'] ?? '' );
 
 		if ( self::NEWSPACK_NEWSLETTERS_LIST_CPT !== $post_type ) {
-			return $post_id;
+			return;
 		}
 
 		if ( ! isset( $_POST['newspack_newsletters_save_list_nonce'] ) ||
 			! wp_verify_nonce( sanitize_text_field( $_POST['newspack_newsletters_save_list_nonce'] ), 'newspack_newsletters_save_list' )
 		) {
-			return $post_id;
+			return;
 		}
 
 		/*
@@ -238,12 +244,13 @@ class Subscription_Lists {
 		 * so we don't want to do anything.
 		 */
 		if ( defined( 'DOING_AUTOSAVE' ) && DOING_AUTOSAVE ) {
-			return $post_id;
+			return;
 		}
 
 		$post_type_object = get_post_type_object( $post_type );
+
 		if ( ! current_user_can( $post_type_object->cap->edit_post, $post_id ) ) {
-			return $post_id;
+			return;
 		}
 
 		$list = sanitize_text_field( $_POST['newspack_newsletters_list'] ?? '' );

--- a/tests/test-subscription-list.php
+++ b/tests/test-subscription-list.php
@@ -185,6 +185,9 @@ class Subscription_List_Test extends WP_UnitTestCase {
 		$this->assertNotNull( $list->get_current_provider_settings() );
 	}
 
+	/**
+	 * Test get_configured_providers method
+	 */
 	public function test_get_configured_providers() {
 		$list = new Subscription_List( self::$posts['without_settings'] );
 		$this->assertSame( [], $list->get_configured_providers() );
@@ -194,6 +197,114 @@ class Subscription_List_Test extends WP_UnitTestCase {
 
 		$list = new Subscription_List( self::$posts['two_settings'] );
 		$this->assertSame( [ 'mailchimp', 'active_campaign' ], $list->get_configured_providers() );
+	}
+
+	/**
+	 * Test get_configured_providers_names method
+	 */
+	public function test_get_configured_providers_names() {
+		$list = new Subscription_List( self::$posts['without_settings'] );
+		$this->assertSame( [], $list->get_configured_providers_names() );
+
+		$list = new Subscription_List( self::$posts['only_mailchimp'] );
+		$this->assertSame( [ 'Mailchimp' ], $list->get_configured_providers_names() );
+
+		$list = new Subscription_List( self::$posts['two_settings'] );
+		$this->assertSame( [ 'Mailchimp', 'Active Campaign' ], $list->get_configured_providers_names() );
+	}
+
+	/**
+	 * Test get_other_configured_providers method
+	 */
+	public function test_get_other_configured_providers() {
+		Newspack_Newsletters::set_service_provider( 'mailchimp' );
+
+		$list = new Subscription_List( self::$posts['without_settings'] );
+		$this->assertSame( [], $list->get_other_configured_providers() );
+
+		$list = new Subscription_List( self::$posts['only_mailchimp'] );
+		$this->assertSame( [], $list->get_other_configured_providers() );
+
+		$list = new Subscription_List( self::$posts['two_settings'] );
+		$this->assertSame( [ 'active_campaign' ], $list->get_other_configured_providers() );
+
+		Newspack_Newsletters::set_service_provider( 'active_campaign' );
+
+		$list = new Subscription_List( self::$posts['only_mailchimp'] );
+		$this->assertSame( [ 'mailchimp' ], $list->get_other_configured_providers() );
+
+		$list = new Subscription_List( self::$posts['two_settings'] );
+		$this->assertSame( [ 'mailchimp' ], $list->get_other_configured_providers() );
+	}
+
+	/**
+	 * Test get_other_configured_providers_names method
+	 */
+	public function test_get_other_configured_providers_names() {
+		Newspack_Newsletters::set_service_provider( 'mailchimp' );
+
+		$list = new Subscription_List( self::$posts['without_settings'] );
+		$this->assertSame( [], $list->get_other_configured_providers_names() );
+
+		$list = new Subscription_List( self::$posts['only_mailchimp'] );
+		$this->assertSame( [], $list->get_other_configured_providers_names() );
+
+		$list = new Subscription_List( self::$posts['two_settings'] );
+		$this->assertSame( [ 'Active Campaign' ], $list->get_other_configured_providers_names() );
+
+		Newspack_Newsletters::set_service_provider( 'active_campaign' );
+
+		$list = new Subscription_List( self::$posts['only_mailchimp'] );
+		$this->assertSame( [ 'Mailchimp' ], $list->get_other_configured_providers_names() );
+
+		$list = new Subscription_List( self::$posts['two_settings'] );
+		$this->assertSame( [ 'Mailchimp' ], $list->get_other_configured_providers_names() );
+	}
+
+	/**
+	 * Test has_other_providers_configured method
+	 */ 
+	public function test_has_other_providers_configured() {
+		Newspack_Newsletters::set_service_provider( 'mailchimp' );
+
+		$list = new Subscription_List( self::$posts['without_settings'] );
+		$this->assertFalse( $list->has_other_providers_configured() );
+
+		$list = new Subscription_List( self::$posts['only_mailchimp'] );
+		$this->assertFalse( $list->has_other_providers_configured() );
+
+		$list = new Subscription_List( self::$posts['two_settings'] );
+		$this->assertTrue( $list->has_other_providers_configured() );
+
+		Newspack_Newsletters::set_service_provider( 'active_campaign' );
+
+		$list = new Subscription_List( self::$posts['only_mailchimp'] );
+		$this->assertTrue( $list->has_other_providers_configured() );
+
+		$list = new Subscription_List( self::$posts['two_settings'] );
+		$this->assertTrue( $list->has_other_providers_configured() );
+	}
+
+	/**
+	 * Test update_current_provider_settings method
+	 */
+	public function test_update_current_provider_settings() {
+		Newspack_Newsletters::set_service_provider( 'mailchimp' );
+
+		$list = new Subscription_List( self::$posts['without_settings'] );
+
+		$this->assertFalse( $list->update_current_provider_settings( '', 'test' ) );
+		$this->assertNull( $list->get_current_provider_settings() );
+
+		$this->assertNotFalse( $list->update_current_provider_settings( '123', 'test' ) );
+		$this->assertSame(
+			[
+				'list' => '123',
+				'tag'  => 'test',
+			],
+			$list->get_current_provider_settings()
+		);
+
 	}
 
 }

--- a/tests/test-subscription-list.php
+++ b/tests/test-subscription-list.php
@@ -1,0 +1,199 @@
+<?php
+/**
+ * Class Newsletters Test Subscription_List
+ *
+ * @package Newspack_Newsletters
+ */
+
+use Newspack\Newsletters\Subscription_List;
+use Newspack\Newsletters\Subscription_Lists;
+use Newspack_Newsletters;
+
+/**
+ * Tests the Subscription_List class
+ */
+class Subscription_List_Test extends WP_UnitTestCase {
+
+	/**
+	 * Testing posts
+	 *
+	 * @var array
+	 */
+	public static $posts;
+
+	/**
+	 * Sets up testing data
+	 *
+	 * @return void
+	 */
+	public function set_up() {
+
+		$without_settings = self::create_post( 1 );
+
+		$only_mailchimp = self::create_post( 2 );
+		update_post_meta(
+			$only_mailchimp,
+			Subscription_List::META_KEY,
+			[
+				'mailchimp' => [
+					'list' => 'mc_list',
+					'tag'  => 'mc_tag',
+				],
+			]
+		);
+
+		$two_settings = self::create_post( 3 );
+		update_post_meta(
+			$two_settings,
+			Subscription_List::META_KEY,
+			[
+				'mailchimp'       => [
+					'list' => 'mc_list',
+					'tag'  => 'mc_tag',
+				],
+				'active_campaign' => [
+					'list' => 'ca_list',
+					'tag'  => 'ac_tag',
+				],
+			]
+		);
+
+		self::$posts = compact( 'without_settings', 'only_mailchimp', 'two_settings' );
+	}
+
+	/**
+	 * Create a test post
+	 *
+	 * @param string|int $index An index to identify the post title and description.
+	 * @return int
+	 */
+	public static function create_post( $index ) {
+		$data = [
+			'post_title'   => 'Test List ' . $index,
+			'post_content' => 'Description ' . $index,
+			'post_type'    => Subscription_Lists::NEWSPACK_NEWSLETTERS_LIST_CPT,
+			'post_status'  => 'publish',
+		];
+		return wp_insert_post( $data );
+	}
+
+	/**
+	 * Tests constructor with ID
+	 */
+	public function test_constructor_with_id() {
+		$list = new Subscription_List( self::$posts['without_settings'] );
+		$this->assertInstanceOf( Subscription_List::class, $list );
+		$this->assertSame( self::$posts['without_settings'], $list->get_id() );
+		$this->assertSame( 'Description 1', $list->get_description() );
+	}
+
+	/**
+	 * Tests constructor with object
+	 */
+	public function test_constructor_with_object() {
+		$list = new Subscription_List( get_post( self::$posts['without_settings'] ) );
+		$this->assertInstanceOf( Subscription_List::class, $list );
+		$this->assertSame( self::$posts['without_settings'], $list->get_id() );
+		$this->assertSame( 'Description 1', $list->get_description() );
+	}
+
+	/**
+	 * Tests constructor with object
+	 */
+	public function test_constructor_with_invalid() {
+		$this->expectException( \InvalidArgumentException::class );
+		$list = new Subscription_List( 9999 );
+	}
+
+	/**
+	 * Test get_all_providers_settings
+	 */
+	public function test_get_all_providers_settings() {
+		$list = new Subscription_List( self::$posts['without_settings'] );
+		$this->assertEquals( [], $list->get_all_providers_settings() );
+
+		$list = new Subscription_List( self::$posts['two_settings'] );
+		$this->assertEquals(
+			[
+				'mailchimp'       => [
+					'list' => 'mc_list',
+					'tag'  => 'mc_tag',
+				],
+				'active_campaign' => [
+					'list' => 'ca_list',
+					'tag'  => 'ac_tag',
+				],
+			],
+			$list->get_all_providers_settings() 
+		);
+	}
+
+	/**
+	 * Test get_all_providers_settings
+	 */
+	public function test_get_providers_settings() {
+		$list = new Subscription_List( self::$posts['without_settings'] );
+		$this->assertNull( $list->get_provider_settings( 'mailchimp' ) );
+		$this->assertNull( $list->get_provider_settings( 'active_campaign' ) );
+		$this->assertNull( $list->get_provider_settings( 'anything' ) );
+
+		$list = new Subscription_List( self::$posts['only_mailchimp'] );
+		$this->assertNotNull( $list->get_provider_settings( 'mailchimp' ) );
+		$this->assertNull( $list->get_provider_settings( 'active_campaign' ) );
+		$this->assertNull( $list->get_provider_settings( 'anything' ) );
+
+		$list = new Subscription_List( self::$posts['two_settings'] );
+		$this->assertNotNull( $list->get_provider_settings( 'mailchimp' ) );
+		$this->assertNotNull( $list->get_provider_settings( 'active_campaign' ) );
+		$this->assertNull( $list->get_provider_settings( 'anything' ) );
+
+		$this->assertSame(
+			[
+				'list' => 'ca_list',
+				'tag'  => 'ac_tag',
+			],
+			$list->get_provider_settings( 'active_campaign' )
+		);
+
+	}
+
+	/**
+	 * Test get_current_provider_settings
+	 */
+	public function test_get_current_provider_settings() {
+
+		Newspack_Newsletters::set_service_provider( 'mailchimp' );
+
+		$list = new Subscription_List( self::$posts['without_settings'] );
+		$this->assertNull( $list->get_current_provider_settings() );
+
+		$list = new Subscription_List( self::$posts['only_mailchimp'] );
+		$this->assertNotNull( $list->get_current_provider_settings() );
+
+		$list = new Subscription_List( self::$posts['two_settings'] );
+		$this->assertNotNull( $list->get_current_provider_settings() );
+
+		Newspack_Newsletters::set_service_provider( 'active_campaign' );
+
+		$list = new Subscription_List( self::$posts['without_settings'] );
+		$this->assertNull( $list->get_current_provider_settings() );
+
+		$list = new Subscription_List( self::$posts['only_mailchimp'] );
+		$this->assertNull( $list->get_current_provider_settings() );
+
+		$list = new Subscription_List( self::$posts['two_settings'] );
+		$this->assertNotNull( $list->get_current_provider_settings() );
+	}
+
+	public function test_get_configured_providers() {
+		$list = new Subscription_List( self::$posts['without_settings'] );
+		$this->assertSame( [], $list->get_configured_providers() );
+
+		$list = new Subscription_List( self::$posts['only_mailchimp'] );
+		$this->assertSame( [ 'mailchimp' ], $list->get_configured_providers() );
+
+		$list = new Subscription_List( self::$posts['two_settings'] );
+		$this->assertSame( [ 'mailchimp', 'active_campaign' ], $list->get_configured_providers() );
+	}
+
+}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

This PR creates the metabox with the providers settings for the Subscriptions Lists

### How to test the changes in this Pull Request:

1. Confirm tests are passing
2. Configure Mailchimp or AC as providers
3. Go to Newsletters > Lists
4. Create a List
5. Use the metabox to save data to the List
6. Confirm the providers Lists (or Audiences) are properly loaded
7. Confirm the field is called "Audiences" for Mailchimp and List for AC


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
