### PR TITLE
Tags support: use tag ids

### DIFF
--- a/includes/class-subscription-list.php
+++ b/includes/class-subscription-list.php
@@ -73,6 +73,15 @@ class Subscription_List {
 	}
 
 	/**
+	 * Generate the tag name that will be added to the ESP based on the post title
+	 *
+	 * @return string
+	 */
+	public function generate_tag_name() {
+		return 'Newspack: ' . $this->get_title();
+	}
+
+	/**
 	 * Returns the settings stored for a provider
 	 *
 	 * @param string $provider_slug The provider slug.
@@ -165,18 +174,27 @@ class Subscription_List {
 	 * Updates the settings of a provider
 	 *
 	 * @param string $list The list ID readers will be added to when they signup for this List.
-	 * @param string $tag The Tag that will be added readers who signup to this List.
+	 * @param int    $tag_id The ID of the tag that will be added readers who signup to this List.
+	 * @param string $tag_name The name of the tag that will be added readers who signup to this List.
+	 * @param string $error The error message in case there was an error creating the tag on the ESP.
 	 * @return int|bool Meta ID if the key didn't exist, true on successful update, false on failure or if the value passed to the function is the same as the one that is already in the database.
 	 */
-	public function update_current_provider_settings( $list, $tag ) {
-		if ( empty( $list ) ) {
-			return false;
-		}
+	public function update_current_provider_settings( $list, $tag_id, $tag_name, $error = '' ) {
 		$settings = $this->get_all_providers_settings();
-		$settings[ Newspack_Newsletters::service_provider() ] = [
-			'list' => $list,
-			'tag'  => $tag,
-		];
+		if ( ! empty( $error ) ) {
+			$settings[ Newspack_Newsletters::service_provider() ] = [
+				'error' => $error,
+			];
+		} elseif ( empty( $list ) || empty( $tag_id ) || empty( $tag_name ) ) {
+			$settings[ Newspack_Newsletters::service_provider() ]['error'] = __( 'Error: Missing information, try updating this list', 'newspack-newsletters' );
+		} else {
+			$settings[ Newspack_Newsletters::service_provider() ] = [
+				'list'     => $list,
+				'tag_id'   => $tag_id,
+				'tag_name' => $tag_name,
+			];
+		}
+		
 		return update_post_meta( $this->get_id(), self::META_KEY, $settings );
 	}
 

--- a/includes/service-providers/class-newspack-newsletters-service-provider.php
+++ b/includes/service-providers/class-newspack-newsletters-service-provider.php
@@ -353,4 +353,62 @@ abstract class Newspack_Newsletters_Service_Provider implements Newspack_Newslet
 		$labels = static::get_labels();
 		return $labels[ $key ] ?? '';
 	}
+
+	/**
+	 * Retrieve the ESP's tag ID from its name
+	 *
+	 * @param string  $tag_name The tag.
+	 * @param boolean $create_if_not_found Whether to create a new tag if not found. Default to true.
+	 * @param string  $list_id The List ID.
+	 * @return int|WP_Error The tag ID on success. WP_Error on failure.
+	 */
+	public function get_tag_id( $tag_name, $create_if_not_found = true, $list_id = null ) {
+		return new WP_Error( 'newspack_newsletters_not_implemented', __( 'Not implemented', 'newspack-newsletters' ), [ 'status' => 400 ] );
+	}
+
+	/**
+	 * Retrieve the ESP's tag name from its ID
+	 *
+	 * @param int    $tag_id The tag ID.
+	 * @param string $list_id The List ID.
+	 * @return string|WP_Error The tag name on success. WP_Error on failure.
+	 */
+	public function get_tag_by_id( $tag_id, $list_id = null ) {
+		return new WP_Error( 'newspack_newsletters_not_implemented', __( 'Not implemented', 'newspack-newsletters' ), [ 'status' => 400 ] );
+	}
+
+	/**
+	 * Create a Tag on the provider
+	 *
+	 * @param string $tag The Tag name.
+	 * @param string $list_id The List ID.
+	 * @return array|WP_Error The tag representation with at least 'id' and 'name' keys on succes. WP_Error on failure.
+	 */
+	public function create_tag( $tag, $list_id = null ) {
+		return new WP_Error( 'newspack_newsletters_not_implemented', __( 'Not implemented', 'newspack-newsletters' ), [ 'status' => 400 ] );
+	}
+
+	/**
+	 * Add a tag to a contact
+	 *
+	 * @param string     $email The contact email.
+	 * @param string|int $tag The tag ID retrieved with get_tag_id() or the the tag string.
+	 * @param string     $list_id The List ID.
+	 * @return true|WP_Error
+	 */
+	public function add_tag_to_contact( $email, $tag, $list_id = null ) {
+		return new WP_Error( 'newspack_newsletters_not_implemented', __( 'Not implemented', 'newspack-newsletters' ), [ 'status' => 400 ] );
+	}
+
+	/**
+	 * Remove a tag from a contact
+	 *
+	 * @param string     $email The contact email.
+	 * @param string|int $tag The tag ID retrieved with get_tag_id() or the the tag string.
+	 * @param string     $list_id The List ID.
+	 * @return true|WP_Error
+	 */
+	public function remove_tag_from_contact( $email, $tag, $list_id = null ) {
+		return new WP_Error( 'newspack_newsletters_not_implemented', __( 'Not implemented', 'newspack-newsletters' ), [ 'status' => 400 ] );
+	}
 }

--- a/includes/service-providers/interface-newspack-newsletters-esp-service.php
+++ b/includes/service-providers/interface-newspack-newsletters-esp-service.php
@@ -113,4 +113,52 @@ interface Newspack_Newsletters_ESP_API_Interface {
 	 * @return true|WP_Error True if the contact was updated or error.
 	 */
 	public function update_contact_lists( $email, $lists_to_add = [], $lists_to_remove = [] );
+
+	/**
+	 * Retrieve the ESP's tag ID from its name
+	 *
+	 * @param string  $tag_name The tag.
+	 * @param boolean $create_if_not_found Whether to create a new tag if not found. Default to true.
+	 * @param string  $list_id The List ID.
+	 * @return int|WP_Error The tag ID on success. WP_Error on failure.
+	 */
+	public function get_tag_id( $tag_name, $create_if_not_found = true, $list_id = null );
+
+	/**
+	 * Retrieve the ESP's tag name from its ID
+	 *
+	 * @param int    $tag_id The tag ID.
+	 * @param string $list_id The List ID.
+	 * @return string|WP_Error The tag name on success. WP_Error on failure.
+	 */
+	public function get_tag_by_id( $tag_id, $list_id = null );
+
+	/**
+	 * Create a Tag on the provider
+	 *
+	 * @param string $tag The Tag name.
+	 * @param string $list_id The List ID.
+	 * @return array|WP_Error The tag representation with at least 'id' and 'name' keys on succes. WP_Error on failure.
+	 */
+	public function create_tag( $tag, $list_id = null );
+
+	/**
+	 * Add a tag to a contact
+	 *
+	 * @param string     $email The contact email.
+	 * @param string|int $tag The tag ID retrieved with get_tag_id() or the the tag string.
+	 * @param string     $list_id The List ID.
+	 * @return true|WP_Error
+	 */
+	public function add_tag_to_contact( $email, $tag, $list_id = null );
+
+	/**
+	 * Remove a tag from a contact
+	 *
+	 * @param string     $email The contact email.
+	 * @param string|int $tag The tag ID retrieved with get_tag_id() or the the tag string.
+	 * @param string     $list_id The List ID.
+	 * @return true|WP_Error
+	 */
+	public function remove_tag_from_contact( $email, $tag, $list_id = null );
 }

--- a/tests/test-subscription-list.php
+++ b/tests/test-subscription-list.php
@@ -293,14 +293,18 @@ class Subscription_List_Test extends WP_UnitTestCase {
 
 		$list = new Subscription_List( self::$posts['without_settings'] );
 
-		$this->assertFalse( $list->update_current_provider_settings( '', 'test' ) );
-		$this->assertNull( $list->get_current_provider_settings() );
+		$this->assertNotFalse( $list->update_current_provider_settings( '', 'test', 'test' ) );
+		$this->assertNotEmpty( $list->get_current_provider_settings()['error'] );
 
-		$this->assertNotFalse( $list->update_current_provider_settings( '123', 'test' ) );
+		$this->assertNotFalse( $list->update_current_provider_settings( '', 'test', 'test', 'error' ) );
+		$this->assertSame( 'error', $list->get_current_provider_settings()['error'] );
+
+		$this->assertNotFalse( $list->update_current_provider_settings( '123', 123, 'test' ) );
 		$this->assertSame(
 			[
-				'list' => '123',
-				'tag'  => 'test',
+				'list'     => '123',
+				'tag_id'   => 123,
+				'tag_name' => 'test',
 			],
 			$list->get_current_provider_settings()
 		);


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

This PR changes how we are dealing with tags in the ESPs and linking them to our local Subscription Lists

* Create abstract method to make sure all providers implement the support tags in the same way
* Create methods to create tags, get tags id and others
* Save the ESP's tag ID as metadata to the Subscription List.

### How to test the changes in this Pull Request:

First, let's test the new methods.

* Configure both Mailchimp and Active Campaign with valid credentials
* Open their dashboards
* Go to `wp shell` and test the methods below (test it with both providers):

```PHP
$tag_name = 'Test tag';
$list_id = null; // required only for Mailchimp
$contact_email = 'test@test.com'; // The email of an existing contact

$provider = Newspack_Newsletters_Mailchimp::instance();
// $provider = Newspack_Newsletters_Active_Campaign::instance();

$tag_id = $provider->get_tag_id($tag_name, true, $list_id);
// Check it returns an ID and the tag was created in the ESP

$provider->add_tag_to_contact($contact_email, $tag_id, $list_id);
// Confirm that the tag was added to the contact (using ID)

$provider->remove_tag_from_contact('renato2@leo.com', $tag_name, $list_id);
// Confirm the tag was removed from the user

$provider->add_tag_to_contact('renato2@leo.com', $tag_name, $list_id);
// Confirm that the tag was added to the contact (using name)

$provider->remove_tag_from_contact('renato2@leo.com', $tag_id, $list_id);
// Confirm the tag was removed from the user

$provider->get_tag_by_id($tag_id, $list_id)
// Confirm you get the tag name

$another_tag = $provider->create_tag('Another tag', $list_id);
// Confirm $another_tag is an array and it has id and name
```
* Read the doc block of each new method and try to use them with many different values. Confirm they behave as you would expect, including error handling.

Now let's test the UI

1. Create a new Subscription List
2. Confirm you no longer have the option to leave the "List/Audience" field blank
3. Save it
4. Confirm you see the tag that was created in the metabox
5. Confirm the tag was actually created in the ESP
6. Change the title of the List and save it again. Confirm the Tag DOES NOT change
7. Go to the ESP and rename the Tag
8. Go back to wp-admin and save the list again. Confirm the Tag is updated to the value in ESP

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
