### PR TITLE
Tags support integrate local lists

### DIFF
--- a/includes/class-newspack-newsletters-subscription.php
+++ b/includes/class-newspack-newsletters-subscription.php
@@ -7,6 +7,8 @@
 
 defined( 'ABSPATH' ) || exit;
 
+use Newspack\Newsletters\Subscription_Lists;
+
 /**
  * Manages Settings Subscription Class.
  */
@@ -160,6 +162,21 @@ class Newspack_Newsletters_Subscription {
 				return $lists;
 			}
 			$config = self::get_lists_config();
+
+			$local_lists = Subscription_Lists::get_configured_for_current_provider();
+
+			$locals = [];
+			foreach ( $local_lists as $local_list ) {
+				$locals[] = [
+					'id'          => $local_list->get_form_id(),
+					'name'        => $local_list->get_title(),
+					'description' => $local_list->get_description(),
+					'type'        => 'local',
+				];
+			}
+
+			$lists = array_merge( $lists, $locals );
+
 			return array_map(
 				function( $list ) use ( $config ) {
 					if ( ! isset( $list['id'], $list['name'] ) || empty( $list['id'] ) || empty( $list['name'] ) ) {
@@ -170,7 +187,8 @@ class Newspack_Newsletters_Subscription {
 						'name'        => $list['name'],
 						'active'      => false,
 						'title'       => $list['name'],
-						'description' => '',
+						'description' => $list_config['description'] ?? '',
+						'type'        => $list['type'] ?? '',
 					];
 					if ( isset( $config[ $list['id'] ] ) ) {
 						$list_config = $config[ $list['id'] ];
@@ -388,7 +406,7 @@ class Newspack_Newsletters_Subscription {
 		} else {
 			foreach ( $lists as $list_id ) {
 				try {
-					$result = $provider->add_contact( $contact, $list_id );
+					$result = $provider->add_contact_handling_local_lists( $contact, $list_id );
 				} catch ( \Exception $e ) {
 					$errors->add( 'newspack_newsletters_subscription_add_contact', $e->getMessage() );
 				}

--- a/includes/class-newspack-newsletters-subscription.php
+++ b/includes/class-newspack-newsletters-subscription.php
@@ -187,7 +187,7 @@ class Newspack_Newsletters_Subscription {
 						'name'        => $list['name'],
 						'active'      => false,
 						'title'       => $list['name'],
-						'description' => $list_config['description'] ?? '',
+						'description' => $list['description'] ?? '',
 						'type'        => $list['type'] ?? '',
 					];
 					if ( isset( $config[ $list['id'] ] ) ) {

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -32,3 +32,6 @@ require_once __DIR__ . '/../vendor/autoload.php';
 
 // Start up the WP testing environment.
 require $_tests_dir . '/includes/bootstrap.php';
+
+// Trait used to test Subscription Lists.
+require_once 'trait-lists-setup.php';

--- a/tests/test-subscription-lists.php
+++ b/tests/test-subscription-lists.php
@@ -1,0 +1,90 @@
+<?php
+/**
+ * Class Newsletters Test Subscription_List
+ *
+ * @package Newspack_Newsletters
+ */
+
+use Newspack\Newsletters\Subscription_List;
+use Newspack\Newsletters\Subscription_Lists;
+use Newspack_Newsletters;
+
+/**
+ * Tests the Subscription_List class
+ */
+class Subscription_Lists_Test extends WP_UnitTestCase {
+
+	use Lists_Setup;
+
+	/**
+	 * Test get_all
+	 */
+	public function test_get_all() {
+		$all = Subscription_Lists::get_all();
+		$this->assertSame( 4, count( $all ) );
+	}
+
+	/**
+	 * Test get_configured_for_provider
+	 */
+	public function test_get_configured_for_provider() {
+		$all = Subscription_Lists::get_configured_for_provider( 'mailchimp' );
+		$this->assertSame( 2, count( $all ) );
+		foreach ( $all as $list ) {
+			$this->assertInstanceOf( Subscription_List::class, $list );
+			$this->assertTrue( $list->is_configured_for_provider( 'mailchimp' ) );
+			$this->assertNotSame( self::$posts['without_settings'], $list->get_id() );
+			$this->assertNotSame( self::$posts['mc_invalid'], $list->get_id() );
+		}
+
+		$all = Subscription_Lists::get_configured_for_provider( 'active_campaign' );
+		$this->assertSame( 2, count( $all ) );
+		foreach ( $all as $list ) {
+			$this->assertInstanceOf( Subscription_List::class, $list );
+			$this->assertTrue( $list->is_configured_for_provider( 'active_campaign' ) );
+			$this->assertNotSame( self::$posts['only_mailchimp'], $list->get_id() );
+		}
+	}
+
+	/**
+	 * Test get_configured_for_provider
+	 */
+	public function test_get_configured_for_current_provider() {
+		Newspack_Newsletters::set_service_provider( 'mailchimp' );
+		$all = Subscription_Lists::get_configured_for_current_provider();
+		$this->assertSame( 2, count( $all ) );
+		foreach ( $all as $list ) {
+			$this->assertInstanceOf( Subscription_List::class, $list );
+			$this->assertTrue( $list->is_configured_for_provider( 'mailchimp' ) );
+			$this->assertNotSame( self::$posts['without_settings'], $list->get_id() );
+			$this->assertNotSame( self::$posts['mc_invalid'], $list->get_id() );
+		}
+
+		Newspack_Newsletters::set_service_provider( 'active_campaign' );
+		$all = Subscription_Lists::get_configured_for_current_provider();
+		$this->assertSame( 2, count( $all ) );
+		foreach ( $all as $list ) {
+			$this->assertInstanceOf( Subscription_List::class, $list );
+			$this->assertTrue( $list->is_configured_for_provider( 'active_campaign' ) );
+			$this->assertNotSame( self::$posts['only_mailchimp'], $list->get_id() );
+		}
+	}
+
+	/**
+	 * Test get_filtered
+	 */
+	public function test_get_filtered() {
+		Newspack_Newsletters::set_service_provider( 'mailchimp' );
+		$id  = self::$posts['only_mailchimp'];
+		$all = Subscription_Lists::get_filtered(
+			function( $list ) use ( $id ) {
+				return $list->get_id() === $id;
+			}
+		);
+
+		$this->assertSame( 1, count( $all ) );
+		$this->assertSame( $id, $all[0]->get_id() );
+		
+	}
+
+}

--- a/tests/trait-lists-setup.php
+++ b/tests/trait-lists-setup.php
@@ -1,0 +1,98 @@
+<?php
+/**
+ * Class Newsletters Test Subscription_List
+ *
+ * @package Newspack_Newsletters
+ */
+
+use Newspack\Newsletters\Subscription_List;
+use Newspack\Newsletters\Subscription_Lists;
+
+/**
+ * Tests the Subscription_List class
+ */
+trait Lists_Setup {
+
+	/**
+	 * Testing posts
+	 *
+	 * @var array
+	 */
+	public static $posts;
+
+	/**
+	 * Sets up testing data
+	 *
+	 * @return void
+	 */
+	public static function set_up_before_class() {
+
+		$without_settings = self::create_post( 1 );
+
+		$only_mailchimp = self::create_post( 2 );
+		update_post_meta(
+			$only_mailchimp,
+			Subscription_List::META_KEY,
+			[
+				'mailchimp' => [
+					'list'     => 'mc_list',
+					'tag_id'   => 12,
+					'tag_name' => 'MC Tag',
+				],
+			]
+		);
+
+		$two_settings = self::create_post( 3 );
+		update_post_meta(
+			$two_settings,
+			Subscription_List::META_KEY,
+			[
+				'mailchimp'       => [
+					'list'     => 'mc_list',
+					'tag_id'   => 12,
+					'tag_name' => 'MC Tag',
+				],
+				'active_campaign' => [
+					'list'     => 'ac_list',
+					'tag_id'   => 13,
+					'tag_name' => 'AC Tag',
+				],
+			]
+		);
+
+		$mc_invalid = self::create_post( 4 );
+		update_post_meta(
+			$mc_invalid,
+			Subscription_List::META_KEY,
+			[
+				'mailchimp'       => [
+					'error' => 'Error',
+				],
+				'active_campaign' => [
+					'list'     => 'ac_list',
+					'tag_id'   => 13,
+					'tag_name' => 'AC Tag',
+				],
+			]
+		);
+
+		self::$posts = compact( 'without_settings', 'only_mailchimp', 'two_settings', 'mc_invalid' );
+	}
+
+	/**
+	 * Create a test post
+	 *
+	 * @param string|int $index An index to identify the post title and description.
+	 * @return int
+	 */
+	public static function create_post( $index ) {
+		$data = [
+			'post_title'   => 'Test List ' . $index,
+			'post_content' => 'Description ' . $index,
+			'post_type'    => Subscription_Lists::CPT,
+			'post_status'  => 'publish',
+		];
+		return wp_insert_post( $data );
+	}
+
+}


### PR DESCRIPTION
This PR depends on #1028

### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR adds the local Subscription Lists to the UI where admins can choose the enabled Lists, can place them as options for readers to sign up to, and will correctly add readers to the correspondent list and tag.

What is not done yet?
* We want to disable the option to edit the list title and details when you activate them and add a link to the custom post type instead
* The manage Newsletters page in "My Account" is not yet done

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

### How to test the changes in this Pull Request:

1. Create one or two local Subscription Lists
2. Enable them in the Newsletter Settings page
3. Add registration blocks to your site and enable the local list as options to subscribe to
4. As a reader, register/subscribe to newsletters
5. Confirm that the reader was added to the expected lists/tags in the provider dashboard
6. Test all entry points where readers can subscribe to newsletters
7. Test it with Mailchimp and Active Campaign

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
