### PR TITLE
Disable local lists edits from selection

### DIFF
--- a/includes/class-newspack-newsletters-settings.php
+++ b/includes/class-newspack-newsletters-settings.php
@@ -218,8 +218,9 @@ class Newspack_Newsletters_Settings {
 	 * Render table for subscription lists management.
 	 */
 	private static function render_lists_table() {
-		$lists = Newspack_Newsletters_Subscription::get_lists();
-		if ( is_wp_error( $lists ) || empty( $lists ) ) {
+		$lists    = Newspack_Newsletters_Subscription::get_lists();
+		$provider = Newspack_Newsletters::get_service_provider();
+		if ( empty( $provider ) || is_wp_error( $lists ) || empty( $lists ) ) {
 			return;
 		}
 		?>
@@ -259,10 +260,23 @@ class Newspack_Newsletters_Settings {
 							</td>
 							<td class="name">
 								<label for="<?php echo esc_attr( $checkbox_id ); ?>"><?php echo esc_html( $list['name'] ); ?></strong>
+								<br/>
+								<small>
+									<?php echo esc_html( $list['type_label'] ); ?>
+									<?php if ( $list['edit_link'] ) : ?>
+										(<a href="<?php echo esc_url( $list['edit_link'] ); ?>"><?php esc_html_e( 'Edit', 'newspack-newsletters' ); ?></a>)
+									<?php endif; ?>
+								</small>
 							</td>
 							<td class="details">
-								<input type="text" placeholder="<?php echo esc_attr_e( 'List title', 'newspack-newsletters' ); ?>" name="lists[<?php echo esc_attr( $list['id'] ); ?>][title]" value="<?php echo esc_attr( $list['title'] ); ?>" />
-								<textarea placeholder="<?php echo esc_attr_e( 'List description', 'newspack-newsletters' ); ?>" name="lists[<?php echo esc_attr( $list['id'] ); ?>][description]"><?php echo esc_textarea( $list['description'] ); ?></textarea>
+								<?php if ( 'local' === $list['type'] ) : ?>
+									<b><?php echo esc_html( $list['title'] ); ?></b>
+									<p><?php echo esc_html( $list['description'] ); ?></p>
+									<input type="hidden" name="lists[<?php echo esc_attr( $list['id'] ); ?>][title]" value="<?php echo esc_attr( $list['title'] ); ?>" />
+								<?php else : ?>
+									<input type="text" placeholder="<?php echo esc_attr_e( 'List title', 'newspack-newsletters' ); ?>" name="lists[<?php echo esc_attr( $list['id'] ); ?>][title]" value="<?php echo esc_attr( $list['title'] ); ?>" />
+									<textarea placeholder="<?php echo esc_attr_e( 'List description', 'newspack-newsletters' ); ?>" name="lists[<?php echo esc_attr( $list['id'] ); ?>][description]"><?php echo esc_textarea( $list['description'] ); ?></textarea>
+								<?php endif; ?>
 							</td>
 						</tr>
 					<?php endforeach; ?>

--- a/includes/class-newspack-newsletters-settings.php
+++ b/includes/class-newspack-newsletters-settings.php
@@ -218,9 +218,8 @@ class Newspack_Newsletters_Settings {
 	 * Render table for subscription lists management.
 	 */
 	private static function render_lists_table() {
-		$lists    = Newspack_Newsletters_Subscription::get_lists();
-		$provider = Newspack_Newsletters::get_service_provider();
-		if ( empty( $provider ) || is_wp_error( $lists ) || empty( $lists ) ) {
+		$lists = Newspack_Newsletters_Subscription::get_lists();
+		if ( is_wp_error( $lists ) || empty( $lists ) ) {
 			return;
 		}
 		?>

--- a/includes/class-newspack-newsletters-subscription.php
+++ b/includes/class-newspack-newsletters-subscription.php
@@ -172,13 +172,14 @@ class Newspack_Newsletters_Subscription {
 					'name'        => $local_list->get_title(),
 					'description' => $local_list->get_description(),
 					'type'        => 'local',
+					'edit_link'   => $local_list->get_edit_link(),
 				];
 			}
 
 			$lists = array_merge( $lists, $locals );
 
 			return array_map(
-				function( $list ) use ( $config ) {
+				function( $list ) use ( $config, $provider ) {
 					if ( ! isset( $list['id'], $list['name'] ) || empty( $list['id'] ) || empty( $list['name'] ) ) {
 						return;
 					}
@@ -188,18 +189,19 @@ class Newspack_Newsletters_Subscription {
 						'active'      => false,
 						'title'       => $list['name'],
 						'description' => $list['description'] ?? '',
+						'edit_link'   => $list['edit_link'] ?? '',
 						'type'        => $list['type'] ?? '',
+						'type_label'  => isset( $list['type'] ) && 'local' === $list['type'] ? __( 'Local list', 'newspack-newsletters' ) : $provider::label( 'name' ) . ' ' . $provider::label( 'List' ),
 					];
 					if ( isset( $config[ $list['id'] ] ) ) {
-						$list_config = $config[ $list['id'] ];
-						$item        = array_merge(
-							$item,
-							[
-								'active'      => $list_config['active'],
-								'title'       => $list_config['title'],
-								'description' => $list_config['description'],
-							]
-						);
+						$list_config    = $config[ $list['id'] ];
+						$item['active'] = $list_config['active'];
+						
+						// If it's a local list, ignore what is stored in the option and always use info from the Subscription_List object.
+						if ( 'local' !== $item['type'] ) {
+							$item['title']       = $list_config['title'];
+							$item['description'] = $list_config['description'];
+						}
 					}
 					return $item;
 				},

--- a/includes/class-subscription-list.php
+++ b/includes/class-subscription-list.php
@@ -124,6 +124,17 @@ class Subscription_List {
 	}
 
 	/**
+	 * Gets the link to edit this list
+	 *
+	 * In some rest requests, the post type is not registered, so we can't use get_edit_post_link
+	 *
+	 * @return string
+	 */
+	public function get_edit_link() {
+		return sprintf( admin_url( 'post.php?post=%d&action=edit' ), $this->get_id() );
+	}
+
+	/**
 	 * Generate the tag name that will be added to the ESP based on the post title
 	 *
 	 * @return string


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Disables the edit of title and description from the list where we select the active Subscription Lists.

Since they are created locally, there is no need to edit the title and description again. Instead of allowing edits, link to the edit page.

### How to test the changes in this Pull Request:

1.Set up Mailchimp or AC as provider
2. Go to Newsletters > Lists and create a couple of lists
3. Go to Newsletters > Settings
4. Go to the "Subscription Lists" section
5. Make sure the Local lists are marked as such and you can't edit their title and description
6. Make sure the edit links points to the righ place
7. Make sure you are still able to enable/disable them
8. And make sure they are still working in the rest of the application (registration form, etc)

![Captura de tela de 2022-11-28 10-21-06](https://user-images.githubusercontent.com/971483/204311368-8ca31aac-2483-45d9-b486-20fd0b183baa.png)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
