### PR TITLE
fix: attribute types in posts inserter block.json

### DIFF
--- a/src/editor/blocks/posts-inserter/block.json
+++ b/src/editor/blocks/posts-inserter/block.json
@@ -1,7 +1,9 @@
 {
 	"name": "newspack-newsletters/posts-inserter",
 	"category": "widgets",
-	"supports": [ "align" ],
+	"supports": [
+		"align"
+	],
 	"attributes": {
 		"areBlocksInserted": {
 			"type": "boolean",
@@ -11,7 +13,15 @@
 			"type": "number",
 			"default": 3
 		},
+		"preventDeduplication": {
+			"type": "boolean",
+			"default": false
+		},
 		"displayPostSubtitle": {
+			"type": "boolean",
+			"default": false
+		},
+		"displayAuthor": {
 			"type": "boolean",
 			"default": false
 		},
@@ -56,13 +66,13 @@
 			"default": []
 		},
 		"textFontSize": {
-			"type": "number"
+			"type": "string"
 		},
 		"headingFontSize": {
-			"type": "number"
+			"type": "string"
 		},
 		"subHeadingFontSize": {
-			"type": "number"
+			"type": "string"
 		},
 		"textColor": {
 			"type": "string"


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes the attribute types for all font-size related attributes in Posts Inserter blocks, and adds the missing `displayAuthor` attribute to the block.json manifest. In both cases the mismatched attribute type/value and the missing attribute prevented those attributes' values from being saved.

Also adds the missing `preventDeduplication` to the block.json manifest, but this isn't currently exposed as an editable option so this shouldn't affect functionality. See /0/1200550061930446/1203451612303419/ for more details.

Closes /0/1200550061930446/1203452267509212.

### How to test the changes in this Pull Request:

1. On `master`, create a newsletter and add a Posts Inserter block.
2. Change the values for "Display author", and the font sizes under "Text style", "Heading style", and "Subtitle style" panels.
3. Save the post and refresh. Observe that the updated attributes have reverted to their defaults.
4. Check out this branch and repeat steps 2-3. Confirm that the attributes are saved properly.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
