### PR TITLE
feat: notice that we cant create segments

### DIFF
--- a/css/subscription-list-editor.css
+++ b/css/subscription-list-editor.css
@@ -1,0 +1,16 @@
+.subscription-list-tag {
+    color: #1e1e1e;
+    margin: 2px 4px;
+    border-radius: 8px;
+    background: #ddd;
+    padding: 2px 8px;
+}
+
+.subscription-list-warning {
+    border: 1px solid #c3c4c7;
+    border-left-width: 4px;
+    box-shadow: 0 1px 1px rgba(0, 0, 0, 0.04);
+    margin: 5px 0 15px;
+    border-left-color: #dba617;
+    padding: 11px 15px;
+}

--- a/includes/class-subscription-lists.php
+++ b/includes/class-subscription-lists.php
@@ -266,6 +266,14 @@ class Subscription_Lists {
 			<p>
 				<?php echo esc_html( $current_settings['tag_name'] ?? __( 'Tag was not created yet, please save the list', 'newspack-newsletters' ) ); ?>
 			</p>
+			<?php 
+			/**
+			 * Fires after the tag field in the list metabox.
+			 *
+			 * @param array $current_settings The current list settings.
+			 */
+			do_action( 'newspack_newsletters_subscription_lists_metabox_after_tag', $current_settings );
+			?>
 		</div>
 
 		<?php if ( $subscription_list->has_other_configured_providers() ) : ?>

--- a/includes/service-providers/active_campaign/class-newspack-newsletters-active-campaign.php
+++ b/includes/service-providers/active_campaign/class-newspack-newsletters-active-campaign.php
@@ -1291,7 +1291,7 @@ final class Newspack_Newsletters_Active_Campaign extends \Newspack_Newsletters_S
 	public function lists_metabox_notice( $settings ) {
 		if ( $settings['tag_name'] ) {
 			?>
-			<p>
+			<p class="subscription-list-warning">
 				<?php
 				echo wp_kses(
 					sprintf(

--- a/includes/service-providers/active_campaign/class-newspack-newsletters-active-campaign.php
+++ b/includes/service-providers/active_campaign/class-newspack-newsletters-active-campaign.php
@@ -50,6 +50,8 @@ final class Newspack_Newsletters_Active_Campaign extends \Newspack_Newsletters_S
 		add_action( 'save_post_' . Newspack_Newsletters::NEWSPACK_NEWSLETTERS_CPT, [ $this, 'save' ], 10, 3 );
 		add_action( 'wp_trash_post', [ $this, 'trash' ], 10, 1 );
 
+		add_action( 'newspack_newsletters_subscription_lists_metabox_after_tag', [ $this, 'lists_metabox_notice' ] );
+
 		parent::__construct( $this );
 	}
 
@@ -1251,5 +1253,36 @@ final class Newspack_Newsletters_Active_Campaign extends \Newspack_Newsletters_S
 				'name' => 'Active Campaign',
 			]
 		);
+	}
+
+	/**
+	 * Add a notice to the Subscription Lists metabox letting the user know that they have to manually create the Segment
+	 *
+	 * @param array $settings The List settings.
+	 * @return void
+	 */
+	public function lists_metabox_notice( $settings ) {
+		if ( $settings['tag_name'] ) {
+			?>
+			<p>
+				<?php
+				echo wp_kses(
+					sprintf(
+						/* translators: %1$s and %2$s are opening and closing link tag to Active Campaign documentation. */
+						__( 'Note for Active Campaign: You need to manually create a segment using the above tag to be able to send campaigns to this list. %1$sLearn more%2$s', 'newspack-newsletters' ),
+						'<a href="https://help.activecampaign.com/hc/en-us/articles/221483407-How-to-create-segments-in-ActiveCampaign" target="_blank">',
+						'</a>'
+					),
+					[
+						'a' => [
+							'href'   => [],
+							'target' => [],
+						],
+					]
+				);
+				?>
+			</p>
+			<?php
+		}
 	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

In Active Campaign, we can't send a campaign for users based on a tag, we need to create a Segment for it.

But unfortunately AC APIs (v1 and v3) do not offer a way to programatically create segments. Therefore, we need to tell users they will have to manually create a Segment for each Local Subscription List they create.

This PR adds a small notice in the metabox

### How to test the changes in this Pull Request:

1. Set Active Campaign as your provider
2. Go to Newsletters > Lists and create a new list
3. Confirm that you don't see any notice in the metabox until you save the list

![Captura de tela de 2022-12-08 16-33-06](https://user-images.githubusercontent.com/971483/206555818-b81331d3-071a-44dd-92a4-d00b157b8ed1.png)

5. After you save the list, confirm the notice is there
6. Check for typos and if the link works

![Captura de tela de 2022-12-08 16-25-59](https://user-images.githubusercontent.com/971483/206556053-40d8605c-225b-44a7-879c-769e751b622c.png)


8. Suggestions on the copy?
9. Go to Newsletters > Lists, confirm that the tags are properly displayed in the list

![Captura de tela de 2022-12-08 16-42-00](https://user-images.githubusercontent.com/971483/206555788-9b4817a4-ecbd-41fe-946e-d2372b06e785.png)




### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
