### PR TITLE
feat(constant-contact): improved oauth flow

### DIFF
--- a/includes/class-newspack-newsletters-settings.php
+++ b/includes/class-newspack-newsletters-settings.php
@@ -230,7 +230,15 @@ class Newspack_Newsletters_Settings {
 		?>
 		<div class="newspack-newsletters-oauth notice notice-warning">
 			<h2><?php esc_html_e( 'Authorize the application', 'newspack-newsletters' ); ?></h2>
-			<p><?php esc_html_e( 'To use this provider, you need to authorize the application.', 'newspack-newsletters' ); ?></p>
+			<p>
+			<?php
+			echo sprintf(
+				/* translators: %s: email service provider name */
+				esc_html__( 'Authorize %s to connect to Newspack.', 'newspack-newsletters' ),
+				esc_html( $provider->name )
+			);
+			?>
+				</p>
 			<p><a href="<?php echo esc_url( $token['auth_url'] ); ?>" class="button"><?php esc_html_e( 'Authorize', 'newspack-newsletters' ); ?></a></p>
 		</div>
 		<?php

--- a/includes/service-providers/active_campaign/class-newspack-newsletters-active-campaign.php
+++ b/includes/service-providers/active_campaign/class-newspack-newsletters-active-campaign.php
@@ -34,6 +34,13 @@ final class Newspack_Newsletters_Active_Campaign extends \Newspack_Newsletters_S
 	private $contact_data = [];
 
 	/**
+	 * Provider name.
+	 *
+	 * @var string
+	 */
+	public $name = 'ActiveCampaign';
+
+	/**
 	 * Class constructor.
 	 */
 	public function __construct() {

--- a/includes/service-providers/campaign_monitor/class-newspack-newsletters-campaign-monitor.php
+++ b/includes/service-providers/campaign_monitor/class-newspack-newsletters-campaign-monitor.php
@@ -16,6 +16,13 @@ define( 'CS_REST_CALL_TIMEOUT', 30 );
 final class Newspack_Newsletters_Campaign_Monitor extends \Newspack_Newsletters_Service_Provider {
 
 	/**
+	 * Provider name.
+	 *
+	 * @var string
+	 */
+	public $name = 'Campaign Monitor';
+
+	/**
 	 * Class constructor.
 	 */
 	public function __construct() {

--- a/includes/service-providers/constant_contact/class-newspack-newsletters-constant-contact-sdk.php
+++ b/includes/service-providers/constant_contact/class-newspack-newsletters-constant-contact-sdk.php
@@ -38,7 +38,7 @@ final class Newspack_Newsletters_Constant_Contact_SDK {
 	 *
 	 * @var string[]
 	 */
-	private $scope = [ 'account_read', 'contact_data', 'campaign_data' ];
+	private $scope = [ 'offline_access', 'account_read', 'contact_data', 'campaign_data' ];
 
 	/**
 	 * API Key

--- a/includes/service-providers/constant_contact/class-newspack-newsletters-constant-contact.php
+++ b/includes/service-providers/constant_contact/class-newspack-newsletters-constant-contact.php
@@ -27,6 +27,13 @@ final class Newspack_Newsletters_Constant_Contact extends \Newspack_Newsletters_
 	private $contact_data = [];
 
 	/**
+	 * Provider name.
+	 *
+	 * @var string
+	 */
+	public $name = 'Contant Constact';
+
+	/**
 	 * Class constructor.
 	 */
 	public function __construct() {

--- a/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp.php
+++ b/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp.php
@@ -15,6 +15,13 @@ use \DrewM\MailChimp\MailChimp;
 final class Newspack_Newsletters_Mailchimp extends \Newspack_Newsletters_Service_Provider {
 
 	/**
+	 * Provider name.
+	 *
+	 * @var string
+	 */
+	public $name = 'Mailchimp';
+
+	/**
 	 * Class constructor.
 	 */
 	public function __construct() {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR is a part of #1023 and fixes an issue with the provider's refresh token.

To obtain a refresh token - so the access token can be seamlessly updated - the API is missing an `offline_access` scope.  The OAuth flow is improved so that it can also be performed on the plugin's settings page:

<img width="544" alt="image" src="https://user-images.githubusercontent.com/820752/206214011-1d1412ff-e1af-4efe-a127-33ac3315c348.png">

### How to test the changes in this Pull Request:

1. Set your ESP to Constant Contact with valid API credentials
2. Make sure to delete these WP options: `newspack_newsletters_constant_contact_api_access_token`, `newspack_newsletters_constant_contact_api_refresh_token`
3. Visit the plugin's settings page
4. Confirm you see the notice on top of the form
5. Click to Authorize and go through with the flow (it may authorize automatically if the app was already previously authorized)
6. Confirm the page is refreshed and the subscription lists are rendered
7. Confirm that both WP options mentioned above exist in the database

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
