### PR TITLE
Add tags support to Constant Contact

### DIFF
--- a/includes/service-providers/active_campaign/class-newspack-newsletters-active-campaign.php
+++ b/includes/service-providers/active_campaign/class-newspack-newsletters-active-campaign.php
@@ -316,7 +316,7 @@ final class Newspack_Newsletters_Active_Campaign extends \Newspack_Newsletters_S
 	 * Add a tag to a contact
 	 *
 	 * @param string     $email The contact email.
-	 * @param string|int $tag The tag ID retrieved with get_tag_id() or the the tag string.
+	 * @param string|int $tag The tag ID.
 	 * @param string     $list_id The List ID. Not needed for Active Campaign.
 	 * @return true|WP_Error
 	 */
@@ -324,12 +324,6 @@ final class Newspack_Newsletters_Active_Campaign extends \Newspack_Newsletters_S
 		$existing_contact = $this->get_contact_data( $email );
 		if ( is_wp_error( $existing_contact ) ) {
 			return $existing_contact;
-		}
-		if ( ! is_integer( $tag ) ) {
-			$tag = $this->get_tag_id( (string) $tag );
-			if ( is_wp_error( $tag ) ) {
-				return $tag;
-			}
 		}
 
 		$contact_tag = [
@@ -362,7 +356,7 @@ final class Newspack_Newsletters_Active_Campaign extends \Newspack_Newsletters_S
 	 * Remove a tag from a contact
 	 *
 	 * @param string     $email The contact email.
-	 * @param string|int $tag The tag ID retrieved with get_tag_id() or the the tag string.
+	 * @param string|int $tag The tag ID.
 	 * @param string     $list_id The List ID. Not needed for Active Campaign.
 	 * @return true|WP_Error
 	 */
@@ -370,12 +364,6 @@ final class Newspack_Newsletters_Active_Campaign extends \Newspack_Newsletters_S
 		$existing_contact = $this->get_contact_data( $email );
 		if ( is_wp_error( $existing_contact ) ) {
 			return $existing_contact;
-		}
-		if ( ! is_integer( $tag ) ) {
-			$tag = $this->get_tag_id( (string) $tag, false );
-			if ( is_wp_error( $tag ) ) {
-				return $tag;
-			}
 		}
 
 		$contact_tag_id = $this->get_contact_tag_id( $email, $tag );
@@ -1152,29 +1140,6 @@ final class Newspack_Newsletters_Active_Campaign extends \Newspack_Newsletters_S
 			if ( is_wp_error( $result ) ) {
 				return $result;
 			}
-		}
-		return true;
-	}
-
-	/**
-	 * Update a contact tags.
-	 *
-	 * @param string   $email          Contact email address.
-	 * @param string[] $tags_to_add    Array of tags to add to the contact.
-	 * @param string[] $tags_to_remove Array of tags to remove from the contact.
-	 *
-	 * @return true|WP_Error True if the contact was updated or error.
-	 */
-	public function update_contact_tags( $email, $tags_to_add = [], $tags_to_remove = [] ) {
-		$existing_contact = $this->get_contact_data( $email );
-		if ( is_wp_error( $existing_contact ) ) {
-			return $existing_contact;
-		}
-		foreach ( $tags_to_add as $tag_add ) {
-			$this->add_tag_to_contact( $email, $tag_add );
-		}
-		foreach ( $tags_to_remove as $tag_remove ) {
-			$this->remove_tag_from_contact( $email, $tag_remove );
 		}
 		return true;
 	}

--- a/includes/service-providers/class-newspack-newsletters-service-provider.php
+++ b/includes/service-providers/class-newspack-newsletters-service-provider.php
@@ -430,7 +430,7 @@ abstract class Newspack_Newsletters_Service_Provider implements Newspack_Newslet
 				}
 
 				if ( static::$support_tags ) {
-					$this->add_tag_to_contact( $contact['email'], (int) $list_settings['tag_id'], $list_settings['list'] );
+					$this->add_tag_to_contact( $contact['email'], $list_settings['tag_id'], $list_settings['list'] );
 				}
 
 				return $added_contact;
@@ -498,9 +498,9 @@ abstract class Newspack_Newsletters_Service_Provider implements Newspack_Newslet
 					$list_settings = $list->get_provider_settings( $this->service );
 
 					if ( 'add' === $action ) {
-						$this->add_tag_to_contact( $email, (int) $list_settings['tag_id'], $list_settings['list'] );
+						$this->add_tag_to_contact( $email, $list_settings['tag_id'], $list_settings['list'] );
 					} elseif ( 'remove' === $action ) {
-						$this->remove_tag_from_contact( $email, (int) $list_settings['tag_id'], $list_settings['list'] );
+						$this->remove_tag_from_contact( $email, $list_settings['tag_id'], $list_settings['list'] );
 					}
 					
 					unset( $lists[ $key ] );
@@ -571,8 +571,8 @@ abstract class Newspack_Newsletters_Service_Provider implements Newspack_Newslet
 	/**
 	 * Retrieve the ESP's tag name from its ID
 	 *
-	 * @param int    $tag_id The tag ID.
-	 * @param string $list_id The List ID.
+	 * @param string|int $tag_id The tag ID.
+	 * @param string     $list_id The List ID.
 	 * @return string|WP_Error The tag name on success. WP_Error on failure.
 	 */
 	public function get_tag_by_id( $tag_id, $list_id = null ) {
@@ -594,7 +594,7 @@ abstract class Newspack_Newsletters_Service_Provider implements Newspack_Newslet
 	 * Add a tag to a contact
 	 *
 	 * @param string     $email The contact email.
-	 * @param string|int $tag The tag ID retrieved with get_tag_id() or the the tag string.
+	 * @param string|int $tag The tag ID.
 	 * @param string     $list_id The List ID.
 	 * @return true|WP_Error
 	 */
@@ -606,7 +606,7 @@ abstract class Newspack_Newsletters_Service_Provider implements Newspack_Newslet
 	 * Remove a tag from a contact
 	 *
 	 * @param string     $email The contact email.
-	 * @param string|int $tag The tag ID retrieved with get_tag_id() or the the tag string.
+	 * @param string|int $tag The tag ID.
 	 * @param string     $list_id The List ID.
 	 * @return true|WP_Error
 	 */

--- a/includes/service-providers/constant_contact/class-newspack-newsletters-constant-contact-sdk.php
+++ b/includes/service-providers/constant_contact/class-newspack-newsletters-constant-contact-sdk.php
@@ -638,16 +638,16 @@ final class Newspack_Newsletters_Constant_Contact_SDK {
 	 * @return stdClass|WP_Error The tag object or a WP_Error if the tag was not found.
 	 */
 	public function get_tag_by_name( $name ) {
-		$limit_attempts     = 10;
-		$itemps_per_attempt = 100;
-		$cursor             = '';
+		$limit_attempts    = 10;
+		$items_per_attempt = 100;
+		$cursor            = '';
 		for ( $attempt = 1; $attempt <= $limit_attempts; $attempt++ ) {
 			$res = $this->request(
 				'GET',
 				'/contact_tags',
 				[
 					'query' => [
-						'limit'  => $itemps_per_attempt,
+						'limit'  => $items_per_attempt,
 						'cursor' => $cursor,
 					],
 				]

--- a/includes/service-providers/constant_contact/class-newspack-newsletters-constant-contact-sdk.php
+++ b/includes/service-providers/constant_contact/class-newspack-newsletters-constant-contact-sdk.php
@@ -474,7 +474,7 @@ final class Newspack_Newsletters_Constant_Contact_SDK {
 				'query' => [
 					'email'   => $email_address,
 					'status'  => 'all',
-					'include' => 'custom_fields,list_memberships',
+					'include' => 'custom_fields,list_memberships,taggings',
 				],
 			]
 		);
@@ -614,6 +614,9 @@ final class Newspack_Newsletters_Constant_Contact_SDK {
 					}
 				}
 			}
+			if ( isset( $data['taggings'] ) ) { // Using isset and not empty because this can be an empty array.
+				$body['taggings'] = $data['taggings'];
+			}
 		}
 		$res = $this->request(
 			$contact ? 'PUT' : 'POST',
@@ -621,5 +624,139 @@ final class Newspack_Newsletters_Constant_Contact_SDK {
 			[ 'body' => wp_json_encode( $body ) ]
 		);
 		return $this->get_contact( $email_address );
+	}
+
+	/**
+	 * Fetches a tag by its name
+	 *
+	 * Constant Contact API does not offer an endpoint to search for a tag by its name, so we have to query for all tags and look through them.
+	 *
+	 * If there are too many tags, we might not go over them all might fail in finding it, but that is a known limitation for now.
+	 * That's why we chose to do a case insensitive search, to increase the chances of finding the tag.
+	 *
+	 * @param string $name The tag name you are looking for. Case insensitive.
+	 * @return stdClass|WP_Error The tag object or a WP_Error if the tag was not found.
+	 */
+	public function get_tag_by_name( $name ) {
+		$limit_attempts     = 10;
+		$itemps_per_attempt = 100;
+		$cursor             = '';
+		for ( $attempt = 1; $attempt <= $limit_attempts; $attempt++ ) {
+			$res = $this->request(
+				'GET',
+				'/contact_tags',
+				[
+					'query' => [
+						'limit'  => $itemps_per_attempt,
+						'cursor' => $cursor,
+					],
+				]
+			);
+			if ( ! empty( $res->tags ) ) {
+				foreach ( $res->tags as $tag ) {
+					if ( strtolower( $name ) === strtolower( $tag->name ) ) {
+						return $tag;
+					}
+				}
+			}
+
+			if ( ! empty( $res->_links ) && ! empty( $res->_links->next ) && ! empty( $res->_links->next->href ) ) {
+				$cursor = preg_match( '/cursor=([^&]+)$/', $res->_links->next->href, $matches ) ? $matches[1] : '';
+			} else {
+				return new WP_Error( 'newspack_newsletter_tag_not_found' );
+			}
+		}
+	}
+
+	/**
+	 * Create a tag
+	 *
+	 * @param string $name The name of the tag to create.
+	 * @return stdClass|WP_Error The tag object or a WP_Error if the tag could not be created.
+	 */
+	public function create_tag( $name ) {
+		try {
+			$res = $this->request(
+				'POST',
+				'/contact_tags',
+				[
+					'body' => wp_json_encode(
+						[
+							'name' => $name,
+						]
+					),
+				]
+			);
+			return $res;
+		} catch ( Exception $e ) {
+			return new WP_Error( 'newspack_newsletter_error_creating_tag', $e->getMessage() );
+		}
+	}
+
+	/**
+	 * Create a Segment that will group users tagged with a given tag
+	 *
+	 * @param string $tag_id The ID of the tag to create a segment for.
+	 * @param string $tag_name The name of the tag to create a segment for.
+	 * @return stdClass|WP_Error The segment object or a WP_Error if the segment could not be created.
+	 */
+	public function create_tag_segment( $tag_id, $tag_name = '' ) {
+		$tag_name = $tag_name ? $tag_name : $tag_id;
+		$name     = 'Tagged with ' . $tag_name;
+		$criteria = [
+			'version'  => '1.0.0',
+			'criteria' => [
+				'type'  => 'and',
+				'group' => [
+					[
+						'type'  => 'or',
+						'group' => [
+							[
+								'source' => 'tags',
+								'field'  => 'tag_id',
+								'op'     => 'eq',
+								'value'  => $tag_id,
+							],
+						],
+					],
+				],
+			],
+		];
+
+		$body = wp_json_encode(
+			[
+				'name'             => $name,
+				'segment_criteria' => wp_json_encode( $criteria ),
+				
+			]
+		);
+
+		try {
+			$res = $this->request(
+				'POST',
+				'/segments',
+				[
+					'body' => $body,
+				]
+			);
+			return $res;
+		} catch ( Exception $e ) {
+			return new WP_Error( 'newspack_newsletter_error_creating_tag_segment', $e->getMessage() );
+		}
+	}
+
+	/**
+	 * Get a tag from its ID
+	 *
+	 * @param string $tag_id The ID of the tag to get.
+	 * @return stdClass|WP_Error The tag object or a WP_Error if the tag could not be found.
+	 */
+	public function get_tag_by_id( $tag_id ) {
+		try {
+			$res = $this->request( 'GET', '/contact_tags/' . $tag_id );
+			return $res;
+		} catch ( Exception $e ) {
+			return new WP_Error( 'newspack_newsletter_tag_not_found', $e->getMessage() );
+		}
 	}
 }

--- a/includes/service-providers/constant_contact/class-newspack-newsletters-constant-contact.php
+++ b/includes/service-providers/constant_contact/class-newspack-newsletters-constant-contact.php
@@ -38,7 +38,7 @@ final class Newspack_Newsletters_Constant_Contact extends \Newspack_Newsletters_
 	 *
 	 * @var boolean
 	 */
-	public static $support_tags = true;
+	public static $support_local_lists = true;
 
 	/**
 	 * Class constructor.

--- a/includes/service-providers/constant_contact/class-newspack-newsletters-constant-contact.php
+++ b/includes/service-providers/constant_contact/class-newspack-newsletters-constant-contact.php
@@ -34,6 +34,13 @@ final class Newspack_Newsletters_Constant_Contact extends \Newspack_Newsletters_
 	public $name = 'Contant Constact';
 
 	/**
+	 * Whether the provider has support to tags and tags based Subscription Lists.
+	 *
+	 * @var boolean
+	 */
+	public static $support_tags = true;
+
+	/**
 	 * Class constructor.
 	 */
 	public function __construct() {
@@ -823,6 +830,113 @@ final class Newspack_Newsletters_Constant_Contact extends \Newspack_Newsletters_
 				'name' => 'Constant Contact',
 			]
 		);
+	}
+
+	/**
+	 * Retrieve the ESP's tag ID from its name
+	 *
+	 * @param string  $tag_name The tag.
+	 * @param boolean $create_if_not_found Whether to create a new tag if not found. Default to true.
+	 * @param string  $list_id The List ID.
+	 * @return int|WP_Error The tag ID on success. WP_Error on failure.
+	 */
+	public function get_tag_id( $tag_name, $create_if_not_found = true, $list_id = null ) {
+		$cc  = new Newspack_Newsletters_Constant_Contact_SDK( $this->api_key(), $this->api_secret(), $this->access_token() );
+		$tag = $cc->get_tag_by_name( $tag_name );
+		if ( is_wp_error( $tag ) && $create_if_not_found ) {
+			$tag = $this->create_tag( $tag_name );
+		}
+		if ( is_wp_error( $tag ) ) {
+			return $tag;
+		}
+		return $tag['id'];
+	}
+
+	/**
+	 * Retrieve the ESP's tag name from its ID
+	 *
+	 * @param string|int $tag_id The tag ID.
+	 * @param string     $list_id The List ID.
+	 * @return string|WP_Error The tag name on success. WP_Error on failure.
+	 */
+	public function get_tag_by_id( $tag_id, $list_id = null ) {
+		$cc  = new Newspack_Newsletters_Constant_Contact_SDK( $this->api_key(), $this->api_secret(), $this->access_token() );
+		$tag = $cc->get_tag_by_id( $tag_id );
+		if ( is_wp_error( $tag ) ) {
+			return $tag;
+		}
+		return $tag->name;
+	}
+
+	/**
+	 * Create a Tag on the provider
+	 *
+	 * @param string $tag The Tag name.
+	 * @param string $list_id The List ID.
+	 * @return array|WP_Error The tag representation with at least 'id' and 'name' keys on succes. WP_Error on failure.
+	 */
+	public function create_tag( $tag, $list_id = null ) {
+		$cc  = new Newspack_Newsletters_Constant_Contact_SDK( $this->api_key(), $this->api_secret(), $this->access_token() );
+		$tag = $cc->create_tag( $tag );
+		if ( is_wp_error( $tag ) ) {
+			return $tag;
+		}
+		// Also create a Segment grouping users tagged with this tag.
+		$cc->create_tag_segment( $tag->tag_id, $tag->name );
+		return [
+			'id'   => $tag->tag_id,
+			'name' => $tag->name,
+		];
+	}
+
+	/**
+	 * Add a tag to a contact
+	 *
+	 * @param string     $email The contact email.
+	 * @param string|int $tag The tag ID.
+	 * @param string     $list_id The List ID.
+	 * @return true|WP_Error
+	 */
+	public function add_tag_to_contact( $email, $tag, $list_id = null ) {
+		$tags = $this->get_contact_tags_ids( $email );
+		if ( in_array( $tag, $tags, true ) ) {
+			return true;
+		}
+		$new_tags = array_merge( $tags, [ $tag ] );
+		$cc       = new Newspack_Newsletters_Constant_Contact_SDK( $this->api_key(), $this->api_secret(), $this->access_token() );
+		return $cc->upsert_contact( $email, [ 'taggings' => $new_tags ] );
+	}
+
+	/**
+	 * Remove a tag from a contact
+	 *
+	 * @param string     $email The contact email.
+	 * @param string|int $tag The tag ID.
+	 * @param string     $list_id The List ID.
+	 * @return true|WP_Error
+	 */
+	public function remove_tag_from_contact( $email, $tag, $list_id = null ) {
+		$tags     = $this->get_contact_tags_ids( $email );
+		$new_tags = array_diff( $tags, [ $tag ] );
+		if ( count( $new_tags ) === count( $tags ) ) {
+			return true;
+		}
+		$cc = new Newspack_Newsletters_Constant_Contact_SDK( $this->api_key(), $this->api_secret(), $this->access_token() );
+		return $cc->upsert_contact( $email, [ 'taggings' => $new_tags ] );
+	}
+
+	/**
+	 * Get the IDs of the tags associated with a contact.
+	 *
+	 * @param string $email The contact email.
+	 * @return array|WP_Error The tag IDs on success. WP_Error on failure.
+	 */
+	public function get_contact_tags_ids( $email ) {
+		$contact_data = $this->get_contact_data( $email );
+		if ( is_wp_error( $contact_data ) ) {
+			return $contact_data;
+		}
+		return $contact_data['taggings'] ?? [];
 	}
 
 }

--- a/includes/service-providers/interface-newspack-newsletters-esp-service.php
+++ b/includes/service-providers/interface-newspack-newsletters-esp-service.php
@@ -146,7 +146,7 @@ interface Newspack_Newsletters_ESP_API_Interface {
 	 * Add a tag to a contact
 	 *
 	 * @param string     $email The contact email.
-	 * @param string|int $tag The tag ID retrieved with get_tag_id() or the the tag string.
+	 * @param string|int $tag The tag ID.
 	 * @param string     $list_id The List ID.
 	 * @return true|WP_Error
 	 */
@@ -156,7 +156,7 @@ interface Newspack_Newsletters_ESP_API_Interface {
 	 * Remove a tag from a contact
 	 *
 	 * @param string     $email The contact email.
-	 * @param string|int $tag The tag ID retrieved with get_tag_id() or the the tag string.
+	 * @param string|int $tag The tag ID.
 	 * @param string     $list_id The List ID.
 	 * @return true|WP_Error
 	 */

--- a/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp.php
+++ b/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp.php
@@ -193,7 +193,7 @@ final class Newspack_Newsletters_Mailchimp extends \Newspack_Newsletters_Service
 	 * Add a tag to a contact
 	 *
 	 * @param string     $email The contact email.
-	 * @param string|int $tag The tag ID retrieved with get_tag_id() or the the tag string.
+	 * @param string|int $tag The tag ID.
 	 * @param string     $list_id The List ID.
 	 * @return true|WP_Error
 	 */
@@ -201,12 +201,6 @@ final class Newspack_Newsletters_Mailchimp extends \Newspack_Newsletters_Service
 		$existing_contact = $this->get_contact_data( $email );
 		if ( is_wp_error( $existing_contact ) ) {
 			return $existing_contact;
-		}
-		if ( ! is_integer( $tag ) ) {
-			$tag = $this->get_tag_id( (string) $tag, true, $list_id );
-			if ( is_wp_error( $tag ) ) {
-				return $tag;
-			}
 		}
 		$mc      = new Mailchimp( $this->api_key() );
 		$created = $mc->post(
@@ -231,7 +225,7 @@ final class Newspack_Newsletters_Mailchimp extends \Newspack_Newsletters_Service
 	 * Remove a tag from a contact
 	 *
 	 * @param string     $email The contact email.
-	 * @param string|int $tag The tag ID retrieved with get_tag_id() or the the tag string.
+	 * @param string|int $tag The tag ID.
 	 * @param string     $list_id The List ID.
 	 * @return true|WP_Error
 	 */
@@ -239,12 +233,6 @@ final class Newspack_Newsletters_Mailchimp extends \Newspack_Newsletters_Service
 		$existing_contact = $this->get_contact_data( $email );
 		if ( is_wp_error( $existing_contact ) ) {
 			return $existing_contact;
-		}
-		if ( ! is_integer( $tag ) ) {
-			$tag = $this->get_tag_id( (string) $tag, false, $list_id );
-			if ( is_wp_error( $tag ) ) {
-				return $tag;
-			}
 		}
 		$mc      = new Mailchimp( $this->api_key() );
 		$created = $mc->post(


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Adds support to Tags for the Constant Contact provider. This will enable the new Lists feature for this provider.

### How to test the changes in this Pull Request:

1. Set Constant Contact as the provider with proper credentials
2. Go to Newsletter > Lists
3. Create a new list
4. Confirm that a correspondent tag is created in the provider
5. Go to Newsletter > Settings and enable the list in the Subsctiption Lists section
6. Add a registration or Newsletter subscription block to your site with that list as an option
7. As a visitor, register to a newsletter selecting that list
8. confirm the contact is created with the correct tag in the provider
9. confirm also that a Segment was created with users tagged with this tag
10. (Note: Constant Contact is not supported in the "My account" page for managing subscriptions, this is unrelated with this PR)
11. As a failsafe, make sure the same steps above are still working with other providers

Also note that the ability to select this segment in the editor when sending newsletters will be added in another PR (UPDATE: It was added in https://github.com/Automattic/newspack-newsletters/pull/1055)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
