### PR TITLE
Allow constant contact to send to segments

### DIFF
--- a/includes/service-providers/constant_contact/class-newspack-newsletters-constant-contact-controller.php
+++ b/includes/service-providers/constant_contact/class-newspack-newsletters-constant-contact-controller.php
@@ -147,6 +147,42 @@ class Newspack_Newsletters_Constant_Contact_Controller extends Newspack_Newslett
 				],
 			]
 		);
+		\register_rest_route(
+			$this->service_provider::BASE_NAMESPACE . $this->service_provider->service,
+			'(?P<id>[\a-z]+)/segment/(?P<segment_id>[\a-z]+)',
+			[
+				'methods'             => \WP_REST_Server::EDITABLE,
+				'callback'            => [ $this, 'api_segment' ],
+				'permission_callback' => [ $this->service_provider, 'api_authoring_permissions_check' ],
+				'args'                => [
+					'id'         => [
+						'sanitize_callback' => 'absint',
+						'validate_callback' => [ 'Newspack_Newsletters', 'validate_newsletter_id' ],
+					],
+					'segment_id' => [
+						'sanitize_callback' => 'esc_attr',
+					],
+				],
+			]
+		);
+		\register_rest_route(
+			$this->service_provider::BASE_NAMESPACE . $this->service_provider->service,
+			'(?P<id>[\a-z]+)/segment/',
+			[
+				'methods'             => \WP_REST_Server::DELETABLE,
+				'callback'            => [ $this, 'api_segment' ],
+				'permission_callback' => [ $this->service_provider, 'api_authoring_permissions_check' ],
+				'args'                => [
+					'id'         => [
+						'sanitize_callback' => 'absint',
+						'validate_callback' => [ 'Newspack_Newsletters', 'validate_newsletter_id' ],
+					],
+					'segment_id' => [
+						'sanitize_callback' => 'esc_attr',
+					],
+				],
+			]
+		);
 	}
 
 	/**
@@ -220,6 +256,26 @@ class Newspack_Newsletters_Constant_Contact_Controller extends Newspack_Newslett
 			$response = $this->service_provider->list(
 				$request['id'],
 				$request['list_id']
+			);
+		}
+		return self::get_api_response( $response );
+	}
+
+	/**
+	 * Set segment for a campaign.
+	 *
+	 * @param WP_REST_Request $request API request object.
+	 * @return WP_REST_Response|mixed API response or error.
+	 */
+	public function api_segment( $request ) {
+		if ( 'DELETE' === $request->get_method() ) {
+			$response = $this->service_provider->unset_segment(
+				$request['id']
+			);
+		} else {
+			$response = $this->service_provider->set_segment(
+				$request['id'],
+				$request['segment_id']
 			);
 		}
 		return self::get_api_response( $response );

--- a/includes/service-providers/constant_contact/class-newspack-newsletters-constant-contact-sdk.php
+++ b/includes/service-providers/constant_contact/class-newspack-newsletters-constant-contact-sdk.php
@@ -314,6 +314,19 @@ final class Newspack_Newsletters_Constant_Contact_SDK {
 	}
 
 	/**
+	 * Get segments
+	 *
+	 * @return array
+	 */
+	public function get_segments() {
+		return $this->request(
+			'GET',
+			'segments',
+			[ 'query' => [ 'sort_by' => 'name' ] ]
+		)->segments;
+	}
+
+	/**
 	 * Get v3 campaign UUID if matches v2 format.
 	 *
 	 * @param string $campaign_id Campaign ID.

--- a/src/service-providers/constant_contact/ProviderSidebar.js
+++ b/src/service-providers/constant_contact/ProviderSidebar.js
@@ -12,6 +12,11 @@ import {
 	Notice,
 } from '@wordpress/components';
 
+/**
+ * Internal dependencies
+ */
+import './style.scss';
+
 const ProviderSidebar = ( {
 	renderSubject,
 	renderFrom,
@@ -119,6 +124,7 @@ const ProviderSidebar = ( {
 
 			{ 'list' === sendMode && (
 				<BaseControl
+					className="newspack-newsletters-constant_contact-lists"
 					id="newspack-newsletters-constant_contact-lists"
 					label={ __( 'Lists', 'newspack-newsletters' ) }
 				>

--- a/src/service-providers/constant_contact/ProviderSidebar.js
+++ b/src/service-providers/constant_contact/ProviderSidebar.js
@@ -2,11 +2,12 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { Fragment, useEffect } from '@wordpress/element';
+import { Fragment, useEffect, useState } from '@wordpress/element';
 import {
 	BaseControl,
 	CheckboxControl,
 	SelectControl,
+	RadioControl,
 	Spinner,
 	Notice,
 } from '@wordpress/components';
@@ -24,6 +25,8 @@ const ProviderSidebar = ( {
 	const campaign = newsletterData.campaign;
 	const lists = newsletterData.lists || [];
 	const segments = newsletterData.segments || [];
+
+	const [ sendMode, setSendMode ] = useState( 'list' );
 
 	let segment_id = '';
 	if ( campaign?.activity?.segment_ids?.length ) {
@@ -62,6 +65,11 @@ const ProviderSidebar = ( {
 				senderName: campaign.activity.from_name,
 				senderEmail: campaign.activity.from_email,
 			} );
+			if ( campaign?.activity?.contact_list_ids?.length ) {
+				setSendMode( 'list' );
+			} else if ( campaign?.activity?.segment_ids?.length ) {
+				setSendMode( 'segment' );
+			}
 		}
 	}, [ campaign ] );
 
@@ -93,38 +101,58 @@ const ProviderSidebar = ( {
 			<strong className="newspack-newsletters__label">
 				{ __( 'Send to', 'newspack-newsletters' ) }
 			</strong>
-			<BaseControl
-				id="newspack-newsletters-constant_contact-lists"
-				label={ __( 'Lists', 'newspack-newsletters' ) }
-			>
-				{ lists.map( ( { list_id: id, name } ) => (
-					<CheckboxControl
-						key={ id }
-						label={ name }
-						value={ id }
-						checked={ campaign?.activity?.contact_list_ids?.some( listId => listId === id ) }
-						onChange={ value => setList( id, value ) }
-						disabled={ inFlight }
-					/>
-				) ) }
+			<BaseControl className="newspack-newsletters__send-mode">
+				<RadioControl
+					className={
+						'newspack-newsletters__sendmode-radiocontrol' + ( inFlight ? ' inFlight' : '' )
+					}
+					label={ __( 'Send Mode', 'newspack-newsletters' ) }
+					selected={ sendMode }
+					onChange={ setSendMode }
+					options={ [
+						{ label: __( 'List', 'newspack-newsletters' ), value: 'list' },
+						{ label: __( 'Segment', 'newspack-newsletters' ), value: 'segment' },
+					] }
+					disabled={ inFlight }
+				/>
 			</BaseControl>
-			<SelectControl
-				label={ __( 'Segment', 'newspack-newsletters' ) }
-				className="newspack-newsletters-constant_contact-segments"
-				value={ segment_id }
-				options={ [
-					{
-						value: null,
-						label: __( '-- Select a segment --', 'newspack-newsletters' ),
-					},
-					...segments.map( ( { segment_id: id, name } ) => ( {
-						value: id,
-						label: name,
-					} ) ),
-				] }
-				onChange={ setSegment }
-				disabled={ inFlight }
-			/>
+
+			{ 'list' === sendMode && (
+				<BaseControl
+					id="newspack-newsletters-constant_contact-lists"
+					label={ __( 'Lists', 'newspack-newsletters' ) }
+				>
+					{ lists.map( ( { list_id: id, name } ) => (
+						<CheckboxControl
+							key={ id }
+							label={ name }
+							value={ id }
+							checked={ campaign?.activity?.contact_list_ids?.some( listId => listId === id ) }
+							onChange={ value => setList( id, value ) }
+							disabled={ inFlight }
+						/>
+					) ) }
+				</BaseControl>
+			) }
+			{ 'segment' === sendMode && (
+				<SelectControl
+					label={ __( 'Segment', 'newspack-newsletters' ) }
+					className="newspack-newsletters-constant_contact-segments"
+					value={ segment_id }
+					options={ [
+						{
+							value: null,
+							label: __( '-- Select a segment --', 'newspack-newsletters' ),
+						},
+						...segments.map( ( { segment_id: id, name } ) => ( {
+							value: id,
+							label: name,
+						} ) ),
+					] }
+					onChange={ setSegment }
+					disabled={ inFlight }
+				/>
+			) }
 		</Fragment>
 	);
 };

--- a/src/service-providers/constant_contact/ProviderSidebar.js
+++ b/src/service-providers/constant_contact/ProviderSidebar.js
@@ -3,7 +3,13 @@
  */
 import { __ } from '@wordpress/i18n';
 import { Fragment, useEffect } from '@wordpress/element';
-import { BaseControl, CheckboxControl, Spinner, Notice } from '@wordpress/components';
+import {
+	BaseControl,
+	CheckboxControl,
+	SelectControl,
+	Spinner,
+	Notice,
+} from '@wordpress/components';
 
 const ProviderSidebar = ( {
 	renderSubject,
@@ -17,11 +23,25 @@ const ProviderSidebar = ( {
 } ) => {
 	const campaign = newsletterData.campaign;
 	const lists = newsletterData.lists || [];
+	const segments = newsletterData.segments || [];
+
+	let segment_id = '';
+	if ( campaign?.activity?.segment_ids?.length ) {
+		segment_id = campaign.activity.segment_ids[ 0 ];
+	}
 
 	const setList = ( listId, value ) => {
 		const method = value ? 'PUT' : 'DELETE';
 		apiFetch( {
 			path: `/newspack-newsletters/v1/constant_contact/${ postId }/list/${ listId }`,
+			method,
+		} );
+	};
+
+	const setSegment = segmentId => {
+		const method = segmentId ? 'PUT' : 'DELETE';
+		apiFetch( {
+			path: `/newspack-newsletters/v1/constant_contact/${ postId }/segment/${ segmentId }`,
 			method,
 		} );
 	};
@@ -88,6 +108,23 @@ const ProviderSidebar = ( {
 					/>
 				) ) }
 			</BaseControl>
+			<SelectControl
+				label={ __( 'Segment', 'newspack-newsletters' ) }
+				className="newspack-newsletters-constant_contact-segments"
+				value={ segment_id }
+				options={ [
+					{
+						value: null,
+						label: __( '-- Select a segment --', 'newspack-newsletters' ),
+					},
+					...segments.map( ( { segment_id: id, name } ) => ( {
+						value: id,
+						label: name,
+					} ) ),
+				] }
+				onChange={ setSegment }
+				disabled={ inFlight }
+			/>
 		</Fragment>
 	);
 };

--- a/src/service-providers/constant_contact/ProviderSidebar.js
+++ b/src/service-providers/constant_contact/ProviderSidebar.js
@@ -5,9 +5,10 @@ import { __ } from '@wordpress/i18n';
 import { Fragment, useEffect, useState } from '@wordpress/element';
 import {
 	BaseControl,
+	Button,
+	ButtonGroup,
 	CheckboxControl,
 	SelectControl,
-	RadioControl,
 	Spinner,
 	Notice,
 } from '@wordpress/components';
@@ -106,27 +107,26 @@ const ProviderSidebar = ( {
 			<strong className="newspack-newsletters__label">
 				{ __( 'Send to', 'newspack-newsletters' ) }
 			</strong>
-			<BaseControl className="newspack-newsletters__send-mode">
-				<RadioControl
-					className={
-						'newspack-newsletters__sendmode-radiocontrol' + ( inFlight ? ' inFlight' : '' )
-					}
-					label={ __( 'Send Mode', 'newspack-newsletters' ) }
-					selected={ sendMode }
-					onChange={ setSendMode }
-					options={ [
-						{ label: __( 'List', 'newspack-newsletters' ), value: 'list' },
-						{ label: __( 'Segment', 'newspack-newsletters' ), value: 'segment' },
-					] }
-					disabled={ inFlight }
+			<ButtonGroup className="newspack-newsletters-cc__send-mode">
+				<Button
+					className="newspack-newsletters-cc__send-mode-button"
+					variant={ sendMode === 'list' ? 'primary' : 'secondary' }
+					onClick={ () => setSendMode( 'list' ) }
+				>
+					{ __( 'List', 'newspack-newsletters' ) }
+				</Button>
+				<Button
+					className="newspack-newsletters-cc__send-mode-button"
+					variant={ sendMode === 'segment' ? 'primary' : 'secondary' }
+					onClick={ () => setSendMode( 'segment' ) }
+					text={ __( 'Segment', 'newspack-newsletters' ) }
 				/>
-			</BaseControl>
+			</ButtonGroup>
 
 			{ 'list' === sendMode && (
 				<BaseControl
 					className="newspack-newsletters-constant_contact-lists"
 					id="newspack-newsletters-constant_contact-lists"
-					label={ __( 'Lists', 'newspack-newsletters' ) }
 				>
 					{ lists.map( ( { list_id: id, name } ) => (
 						<CheckboxControl
@@ -142,7 +142,6 @@ const ProviderSidebar = ( {
 			) }
 			{ 'segment' === sendMode && (
 				<SelectControl
-					label={ __( 'Segment', 'newspack-newsletters' ) }
 					className="newspack-newsletters-constant_contact-segments"
 					value={ segment_id }
 					options={ [

--- a/src/service-providers/constant_contact/style.scss
+++ b/src/service-providers/constant_contact/style.scss
@@ -1,0 +1,4 @@
+.newspack-newsletters-constant_contact-lists {
+	max-height: 14em;
+	overflow-y: auto;
+}

--- a/src/service-providers/constant_contact/style.scss
+++ b/src/service-providers/constant_contact/style.scss
@@ -1,3 +1,4 @@
+@use '~@wordpress/base-styles/colors' as wp-colors;
 .newspack-newsletters-constant_contact-lists {
 	max-height: 14em;
 	overflow-y: auto;
@@ -11,4 +12,8 @@
 .newspack-newsletters-cc__send-mode .newspack-newsletters-cc__send-mode-button {
 	width: 50%;
 	display: inline;
+	box-shadow: inset 0 0 0 1px wp-colors.$gray-900;
+	&.is-secondary {
+		color: wp-colors.$gray-900;
+	}
 }

--- a/src/service-providers/constant_contact/style.scss
+++ b/src/service-providers/constant_contact/style.scss
@@ -2,3 +2,13 @@
 	max-height: 14em;
 	overflow-y: auto;
 }
+
+.newspack-newsletters-cc__send-mode {
+	width: 100%;
+	margin-bottom: 12px;
+}
+
+.newspack-newsletters-cc__send-mode .newspack-newsletters-cc__send-mode-button {
+	width: 50%;
+	display: inline;
+}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Allow users to send Newsletters to Segments using Constant Contact provider

### How to test the changes in this Pull Request:

1. Set Constant Contact as the provider with proper credentials
2. Create a new Newsletter
3. Verify the UI on the Sidebar Newsletter settings where you select the option to "SEND TO"
4. If you select one or more Lists, the Segments Select should be emptied
5. If you select one Segment, the Lists should all be unchecked
6. Play with these changes and verify that the Campaign in the Constant Contact dashboard is being updated with the correct values
7. Change the value on the CC dashboard and refresh the editor. Verify that the new values are correctly set up

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
