### PR TITLE
feat: add caching to mailchimp

### DIFF
--- a/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp-cached-data.php
+++ b/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp-cached-data.php
@@ -129,6 +129,8 @@ final class Newspack_Newsletters_Mailchimp_Cached_Data {
 			return self::$memoized_data;
 		}
 
+		Newspack_Newsletters_Logger::log( 'Mailchimp cache: getting data for list ' . $list_id );
+
 		$data = get_transient( self::get_cache_key( $list_id ) );
 		if ( $data ) {
 			Newspack_Newsletters_Logger::log( 'Mailchimp cache: serving from cache' );

--- a/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp-cached-data.php
+++ b/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp-cached-data.php
@@ -17,8 +17,8 @@ use \DrewM\MailChimp\MailChimp;
  * The purpose of this class is to implement a non-obstrusive chat, in which refreshing the cache will happen in the background in an async request
  * and will never keep the user waiting.
  *
- * 1. It will check for the information in cache
- * 2. If it does not exist, it will check for the last_cached value, stored as an option
+ * 1. It will check for the information in cache (favor wp_cache because it's faster than options, especially with memcached)
+ * 2. If it does not exist, it will check for the last_cached value, stored as an option (with auto_load as false, to avoid unnecessary queries)
  * 3. It will then dispatch an async request to refresh the cache, while returning the last cached data immediately
  * 4. It will clear the last cached data, to make sure cache will be refreshed eventually, even if the async request fails for any reason
  * 5. The async request will fetch data from the Mailchimp server and pouplate the cache

--- a/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp-cached-data.php
+++ b/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp-cached-data.php
@@ -1,0 +1,349 @@
+<?php
+/**
+ * Mailchimp Cached data
+ *
+ * @package Newspack
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+use \DrewM\MailChimp\MailChimp;
+
+/**
+ * Mailchimp cached class data
+ *
+ * This class handles fetching and caching segments and interests data from Mailchimp
+ *
+ * The purpose of this class is to implement a non-obstrusive chat, in which refreshing the cache will happen in the background in an async request
+ * and will never keep the user waiting.
+ *
+ * 1. It will check for the information in cache
+ * 2. If it does not exist, it will check for the last_cached value, stored as an option
+ * 3. It will then dispatch an async request to refresh the cache, while returning the last cached data immediately
+ * 4. It will clear the last cached data, to make sure cache will be refreshed eventually, even if the async request fails for any reason
+ * 5. The async request will fetch data from the Mailchimp server and pouplate the cache
+ * 6. The first time we ask for data in a given list, there will be no cache nor last_cached option, so we'll fetch the data synchronously
+ */
+final class Newspack_Newsletters_Mailchimp_Cached_Data {
+
+	/**
+	 * The cache group name
+	 *
+	 * @var string
+	 */
+	const CACHE_GROUP = 'newspack_nl_mailchimp_data';
+
+	/**
+	 * The last cache option name
+	 *
+	 * @var string
+	 */
+	const OPTION_NAME = 'newspack_nl_mailchimp_last_cache';
+
+	/**
+	 * The ajax action name used to dispatch the cache refresh
+	 *
+	 * @var string
+	 */
+	const AJAX_ACTION = 'newspack_nl_mailchimp_refresh_cached_data';
+
+	/**
+	 * Memoized data to be served across the same request
+	 *
+	 * @var ?array
+	 */
+	private static $memoized_data;
+	
+	/**
+	 * Initializes this class
+	 */
+	public static function init() {
+		add_action( 'wp_ajax_' . self::AJAX_ACTION, [ __CLASS__, 'handle_dispatch_refresh' ] );
+	}
+
+	/**
+	 * Get segments of a given list
+	 *
+	 * @param string $list_id The List ID.
+	 * @throws Exception In case of errors while fetching data from the server.
+	 * @return array The list segments
+	 */
+	public static function get_segments( $list_id ) {
+		$data = self::get_data( $list_id );
+		return $data['segments'] ?? null;
+	}
+
+	/**
+	 * Get Interest Categories (aka Groups) of a given list
+	 *
+	 * @param string $list_id The List ID.
+	 * @throws Exception In case of errors while fetching data from the server.
+	 * @return array The list interest categories
+	 */
+	public static function get_interest_categories( $list_id ) {
+		$data = self::get_data( $list_id );
+		return $data['interest_categories'] ?? null;
+	}
+
+	/**
+	 * Get merge_fields of a given list
+	 *
+	 * @param string $list_id The List ID.
+	 * @throws Exception In case of errors while fetching data from the server.
+	 * @return array The list merge_fields
+	 */
+	public static function get_merge_fields( $list_id ) {
+		$data = self::get_data( $list_id );
+		return $data['merge_fields'] ?? null;
+	}
+
+	/**
+	 * Retrieves the main Mailchimp instance
+	 *
+	 * @return Newspack_Newsletters_Mailchimp
+	 */
+	private static function mc() {
+		return Newspack_Newsletters_Mailchimp::instance();
+	}
+
+	/**
+	 * Gets the raw data for a given List
+	 *
+	 * @param string $list_id The List ID.
+	 * @throws Exception In case of errors while fetching data from the server.
+	 * @return array The list data with segments and interest_categories
+	 */
+	private static function get_data( $list_id ) {
+
+		if ( ! empty( self::$memoized_data ) ) {
+			return self::$memoized_data;
+		}
+
+		$data = wp_cache_get( self::CACHE_GROUP, $list_id );
+		if ( $data ) {
+			Newspack_Newsletters_Logger::log( 'Mailchimp cache: serving from cache' );
+			self::$memoized_data = $data;
+			return $data;
+		}
+
+		$data = self::get_last_cached_data( $list_id );
+
+		if ( ! $data ) {
+			// First time we ask for data in this list, let's fetch it from the server.
+			Newspack_Newsletters_Logger::log( 'Mailchimp cache: serving from remote service' );
+			$data                = self::refresh_cached_data( $list_id );
+			self::$memoized_data = $data;
+			return $data;
+		}
+
+		Newspack_Newsletters_Logger::log( 'Mailchimp cache: Dispatching refresh' );
+		self::dispatch_refresh( $list_id );
+		
+		Newspack_Newsletters_Logger::log( 'Mailchimp cache: serving from last_cache option' );
+		self::$memoized_data = $data;
+		return $data;
+	}
+
+	/**
+	 * Gets the last cached data for a given List
+	 *
+	 * @param string $list_id The List ID.
+	 * @return array The list data with segments and interest_categories
+	 */
+	private static function get_last_cached_data( $list_id ) {
+		$data = get_option( self::OPTION_NAME );
+		if ( ! empty( $data[ $list_id ] ) ) {
+			$list_data = $data[ $list_id ];
+			unset( $data[ $list_id ] );
+			update_option( self::OPTION_NAME, $data, false );
+			return $list_data;
+		}
+	}
+
+	/**
+	 * Dispatches a new request to refresh the cache
+	 *
+	 * @param string $list_id The List ID.
+	 * @return void
+	 */
+	private static function dispatch_refresh( $list_id ) {
+		$url = add_query_arg(
+			[
+				'action'   => self::AJAX_ACTION,
+				'_wpnonce' => wp_create_nonce( self::AJAX_ACTION ),
+			],
+			admin_url( 'admin-ajax.php' )
+		);
+
+		$body = [
+			'list_id' => $list_id,
+		];
+
+		wp_remote_post(
+			$url,
+			[
+				'timeout'   => 0.01,
+				'blocking'  => false,
+				'body'      => $body,
+				'sslverify' => apply_filters( 'https_local_ssl_verify', false ),
+                'cookies'   => $_COOKIE, // phpcs:ignore
+			]
+		);
+
+	}
+
+	/**
+	 * Handles the ajax action to refresh the cache
+	 *
+	 * @throws Exception In case of errors while fetching data from the server.
+	 * @return void
+	 */
+	public static function handle_dispatch_refresh() {
+		Newspack_Newsletters_Logger::log( 'Mailchimp cache: Handling ajax request to refresh cache' );
+		check_admin_referer( self::AJAX_ACTION );
+		$list_id = isset( $_POST['list_id'] ) ? sanitize_text_field( $_POST['list_id'] ) : null;
+		if ( ! $list_id ) {
+			die;
+		}
+		try {
+			self::refresh_cached_data( $list_id );
+		} catch ( Exception $e ) {
+			Newspack_Newsletters_Logger::log( 'Error refreshing cache: ' . $e->getMessage() );
+		}
+		die;
+	}
+
+	/**
+	 * Fetches data from the server and updates the cache
+	 *
+	 * @param string $list_id The List ID.
+	 * @throws Exception In case of errors while fetching data from the server.
+	 * @return array The list data with segments and interest_categories
+	 */
+	private static function refresh_cached_data( $list_id ) {
+		Newspack_Newsletters_Logger::log( 'Mailchimp cache: Refreshing cache' );
+		try {
+			$segments            = self::fetch_segments( $list_id );
+			$interest_categories = self::fetch_interest_categories( $list_id );
+			$merge_fields        = self::fetch_merge_fields( $list_id );
+			$list_data           = [
+				'segments'            => $segments,
+				'interest_categories' => $interest_categories,
+				'merge_fields'        => $merge_fields,
+			];
+			wp_cache_set( self::CACHE_GROUP, $list_data, $list_id, 10 * MINUTE_IN_SECONDS );
+
+			$data             = get_option( self::OPTION_NAME );
+			$data[ $list_id ] = $list_data;
+			update_option( self::OPTION_NAME, $data, false );
+			return $list_data;
+		} catch ( Exception $e ) {
+			Newspack_Newsletters_Logger::log( 'Mailchimp cache: error fetching data. Clearing cache to surface errors.' );
+			self::clear_cache( $list_id );
+			throw $e;
+		}
+	}
+
+	/**
+	 * Clears the cache for a given List
+	 *
+	 * @param string $list_id The List ID.
+	 * @throws Exception In case of errors while fetching data from the server.
+	 * @return void
+	 */
+	private static function clear_cache( $list_id ) {
+		wp_cache_delete( self::CACHE_GROUP, $list_id );
+		$option = get_option( self::OPTION_NAME );
+		if ( ! empty( $option[ $list_id ] ) ) {
+			unset( $option[ $list_id ] );
+			update_option( self::OPTION_NAME, $option, false );
+		}
+
+	}
+
+	/**
+	 * Fetches the segments for a given List from the Mailchimp server
+	 *
+	 * @param string $list_id The List ID.
+	 * @throws Exception In case of errors while fetching data from the server.
+	 * @return array The list segments 
+	 */
+	private static function fetch_segments( $list_id ) {
+		$mc       = new Mailchimp( ( self::mc() )->api_key() );
+		$segments = [];
+
+		$saved_segments_response  = ( self::mc() )->validate(
+			$mc->get(
+				"lists/$list_id/segments",
+				[
+					'type'  => 'saved',
+					'count' => 1000,
+				],
+				60
+			),
+			__( 'Error retrieving Mailchimp segments.', 'newspack_newsletters' )
+		);
+		$static_segments_response = ( self::mc() )->validate(
+			$mc->get(
+				"lists/$list_id/segments",
+				[
+					'type'  => 'static',
+					'count' => 1000,
+				],
+				60
+			),
+			__( 'Error retrieving Mailchimp segments.', 'newspack_newsletters' )
+		);
+		$segments                 = array_merge( $saved_segments_response['segments'], $static_segments_response['segments'] );
+
+		return $segments;
+	}
+
+	/**
+	 * Fetches the interest_categories (aka Groups) for a given List from the Mailchimp server
+	 *
+	 * @param string $list_id The List ID.
+	 * @throws Exception In case of errors while fetching data from the server.
+	 * @return array The list interest_categories 
+	 */
+	private static function fetch_interest_categories( $list_id ) {
+		$mc                  = new Mailchimp( ( self::mc() )->api_key() );
+		$interest_categories = $list_id ? ( self::mc() )->validate(
+			$mc->get( "lists/$list_id/interest-categories" ),
+			__( 'Error retrieving Mailchimp groups.', 'newspack_newsletters' )
+		) : null;
+
+		if ( $interest_categories && count( $interest_categories['categories'] ) ) {
+			foreach ( $interest_categories['categories'] as &$category ) {
+				$category_id           = $category['id'];
+				$category['interests'] = ( self::mc() )->validate(
+					$mc->get( "lists/$list_id/interest-categories/$category_id/interests" ),
+					__( 'Error retrieving Mailchimp groups.', 'newspack_newsletters' )
+				);
+			}
+		}
+
+		return $interest_categories;
+	}
+
+	/**
+	 * Fetches the merge fields for a given List from the Mailchimp server
+	 *
+	 * @param string $list_id The List ID.
+	 * @throws Exception In case of errors while fetching data from the server.
+	 * @return array The list interest_categories 
+	 */
+	private static function fetch_merge_fields( $list_id ) {
+		$mc       = new Mailchimp( ( self::mc() )->api_key() );
+		$response = ( self::mc() )->validate(
+			$mc->get(
+				"lists/$list_id/merge-fields",
+				[
+					'count' => 1000,
+				]
+			),
+			__( 'Error retrieving Mailchimp list merge fields.', 'newspack_newsletters' )
+		);
+		return $response['merge_fields'];
+	}
+}

--- a/newspack-newsletters.php
+++ b/newspack-newsletters.php
@@ -34,6 +34,7 @@ require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/service-providers/cla
 require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/service-providers/class-newspack-newsletters-service-provider-controller.php';
 require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp.php';
 require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp-controller.php';
+require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp-cached-data.php';
 require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/service-providers/constant_contact/class-newspack-newsletters-constant-contact.php';
 require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/service-providers/constant_contact/class-newspack-newsletters-constant-contact-controller.php';
 require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/service-providers/constant_contact/class-newspack-newsletters-constant-contact-sdk.php';


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes 1203536997639429-as-1203697115315826 .

This PR adds a cache layer to the mailchimp provider to improve the performance of the editor.

It caches Segments, Groups and Merge fileds when the `retrieve` method is called to retrieve a campaign. Since this method is called every time you make a change to a Newsletter, the editor gets very slow especially if you have too many segments or groups.

#### Why so complicated?

Why not simply caching the return of the api call for a certain amount of time? What's all this?

It's a tricky situation. We can't cache this information for too long, because users can make changes directly in the MC dashboard and we want to reflect them asap.

On the other hand, if we cached this for just a couple of minutes, in practice the user will experience a slow editor every time, because Newsletters are not something you are constantly editing.

So the approach I took was to keep a cache for 10 minutes and, when the cache expires, serve the cache for the last time and trigger an async request to refresh the cache in the background.

Details in the implementation are in the doc blocks of the class (and I hope the code is readable)

### How to test the changes in this Pull Request:

NOTE: ~Before merging it, I want to test this build on a site with known performance issues to see if it delivers its promise.~ Done! It speeds up the editor to a normal/acceptable speed again.

1. Define Mailchimp as the ESP in Newsletters > Settings
2. Make sure you have loggin enabled by adding this to your wp-config:
```
define( 'NEWSPACK_LOG_LEVEL', 2);
```
3. Create a new Newsletter
4. On the Sidebar, go to "SEND TO" and select an Audience
5. Observe the logs, hte data will be fetched from the remote server:
```
[NEWSPACK-NEWSLETTERS][Newspack_Newsletters_Mailchimp_Cached_Data::get_data]: Mailchimp cache: getting data for list xxxxxxxxxx
[NEWSPACK-NEWSLETTERS][Newspack_Newsletters_Mailchimp_Cached_Data::get_data]: Mailchimp cache: serving from remote service
[NEWSPACK-NEWSLETTERS][Newspack_Newsletters_Mailchimp_Cached_Data::refresh_cached_data]: Mailchimp cache: Refreshing cache
```
6. From this point on, data will be served from the cache
7. Select a different Group or segment and you should see this in the logs:
```
[NEWSPACK-NEWSLETTERS][Newspack_Newsletters_Mailchimp_Cached_Data::get_data]: Mailchimp cache: getting data for list xxxxxxxxxx
[NEWSPACK-NEWSLETTERS][Newspack_Newsletters_Mailchimp_Cached_Data::get_data]: Mailchimp cache: serving from cache
```
8. The cache will last 10 minutes, so let's go ahead and manually clear it using
```
wp cache flush
wp transient delete newspack_nl_mailchimp_data_xxxxxx // where xxxxx is the list ID you see in the logs

```
9. Change the segment again, note that the response should be quick (take as long as when we were using the cache)
10. Check the logs that a async request was dispatched to refresh the cache, while the last_cache option was served
```
[NEWSPACK-NEWSLETTERS][Newspack_Newsletters_Mailchimp_Cached_Data::get_data]: Mailchimp cache: getting data for list xxxxxxxxxx
[NEWSPACK-NEWSLETTERS][Newspack_Newsletters_Mailchimp_Cached_Data::get_data]: Mailchimp cache: Dispatching refresh
[NEWSPACK-NEWSLETTERS][Newspack_Newsletters_Mailchimp_Cached_Data::get_data]: Mailchimp cache: serving from last_cache option
```
11. After a few moments, you should see the cache being refreshed by the async request
```
[NEWSPACK-NEWSLETTERS][Newspack_Newsletters_Mailchimp_Cached_Data::handle_dispatch_refresh]: Mailchimp cache: Handling ajax request to refresh cache
[NEWSPACK-NEWSLETTERS][Newspack_Newsletters_Mailchimp_Cached_Data::refresh_cached_data]: Mailchimp cache: Refreshing cache
```
12. Continue using the editor and confirm the cache version is being served

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
