### PR TITLE
fix(activecampaign): handle error on field creation

### DIFF
--- a/includes/service-providers/active_campaign/class-newspack-newsletters-active-campaign.php
+++ b/includes/service-providers/active_campaign/class-newspack-newsletters-active-campaign.php
@@ -39,7 +39,7 @@ final class Newspack_Newsletters_Active_Campaign extends \Newspack_Newsletters_S
 	 * @var boolean
 	 */
 	public static $support_tags = false;
-	
+
 	/**
 	 * Provider name.
 	 *
@@ -1009,6 +1009,9 @@ final class Newspack_Newsletters_Active_Campaign extends \Newspack_Newsletters_S
 							),
 						]
 					);
+					if ( \is_wp_error( $fields_res ) ) {
+						return $fields_res;
+					}
 					/** Set list relation. */
 					$this->api_v3_request(
 						'fieldRels',


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Closes #1068 

### How to test the changes in this Pull Request:

1. Make sure you have ActiveCampaign configured
2. Add `$existing_fields = [];` to line `994` of `includes/service-providers/active_campaign/class-newspack-newsletters-active-campaign.php` so it attempts to create the fields
3. Subscribe with a new email using the subscription block
4. If it's a completely new AC account, subscribe again with another email so it attempts to create the fields again
5. Confirm you see the error and are unable to subscribe because it tried to create fields that already exist (duplicate `perstag`)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
