### PR TITLE
fix: ensure images width are preserved

### DIFF
--- a/src/editor/api/index.js
+++ b/src/editor/api/index.js
@@ -22,6 +22,45 @@ const POST_META_WHITELIST = [
 ];
 
 /**
+ * Get the image size given its URL.
+ *
+ * @param {string} src The image URL.
+ * @return {Promise} A promise that resolves with the image size.
+ */
+const getImageSize = src => {
+	return new Promise( ( resolve, reject ) => {
+		const img = new Image();
+		img.onload = () => {
+			resolve( { width: img.width, height: img.height } );
+		};
+		img.onerror = reject;
+		img.src = src;
+	} );
+};
+
+/**
+ * Ensure that all images have a width attribute so it doesn't default to 100%.
+ *
+ * @param {string} mjml MJML markup.
+ *
+ * @return {Promise} A promise that resolves with the HTML markup.
+ */
+const fixImagesWidth = async mjml => {
+	const template = document.createElement( 'template' );
+	template.innerHTML = mjml;
+	const images = template.content.querySelectorAll( 'mj-image' );
+	for ( let i = 0; i < images.length; i++ ) {
+		const element = images[ i ];
+		if ( ! element.getAttribute( 'width' ) ) {
+			const src = element.getAttribute( 'src' );
+			const size = await getImageSize( src );
+			element.setAttribute( 'width', size.width );
+		}
+	}
+	return template.innerHTML;
+};
+
+/**
  * Use a middleware to hijack the post update request.
  * When a post is about to be updated, first the email-compliant HTML has
  * to be produced. To do that, MJML (more at mjml.io) is used.
@@ -71,7 +110,7 @@ apiFetch.use( async ( options, next ) => {
 
 	// Then, send the content over to the server to convert the post content
 	// into MJML markup.
-	const { mjml } = await apiFetch( {
+	let { mjml } = await apiFetch( {
 		path: `/newspack-newsletters/v1/post-mjml`,
 		method: 'POST',
 		data: {
@@ -80,6 +119,9 @@ apiFetch.use( async ( options, next ) => {
 			content: data.content,
 		},
 	} );
+
+	// Ensure all images have a width attribute so it doesn't default to 100%.
+	mjml = await fixImagesWidth( mjml );
 
 	// Once received MJML markup, convert it to email-compliant HTML
 	// and save as post meta for later retrieval.


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR ensures the width of images so it doesn't default to 100%.

The default behavior for Gutenberg (and browser rendering in general) for images without a determined width is to use the image's native width.

This is not the case for MJML. The `mj-image` element defaults the `width` attribute to the parent's width in pixels. This creates unwanted behavior and breaks the WYSIWYG aspect of the editor.

| Rendered email | Editor |
| --- | --- |
| <img width="779" alt="image" src="https://user-images.githubusercontent.com/820752/215809071-14751294-924b-4331-a57f-e90e792a9bcc.png"> | <img width="835" alt="image" src="https://user-images.githubusercontent.com/820752/215809155-19d213bf-8adc-496b-b8c3-144838f84f92.png"> |


 
### How to test the changes in this Pull Request:

1. While on the master branch, draft a newsletter and add an image with less than 300 pixels of width
2. Add another image, but with a width larger than 1000 pixels
3. Don't edit anything from the added blocks and save the draft
4. Confirm the rendered HTML shows a full-width image
5. Check out this branch, save the draft again, and confirm the image size is preserved and the larger image also behaves as expected (not extrapolating bounds)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
