### PR TITLE
feat(mailchimp): support folder selection

### DIFF
--- a/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp-controller.php
+++ b/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp-controller.php
@@ -121,17 +121,20 @@ class Newspack_Newsletters_Mailchimp_Controller extends Newspack_Newsletters_Ser
 		);
 		\register_rest_route(
 			$this->service_provider::BASE_NAMESPACE . $this->service_provider->service,
-			'(?P<id>[\a-z]+)/folder/(?P<folder_id>[\a-z]+)',
+			'(?P<id>[\a-z]+)/folder',
 			[
 				'methods'             => \WP_REST_Server::EDITABLE,
 				'callback'            => [ $this, 'api_folder' ],
 				'permission_callback' => [ $this->service_provider, 'api_authoring_permissions_check' ],
 				'args'                => [
-					'id'      => [
+					'id'        => [
 						'sanitize_callback' => 'absint',
 						'validate_callback' => [ 'Newspack_Newsletters', 'validate_newsletter_id' ],
 					],
-					'list_id' => [
+					'list_id'   => [
+						'sanitize_callback' => 'esc_attr',
+					],
+					'folder_id' => [
 						'sanitize_callback' => 'esc_attr',
 					],
 				],

--- a/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp-controller.php
+++ b/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp-controller.php
@@ -121,6 +121,24 @@ class Newspack_Newsletters_Mailchimp_Controller extends Newspack_Newsletters_Ser
 		);
 		\register_rest_route(
 			$this->service_provider::BASE_NAMESPACE . $this->service_provider->service,
+			'(?P<id>[\a-z]+)/folder/(?P<folder_id>[\a-z]+)',
+			[
+				'methods'             => \WP_REST_Server::EDITABLE,
+				'callback'            => [ $this, 'api_folder' ],
+				'permission_callback' => [ $this->service_provider, 'api_authoring_permissions_check' ],
+				'args'                => [
+					'id'      => [
+						'sanitize_callback' => 'absint',
+						'validate_callback' => [ 'Newspack_Newsletters', 'validate_newsletter_id' ],
+					],
+					'list_id' => [
+						'sanitize_callback' => 'esc_attr',
+					],
+				],
+			]
+		);
+		\register_rest_route(
+			$this->service_provider::BASE_NAMESPACE . $this->service_provider->service,
 			'(?P<id>[\a-z]+)/list/(?P<list_id>[\a-z]+)',
 			[
 				'methods'             => \WP_REST_Server::EDITABLE,
@@ -198,6 +216,20 @@ class Newspack_Newsletters_Mailchimp_Controller extends Newspack_Newsletters_Ser
 			$request['id'],
 			$request['from_name'],
 			$request['reply_to']
+		);
+		return self::get_api_response( $response );
+	}
+
+	/**
+	 * Set folder for a campaign.
+	 *
+	 * @param WP_REST_Request $request API request object.
+	 * @return WP_REST_Response|mixed API response or error.
+	 */
+	public function api_folder( $request ) {
+		$response = $this->service_provider->folder(
+			$request['id'],
+			$request['folder_id']
 		);
 		return self::get_api_response( $response );
 	}

--- a/src/service-providers/mailchimp/ProviderSidebar.js
+++ b/src/service-providers/mailchimp/ProviderSidebar.js
@@ -106,10 +106,27 @@ const ProviderSidebar = ( {
 			method: 'POST',
 		} );
 
-	const setFolder = folderId =>
+	const getFolderOptions = () => {
+		const options = folders.map( folder => ( {
+			label: folder.name,
+			value: folder.id,
+		} ) );
+		if ( ! campaign?.settings?.folder_id ) {
+			options.unshift( {
+				label: __( 'No folder', 'newspack-newsletters' ),
+				value: '',
+			} );
+		}
+		return options;
+	};
+
+	const setFolder = folder_id =>
 		apiFetch( {
-			path: `/newspack-newsletters/v1/mailchimp/${ postId }/folder/${ folderId }`,
+			path: `/newspack-newsletters/v1/mailchimp/${ postId }/folder`,
 			method: 'POST',
+			data: {
+				folder_id,
+			},
 		} );
 
 	const updateSegments = target_id => {
@@ -196,16 +213,7 @@ const ProviderSidebar = ( {
 					<SelectControl
 						label={ __( 'Folder', 'newspack-newsletters' ) }
 						value={ campaign?.settings?.folder_id }
-						options={ [
-							{
-								label: __( 'No folder', 'newspack-newsletters' ),
-								value: '',
-							},
-							...folders.map( folder => ( {
-								label: folder.name,
-								value: folder.id,
-							} ) ),
-						] }
+						options={ getFolderOptions() }
 						onChange={ setFolder }
 						disabled={ inFlight }
 					/>

--- a/src/service-providers/mailchimp/ProviderSidebar.js
+++ b/src/service-providers/mailchimp/ProviderSidebar.js
@@ -97,11 +97,18 @@ const ProviderSidebar = ( {
 } ) => {
 	const campaign = newsletterData.campaign;
 	const lists = newsletterData.lists || [];
+	const folders = newsletterData.folders || [];
 	const segments = newsletterData.segments || newsletterData.tags || []; // Keep .tags for backwards compatibility.
 
 	const setList = listId =>
 		apiFetch( {
 			path: `/newspack-newsletters/v1/mailchimp/${ postId }/list/${ listId }`,
+			method: 'POST',
+		} );
+
+	const setFolder = folderId =>
+		apiFetch( {
+			path: `/newspack-newsletters/v1/mailchimp/${ postId }/folder/${ folderId }`,
 			method: 'POST',
 		} );
 
@@ -184,6 +191,27 @@ const ProviderSidebar = ( {
 			{ renderSubject() }
 			{ renderPreviewText() }
 			<hr />
+			{ folders.length ? (
+				<Fragment>
+					<SelectControl
+						label={ __( 'Folder', 'newspack-newsletters' ) }
+						value={ campaign?.settings?.folder_id }
+						options={ [
+							{
+								label: __( 'No folder', 'newspack-newsletters' ),
+								value: '',
+							},
+							...folders.map( folder => ( {
+								label: folder.name,
+								value: folder.id,
+							} ) ),
+						] }
+						onChange={ setFolder }
+						disabled={ inFlight }
+					/>
+					<hr />
+				</Fragment>
+			) : null }
 			{ renderFrom( { handleSenderUpdate: setSender } ) }
 			<hr />
 			<strong className="newspack-newsletters__label">


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR introduces support for Mailchimp folders. The editor should be able to select a folder for campaigns:

![mailchimp-folders](https://user-images.githubusercontent.com/820752/215863121-9d78eb0e-cd20-4fb4-aebf-e85cc146904a.gif)

### How to test the changes in this Pull Request:

1. Make sure you have Mailchimp configured as your ESP
2. Make sure you have configured folders on your MC dashboard
3. Draft a new newsletter, select a folder and save the draft
4. Visit your Mailchimp dashboard and confirm the draft is in the selected folder

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
