### PR TITLE
feat: add groups support to mailchimp

### DIFF
--- a/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp-groups.php
+++ b/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp-groups.php
@@ -1,0 +1,253 @@
+<?php
+/**
+ * Service Provider: Mailchimp Groups Implementation
+ *
+ * @package Newspack
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+use \DrewM\MailChimp\MailChimp;
+
+/**
+ * This tratis adds the Mailchimp Groups implementation to the Mailchimp Service Provider.
+ *
+ * In Mailchimp, Groups are also called Interests. Interests are categorized in Interest Categories.
+ *
+ * In this implementation, we will always add groups/interests to a category called "Newspack Newsletters". If this category
+ * doesn't exist, it will be created.
+ *
+ * From that point on, groups will always be added to this category.
+ */
+trait Newspack_Newsletters_Mailchimp_Groups {
+
+	/**
+	 * Gets the Newspack Newsletter group category ID, and creates it if it doesn't exist.
+	 *
+	 * @param string $list_id The list ID.
+	 * @return string|WP_Error The group category ID on success . WP_Error on failure .
+	 */
+	public function get_groups_category_id( $list_id ) {
+		$option_name        = 'newspack_newsletters_mailchimp_group_category_id';
+		$group_category_ids = get_option( $option_name );
+		if ( ! array( $group_category_ids ) ) {
+			$group_category_ids = [];
+		}
+		$group_category_id = $group_category_ids[ $list_id ] ?? null;
+		if ( $group_category_id ) {
+			return $group_category_id;
+		}
+		$mc     = new Mailchimp( $this->api_key() );
+		$create = $mc->post(
+			sprintf( 'lists/%s/interest-categories', $list_id ),
+			[
+				'title' => 'Newspack Newsletters',
+				'type'  => 'checkboxes',
+			]
+		);
+		
+		// If there was an error creating the category, let's check if it already exists.
+		if ( ! empty( $create['status'] ) && 400 === $create['status'] ) {
+			$search = $mc->get(
+				sprintf( 'lists/%s/interest-categories', $list_id ),
+				[
+					'count' => 100,
+				]
+			);
+			if ( ! empty( $search['total_items'] ) ) {
+				foreach ( $search['categories'] as $found_category ) {
+					if ( 'Newspack Newsletters' === $found_category['title'] ) {
+						$group_category_ids[ $list_id ] = $found_category['id'];
+						update_option( $option_name, $group_category_ids );
+						return $found_category['id'];
+					}
+				}
+			}
+		}
+			
+		if ( ! empty( $create['id'] ) ) {
+			$group_category_ids[ $list_id ] = $create['id'];
+			update_option( $option_name, $group_category_ids );
+			return $create['id'];
+		} else {
+			return new WP_Error(
+				'newspack_newsletter_unable_to_create_group_category'
+			);
+		}
+	}
+
+	/**
+	 * Retrieve the Mailchimp's group ID from its name
+	 *
+	 * @param string  $group_name The group .
+	 * @param boolean $create_if_not_found Whether to create a new group() if not found . default to true .
+	 * @param string  $list_id The list ID .
+	 * @return string | WP_Error The group ID on success . WP_Error on failure .
+	 */
+	public function get_group_id( $group_name, $create_if_not_found = true, $list_id = null ) {
+		$mc     = new Mailchimp( $this->api_key() );
+		$search = $mc->get(
+			sprintf( '/lists/%s/interest-categories/%s/interests', $list_id, $this->get_groups_category_id( $list_id ) ),
+			[
+				'count' => 100,
+			]
+		);
+		if ( ! empty( $search['total_items'] ) ) {
+			foreach ( $search['interests'] as $found_group ) {
+				if ( strtolower( $group_name ) === strtolower( $found_group['name'] ) ) {
+					return $found_group['id'];
+				}
+			}
+		}
+
+		// Group was not found.
+		if ( ! $create_if_not_found ) {
+			return new WP_Error(
+				'newspack_newsletter_group_not_found'
+			);
+		}
+
+		$created = $this->create_group( $group_name, $list_id );
+
+		if ( is_wp_error( $created ) ) {
+			return $created;
+		}
+
+		return $created['id'];
+	}
+
+	/**
+	 * Retrieve the ESP's group name from its ID
+	 *
+	 * @param int    $group_id The group ID.
+	 * @param string $list_id The List ID.
+	 * @return string|WP_Error The group name on success. WP_Error on failure.
+	 */
+	public function get_group_by_id( $group_id, $list_id = null ) {
+		$mc     = new Mailchimp( $this->api_key() );
+		$search = $mc->get(
+			sprintf( '/lists/%s/interest-categories/%s/interests/%s', $list_id, $this->get_groups_category_id( $list_id ), $group_id )
+		);
+		if ( ! empty( $search['name'] ) ) {
+			return $search['name'];
+		}
+		return new WP_Error(
+			'newspack_newsletter_group_not_found'
+		);
+	}
+
+	/**
+	 * Create a Group on Mailchimp
+	 *
+	 * @param string $group The Group name.
+	 * @param string $list_id The List ID.
+	 * @return array|WP_Error The group representation sent from the server on succes. WP_Error on failure.
+	 */
+	public function create_group( $group, $list_id = null ) {
+		
+		$mc      = new Mailchimp( $this->api_key() );
+		$created = $mc->post(
+			sprintf( '/lists/%s/interest-categories/%s/interests', $list_id, $this->get_groups_category_id( $list_id ) ),
+			[
+				'name' => $group,
+			]
+		);
+
+		if ( is_array( $created ) && ! empty( $created['id'] ) && ! empty( $created['name'] ) ) {
+			return $created;
+		}
+		return new WP_Error(
+			'newspack_newsletters_error_creating_group',
+			! empty( $created['detail'] ) ? $created['detail'] : ''
+		);
+	}
+
+	/**
+	 * Add a group to a contact
+	 *
+	 * @param string $email The contact email.
+	 * @param string $group_id The group ID.
+	 * @param string $list_id The List ID.
+	 * @return true|WP_Error
+	 */
+	public function add_group_to_contact( $email, $group_id, $list_id = null ) {
+		$existing_contact = $this->get_contact_data( $email );
+		if ( is_wp_error( $existing_contact ) ) {
+			return $existing_contact;
+		}
+
+		$mc    = new Mailchimp( $this->api_key() );
+		$added = $mc->put(
+			sprintf( 'lists/%s/members/%s', $list_id, $existing_contact['id'] ),
+			[
+				'interests' => [ $group_id => true ],
+			]
+		);
+
+		if ( is_array( $added ) && ! empty( $added['status'] ) ) {
+			return true;
+		}
+
+		return new WP_Error(
+			'newspack_newsletter_error_adding_group_to_contact',
+			! empty( $added['errors'] ) && ! empty( $added['errors'][0]['error'] ) ? $added['errors'][0]['error'] : ''
+		);
+
+	}
+
+	/**
+	 * Remove a group from a contact
+	 *
+	 * @param string $email The contact email.
+	 * @param string $group_id The group ID.
+	 * @param string $list_id The List ID.
+	 * @return true|WP_Error
+	 */
+	public function remove_group_from_contact( $email, $group_id, $list_id = null ) {
+		$existing_contact = $this->get_contact_data( $email );
+		if ( is_wp_error( $existing_contact ) ) {
+			return $existing_contact;
+		}
+
+		$mc    = new Mailchimp( $this->api_key() );
+		$added = $mc->put(
+			sprintf( 'lists/%s/members/%s', $list_id, $existing_contact['id'] ),
+			[
+				'interests' => [ $group_id => false ],
+			]
+		);
+
+		if ( is_array( $added ) && ! empty( $added['status'] ) ) {
+			return true;
+		}
+
+		return new WP_Error(
+			'newspack_newsletter_error_adding_group_to_contact',
+			! empty( $added['errors'] ) && ! empty( $added['errors'][0]['error'] ) ? $added['errors'][0]['error'] : ''
+		);
+
+	}
+
+	/**
+	 * Get the IDs of the groups associated with a contact.
+	 *
+	 * @param string $email The contact email.
+	 * @return array|WP_Error The groups IDs on success. WP_Error on failure.
+	 */
+	public function get_contact_groups_ids( $email ) {
+		$contact_data = $this->get_contact_data( $email );
+		if ( is_wp_error( $contact_data ) ) {
+			return $contact_data;
+		}
+
+		$groups = [];
+
+		foreach ( $contact_data['interests'] as $group_id => $is_subscribed ) {
+			if ( $is_subscribed ) {
+				$groups[] = $group_id;
+			}
+		}
+		
+		return $groups;
+	}       
+}

--- a/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp-groups.php
+++ b/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp-groups.php
@@ -10,7 +10,7 @@ defined( 'ABSPATH' ) || exit;
 use \DrewM\MailChimp\MailChimp;
 
 /**
- * This tratis adds the Mailchimp Groups implementation to the Mailchimp Service Provider.
+ * This trait adds the Mailchimp Groups implementation to the Mailchimp Service Provider.
  *
  * In Mailchimp, Groups are also called Interests. Interests are categorized in Interest Categories.
  *

--- a/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp.php
+++ b/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp.php
@@ -14,6 +14,8 @@ use \DrewM\MailChimp\MailChimp;
  */
 final class Newspack_Newsletters_Mailchimp extends \Newspack_Newsletters_Service_Provider {
 
+	use Newspack_Newsletters_Mailchimp_Groups;
+
 	/**
 	 * Whether the provider has support to tags and tags based Subscription Lists.
 	 *
@@ -1129,7 +1131,7 @@ final class Newspack_Newsletters_Mailchimp extends \Newspack_Newsletters_Service
 			return new WP_Error( 'newspack_newsletters_mailchimp_contact_not_found', __( 'Contact not found', 'newspack-newsletters' ) );
 		}
 
-		$keys = [ 'full_name', 'email_address', 'id', 'tags' ];
+		$keys = [ 'full_name', 'email_address', 'id', 'tags', 'interests' ];
 		$data = [ 'lists' => [] ];
 		foreach ( $found as $contact ) {
 			foreach ( $keys as $key ) {

--- a/newspack-newsletters.php
+++ b/newspack-newsletters.php
@@ -32,6 +32,7 @@ require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/service-providers/int
 require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/service-providers/interface-newspack-newsletters-wp-hookable.php';
 require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/service-providers/class-newspack-newsletters-service-provider.php';
 require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/service-providers/class-newspack-newsletters-service-provider-controller.php';
+require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp-groups.php';
 require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp.php';
 require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp-controller.php';
 require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp-cached-data.php';


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR adds all the methods to allow the Mailchimp service provider to manipulate groups. In the next PR, we will use it to make Mailchimp create Groups instead of Tags for local subscription lists.

### How to test the changes in this Pull Request:

We are going to manually test each method added by this PR

Start with a site with the Mailchimp credentials set, and 'mailchimp' selected as the provider in Newsletters > Settings

Go to your Mailchimp dashboard: Go to Audience Dashboard. Click on "Manage Audience > Manage Contacts" on the dropdown at the top right corner of the page. Scroll down and click on "Groups". We are going to check the groups being created here in this page.

1. Open a wp shell `wp shell`
2. Get a new instance of the provider class: `$mc = Newspack_Newsletters_Mailchimp::instance();`
3. Now we need to get the ID of your main list:
4. `$lists = $mc->get_lists();`
5. `$list_id = $lists[0]['id'];`
6. Ok, now we can start testing! Let's start with the first method:
7. `$mc->get_groups_category_id( $list_id );`
8. Confirm it returns a string
9. Refresh the Groups page in the Mailchimp dashboard and confirm you see the "Newspack Newsletters" category was created.

![Captura de tela de 2023-02-14 15-47-39](https://user-images.githubusercontent.com/971483/218831881-38fb9c9d-9105-4b2f-bb1d-79e8abdf6225.png)

10. Call the same method again and confirm it returns the string instantly (no requests are made to the server).
11. Delete the option and try again, to make sure there is no error when the category already exists in the server:
12. `delete_option('newspack_newsletters_mailchimp_group_category_id');`
13. `$mc->get_groups_category_id( $list_id );`
14. Let's go to the next method:
15. `$mc->get_group_id( 'Test group', false, $list_id );
16. Confirm it return an error saying the group was not found. Now let's tell it to create it:
17. `$group1 = $mc->get_group_id( 'Test group', true, $list_id );`
18. Confirm it returns a string
19. Refresh the page on the Mailchimp dashboard. Click "View groups" in the "Newspack Newsletters" category and confirm you see the new group created.
20. Also, if you visit "All Contacts" in your Mailchimp dashboard, you should see a new "Newspack Newsletters" column in the contacts table
21. Run `$mc->get_group_id( 'Test group', true, $list_id );` again and confirm the same ID is returned.
22. Next text. Let's try to get this group we have just created:
23. `$mc->get_group_by_id( $group1, $list_id );`
24. Confirm "Test group" was returned.
25. Next: `$created = $mc->create_group( 'A new group', $list_id );`
26. Go to the mailchimp Groups dashboard and confirm the new group was created
27. `echo $created['id']; ` and confirm it is a string with the grtoup id.
28. `$mc->get_group_by_id( $created['id'], $list_id );` and confirm you see "A new group".
29. Now choose an email of a contact that already exists in Mailchimp. Ex: `$contact = 'existing@contact.com';`.
30. `$mc->add_group_to_contact( $contact, $group1, $list_id);`
31. Go to "All contacts" in the Mailchimp dashboard and confirm the group was added to the contact.
32. Do the same with the other list:
33. `$mc->add_group_to_contact( $contact, $created['id'], $list_id);`
34. Remove one of the lists:
35. `$mc->remove_group_from_contact( $contact, $group1, $list_id);`
36. Confirm the changes are reflected in the contact on the Mailchimp dashboard
37. Call `$mc->get_contact_groups_ids( $contact );` and confirm it shows the correct status of the list of group ids the contact has
38. Feel free to test the methods with different combinations and order


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
