### PR TITLE
fix: disable JP Photon for newsletters

### DIFF
--- a/includes/class-newspack-newsletters-renderer.php
+++ b/includes/class-newspack-newsletters-renderer.php
@@ -1114,6 +1114,8 @@ final class Newspack_Newsletters_Renderer {
 	 * @return array[] Blocks.
 	 */
 	private static function get_valid_post_blocks( $post ) {
+		// Disable photon for newsletter images (webp is not supported on some email clients).
+		add_filter( 'jetpack_photon_skip_image', '__return_true' );
 		return array_filter(
 			parse_blocks( $post->post_content ),
 			function ( $block ) {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Jetpack's Photon transforms images to webp, which is not supported by some email clients. This PR implements a filter to skip Photon processing while rendering the newsletter body.

### How to test the changes in this Pull Request:

1. Make sure your instance has Jetpack and Photon enabled
2. While on master, draft a newsletter with an image and confirm the generated source has `i0.wp.com` images
3. Check out this branch and confirm the images are now from your domain
4. Visit the home page and confirm the images are still coming from `i0.wp.com` (not affecting other places)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
