### PR TITLE
feat: enable local lists and mailchimp groups

### DIFF
--- a/includes/class-subscription-list.php
+++ b/includes/class-subscription-list.php
@@ -137,10 +137,12 @@ class Subscription_List {
 	/**
 	 * Generate the tag name that will be added to the ESP based on the post title
 	 *
+	 * @param string $prefix The prefix to be added to the tag name.
+	 *
 	 * @return string
 	 */
-	public function generate_tag_name() {
-		return 'Newspack: ' . $this->get_title();
+	public function generate_tag_name( $prefix = 'Newspack: ' ) {
+		return $prefix . $this->get_title();
 	}
 
 	/**

--- a/includes/service-providers/active_campaign/class-newspack-newsletters-active-campaign.php
+++ b/includes/service-providers/active_campaign/class-newspack-newsletters-active-campaign.php
@@ -38,7 +38,7 @@ final class Newspack_Newsletters_Active_Campaign extends \Newspack_Newsletters_S
 	 *
 	 * @var boolean
 	 */
-	public static $support_tags = false;
+	public static $support_local_lists = true;
 
 	/**
 	 * Provider name.

--- a/includes/service-providers/class-newspack-newsletters-service-provider.php
+++ b/includes/service-providers/class-newspack-newsletters-service-provider.php
@@ -50,7 +50,7 @@ abstract class Newspack_Newsletters_Service_Provider implements Newspack_Newslet
 	 *
 	 * @var boolean
 	 */
-	public static $support_tags = false;
+	public static $support_local_lists = false;
 
 	/**
 	 * Class constructor.
@@ -376,11 +376,14 @@ abstract class Newspack_Newsletters_Service_Provider implements Newspack_Newslet
 	 */
 	public static function get_labels() {
 		return [
-			'name'  => '', // The provider name.
-			'list'  => __( 'list', 'newspack-newsletters' ), // "list" in lower case singular format.
-			'lists' => __( 'lists', 'newspack-newsletters' ), // "list" in lower case plural format.
-			'List'  => __( 'List', 'newspack-newsletters' ), // "list" in uppercase case singular format.
-			'Lists' => __( 'Lists', 'newspack-newsletters' ), // "list" in uppercase case plural format.
+			'name'                    => '', // The provider name.
+			'list'                    => __( 'list', 'newspack-newsletters' ), // "list" in lower case singular format.
+			'lists'                   => __( 'lists', 'newspack-newsletters' ), // "list" in lower case plural format.
+			'List'                    => __( 'List', 'newspack-newsletters' ), // "list" in uppercase case singular format.
+			'Lists'                   => __( 'Lists', 'newspack-newsletters' ), // "list" in uppercase case plural format.
+			'tag_prefix'              => 'Newspack: ', // The prefix to be used in tags.
+			'tag_metabox_before_save' => __( 'Once this list is saved, a tag will be created for it.', 'newspack-newsletters' ),
+			'tag_metabox_after_save'  => __( 'Tag created for this list', 'newspack-newsletters' ),
 		];
 	}
 
@@ -429,8 +432,8 @@ abstract class Newspack_Newsletters_Service_Provider implements Newspack_Newslet
 					return $added_contact;
 				}
 
-				if ( static::$support_tags ) {
-					$this->add_tag_to_contact( $contact['email'], (int) $list_settings['tag_id'], $list_settings['list'] );
+				if ( static::$support_local_lists ) {
+					$this->add_esp_local_list_to_contact( $contact['email'], $list_settings['tag_id'], $list_settings['list'] );
 				}
 
 				return $added_contact;
@@ -464,7 +467,7 @@ abstract class Newspack_Newsletters_Service_Provider implements Newspack_Newslet
 			}
 			return true;
 		}
-		if ( static::$support_tags ) {
+		if ( static::$support_local_lists ) {
 			$lists_to_add    = $this->update_contact_local_lists( $email, $lists_to_add, 'add' );
 			$lists_to_remove = $this->update_contact_local_lists( $email, $lists_to_remove, 'remove' );
 			if ( is_wp_error( $lists_to_add ) ) {
@@ -498,9 +501,9 @@ abstract class Newspack_Newsletters_Service_Provider implements Newspack_Newslet
 					$list_settings = $list->get_provider_settings( $this->service );
 
 					if ( 'add' === $action ) {
-						$this->add_tag_to_contact( $email, (int) $list_settings['tag_id'], $list_settings['list'] );
+						$this->add_esp_local_list_to_contact( $email, $list_settings['tag_id'], $list_settings['list'] );
 					} elseif ( 'remove' === $action ) {
-						$this->remove_tag_from_contact( $email, (int) $list_settings['tag_id'], $list_settings['list'] );
+						$this->remove_esp_local_list_from_contact( $email, $list_settings['tag_id'], $list_settings['list'] );
 					}
 					
 					unset( $lists[ $key ] );
@@ -520,7 +523,7 @@ abstract class Newspack_Newsletters_Service_Provider implements Newspack_Newslet
 	 * @return string[] Array of local lists IDs or error.
 	 */
 	public function get_contact_local_lists( $email ) {
-		$tags = $this->get_contact_tags_ids( $email );
+		$tags = $this->get_contact_esp_local_lists_ids( $email );
 		if ( is_wp_error( $tags ) ) {
 			return [];
 		}
@@ -547,7 +550,7 @@ abstract class Newspack_Newsletters_Service_Provider implements Newspack_Newslet
 			return $lists;
 		}
 		$local_lists = [];
-		if ( static::$support_tags ) {
+		if ( static::$support_local_lists ) {
 			$local_lists = $this->get_contact_local_lists( $email );
 			if ( is_wp_error( $local_lists ) ) {
 				return $local_lists;
@@ -622,5 +625,85 @@ abstract class Newspack_Newsletters_Service_Provider implements Newspack_Newslet
 	 */
 	public function get_contact_tags_ids( $email ) {
 		return new WP_Error( 'newspack_newsletters_not_implemented', __( 'Not implemented', 'newspack-newsletters' ), [ 'status' => 400 ] );
+	}
+
+	/**
+	 * Retrieve the ESP's Local list ID from its name
+	 *
+	 * By default it will use Tags, but the provider can override this method to use something else
+	 *
+	 * @param string  $esp_local_list_name The esp_local_list.
+	 * @param boolean $create_if_not_found Whether to create a new esp_local_list if not found. Default to true.
+	 * @param string  $list_id The List ID.
+	 * @return int|WP_Error The esp_local_list ID on success. WP_Error on failure.
+	 */
+	public function get_esp_local_list_id( $esp_local_list_name, $create_if_not_found = true, $list_id = null ) {
+		return $this->get_tag_id( $esp_local_list_name, $create_if_not_found, $list_id );
+	}
+
+	/**
+	 * Retrieve the ESP's Local list name from its ID
+	 *
+	 * By default it will use Tags, but the provider can override this method to use something else
+	 *
+	 * @param int    $esp_local_list_id The esp_local_list ID.
+	 * @param string $list_id The List ID.
+	 * @return string|WP_Error The esp_local_list name on success. WP_Error on failure.
+	 */
+	public function get_esp_local_list_by_id( $esp_local_list_id, $list_id = null ) {
+		return $this->get_tag_by_id( $esp_local_list_id, $list_id );
+	}
+
+	/**
+	 * Create a Local list on the ESP
+	 *
+	 * By default it will use Tags, but the provider can override this method to use something else
+	 *
+	 * @param string $esp_local_list The Tag name.
+	 * @param string $list_id The List ID.
+	 * @return array|WP_Error The esp_local_list representation with at least 'id' and 'name' keys on succes. WP_Error on failure.
+	 */
+	public function create_esp_local_list( $esp_local_list, $list_id = null ) {
+		return $this->create_tag( $esp_local_list, $list_id );
+	}
+
+	/**
+	 * Add a Local list to a contact in the ESP
+	 *
+	 * By default it will use Tags, but the provider can override this method to use something else
+	 *
+	 * @param string     $email The contact email.
+	 * @param string|int $esp_local_list The esp_local_list ID retrieved with get_esp_local_list_id() or the the esp_local_list string.
+	 * @param string     $list_id The List ID.
+	 * @return true|WP_Error
+	 */
+	public function add_esp_local_list_to_contact( $email, $esp_local_list, $list_id = null ) {
+		return $this->add_tag_to_contact( $email, $esp_local_list, $list_id );
+	}
+
+	/**
+	 * Remove a Local list from a contact in the ESP
+	 *
+	 * By default it will use Tags, but the provider can override this method to use something else
+	 *
+	 * @param string     $email The contact email.
+	 * @param string|int $esp_local_list The esp_local_list ID retrieved with get_esp_local_list_id() or the the esp_local_list string.
+	 * @param string     $list_id The List ID.
+	 * @return true|WP_Error
+	 */
+	public function remove_esp_local_list_from_contact( $email, $esp_local_list, $list_id = null ) {
+		return $this->remove_tag_from_contact( $email, $esp_local_list, $list_id );
+	}
+
+	/**
+	 * Get the IDs of the Local lists associated with a contact in the ESP.
+	 *
+	 * By default it will use Tags, but the provider can override this method to use something else
+	 *
+	 * @param string $email The contact email.
+	 * @return array|WP_Error The esp_local_list IDs on success. WP_Error on failure.
+	 */
+	public function get_contact_esp_local_lists_ids( $email ) {
+		return $this->get_contact_tags_ids( $email );
 	}
 }

--- a/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp-groups.php
+++ b/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp-groups.php
@@ -17,9 +17,107 @@ use \DrewM\MailChimp\MailChimp;
  * In this implementation, we will always add groups/interests to a category called "Newspack Newsletters". If this category
  * doesn't exist, it will be created.
  *
+ * You can override the category name by defining the constant NEWSPACK_NEWSLETTERS_MAILCHIMP_GROUPS_CATEGORY_NAME.
+ * But only do this if you haven't created any groups/interests yet.
+ *
  * From that point on, groups will always be added to this category.
  */
 trait Newspack_Newsletters_Mailchimp_Groups {
+
+	/**
+	 * Retrieve the ESP's Local list ID from its name
+	 *
+	 * Mailchimp overrides it to use Groups instead of Tags
+	 *
+	 * @param string  $esp_local_list_name The esp_local_list.
+	 * @param boolean $create_if_not_found Whether to create a new esp_local_list if not found. Default to true.
+	 * @param string  $list_id The List ID.
+	 * @return int|WP_Error The esp_local_list ID on success. WP_Error on failure.
+	 */
+	public function get_esp_local_list_id( $esp_local_list_name, $create_if_not_found = true, $list_id = null ) {
+		return $this->get_group_id( $esp_local_list_name, $create_if_not_found, $list_id );
+	}
+
+	/**
+	 * Retrieve the ESP's Local list name from its ID
+	 *
+	 * Mailchimp overrides it to use Groups instead of Tags
+	 *
+	 * @param int    $esp_local_list_id The esp_local_list ID.
+	 * @param string $list_id The List ID.
+	 * @return string|WP_Error The esp_local_list name on success. WP_Error on failure.
+	 */
+	public function get_esp_local_list_by_id( $esp_local_list_id, $list_id = null ) {
+		return $this->get_group_by_id( $esp_local_list_id, $list_id );
+	}
+
+	/**
+	 * Create a Local list on the ESP
+	 *
+	 * Mailchimp overrides it to use Groups instead of Tags
+	 *
+	 * @param string $esp_local_list The Tag name.
+	 * @param string $list_id The List ID.
+	 * @return array|WP_Error The esp_local_list representation with at least 'id' and 'name' keys on succes. WP_Error on failure.
+	 */
+	public function create_esp_local_list( $esp_local_list, $list_id = null ) {
+		return $this->create_group( $esp_local_list, $list_id );
+	}
+
+	/**
+	 * Add a Local list to a contact in the ESP
+	 *
+	 * Mailchimp overrides it to use Groups instead of Tags
+	 *
+	 * @param string     $email The contact email.
+	 * @param string|int $esp_local_list The esp_local_list ID retrieved with get_esp_local_list_id() or the the esp_local_list string.
+	 * @param string     $list_id The List ID.
+	 * @return true|WP_Error
+	 */
+	public function add_esp_local_list_to_contact( $email, $esp_local_list, $list_id = null ) {
+		return $this->add_group_to_contact( $email, $esp_local_list, $list_id );
+	}
+
+	/**
+	 * Remove a Local list from a contact in the ESP
+	 *
+	 * Mailchimp overrides it to use Groups instead of Tags
+	 *
+	 * @param string     $email The contact email.
+	 * @param string|int $esp_local_list The esp_local_list ID retrieved with get_esp_local_list_id() or the the esp_local_list string.
+	 * @param string     $list_id The List ID.
+	 * @return true|WP_Error
+	 */
+	public function remove_esp_local_list_from_contact( $email, $esp_local_list, $list_id = null ) {
+		return $this->remove_group_from_contact( $email, $esp_local_list, $list_id );
+	}
+
+	/**
+	 * Get the IDs of the Local lists associated with a contact in the ESP.
+	 *
+	 * Mailchimp overrides it to use Groups instead of Tags
+	 *
+	 * @param string $email The contact email.
+	 * @return array|WP_Error The esp_local_list IDs on success. WP_Error on failure.
+	 */
+	public function get_contact_esp_local_lists_ids( $email ) {
+		return $this->get_contact_groups_ids( $email );
+	}
+
+	/**
+	 * Get the name of the Group Category that will be used to store the groups.
+	 *
+	 * WARNING: If you change this after you have created groups, new groups with the same name will be created in the new category and new readers will be added to the new group.
+	 * Only change this if you are setting up Local lists for the first time.
+	 *
+	 * @return string
+	 */
+	public static function get_group_category_name() {
+		if ( defined( 'NEWSPACK_NEWSLETTERS_MAILCHIMP_GROUP_CATEGORY_NAME' ) ) {
+			return NEWSPACK_NEWSLETTERS_MAILCHIMP_GROUP_CATEGORY_NAME;
+		}
+		return 'Newspack Newsletters';
+	}
 
 	/**
 	 * Gets the Newspack Newsletter group category ID, and creates it if it doesn't exist.
@@ -41,7 +139,7 @@ trait Newspack_Newsletters_Mailchimp_Groups {
 		$create = $mc->post(
 			sprintf( 'lists/%s/interest-categories', $list_id ),
 			[
-				'title' => 'Newspack Newsletters',
+				'title' => self::get_group_category_name(),
 				'type'  => 'checkboxes',
 			]
 		);
@@ -56,7 +154,7 @@ trait Newspack_Newsletters_Mailchimp_Groups {
 			);
 			if ( ! empty( $search['total_items'] ) ) {
 				foreach ( $search['categories'] as $found_category ) {
-					if ( 'Newspack Newsletters' === $found_category['title'] ) {
+					if ( self::get_group_category_name() === $found_category['title'] ) {
 						$group_category_ids[ $list_id ] = $found_category['id'];
 						update_option( $option_name, $group_category_ids );
 						return $found_category['id'];

--- a/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp.php
+++ b/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp.php
@@ -21,7 +21,7 @@ final class Newspack_Newsletters_Mailchimp extends \Newspack_Newsletters_Service
 	 *
 	 * @var boolean
 	 */
-	public static $support_tags = false;
+	public static $support_local_lists = true;
 
 	/**
 	 * Provider name.
@@ -1219,11 +1219,15 @@ final class Newspack_Newsletters_Mailchimp extends \Newspack_Newsletters_Service
 	 */
 	public static function get_labels() {
 		return [
-			'name'  => 'Mailchimp', // The provider name.
-			'list'  => __( 'audience', 'newspack-newsletters' ), // "list" in lower case singular format.
-			'lists' => __( 'audiences', 'newspack-newsletters' ), // "list" in lower case plural format.
-			'List'  => __( 'Audience', 'newspack-newsletters' ), // "list" in uppercase case singular format.
-			'Lists' => __( 'Audiences', 'newspack-newsletters' ), // "list" in uppercase case plural format.
+			'name'                    => 'Mailchimp', // The provider name.
+			'list'                    => __( 'audience', 'newspack-newsletters' ), // "list" in lower case singular format.
+			'lists'                   => __( 'audiences', 'newspack-newsletters' ), // "list" in lower case plural format.
+			'List'                    => __( 'Audience', 'newspack-newsletters' ), // "list" in uppercase case singular format.
+			'Lists'                   => __( 'Audiences', 'newspack-newsletters' ), // "list" in uppercase case plural format.
+			'tag_prefix'              => '',
+			'tag_metabox_before_save' => __( 'Once this list is saved, a Group will be created for it.', 'newspack-newsletters' ),
+			// translators: %s is the name of the group category. "Newspack newsletters" by default.
+			'tag_metabox_after_save'  => sprintf( __( 'Group created for this list under %s:', 'newspack-newsletters' ), self::get_group_category_name() ),
 		];
 	}
 }

--- a/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp.php
+++ b/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp.php
@@ -42,6 +42,8 @@ final class Newspack_Newsletters_Mailchimp extends \Newspack_Newsletters_Service
 		add_action( 'wp_trash_post', [ $this, 'trash' ], 10, 1 );
 		add_filter( 'newspack_newsletters_process_link', [ $this, 'process_link' ], 10, 2 );
 
+		add_action( 'newspack_newsletters_subscription_lists_metabox_after_tag', [ $this, 'lists_metabox_notice' ] );
+
 		parent::__construct( $this );
 	}
 
@@ -1229,5 +1231,23 @@ final class Newspack_Newsletters_Mailchimp extends \Newspack_Newsletters_Service
 			// translators: %s is the name of the group category. "Newspack newsletters" by default.
 			'tag_metabox_after_save'  => sprintf( __( 'Group created for this list under %s:', 'newspack-newsletters' ), self::get_group_category_name() ),
 		];
+	}
+
+	/**
+	 * Add a notice to the Subscription Lists metabox letting the user know that readers are also subscribed to the parent Audience
+	 *
+	 * @param array $settings The List settings.
+	 * @return void
+	 */
+	public function lists_metabox_notice( $settings ) {
+		if ( $settings['tag_name'] ) {
+			?>
+			<p class="subscription-list-warning">
+				<?php
+				esc_html_e( 'Note for Mailchimp: The group is part of the Audience. When a reader subscribes to this List, they will also be subscribed to the Audience.', 'newspack-newsletters' );
+				?>
+			</p>
+			<?php
+		}
 	}
 }

--- a/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp.php
+++ b/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp.php
@@ -1244,7 +1244,7 @@ final class Newspack_Newsletters_Mailchimp extends \Newspack_Newsletters_Service
 			?>
 			<p class="subscription-list-warning">
 				<?php
-				esc_html_e( 'Note for Mailchimp: The group is part of the Audience. When a reader subscribes to this List, they will also be subscribed to the Audience.', 'newspack-newsletters' );
+				esc_html_e( 'Note for Mailchimp: The group is a subset of the Audience selected above. When a reader subscribes to this List, they will also be subscribed to the selected Audience.', 'newspack-newsletters' );
 				?>
 			</p>
 			<?php


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Re-enables the tag based Lists (local lists) for Active Campaign and Mailchimp.

For mailchimp, make it work with Groups instead of Tags.

### How to test the changes in this Pull Request:

1. Set your ESP as Mailchimp
2. Create a couple of Local lists in Newsletter > Lists
3. Register as a new user to your site
4. Subscribe to a newsletter
5. In Mailchimp dashboard, confirm that the "Newspack Newsletter" Group category was created (a new column in the all contacts list)
6. In Mailchimp dashboard, confirm the user was created with the expected Group
7. Go to My Account > Newsletters
8. Confirm that the page correctly shows the newsletters you have subscribed to
9. Check and uncheck different newsletters and save
10. Confirm that every time the correct Groups are applied to the contact on Mailchimp and the checkboxes are properly updated
11. In the admin (as an admin) switch the ESP to Active Campaign
12. Back to your reader user, go to My Account > Newsletters again
13. All newsletters should be unchecked
14. This user does not exist in the ESP yet, let's see if it will be created on the fly
15. Check one or several newsletters and submit
16. Confirm the user is created in the ESP
17. Play again with checking and unchecking Lists and see if they are correctly updated
18. In Active Campaign, the Lists will be stored as Tags in the contact
19. Check you error log for warnings and errors.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
