### PR TITLE
feat: add support to campaigns data event listeners

### DIFF
--- a/src/blocks/subscribe/index.php
+++ b/src/blocks/subscribe/index.php
@@ -329,8 +329,14 @@ function process_form() {
 		$lists
 	);
 
+	$popup_id = isset( $_REQUEST['newspack_popup_id'] ) ? (int) $_REQUEST['newspack_popup_id'] : false;
+
 	if ( ! \is_user_logged_in() && \class_exists( '\Newspack\Reader_Activation' ) && \Newspack\Reader_Activation::is_enabled() ) {
 		$metadata = array_merge( $metadata, [ 'registration_method' => 'newsletters-subscription' ] );
+		if ( $popup_id ) {
+			$metadata['popup_id']            = $popup_id;
+			$metadata['registration_method'] = 'newsletters-subscription-popup';
+		}
 		\Newspack\Reader_Activation::register_reader( $email, $name, true, $metadata );
 	}
 
@@ -339,8 +345,9 @@ function process_form() {
 	 *
 	 * @param string         $email  Email address of the reader.
 	 * @param array|WP_Error $result Contact data if it was added, or error otherwise.
+	 * @param int|false $popup_id The ID of the popup that triggered the registration, or false if not triggered by a popup.
 	 */
-	\do_action( 'newspack_newsletters_subscribe_form_processed', $email, $result );
+	\do_action( 'newspack_newsletters_subscribe_form_processed', $email, $result, $popup_id );
 
 	return send_form_response( $result );
 }

--- a/src/blocks/subscribe/index.php
+++ b/src/blocks/subscribe/index.php
@@ -126,7 +126,7 @@ function render_block( $attrs ) {
 				<?php \wp_nonce_field( FORM_ACTION, FORM_ACTION ); ?>
 				<?php
 				/**
-				 * Action to add custom fields before the form fields of the registration block.
+				 * Action to add custom fields before the form fields of the Newsletter Subscription block.
 				 *
 				 * @param array $attrs Block attributes.
 				 */


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Add support to Popups events in the Data Events api

### How to test the changes in this Pull Request:

See https://github.com/Automattic/newspack-plugin/pull/2291

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
