### PR TITLE
feat: open Newsletter menu when editing lists

### DIFF
--- a/includes/class-subscription-lists.php
+++ b/includes/class-subscription-lists.php
@@ -45,15 +45,23 @@ class Subscription_Lists {
 	}
 
 	/**
-	 * Add custom CSS to the List post type edit screen
+	 * Add custom CSS and JS to the List post type edit screen
 	 */
 	public static function admin_enqueue_scripts() {
-		if ( get_current_screen()->post_type === self::CPT ) {
+		$current_screen = get_current_screen();
+		if ( self::CPT === $current_screen->post_type && 'post' === $current_screen->base ) {
 			wp_enqueue_style(
 				'newspack-newsletters-subscription-list-editor',
 				plugins_url( '../css/subscription-list-editor.css', __FILE__ ),
 				[],
 				filemtime( NEWSPACK_NEWSLETTERS_PLUGIN_FILE . 'css/subscription-list-editor.css' )
+			);
+			wp_enqueue_script(
+				'newspack-newsletters-subscription-list-editor',
+				plugins_url( '../js/subscription-list-editor.js', __FILE__ ),
+				[],
+				filemtime( NEWSPACK_NEWSLETTERS_PLUGIN_FILE . 'js/subscription-list-editor.js' ),
+				true
 			);
 		}
 	}

--- a/js/subscription-list-editor.js
+++ b/js/subscription-list-editor.js
@@ -1,0 +1,12 @@
+jQuery( document ).ready( function ( $ ) {
+	$( '#menu-posts-newspack_nl_cpt' )
+		.addClass( 'wp-has-current-submenu wp-menu-open menu-top menu-top-first' )
+		.removeClass( 'wp-not-current-submenu' );
+	$( '#menu-posts-newspack_nl_cpt > a' )
+		.addClass( 'wp-has-current-submenu' )
+		.removeClass( 'wp-not-current-submenu' );
+	$( 'a[href$="edit.php?post_type=newspack_nl_list"]' )
+		.addClass( 'current' )
+		.parent()
+		.addClass( 'current' );
+} );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Opens the Newsletter menu and mark "Lists" as the current item when editing a List

### How to test the changes in this Pull Request:

1. Go to Newsletters > Lists
2. Verify that the Newsletter top menu level is open and that "Lists" is the current active menu item
3. Add a new List or edit an existing one
4. Verify that the Newsletter top menu level is open and that "Lists" is the current active menu item

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
