### PR TITLE
Update/two way sync tag names

### DIFF
--- a/includes/class-subscription-lists.php
+++ b/includes/class-subscription-lists.php
@@ -344,33 +344,53 @@ class Subscription_Lists {
 			return;
 		}
 
-		$provider          = Newspack_Newsletters::get_service_provider();
-		$tag_prefix        = $provider::label( 'tag_prefix' );
-		$subscription_list = new Subscription_List( $post_id );
-		$current_settings  = $subscription_list->get_current_provider_settings();
-		$tag_id            = $current_settings['tag_id'] ?? false;
-		$tag_name          = $current_settings['tag_name'] ?? $subscription_list->generate_tag_name( $tag_prefix );
-		$error             = '';
+		$provider            = Newspack_Newsletters::get_service_provider();
+		$tag_prefix          = $provider::label( 'tag_prefix' );
+		$subscription_list   = new Subscription_List( $post_id );
+		$new_tag_name        = $subscription_list->generate_tag_name( $tag_prefix );
+		$current_settings    = $subscription_list->get_current_provider_settings();
+		$tag_id              = $current_settings['tag_id'] ?? false;
+		$current_tag_name    = $current_settings['tag_name'] ?? $subscription_list->generate_tag_name( $tag_prefix );
+		$error               = '';
+		$needs_remote_update = $new_tag_name !== $current_tag_name; // Name was changed locally, needs to be updated on the ESP.
+		$needs_local_update  = false;
 
 		if ( $tag_id ) {
-			// Check if tag still exists on the ESP. Also, update tag_name if it was changed on the ESP.
-			$tag_name = $provider->get_esp_local_list_by_id( $current_settings['tag_id'], $list );
-
-			if ( is_wp_error( $tag_name ) ) {
+			// Check if tag still exists on the ESP. Will return a new name if name was changed on the ESP's dashboard.
+			$esp_tag_name = $provider->get_esp_local_list_by_id( $current_settings['tag_id'], $list );
+			if ( is_wp_error( $esp_tag_name ) ) {
 				// Tag was not found. We need to create a new one. In Mailchimp, this can happen if you changed the Audience.
-				$tag_id   = false;
-				$tag_name = $subscription_list->generate_tag_name( $tag_prefix );
+				$tag_id             = false; // Force create a new tag.
+				$new_tag_name       = $subscription_list->generate_tag_name( $tag_prefix );
+				$needs_local_update = false;
+			} elseif ( $esp_tag_name !== $current_tag_name ) {
+				// Tag name was changed on the ESP's dashboard. We need to update the local tag name.
+				$needs_local_update = true;
 			}
 		}
 
 		if ( ! $tag_id ) {
-			$tag_id = $provider->get_esp_local_list_id( $tag_name, true, $list );
+			// Get an existing tag id in the ESP or create a new one.
+			$tag_id = $provider->get_esp_local_list_id( $new_tag_name, true, $list );
 			if ( is_wp_error( $tag_id ) ) {
 				$error = $tag_id->get_error_message();
 			}
 		}
 
-		$subscription_list->update_current_provider_settings( $list, $tag_id, $tag_name, $error );
+		// Sync tag name with ESP. If tag name was changed on both ends, local changes will have precedence.
+		if ( $needs_remote_update ) {
+			$provider->update_esp_local_list( $tag_id, $new_tag_name, $list );
+		} elseif ( $needs_local_update ) {
+			$new_tag_name = $esp_tag_name;
+			wp_update_post(
+				[
+					'ID'         => $post_id,
+					'post_title' => str_replace( $tag_prefix, '', $new_tag_name ),
+				]
+			);
+		}
+
+		$subscription_list->update_current_provider_settings( $list, $tag_id, $new_tag_name, $error );
 
 	}
 

--- a/includes/service-providers/active_campaign/class-newspack-newsletters-active-campaign.php
+++ b/includes/service-providers/active_campaign/class-newspack-newsletters-active-campaign.php
@@ -313,6 +313,40 @@ final class Newspack_Newsletters_Active_Campaign extends \Newspack_Newsletters_S
 	}
 
 	/**
+	 * Updates a Tag name on the provider
+	 *
+	 * @param string|int $tag_id The tag ID.
+	 * @param string     $tag The Tag new name.
+	 * @param string     $list_id The List ID. Not needed for Active Campaign.
+	 * @return array|WP_Error The tag representation with at least 'id' and 'name' keys on succes. WP_Error on failure.
+	 */
+	public function update_tag( $tag_id, $tag, $list_id = null ) {
+		$tag_info = [
+			'tag' => [
+				'tag'         => $tag,
+				'tagType'     => 'contact',
+				'description' => 'Created by Newspack Newsletters to manage subscription lists',
+			],
+		];
+
+		$created = $this->api_v3_request(
+			sprintf( 'tags/%d', $tag_id ),
+			'PUT',
+			[
+				'body' => wp_json_encode( $tag_info ),
+			]
+		);
+		if ( is_array( $created ) && ! empty( $created['tag'] ) && ! empty( $created['tag']['id'] ) ) {
+			$created['tag']['name'] = $created['tag']['tag'];
+			return $created['tag'];
+		}
+		return new WP_Error(
+			'newspack_newsletters_error_updating_tag',
+			! empty( $created['error'] ) ? $created['error'] : ''
+		);
+	}
+
+	/**
 	 * Add a tag to a contact
 	 *
 	 * @param string     $email The contact email.

--- a/includes/service-providers/class-newspack-newsletters-service-provider.php
+++ b/includes/service-providers/class-newspack-newsletters-service-provider.php
@@ -594,6 +594,18 @@ abstract class Newspack_Newsletters_Service_Provider implements Newspack_Newslet
 	}
 
 	/**
+	 * Updates a Tag name on the provider
+	 *
+	 * @param string|int $tag_id The tag ID.
+	 * @param string     $tag The Tag new name.
+	 * @param string     $list_id The List ID.
+	 * @return array|WP_Error The tag representation with at least 'id' and 'name' keys on succes. WP_Error on failure.
+	 */
+	public function update_tag( $tag_id, $tag, $list_id = null ) {
+		return new WP_Error( 'newspack_newsletters_not_implemented', __( 'Not implemented', 'newspack-newsletters' ), [ 'status' => 400 ] );
+	}
+
+	/**
 	 * Add a tag to a contact
 	 *
 	 * @param string     $email The contact email.

--- a/includes/service-providers/class-newspack-newsletters-service-provider.php
+++ b/includes/service-providers/class-newspack-newsletters-service-provider.php
@@ -658,8 +658,8 @@ abstract class Newspack_Newsletters_Service_Provider implements Newspack_Newslet
 	 *
 	 * By default it will use Tags, but the provider can override this method to use something else
 	 *
-	 * @param int    $esp_local_list_id The esp_local_list ID.
-	 * @param string $list_id The List ID.
+	 * @param string|int $esp_local_list_id The esp_local_list ID.
+	 * @param string     $list_id The List ID.
 	 * @return string|WP_Error The esp_local_list name on success. WP_Error on failure.
 	 */
 	public function get_esp_local_list_by_id( $esp_local_list_id, $list_id = null ) {
@@ -677,6 +677,20 @@ abstract class Newspack_Newsletters_Service_Provider implements Newspack_Newslet
 	 */
 	public function create_esp_local_list( $esp_local_list, $list_id = null ) {
 		return $this->create_tag( $esp_local_list, $list_id );
+	}
+
+	/**
+	 * Update a Local list name on the ESP
+	 *
+	 * By default it will use Tags, but the provider can override this method to use something else
+	 *
+	 * @param string|int $esp_local_list_id The esp_local_list ID.
+	 * @param string     $esp_local_list The Tag name.
+	 * @param string     $list_id The List ID.
+	 * @return array|WP_Error The esp_local_list representation with at least 'id' and 'name' keys on succes. WP_Error on failure.
+	 */
+	public function update_esp_local_list( $esp_local_list_id, $esp_local_list, $list_id = null ) {
+		return $this->update_tag( $esp_local_list_id, $esp_local_list, $list_id );
 	}
 
 	/**

--- a/includes/service-providers/constant_contact/class-newspack-newsletters-constant-contact-sdk.php
+++ b/includes/service-providers/constant_contact/class-newspack-newsletters-constant-contact-sdk.php
@@ -707,6 +707,32 @@ final class Newspack_Newsletters_Constant_Contact_SDK {
 	}
 
 	/**
+	 * Updates a Tag name on the provider
+	 *
+	 * @param string|int $tag_id The tag ID.
+	 * @param string     $tag_name The Tag new name.
+	 * @return array|WP_Error The tag representation with at least 'id' and 'name' keys on succes. WP_Error on failure.
+	 */
+	public function update_tag( $tag_id, $tag_name ) {
+		try {
+			$res = $this->request(
+				'PUT',
+				sprintf( '/contact_tags/%s', $tag_id ),
+				[
+					'body' => wp_json_encode(
+						[
+							'name' => $tag_name,
+						]
+					),
+				]
+			);
+			return $res;
+		} catch ( Exception $e ) {
+			return new WP_Error( 'newspack_newsletter_error_updating_tag', $e->getMessage() );
+		}
+	}
+
+	/**
 	 * Create a Segment that will group users tagged with a given tag
 	 *
 	 * @param string $tag_id The ID of the tag to create a segment for.

--- a/includes/service-providers/constant_contact/class-newspack-newsletters-constant-contact.php
+++ b/includes/service-providers/constant_contact/class-newspack-newsletters-constant-contact.php
@@ -969,6 +969,26 @@ final class Newspack_Newsletters_Constant_Contact extends \Newspack_Newsletters_
 	}
 
 	/**
+	 * Updates a Tag name on the provider
+	 *
+	 * @param string|int $tag_id The tag ID.
+	 * @param string     $tag The Tag new name.
+	 * @param string     $list_id The List ID.
+	 * @return array|WP_Error The tag representation with at least 'id' and 'name' keys on succes. WP_Error on failure.
+	 */
+	public function update_tag( $tag_id, $tag, $list_id = null ) {
+		$cc  = new Newspack_Newsletters_Constant_Contact_SDK( $this->api_key(), $this->api_secret(), $this->access_token() );
+		$tag = $cc->update_tag( $tag_id, $tag );
+		if ( is_wp_error( $tag ) ) {
+			return $tag;
+		}
+		return [
+			'id'   => $tag->tag_id,
+			'name' => $tag->name,
+		];
+	}
+
+	/**
 	 * Add a tag to a contact
 	 *
 	 * @param string     $email The contact email.

--- a/includes/service-providers/interface-newspack-newsletters-esp-service.php
+++ b/includes/service-providers/interface-newspack-newsletters-esp-service.php
@@ -143,6 +143,16 @@ interface Newspack_Newsletters_ESP_API_Interface {
 	public function create_tag( $tag, $list_id = null );
 
 	/**
+	 * Updates a Tag name on the provider
+	 *
+	 * @param string|int $tag_id The tag ID.
+	 * @param string     $tag The Tag new name.
+	 * @param string     $list_id The List ID.
+	 * @return array|WP_Error The tag representation with at least 'id' and 'name' keys on succes. WP_Error on failure.
+	 */
+	public function update_tag( $tag_id, $tag, $list_id = null );
+
+	/**
 	 * Add a tag to a contact
 	 *
 	 * @param string     $email The contact email.

--- a/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp-groups.php
+++ b/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp-groups.php
@@ -261,6 +261,33 @@ trait Newspack_Newsletters_Mailchimp_Groups {
 	}
 
 	/**
+	 * Create a Group on Mailchimp
+	 *
+	 * @param string $group_id The group ID.
+	 * @param string $group The Group name.
+	 * @param string $list_id The List ID.
+	 * @return array|WP_Error The group representation sent from the server on succes. WP_Error on failure.
+	 */
+	public function update_group( $group_id, $group, $list_id = null ) {
+		
+		$mc      = new Mailchimp( $this->api_key() );
+		$created = $mc->patch(
+			sprintf( '/lists/%s/interest-categories/%s/interests/%s', $list_id, $this->get_groups_category_id( $list_id ), $group_id ),
+			[
+				'name' => $group,
+			]
+		);
+
+		if ( is_array( $created ) && ! empty( $created['id'] ) && ! empty( $created['name'] ) ) {
+			return $created;
+		}
+		return new WP_Error(
+			'newspack_newsletters_error_updating_group',
+			! empty( $created['detail'] ) ? $created['detail'] : ''
+		);
+	}
+
+	/**
 	 * Add a group to a contact
 	 *
 	 * @param string $email The contact email.

--- a/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp-groups.php
+++ b/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp-groups.php
@@ -43,8 +43,8 @@ trait Newspack_Newsletters_Mailchimp_Groups {
 	 *
 	 * Mailchimp overrides it to use Groups instead of Tags
 	 *
-	 * @param int    $esp_local_list_id The esp_local_list ID.
-	 * @param string $list_id The List ID.
+	 * @param int|string $esp_local_list_id The esp_local_list ID.
+	 * @param string     $list_id The List ID.
 	 * @return string|WP_Error The esp_local_list name on success. WP_Error on failure.
 	 */
 	public function get_esp_local_list_by_id( $esp_local_list_id, $list_id = null ) {
@@ -62,6 +62,20 @@ trait Newspack_Newsletters_Mailchimp_Groups {
 	 */
 	public function create_esp_local_list( $esp_local_list, $list_id = null ) {
 		return $this->create_group( $esp_local_list, $list_id );
+	}
+
+	/**
+	 * Updates a Local list name on the ESP
+	 *
+	 * Mailchimp overrides it to use Groups instead of Tags
+	 *
+	 * @param int|string $esp_local_list_id The esp_local_list ID.
+	 * @param string     $esp_local_list The Tag name.
+	 * @param string     $list_id The List ID.
+	 * @return array|WP_Error The esp_local_list representation with at least 'id' and 'name' keys on succes. WP_Error on failure.
+	 */
+	public function update_esp_local_list( $esp_local_list_id, $esp_local_list, $list_id = null ) {
+		return $this->update_group( $esp_local_list_id, $esp_local_list, $list_id );
 	}
 
 	/**

--- a/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp.php
+++ b/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp.php
@@ -195,6 +195,33 @@ final class Newspack_Newsletters_Mailchimp extends \Newspack_Newsletters_Service
 	}
 
 	/**
+	 * Updates a Tag name on the provider
+	 *
+	 * @param string|int $tag_id The tag ID.
+	 * @param string     $tag The Tag new name.
+	 * @param string     $list_id The List ID.
+	 * @return array|WP_Error The tag representation with at least 'id' and 'name' keys on succes. WP_Error on failure.
+	 */
+	public function update_tag( $tag_id, $tag, $list_id = null ) {
+		$mc      = new Mailchimp( $this->api_key() );
+		$created = $mc->patch(
+			sprintf( 'lists/%s/segments/%s', $list_id, $tag_id ),
+			[
+				'name'           => $tag,
+				'static_segment' => [],
+			]
+		);
+
+		if ( is_array( $created ) && ! empty( $created['id'] ) && ! empty( $created['name'] ) ) {
+			return $created;
+		}
+		return new WP_Error(
+			'newspack_newsletters_error_updating_tag',
+			! empty( $created['detail'] ) ? $created['detail'] : ''
+		);
+	}
+
+	/**
 	 * Add a tag to a contact
 	 *
 	 * @param string     $email The contact email.


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

This PR ensures that if a "Local List" name is edited, the tag/group name will also be edited in the ESP. And if the tag/group is edited on the ESP, the Local list name will be updated on the local site when it's saved.

### How to test the changes in this Pull Request:

1. Let's test this for: Active Campaign, Constant Contact and Mailchimp
2. Go to Newsletters >  Settings and configure the provider
3. Go to Newsletters > List and create a new List
4. Confirm that the tag (group in MC) was created in the ESP dashboard
5. Edit the list name and save
6. Confirm that the tag (group in MC) name was updated in the ESP dashboard
7. Edit the tag/group name in the ESP dashboard
8. Back to the List edit page on WordPress, save the list without changes to the title
9. Confirm the name of the list was updated with the name that was set in the ESP
10. Edit the tag/group name in the ESP dashboard again
11. Back to the List edit page on WordPress, save the list WITH changes in the title
12. Confirm that the change made on the WP editor takes precedence and is reflected on the ESP

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
