### PR TITLE
fix: remove list from settings when deleted

### DIFF
--- a/includes/class-subscription-lists.php
+++ b/includes/class-subscription-lists.php
@@ -8,6 +8,7 @@
 namespace Newspack\Newsletters;
 
 use Newspack_Newsletters;
+use Newspack_Newsletters_Subscription;
 use WP_Post;
 
 defined( 'ABSPATH' ) || exit;
@@ -41,6 +42,9 @@ class Subscription_Lists {
 		add_filter( 'manage_' . self::CPT . '_posts_columns', [ __CLASS__, 'posts_columns' ] );
 		add_action( 'manage_' . self::CPT . '_posts_custom_column', [ __CLASS__, 'posts_columns_values' ], 10, 2 );
 		add_action( 'admin_enqueue_scripts', [ __CLASS__, 'admin_enqueue_scripts' ] );
+
+		add_action( 'delete_post', [ __CLASS__, 'delete_post' ] );
+		add_action( 'wp_trash_post', [ __CLASS__, 'delete_post' ] );
 	}
 
 	/**
@@ -445,5 +449,49 @@ class Subscription_Lists {
 				return $list->is_configured_for_current_provider();
 			}
 		);
+	}
+
+	/**
+	 * Callback for the delete_post and wp_trash_post actions. Will remove the deleted/trashed list from the config.
+	 *
+	 * @param int           $post_id The Post ID.
+	 * @param false|WP_Post $post Informed by the delete_post action, but not by the wp_trash_post action. The deleted post object.
+	 * @return void
+	 */
+	public static function delete_post( $post_id, $post = false ) {
+		if ( ! $post ) {
+			$post = get_post( $post_id );
+		}
+		if ( ! $post instanceof WP_Post ) {
+			return;
+		}
+		if ( self::CPT !== $post->post_type ) {
+			return;
+		}
+		$list_config = Newspack_Newsletters_Subscription::get_lists_config();
+		if ( empty( $list_config ) || \is_wp_error( $list_config ) ) {
+			return;
+		}
+
+		$id = Subscription_List::FORM_ID_PREFIX . $post_id;
+		
+		if ( ! isset( $list_config[ $id ] ) ) {
+			return;
+		}
+		
+		unset( $list_config[ $id ] );
+
+		$new_list_config = [];
+		// generate a new list config without the deleted list.
+		foreach ( $list_config as $list_id => $list ) {
+			$new_list_config[] = [
+				'id'          => $list_id,
+				'active'      => $list['active'],
+				'title'       => $list['title'],
+				'description' => $list['description'],
+			];
+		}
+
+		Newspack_Newsletters_Subscription::update_lists( $new_list_config );
 	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

When a Local list is deleted, it still shows up as an option in the Subscription Block. This PR fixes it

### How to test the changes in this Pull Request:

Confirm the bug

1. Create a couple of local lists
2. Go to Newsletters > Settings an enable them
3. On a new tab, create a page and insert the Newsletter Subscription Block
4. Check that in the block options you see the Local lists as options
5. Go to Newsletters > Lists and delete/trash one of the lists
6. Go back to the page, add the Subscription block again and see that the deleted list is still there

Checkout this PR and repeat the process. Confirm that the list is no longer there in step 6

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
