### PR TITLE
fix: typo causing fatal errors

### DIFF
--- a/includes/service-providers/active_campaign/class-newspack-newsletters-active-campaign.php
+++ b/includes/service-providers/active_campaign/class-newspack-newsletters-active-campaign.php
@@ -1035,8 +1035,8 @@ final class Newspack_Newsletters_Active_Campaign extends \Newspack_Newsletters_S
 							),
 						]
 					);
-					if ( \is_wp_error( $fields_res ) ) {
-						return $fields_res;
+					if ( \is_wp_error( $field_res ) ) {
+						return $field_res;
 					}
 					/** Set list relation. */
 					$this->api_v3_request(


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes a typo that is causing an error when $field_res is a WP_Error.

```
[02-Mar-2023 00:17:28 UTC] PHP Warning:  Undefined variable $fields_res in /newspack-repos/newspack-newsletters/includes/service-providers/active_campaign/class-newspack-newsletters-active-campaign.php on line 1004
[02-Mar-2023 00:17:28 UTC] PHP Fatal error:  Uncaught Error: Cannot use object of type WP_Error as array in /newspack-repos/newspack-newsletters/includes/service-providers/active_campaign/class-newspack-newsletters-active-campaign.php:1015

```

### How to test the changes in this Pull Request:

1. check the code

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
