### PR TITLE
Update/remove local list menu

### DIFF
--- a/includes/class-newspack-newsletters-settings.php
+++ b/includes/class-newspack-newsletters-settings.php
@@ -7,6 +7,8 @@
 
 defined( 'ABSPATH' ) || exit;
 
+use Newspack\Newsletters\Subscription_Lists;
+
 /**
  * Manages Settings page.
  */
@@ -255,6 +257,7 @@ class Newspack_Newsletters_Settings {
 		?>
 		<div class="newspack-newsletters-subscription-lists">
 			<h2><?php esc_html_e( 'Subscription Lists', 'newspack-newsletters' ); ?></h2>
+			<a class="primary button" id="newspack-newsletters-create" href="<?php echo esc_url( Subscription_Lists::get_add_new_url() ); ?>"><?php esc_html_e( 'Add new', 'newspack-newsletters' ); ?></a>
 			<div class="notice notice-warning changed-provider">
 				<p><?php esc_html_e( 'Save changes to display the selected provider lists.', 'newspack-newsletters' ); ?></p>
 			</div>

--- a/includes/class-newspack-newsletters-settings.php
+++ b/includes/class-newspack-newsletters-settings.php
@@ -257,7 +257,9 @@ class Newspack_Newsletters_Settings {
 		?>
 		<div class="newspack-newsletters-subscription-lists">
 			<h2><?php esc_html_e( 'Subscription Lists', 'newspack-newsletters' ); ?></h2>
-			<a class="primary button" id="newspack-newsletters-create" href="<?php echo esc_url( Subscription_Lists::get_add_new_url() ); ?>"><?php esc_html_e( 'Add new', 'newspack-newsletters' ); ?></a>
+			<?php if ( Subscription_Lists::get_add_new_url() ) : ?>
+				<a class="primary button" id="newspack-newsletters-create" href="<?php echo esc_url( Subscription_Lists::get_add_new_url() ); ?>"><?php esc_html_e( 'Add new', 'newspack-newsletters' ); ?></a>
+			<?php endif; ?>
 			<div class="notice notice-warning changed-provider">
 				<p><?php esc_html_e( 'Save changes to display the selected provider lists.', 'newspack-newsletters' ); ?></p>
 			</div>

--- a/includes/class-newspack-newsletters-subscription.php
+++ b/includes/class-newspack-newsletters-subscription.php
@@ -191,7 +191,7 @@ class Newspack_Newsletters_Subscription {
 						'description' => $list['description'] ?? '',
 						'edit_link'   => $list['edit_link'] ?? '',
 						'type'        => $list['type'] ?? '',
-						'type_label'  => isset( $list['type'] ) && 'local' === $list['type'] ? __( 'Local list', 'newspack-newsletters' ) : $provider::label( 'name' ) . ' ' . $provider::label( 'List' ),
+						'type_label'  => isset( $list['type'] ) && 'local' === $list['type'] ? __( 'Local list', 'newspack-newsletters' ) . '. ' . $provider::label( 'local_list_explanation' ) : $provider::label( 'list_explanation' ),
 					];
 					if ( isset( $config[ $list['id'] ] ) ) {
 						$list_config    = $config[ $list['id'] ];

--- a/includes/class-newspack-newsletters-subscription.php
+++ b/includes/class-newspack-newsletters-subscription.php
@@ -191,7 +191,7 @@ class Newspack_Newsletters_Subscription {
 						'description' => $list['description'] ?? '',
 						'edit_link'   => $list['edit_link'] ?? '',
 						'type'        => $list['type'] ?? '',
-						'type_label'  => isset( $list['type'] ) && 'local' === $list['type'] ? __( 'Local list', 'newspack-newsletters' ) . '. ' . $provider::label( 'local_list_explanation' ) : $provider::label( 'list_explanation' ),
+						'type_label'  => isset( $list['type'] ) && 'local' === $list['type'] ? $provider::label( 'local_list_explanation' ) : $provider::label( 'list_explanation' ),
 					];
 					if ( isset( $config[ $list['id'] ] ) ) {
 						$list_config    = $config[ $list['id'] ];

--- a/includes/class-subscription-lists.php
+++ b/includes/class-subscription-lists.php
@@ -8,6 +8,7 @@
 namespace Newspack\Newsletters;
 
 use Newspack_Newsletters;
+use Newspack_Newsletters_Settings;
 use Newspack_Newsletters_Subscription;
 use WP_Post;
 
@@ -45,6 +46,9 @@ class Subscription_Lists {
 
 		add_action( 'delete_post', [ __CLASS__, 'delete_post' ] );
 		add_action( 'wp_trash_post', [ __CLASS__, 'delete_post' ] );
+
+		add_action( 'edit_form_before_permalink', [ __CLASS__, 'edit_form_before_permalink' ] );
+		add_action( 'edit_form_top', [ __CLASS__, 'edit_form_top' ] );
 	}
 
 	/**
@@ -516,11 +520,36 @@ class Subscription_Lists {
 	}
 
 	/**
-	 * Get the URL to add a new Subscription List
+	 * Get the URL to add a new Subscription List if the current provider supports it Empty string otherwise
 	 *
-	 * @return string
+	 * @return ?string
 	 */
 	public static function get_add_new_url() {
-		return admin_url( 'post-new.php?post_type=' . self::CPT );
+		if ( self::should_initialize_lists() ) {
+			return admin_url( 'post-new.php?post_type=' . self::CPT );
+		}
+	}
+
+	/**
+	 * Outputs a title for the description field in the post editor.
+	 */
+	public static function edit_form_before_permalink() {
+		if ( self::CPT === get_post_type() ) {
+			printf( '<h2>%s</h2>', esc_html__( 'Description', 'newspack-newsletters' ) );
+		}
+	}
+	
+	/**
+	 * Outputs a link back to the Settings page above the title in the post editor.
+	 */
+	public static function edit_form_top() {
+		if ( self::CPT === get_post_type() ) {
+			?>
+			<a href="<?php echo esc_url( Newspack_Newsletters_Settings::get_settings_url() ); ?>">
+				&lt;&lt;
+				<?php esc_html_e( 'Back to Subscription Lists management', 'newspack-newsletters' ); ?>
+			</a>
+			<?php
+		}
 	}
 }

--- a/includes/class-subscription-lists.php
+++ b/includes/class-subscription-lists.php
@@ -141,7 +141,7 @@ class Subscription_Lists {
 			'hierarchical'         => false,
 			'public'               => false,
 			'show_ui'              => true,
-			'show_in_menu'         => 'edit.php?post_type=' . Newspack_Newsletters::NEWSPACK_NEWSLETTERS_CPT,
+			'show_in_menu'         => false,
 			'can_export'           => false,
 			'capability_type'      => 'page',
 			'show_in_rest'         => false,
@@ -445,5 +445,14 @@ class Subscription_Lists {
 				return $list->is_configured_for_current_provider();
 			}
 		);
+	}
+
+	/**
+	 * Get the URL to add a new Subscription List
+	 *
+	 * @return string
+	 */
+	public static function get_add_new_url() {
+		return admin_url( 'post-new.php?post_type=' . self::CPT );
 	}
 }

--- a/includes/service-providers/active_campaign/class-newspack-newsletters-active-campaign.php
+++ b/includes/service-providers/active_campaign/class-newspack-newsletters-active-campaign.php
@@ -1269,7 +1269,9 @@ final class Newspack_Newsletters_Active_Campaign extends \Newspack_Newsletters_S
 		return array_merge(
 			parent::get_labels(),
 			[
-				'name' => 'Active Campaign',
+				'name'                   => 'Active Campaign',
+				'list_explanation'       => __( 'Active Campaign List', 'newspack-newsletters' ),
+				'local_list_explanation' => __( 'Active Campaign Tag', 'newspack-newsletters' ),
 			]
 		);
 	}

--- a/includes/service-providers/active_campaign/class-newspack-newsletters-active-campaign.php
+++ b/includes/service-providers/active_campaign/class-newspack-newsletters-active-campaign.php
@@ -212,9 +212,10 @@ final class Newspack_Newsletters_Active_Campaign extends \Newspack_Newsletters_S
 				],
 			]
 		);
+
 		if ( ! empty( $search['tags'] ) ) {
 			foreach ( $search['tags'] as $found_tag ) {
-				if ( ! empty( $found_tag['tag'] ) && $tag_name === $found_tag['tag'] ) {
+				if ( ! empty( $found_tag['tag'] ) && strtolower( $tag_name ) === strtolower( $found_tag['tag'] ) ) {
 					return (int) $found_tag['id'];
 				}
 			}
@@ -228,6 +229,10 @@ final class Newspack_Newsletters_Active_Campaign extends \Newspack_Newsletters_S
 		}
 
 		$created = $this->create_tag( $tag_name );
+
+		if ( is_wp_error( $created ) ) {
+			return $created;
+		}
 
 		return (int) $created['id'];
 	}

--- a/includes/service-providers/constant_contact/class-newspack-newsletters-constant-contact.php
+++ b/includes/service-providers/constant_contact/class-newspack-newsletters-constant-contact.php
@@ -906,7 +906,9 @@ final class Newspack_Newsletters_Constant_Contact extends \Newspack_Newsletters_
 		return array_merge(
 			parent::get_labels(),
 			[
-				'name' => 'Constant Contact',
+				'name'                   => 'Constant Contact',
+				'list_explanation'       => __( 'Constant Contact List', 'newspack-newsletters' ),
+				'local_list_explanation' => __( 'Represented by a Tag in Constant Contact', 'newspack-newsletters' ),
 			]
 		);
 	}

--- a/includes/service-providers/constant_contact/class-newspack-newsletters-constant-contact.php
+++ b/includes/service-providers/constant_contact/class-newspack-newsletters-constant-contact.php
@@ -908,7 +908,7 @@ final class Newspack_Newsletters_Constant_Contact extends \Newspack_Newsletters_
 			[
 				'name'                   => 'Constant Contact',
 				'list_explanation'       => __( 'Constant Contact List', 'newspack-newsletters' ),
-				'local_list_explanation' => __( 'Represented by a Tag in Constant Contact', 'newspack-newsletters' ),
+				'local_list_explanation' => __( 'Constant Contact Tag', 'newspack-newsletters' ),
 			]
 		);
 	}

--- a/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp.php
+++ b/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp.php
@@ -1214,6 +1214,8 @@ final class Newspack_Newsletters_Mailchimp extends \Newspack_Newsletters_Service
 			'lists'                   => __( 'audiences', 'newspack-newsletters' ), // "list" in lower case plural format.
 			'List'                    => __( 'Audience', 'newspack-newsletters' ), // "list" in uppercase case singular format.
 			'Lists'                   => __( 'Audiences', 'newspack-newsletters' ), // "list" in uppercase case plural format.
+			'list_explanation'        => __( 'Mailchimp Audience', 'newspack-newsletters' ),
+			'local_list_explanation'  => __( 'Represented by a Gourp in Mailchimp', 'newspack-newsletters' ),
 			'tag_prefix'              => '',
 			'tag_metabox_before_save' => __( 'Once this list is saved, a Group will be created for it.', 'newspack-newsletters' ),
 			// translators: %s is the name of the group category. "Newspack newsletters" by default.

--- a/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp.php
+++ b/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp.php
@@ -1215,7 +1215,8 @@ final class Newspack_Newsletters_Mailchimp extends \Newspack_Newsletters_Service
 			'List'                    => __( 'Audience', 'newspack-newsletters' ), // "list" in uppercase case singular format.
 			'Lists'                   => __( 'Audiences', 'newspack-newsletters' ), // "list" in uppercase case plural format.
 			'list_explanation'        => __( 'Mailchimp Audience', 'newspack-newsletters' ),
-			'local_list_explanation'  => __( 'Represented by a Gourp in Mailchimp', 'newspack-newsletters' ),
+			// translators: %s is the name of the group category. "Newspack newsletters" by default.
+			'local_list_explanation'  => sprintf( __( 'Mailchimp Group under the %s category', 'newspack-newsletters' ), self::get_group_category_name() ),
 			'tag_prefix'              => '',
 			'tag_metabox_before_save' => __( 'Once this list is saved, a Group will be created for it.', 'newspack-newsletters' ),
 			// translators: %s is the name of the group category. "Newspack newsletters" by default.


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

This PR improves the usability of lists by removing it from the menu and adding a "Add new" button to the Subscription Lists manager, among other things

### How to test the changes in this Pull Request:

1. Go to Newsletters > Settings
2. Confirm you don't see a "Lists" menu item under the Newsletters menu
3. Choose Mailchimp, Active Campaign or Custom Contact
4. Confirm you see a "Add new" button below "Subscription Lists"
5. Choose Campaign Monitor and confirm you no longer see the button
6. Back to one of the previous providers
7. Click on the Add new button
8. Confirm you see the page to create a new list
9. Confirm there's a "Description" title above the textarea
10. Confirm there's a link above the title to go back to the Subscription Lists manager (where you came from) (Note that if Newspack plugin is active, it will take you to the wizard, otherwise, to the Settings page under Newsletters)
12. How does it feel?

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
