### PR TITLE
Fix and improve error messages

### DIFF
--- a/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp.php
+++ b/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp.php
@@ -605,7 +605,7 @@ final class Newspack_Newsletters_Mailchimp extends \Newspack_Newsletters_Service
 		} catch ( Exception $e ) {
 			return new WP_Error(
 				'newspack_newsletters_mailchimp_error',
-				$e->getMessage()
+				$this->get_better_error_message( $e->getMessage() )
 			);
 		}
 	}
@@ -1267,5 +1267,18 @@ final class Newspack_Newsletters_Mailchimp extends \Newspack_Newsletters_Service
 			</p>
 			<?php
 		}
+	}
+
+	/**
+	 * Replace some of the error messages sent by Mailchimp servers with a message that makes more sense to the user in the context of the plugin
+	 *
+	 * @param string $message The error message retrieved by the API.
+	 * @return string The new error message if we have an option for it. The same message otherwise.
+	 */
+	public function get_better_error_message( $message ) {
+		$known_errors = [
+			'Error sending test email. This campaign cannot be tested:" A From Name must be entered on the Setup step."' => __( 'Error sending test email. Please enter a name and email in the "FROM" section.', 'newspack-newsletters' ),
+		];
+		return isset( $known_errors[ $message ] ) ? $known_errors[ $message ] : $message;
 	}
 }

--- a/src/components/with-api-handler/index.js
+++ b/src/components/with-api-handler/index.js
@@ -31,7 +31,7 @@ export default () =>
 			};
 			const apiFetchWithErrorHandling = apiRequest => {
 				setInFlight( true );
-				return new Promise( ( resolve, reject ) => {
+				return new Promise( resolve => {
 					apiFetch( apiRequest )
 						.then( response => {
 							getNotices().forEach( notice => {
@@ -55,7 +55,6 @@ export default () =>
 							createErrorNotice( error.message );
 							setInFlight( false );
 							setErrors( { [ error.code ]: true } );
-							reject( error );
 						} );
 				} );
 			};


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Very often, error messages are not displayed when trying to set Newsletter sender or sending Test emails.

This is a little hard to test because I've seen this happening intermittently.

My best guess was that it was a race condition that sometimes would not display the error notice because of a uncaught error.

The error was being thrown because all consumers of the `apiFetchWithErrorHandling` call it without a `.catch()` callback. When it rejects the error, the error is not caught and we see it on the console.

I have removed the `reject` call from it. Since I understand that the expectation is that this method will handle the errors, I thought this was acceptable. Otherwise, we would have to add a `.catch()` callback to all the places where this method is invoked.

I'm not sure it fixes the issue 100% though. I think I saw it happening once, right after I changed the ESP, but then could never reproduce the problem again...

### How to test the changes in this Pull Request:

Test this with both Mailchimp and Active Campaign

1. Create a new Newsletter
2. Make sure the FROM fields are empty
3. Try to send a Test email
4. Make sure there's no `Uncaught (in promise) ...` error in the console
5. Make sure the error notice appears at the top of the editor

![Captura de tela de 2023-03-08 12-02-42](https://user-images.githubusercontent.com/971483/223748610-f116b4bb-3b26-474a-a3e6-07c9f166432c.png)

6. Try to update the sender information with an invalid email
7. Try to update the sender email with a random domain (mailchimp will complain is not an authorized domain)
8. With everything set, try to send a test email. Active Campaign should display an error about limitations in their API

![Captura de tela de 2023-03-08 12-00-27](https://user-images.githubusercontent.com/971483/223748419-8633affa-e54f-4ec3-a4ae-1fc224258c84.png)


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
