### PR TITLE
fix: date field types for custom ESP metadata fields

### DIFF
--- a/includes/service-providers/active_campaign/class-newspack-newsletters-active-campaign.php
+++ b/includes/service-providers/active_campaign/class-newspack-newsletters-active-campaign.php
@@ -960,7 +960,7 @@ final class Newspack_Newsletters_Active_Campaign extends \Newspack_Newsletters_S
 		];
 
 		foreach ( $date_fields as $date_field ) {
-			if ( str_contains( $date_field, $field_name ) ) {
+			if ( str_contains( $field_name, $date_field ) ) {
 				return 'date';
 			}
 		}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes an incorrect param order for `str_contains` which is causing custom ActiveCampaign metadata fields to be created with the wrong type in the connected ESP.

### How to test the changes in this Pull Request:

1. On a site connected to ActiveCampaign and with RAS enabled, dheck out this branch, go to **Newspack > Engagement > Reader Activation** and set the **Metadata field prefix** field to a custom prefix so that new fields will be created.
2. On the front-end, make a recurring donation.
3. In the ActiveCampaign dashboard, go to **Contacts > Fields** and confirm that new fields were created with your custom prefix, and that the following field types were all created with a field type of "Date" (note that the end date might not be created until you cancel the subscription):

- 'Registration Date'
- 'Last Payment Date'
- 'Next Payment Date'
- 'Current Subscription End Date'
- 'Current Subscription Start Date'

4. Confirm that the fields were synced with correct dates data in the contact.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
