### PR TITLE
fix: editor title with selected header font

### DIFF
--- a/src/editor/style.scss
+++ b/src/editor/style.scss
@@ -14,6 +14,11 @@
 		font-size: 16px;
 	}
 
+	.editor-post-title {
+		font-family: var( --newspack-header-font );
+		line-height: 1.5;
+	}
+
 	.block-editor-block-list__layout {
 		--wp--preset--font-size--small: 12px;
 		--wp--preset--font-size--normal: 16px;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR fixes the styles of the newsletter title so the select header font is applied.

| Before | After |
| --- | --- |
| <img width="568" alt="image" src="https://user-images.githubusercontent.com/820752/225947582-dea4d811-57f3-4288-a6af-83331c8232f0.png"> | <img width="607" alt="image" src="https://user-images.githubusercontent.com/820752/225947478-ee2d582c-e68e-489d-b5d9-4ab273480717.png"> |


### How to test the changes in this Pull Request:

1. Check out this branch and draft a new newletter
2. Mark the newsletter as public so the title shows up in the editor
3. In the "Newsletter Styles", change the "Headings Font" option
4. Confirm the selection is applied to the newsletter title

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
