### PR TITLE
fix(posts-inserter): preview styles for WP 6.2

### DIFF
--- a/src/editor/blocks/posts-inserter/index.js
+++ b/src/editor/blocks/posts-inserter/index.js
@@ -283,7 +283,11 @@ const PostsInserterBlock = ( {
 				) }
 			</BlockControls>
 
-			<div className="newspack-posts-inserter">
+			<div
+				className={ `newspack-posts-inserter ${
+					! isReady ? 'newspack-posts-inserter--loading' : ''
+				}` }
+			>
 				<div className="newspack-posts-inserter__header">
 					<Icon icon={ pages } />
 					<span>{ __( 'Posts Inserter', 'newspack-newsletters' ) }</span>

--- a/src/editor/blocks/posts-inserter/style.scss
+++ b/src/editor/blocks/posts-inserter/style.scss
@@ -65,6 +65,7 @@
 			.block-editor-block-preview__content {
 				@media only screen and ( min-width: 624px ) {
 					margin-left: calc( var( --newspack-post-inserter-width ) / -2 );
+					padding: 14px;
 					transform: scale( 1 ) !important;
 					transform-origin: 0 50% 0;
 				}

--- a/src/editor/blocks/posts-inserter/style.scss
+++ b/src/editor/blocks/posts-inserter/style.scss
@@ -30,11 +30,16 @@
 		padding: 1em;
 	}
 
+	&--loading {
+		.newspack-posts-inserter__preview {
+			display: flex;
+			justify-content: center;
+			align-items: center;
+		}
+	}
+
 	&__preview {
-		align-items: center;
-		display: flex;
-		justify-content: center;
-		min-height: 4rem;
+		min-height: 6rem;
 
 		&:empty {
 			border: 0;
@@ -43,7 +48,6 @@
 
 		.block-editor-block-preview {
 			&__container {
-				max-height: 400px;
 				overflow-y: scroll;
 			}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR fixes the styling of the Posts Inserter block preview for WP 6.2.

The use of flexbox is only applied when loading, so the spinner can be properly centered.

### How to test the changes in this Pull Request:

1. While on master and with WP 6.2, draft a new newsletter with Posts Inserter 
2. Confirm the cut-off and incorrectly aligned content
3. Check out this branch, refresh the editor
4. Confirm it's styled as expected and the spinner is also properly centered
5. Repeat the steps on the latest stable version (6.1.1) and confirm it also renders as expected

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
