### PR TITLE
feat: Change the default button label to Sign up

### DIFF
--- a/src/blocks/subscribe/block.json
+++ b/src/blocks/subscribe/block.json
@@ -29,7 +29,7 @@
 		},
 		"label": {
 			"type": "string",
-			"default": "Subscribe"
+			"default": "Sign up"
 		},
 		"displayDescription": {
 			"type": "boolean",


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Changes the default button label.

Note that this PR will also change the label of existing blocks that didn't customize their buttons.

See 1200550061930446-as-1204189922401733

### How to test the changes in this Pull Request:

1. Add a newsletter subscription block
2. Make sure the default button label is "Sign up"

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
