### PR TITLE
feat: add customizable success message

### DIFF
--- a/src/blocks/subscribe/block.json
+++ b/src/blocks/subscribe/block.json
@@ -44,7 +44,7 @@
 		},
 		"successMessage": {
 			"type": "string",
-			"default": "Thank you for subscribing!"
+			"default": "Thank you for signing up!"
 		}
 	},
 	"supports": {

--- a/src/blocks/subscribe/block.json
+++ b/src/blocks/subscribe/block.json
@@ -38,7 +38,13 @@
 		"lists": {
 			"type": "array",
 			"default": [],
-			"items": { "type": "string" }
+			"items": {
+				"type": "string"
+			}
+		},
+		"successMessage": {
+			"type": "string",
+			"default": "Thank you for subscribing!"
 		}
 	},
 	"supports": {

--- a/src/blocks/subscribe/edit.js
+++ b/src/blocks/subscribe/edit.js
@@ -33,6 +33,7 @@ export default function SubscribeEdit( {
 		namePlaceholder,
 		lastNamePlaceholder,
 		label,
+		successMessage,
 		lists,
 		displayDescription,
 	},
@@ -104,6 +105,11 @@ export default function SubscribeEdit( {
 						label={ __( 'Button label', 'newspack-newsletters' ) }
 						value={ label }
 						onChange={ value => setAttributes( { label: value } ) }
+					/>
+					<TextControl
+						label={ __( 'Success message', 'newspack-newsletters' ) }
+						value={ successMessage }
+						onChange={ value => setAttributes( { successMessage: value } ) }
 					/>
 					{ lists.length > 1 && (
 						<ToggleControl

--- a/src/blocks/subscribe/style.scss
+++ b/src/blocks/subscribe/style.scss
@@ -101,6 +101,12 @@
 			margin: 0.5rem 0 0;
 		}
 	}
+	.message.status-200 {
+		color: wp-colors.$alert-green;
+	}
+	.message.status-400 {
+		color: wp-colors.$alert-red;
+	}
 	.nphp {
 		border: 0;
 		clip: rect( 1px, 1px, 1px, 1px );

--- a/src/blocks/subscribe/view.js
+++ b/src/blocks/subscribe/view.js
@@ -42,11 +42,13 @@ import './style.scss';
 			};
 			const emailInput = container.querySelector( 'input[type="email"]' );
 			const submit = container.querySelector( 'input[type="submit"]' );
-			form.endFlow = ( message, status = 500 ) => {
+			form.endFlow = ( message, status = 500, wasSubscribed = false ) => {
 				const messageNode = document.createElement( 'p' );
 				emailInput.removeAttribute( 'disabled' );
 				submit.removeAttribute( 'disabled' );
-				messageNode.innerHTML = message;
+				messageNode.innerHTML = wasSubscribed
+					? container.getAttribute( 'data-success-message' )
+					: message;
 				messageNode.className = `message status-${ status }`;
 				if ( status === 200 ) {
 					container.replaceChild( messageNode, form );
@@ -97,8 +99,8 @@ import './style.scss';
 						} ).then( res => {
 							emailInput.disabled = false;
 							submit.disabled = false;
-							res.json().then( ( { message } ) => {
-								form.endFlow( message, res.status );
+							res.json().then( ( { message, newspack_newsletters_subscribed: wasSubscribed } ) => {
+								form.endFlow( message, res.status, wasSubscribed );
 							} );
 						} );
 					} );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Adds an optional field to block attributes to customize the success message.

Closes `1204166503564710/1204261432690203`.

### How to test the changes in this Pull Request:

1. Add a Subscription Form block to a post or page.
2. In the block sidebar, confirm there's a new field containing the previously hard-coded message as a default (note that the default is changed "thank you for signing up" instead of "subscribing", for consistency with the default button label as changed in #1125):

<img width="264" alt="Screen Shot 2023-03-27 at 5 31 40 PM" src="https://user-images.githubusercontent.com/2230142/228089770-b9a5b076-0fbc-4659-901a-f54aa19f84fc.png">

3. Edit the default message to something else and save.
4. On the front-end submit an email address to the form. Confirm that your custom success message is displayed in WP green upon success.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
