### PR TITLE
fix: only add newsletters to categories and tags archives queries

### DIFF
--- a/includes/class-newspack-newsletters.php
+++ b/includes/class-newspack-newsletters.php
@@ -1208,7 +1208,7 @@ final class Newspack_Newsletters {
 		if ( is_admin() || ! $query->is_main_query() ) {
 			return;
 		}
-		if ( ( $query->is_tag() || $query->is_category() ) && $query->is_archive() ) {
+		if ( $query->is_tag() || $query->is_category() ) {
 			$post_type = $query->get( 'post_type' );
 			if ( empty( $post_type ) ) {
 				$post_type = [ 'post' ];

--- a/includes/class-newspack-newsletters.php
+++ b/includes/class-newspack-newsletters.php
@@ -1208,7 +1208,7 @@ final class Newspack_Newsletters {
 		if ( is_admin() || ! $query->is_main_query() ) {
 			return;
 		}
-		if ( $query->is_archive() && ! $query->is_post_type_archive() ) {
+		if ( ( $query->is_tag() || $query->is_category() ) && $query->is_archive() ) {
 			$post_type = $query->get( 'post_type' );
 			if ( empty( $post_type ) ) {
 				$post_type = [ 'post' ];


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Ensure the hook to display newsletters in archives only applies to the archives it belongs (categories and tags).

The overwrite of empty `post_type` can mess with how custom taxonomies and custom post types interact.

Closes #637

### How to test the changes in this Pull Request:

Make sure #637 is no longer reproducible and public newsletters are still shown in categories/tags archives.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
