### PR TITLE
fix(subscribe-block): optimize js dependencies

### DIFF
--- a/src/blocks/subscribe/index.php
+++ b/src/blocks/subscribe/index.php
@@ -37,7 +37,7 @@ function enqueue_scripts() {
 	);
 
 	$use_captcha  = method_exists( '\Newspack\Recaptcha', 'can_use_captcha' ) && \Newspack\Recaptcha::can_use_captcha();
-	$dependencies = [ 'wp-polyfill', 'wp-i18n' ];
+	$dependencies = [];
 	if ( $use_captcha ) {
 		$dependencies[] = \Newspack\Recaptcha::SCRIPT_HANDLE;
 	}
@@ -49,10 +49,17 @@ function enqueue_scripts() {
 		filemtime( NEWSPACK_NEWSLETTERS_PLUGIN_FILE . 'dist/subscribeBlock.js' ),
 		true
 	);
+	\wp_localize_script(
+		$handle,
+		'newspack_newsletters_subscribe_block',
+		[
+			'recaptcha_error' => __( 'Error loading the reCaptcha library.', 'newspack-newsletters' ),
+			'invalid_email'   => __( 'Please enter a valid email address', 'newspack-newsletter' ),
+		]
+	);
 	\wp_script_add_data( $handle, 'async', true );
 	\wp_script_add_data( $handle, 'amp-plus', true );
 }
-add_action( 'wp_enqueue_scripts', __NAMESPACE__ . '\\enqueue_scripts' );
 
 /**
  * Generate a unique ID for each subscription form.
@@ -89,6 +96,9 @@ function render_block( $attrs ) {
 	if ( empty( $available_lists ) ) {
 		$available_lists = [ $lists[0] ];
 	}
+
+	// Enqueue scripts.
+	enqueue_scripts();
 
 	if ( \is_user_logged_in() ) {
 		$email = \wp_get_current_user()->user_email;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Optimizes the javascript dependencies for the Newsletters Subscription Form block. The labels are now passed through script localization and its script is only enqueued when the block is rendered.

The reCaptcha was also tweaked to implement the same logic as here: https://github.com/Automattic/newspack-plugin/pull/2363

### How to test the changes in this Pull Request:

1. Check out this branch
2. Visit a page without the block being rendered anywhere and confirm the `subscribeBlock.js` is not loaded
3. Make sure you have reCaptcha v3 enabled in the Connections wizard
4. Visit a page with the block and confirm the js loads and behaves as expected
5. Disable reCaptcha v3 and repeat step 4

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
