### PR TITLE
fix: restrict custom editor font sizes

### DIFF
--- a/includes/class-newspack-newsletters-editor.php
+++ b/includes/class-newspack-newsletters-editor.php
@@ -210,6 +210,11 @@ final class Newspack_Newsletters_Editor {
 					'slug' => 'normal',
 				],
 				[
+					'name' => _x( 'Medium', 'font size name', 'newspack-newsletters' ),
+					'size' => 16,
+					'slug' => 'medium',
+				],
+				[
 					'name' => _x( 'Large', 'font size name', 'newspack-newsletters' ),
 					'size' => 24,
 					'slug' => 'large',
@@ -218,6 +223,11 @@ final class Newspack_Newsletters_Editor {
 					'name' => _x( 'Extra Large', 'font size name', 'newspack-newsletters' ),
 					'size' => 36,
 					'slug' => 'x-large',
+				],
+				[
+					'name' => _x( 'Huge', 'font size name', 'newspack-newsletters' ),
+					'size' => 36,
+					'slug' => 'huge',
 				],
 			]
 		);

--- a/includes/class-newspack-newsletters-editor.php
+++ b/includes/class-newspack-newsletters-editor.php
@@ -193,6 +193,9 @@ final class Newspack_Newsletters_Editor {
 	 * Define Editor Font Sizes.
 	 */
 	public static function newspack_font_sizes() {
+		if ( ! self::is_editing_email() ) {
+			return;
+		}
 		add_theme_support(
 			'editor-font-sizes',
 			[

--- a/src/editor/style.scss
+++ b/src/editor/style.scss
@@ -202,7 +202,7 @@
 				text-align: inherit;
 			}
 
-			&:not(.is-style-plain, .is-style-large) {
+			&:not( .is-style-plain, .is-style-large ) {
 				border: 0;
 				margin: 12px auto;
 				padding: 0;
@@ -220,7 +220,7 @@
 					width: 0.25em;
 				}
 
-				+ .wp-block-quote:not(.is-style-plain, .is-style-large) {
+				+ .wp-block-quote:not( .is-style-plain, .is-style-large ) {
 					margin-top: 24px;
 				}
 			}
@@ -294,7 +294,7 @@
 				opacity: 1;
 				padding-top: 12px;
 
-				&:not(.is-style-wide, .is-style-dots) {
+				&:not( .is-style-wide, .is-style-dots ) {
 					border-bottom-width: 1px;
 					width: 128px;
 				}
@@ -339,6 +339,24 @@
 					margin-right: 0;
 				}
 			}
+		}
+		.has-small-font-size {
+			font-size: var( --wp--preset--font-size--small ) !important;
+		}
+		.has-normal-font-size {
+			font-size: var( --wp--preset--font-size--normal ) !important;
+		}
+		.has-medium-font-size {
+			font-size: var( --wp--preset--font-size--medium ) !important;
+		}
+		.has-large-font-size {
+			font-size: var( --wp--preset--font-size--large ) !important;
+		}
+		.has-x-large-font-size {
+			font-size: var( --wp--preset--font-size--x-large ) !important;
+		}
+		.has-huge-font-size {
+			font-size: var( --wp--preset--font-size--huge ) !important;
 		}
 	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Restricts the custom font sizes to the newsletters' editor only, preventing this definition to mess with theme definitions in other places.

Some Gutenberg behavior is also not allowing the newsletters' editor to have a consistent font size experience. Small and Large font sizes are applied as expected due to an `!important` flag in their rules, which is not applied to normal, medium, and x large. Although not ideal, 27de7726c7be9c139f5ffaa1e6006199fd3a432f enforces the font sizes for the editor across all options.

Closes #755

### How to test the changes in this Pull Request:

1. Check out this branch, edit a post with different font size definitions and confirm the choices are consistent between the editor and page
2. Draft a new newsletter and confirm the font sizes are as defined in pixels (12, 16, 24 and 36)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
