### PR TITLE
fix: avoid fatal error on Constant Contact

### DIFF
--- a/includes/service-providers/constant_contact/class-newspack-newsletters-constant-contact.php
+++ b/includes/service-providers/constant_contact/class-newspack-newsletters-constant-contact.php
@@ -87,21 +87,20 @@ final class Newspack_Newsletters_Constant_Contact extends \Newspack_Newsletters_
 	 * @return array
 	 */
 	public function verify_token( $refresh = true ) {
-		$credentials  = $this->api_credentials();
-		$redirect_uri = $this->get_oauth_redirect_uri();
-		$cc           = new Newspack_Newsletters_Constant_Contact_SDK(
-			$credentials['api_key'],
-			$credentials['api_secret'],
-			$credentials['access_token']
-		);
-
-		$response = [
-			'error'    => null,
-			'valid'    => false,
-			'auth_url' => $cc->get_auth_code_url( wp_create_nonce( 'constant_contact_oauth2' ), $redirect_uri ),
-		];
-
 		try {
+			$credentials  = $this->api_credentials();
+			$redirect_uri = $this->get_oauth_redirect_uri();
+			$cc           = new Newspack_Newsletters_Constant_Contact_SDK(
+				$credentials['api_key'],
+				$credentials['api_secret'],
+				$credentials['access_token']
+			);
+	
+			$response = [
+				'error'    => null,
+				'valid'    => false,
+				'auth_url' => $cc->get_auth_code_url( wp_create_nonce( 'constant_contact_oauth2' ), $redirect_uri ),
+			];
 			// If we have a valid access token, we're connected.
 			if ( $cc->validate_token() ) {
 				$response['valid'] = true;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Avoids a fatal error when Constant Contact settings is incomplete

### How to test the changes in this Pull Request:

1. On master, start with a site configured for Constant Contact
2. Go to Newsletters > Settings. Delete the "Constant Contact API Key" and save
3. Confirm you see a Fatal error
4. Checkout this branch and confirm the settings page is usable again

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
