### PR TITLE
feat(subscribe-block): support input labels

### DIFF
--- a/src/blocks/subscribe/block.json
+++ b/src/blocks/subscribe/block.json
@@ -7,7 +7,15 @@
 	"description": "Subscribe an email to a newsletter list.",
 	"textdomain": "newspack-newsletters",
 	"attributes": {
+		"displayInputLabels": {
+			"type": "boolean",
+			"default": false
+		},
 		"placeholder": {
+			"type": "string",
+			"default": "Email Address"
+		},
+		"emailLabel": {
 			"type": "string",
 			"default": "Email Address"
 		},
@@ -21,9 +29,17 @@
 		},
 		"namePlaceholder": {
 			"type": "string",
-			"default": ""
+			"default": "Name"
+		},
+		"nameLabel": {
+			"type": "string",
+			"default": "Name"
 		},
 		"lastNamePlaceholder": {
+			"type": "string",
+			"default": "Last Name"
+		},
+		"lastNameLabel": {
 			"type": "string",
 			"default": "Last Name"
 		},

--- a/src/blocks/subscribe/edit.js
+++ b/src/blocks/subscribe/edit.js
@@ -1,4 +1,5 @@
 /* globals newspack_newsletters_blocks */
+/* eslint jsx-a11y/label-has-for: 0 */
 /**
  * External dependencies.
  */
@@ -12,7 +13,7 @@ import apiFetch from '@wordpress/api-fetch';
 import { __, sprintf } from '@wordpress/i18n';
 import { useState, useEffect } from '@wordpress/element';
 import { TextControl, ToggleControl, PanelBody, Notice, Spinner } from '@wordpress/components';
-import { useBlockProps, InspectorControls } from '@wordpress/block-editor';
+import { useBlockProps, InspectorControls, RichText } from '@wordpress/block-editor';
 
 /**
  * Internal dependencies
@@ -28,11 +29,15 @@ const settingsUrl = newspack_newsletters_blocks.settings_url;
 export default function SubscribeEdit( {
 	setAttributes,
 	attributes: {
+		displayInputLabels,
 		placeholder,
+		emailLabel,
 		displayNameField,
 		displayLastNameField,
 		namePlaceholder,
+		nameLabel,
 		lastNamePlaceholder,
+		lastNameLabel,
 		label,
 		successMessage,
 		lists,
@@ -57,19 +62,15 @@ export default function SubscribeEdit( {
 			setAttributes( { lists: [ Object.keys( listConfig )[ 0 ] ] } );
 		}
 	}, [ listConfig ] );
-	const getNameFieldPlaceholder = () => {
-		if ( namePlaceholder ) {
-			return namePlaceholder;
-		}
-		if ( displayLastNameField ) {
-			return __( 'First Name', 'newspack-newsletters' );
-		}
-		return __( 'Name', 'newspack-newsletters' );
-	};
 	return (
 		<>
 			<InspectorControls>
 				<PanelBody title={ __( 'Form settings', 'newspack-newsletters' ) }>
+					<ToggleControl
+						label={ __( 'Display input labels', 'newspack-newsletters' ) }
+						checked={ displayInputLabels }
+						onChange={ value => setAttributes( { displayInputLabels: value } ) }
+					/>
 					<TextControl
 						label={ __( 'Email placeholder', 'newspack-newsletters' ) }
 						value={ placeholder }
@@ -85,7 +86,6 @@ export default function SubscribeEdit( {
 							<TextControl
 								label={ __( 'Name placeholder', 'newspack-newsletters' ) }
 								value={ namePlaceholder }
-								placeholder={ getNameFieldPlaceholder() }
 								onChange={ value => setAttributes( { namePlaceholder: value } ) }
 							/>
 							<ToggleControl
@@ -102,11 +102,6 @@ export default function SubscribeEdit( {
 							) }
 						</>
 					) }
-					<TextControl
-						label={ __( 'Button label', 'newspack-newsletters' ) }
-						value={ label }
-						onChange={ value => setAttributes( { label: value } ) }
-					/>
 					<TextControl
 						label={ __( 'Success message', 'newspack-newsletters' ) }
 						value={ successMessage }
@@ -224,15 +219,56 @@ export default function SubscribeEdit( {
 							) }
 							{ displayNameField && (
 								<div className="newspack-newsletters-name-input">
-									<input type="text" placeholder={ getNameFieldPlaceholder() } />
+									<div className="newspack-newsletters-name-input-item">
+										<label>
+											{ displayInputLabels && (
+												<RichText
+													onChange={ value => setAttributes( { nameLabel: value } ) }
+													placeholder={ __( 'Name', 'newspack' ) }
+													value={ nameLabel }
+													tagName="span"
+												/>
+											) }
+										</label>
+										<input type="text" placeholder={ namePlaceholder } />
+									</div>
 									{ displayLastNameField && (
-										<input type="text" placeholder={ lastNamePlaceholder } />
+										<div className="newspack-newsletters-name-input-item">
+											<label>
+												{ displayInputLabels && (
+													<RichText
+														onChange={ value => setAttributes( { lastNameLabel: value } ) }
+														placeholder={ __( 'Last Name', 'newspack' ) }
+														value={ lastNameLabel }
+														tagName="span"
+													/>
+												) }
+											</label>
+											<input type="text" placeholder={ lastNamePlaceholder } />
+										</div>
 									) }
 								</div>
 							) }
 							<div className="newspack-newsletters-email-input">
+								<label>
+									{ displayInputLabels && (
+										<RichText
+											onChange={ value => setAttributes( { emailLabel: value } ) }
+											placeholder={ __( 'Email Address', 'newspack' ) }
+											value={ emailLabel }
+											tagName="span"
+										/>
+									) }
+								</label>
 								<input type="email" placeholder={ placeholder } />
-								<input type="submit" value={ label } />
+								<button type="submit">
+									<RichText
+										onChange={ value => setAttributes( { label: value } ) }
+										placeholder={ __( 'Sign up', 'newspack' ) }
+										value={ label }
+										tagName="span"
+									/>
+								</button>
 							</div>
 						</form>
 					</div>

--- a/src/blocks/subscribe/editor.scss
+++ b/src/blocks/subscribe/editor.scss
@@ -14,7 +14,7 @@
 			border-radius: 0;
 			font-size: 1rem;
 		}
-		input[type='submit'] {
+		[type='submit'] {
 			transition: background 150ms ease-in-out;
 			background: #d33;
 			border: none;

--- a/src/blocks/subscribe/index.php
+++ b/src/blocks/subscribe/index.php
@@ -125,6 +125,10 @@ function render_block( $attrs ) {
 			$list_map = array_flip( array_map( 'sanitize_text_field', $_REQUEST['lists'] ) );
 		}
 	}
+
+	$display_input_label = ! empty( $attrs['displayInputLabels'] );
+	$email_label         = $display_input_label ? $attrs['emailLabel'] : '';
+	$input_id            = sprintf( 'newspack-newsletters-subscribe-block-input-%s', $block_id );
 	// phpcs:enable
 	ob_start();
 	?>
@@ -185,22 +189,36 @@ function render_block( $attrs ) {
 				<?php endif; ?>
 				<?php
 				if ( $attrs['displayNameField'] ) :
+					$name_label            = $attrs['nameLabel'];
 					$name_placeholder      = $attrs['namePlaceholder'];
+					$last_name_label       = $attrs['lastNameLabel'];
 					$last_name_placeholder = $attrs['lastNamePlaceholder'];
 					$display_last_name     = $attrs['displayLastNameField'];
-					if ( empty( $name_placeholder ) ) {
-						$name_placeholder = $display_last_name ? __( 'First Name', 'newspack-newsletters' ) : __( 'Name', 'newspack-newsletters' );
-					}
 					?>
 					<div class="newspack-newsletters-name-input">
-						<input type="text" name="name" placeholder="<?php echo \esc_attr( $name_placeholder ); ?>" />
+
+						<div class="newspack-newsletters-name-input-item">
+							<?php if ( $display_input_label ) : ?>
+								<label for="<?php echo \esc_attr( $input_id . '-name' ); ?>"><?php echo \esc_html( $name_label ); ?></label>
+							<?php endif; ?>
+							<input id="<?php echo \esc_attr( $input_id . '-name' ); ?>" type="text" name="name" placeholder="<?php echo \esc_attr( $name_placeholder ); ?>" />
+						</div>
 						<?php if ( $display_last_name ) : ?>
-							<input type="text" name="last_name" placeholder="<?php echo \esc_attr( $last_name_placeholder ); ?>" />
+							<div class="newspack-newsletters-name-input-item">
+								<?php if ( $display_input_label ) : ?>
+									<label for="<?php echo \esc_attr( $input_id . '-last-name' ); ?>"><?php echo \esc_html( $last_name_label ); ?></label>
+								<?php endif; ?>
+								<input id="<?php echo \esc_attr( $input_id . '-last-name' ); ?>" type="text" name="last_name" placeholder="<?php echo \esc_attr( $last_name_placeholder ); ?>" />
+							</div>
 						<?php endif; ?>
 					</div>
 				<?php endif; ?>
 				<div class="newspack-newsletters-email-input">
+					<?php if ( $email_label ) : ?>
+						<label for="<?php echo \esc_attr( $input_id . '-email' ); ?>"><?php echo \esc_html( $email_label ); ?></label>
+					<?php endif; ?>
 					<input
+						id="<?php echo \esc_attr( $input_id . '-email' ); ?>"
 						type="email"
 						name="npe"
 						autocomplete="email"

--- a/src/blocks/subscribe/style.scss
+++ b/src/blocks/subscribe/style.scss
@@ -23,6 +23,22 @@
 		@media ( min-width: 782px ) {
 			gap: 0.4rem;
 		}
+
+		.newspack-newsletters-name-input-item {
+			display: flex;
+			flex: 1 1 100%;
+			flex-wrap: wrap;
+			gap: 0.5rem;
+			@media ( min-width: 782px ) {
+				flex-basis: auto;
+				gap: 0.4rem;
+			}
+		}
+	}
+	label {
+		font-size: 0.9rem;
+		font-weight: 700;
+		flex: 1 1 100%;
 	}
 	input[type='text'],
 	input[type='email'] {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Implements the support for toggling input labels to improve accessibility.

<img width="814" alt="image" src="https://user-images.githubusercontent.com/820752/233462824-76522e5a-a654-4187-9449-e491bdea7a93.png">

<img width="1210" alt="image" src="https://user-images.githubusercontent.com/820752/233462962-22779c12-883c-426e-a35a-5f197c1c25f4.png">

The labels are editable inline, through the `RichText` component.

This PR also changes the submit button label to be edited inline.

### How to test the changes in this Pull Request:

1. Check out this branch and draft a new page with the Newsletters Subscription Form block
2. Toggle the new "Display input labels" field
3. Confirm the label appears on top of the email input
4. Click on the label to edit its text and save the changes
5. Confirm the label is visible on the rendered page
6. Toggle the "Display name field" and "Display 'Last Name' Field"
7. Edit their respective labels and save
8. Confirm the change is visible on the rendered page
9. Edit the "Sign up" label inline, just like the other labels
10. Save the changes and confirm it renders correctly

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
