### PR TITLE
feat: offer groups as Subscription Lists

### DIFF
--- a/includes/class-newspack-newsletters-subscription.php
+++ b/includes/class-newspack-newsletters-subscription.php
@@ -191,7 +191,7 @@ class Newspack_Newsletters_Subscription {
 						'description' => $list['description'] ?? '',
 						'edit_link'   => $list['edit_link'] ?? '',
 						'type'        => $list['type'] ?? '',
-						'type_label'  => isset( $list['type'] ) && 'local' === $list['type'] ? $provider::label( 'local_list_explanation' ) : $provider::label( 'list_explanation' ),
+						'type_label'  => isset( $list['type'] ) && 'local' === $list['type'] ? $provider::label( 'local_list_explanation', $list ) : $provider::label( 'list_explanation', $list ),
 					];
 					if ( isset( $config[ $list['id'] ] ) ) {
 						$list_config    = $config[ $list['id'] ];

--- a/includes/service-providers/active_campaign/class-newspack-newsletters-active-campaign.php
+++ b/includes/service-providers/active_campaign/class-newspack-newsletters-active-campaign.php
@@ -1297,9 +1297,10 @@ final class Newspack_Newsletters_Active_Campaign extends \Newspack_Newsletters_S
 	 *
 	 * This allows us to make reference to provider specific features in the way the user is used to see them in the provider's UI
 	 *
+	 * @param mixed $context The context in which the labels are being applied.
 	 * @return array
 	 */
-	public static function get_labels() {
+	public static function get_labels( $context = '' ) {
 		return array_merge(
 			parent::get_labels(),
 			[

--- a/includes/service-providers/campaign_monitor/class-newspack-newsletters-campaign-monitor.php
+++ b/includes/service-providers/campaign_monitor/class-newspack-newsletters-campaign-monitor.php
@@ -648,9 +648,10 @@ final class Newspack_Newsletters_Campaign_Monitor extends \Newspack_Newsletters_
 	 *
 	 * This allows us to make reference to provider specific features in the way the user is used to see them in the provider's UI
 	 *
+	 * @param mixed $context The context in which the labels are being applied.
 	 * @return array
 	 */
-	public static function get_labels() {
+	public static function get_labels( $context = '' ) {
 		return array_merge(
 			parent::get_labels(),
 			[

--- a/includes/service-providers/class-newspack-newsletters-service-provider.php
+++ b/includes/service-providers/class-newspack-newsletters-service-provider.php
@@ -372,9 +372,10 @@ abstract class Newspack_Newsletters_Service_Provider implements Newspack_Newslet
 	 *
 	 * This allows us to make reference to provider specific features in the way the user is used to see them in the provider's UI
 	 *
+	 * @param mixed $context The context in which the labels are being applied.
 	 * @return array
 	 */
-	public static function get_labels() {
+	public static function get_labels( $context = '' ) {
 		return [
 			'name'                    => '', // The provider name.
 			'list'                    => __( 'list', 'newspack-newsletters' ), // "list" in lower case singular format.
@@ -391,10 +392,11 @@ abstract class Newspack_Newsletters_Service_Provider implements Newspack_Newslet
 	 * Get one specific label for the current provider
 	 *
 	 * @param string $key The label key.
+	 * @param mixed  $context The context of the label. Optional.
 	 * @return string Empty string in case the label is not found.
 	 */
-	public static function label( $key ) {
-		$labels = static::get_labels();
+	public static function label( $key, $context = '' ) {
+		$labels = static::get_labels( $context );
 		return $labels[ $key ] ?? '';
 	}
 

--- a/includes/service-providers/constant_contact/class-newspack-newsletters-constant-contact.php
+++ b/includes/service-providers/constant_contact/class-newspack-newsletters-constant-contact.php
@@ -899,9 +899,10 @@ final class Newspack_Newsletters_Constant_Contact extends \Newspack_Newsletters_
 	 *
 	 * This allows us to make reference to provider specific features in the way the user is used to see them in the provider's UI
 	 *
+	 * @param mixed $context The context in which the labels are being applied.
 	 * @return array
 	 */
-	public static function get_labels() {
+	public static function get_labels( $context = '' ) {
 		return array_merge(
 			parent::get_labels(),
 			[

--- a/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp.php
+++ b/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp.php
@@ -8,6 +8,7 @@
 defined( 'ABSPATH' ) || exit;
 
 use \DrewM\MailChimp\MailChimp;
+use Newspack\Newsletters\Subscription_Lists;
 
 /**
  * Main Newspack Newsletters Class.
@@ -442,7 +443,36 @@ final class Newspack_Newsletters_Mailchimp extends \Newspack_Newsletters_Service
 					$lists_response->getMessage()
 				);
 			}
-			return $lists_response['lists'];
+			$lists = [];
+
+			// In addition to Audiences, we also automatically fetch all groups and offer them as Subscription Lists.
+			// Build the final list inside the loop so groups are added after the list they belong to and we can then represent the hierarchy in the UI.
+			foreach ( $lists_response['lists'] as $list ) {
+				
+				$lists[]        = $list;
+				$all_categories = $this->get_all_categories( $list['id'] );
+				
+				foreach ( $all_categories as $found_category ) {
+					
+					// Do not include groups under the category we use to store "Local" lists.
+					if ( $this->get_groups_category_id( $list['id'] ) === $found_category['id'] ) {
+						continue;
+					}
+
+					$all_groups = $this->get_all_groups_in_category( $list['id'], $found_category['id'] );
+
+					$groups = array_map(
+						function( $group ) use ( $list ) {
+							$group['id']   = $this->create_group_list_id( $group['id'], $list['id'] );
+							$group['type'] = 'mailchimp-group';
+							return $group;
+						},
+						$all_groups
+					);
+					$lists  = array_merge( $lists, $groups );
+				}
+			}
+			return $lists;
 		} catch ( Exception $e ) {
 			return new WP_Error(
 				'newspack_newsletters_mailchimp_error',
@@ -999,6 +1029,11 @@ final class Newspack_Newsletters_Mailchimp extends \Newspack_Newsletters_Service
 		if ( false === $list_id ) {
 			return new WP_Error( 'newspack_newsletters_mailchimp_list_id', __( 'Missing list id.' ) );
 		}
+		$list = $this->maybe_extract_group_list( $list_id );
+		if ( $list ) {
+			$list_id  = $list['list_id'];
+			$group_id = $list['group_id'];
+		}
 		try {
 			$mc             = new Mailchimp( $this->api_key() );
 			$email_address  = $contact['email'];
@@ -1044,6 +1079,12 @@ final class Newspack_Newsletters_Mailchimp extends \Newspack_Newsletters_Service
 						$update_payload['merge_fields'][ $created_merge_field['tag'] ] = (string) $value;
 					}
 				}
+			}
+
+			if ( ! empty( $group_id ) ) {
+				$update_payload['interests'] = [
+					$group_id => true,
+				];
 			}
 
 			// Create or update a list member.
@@ -1116,7 +1157,7 @@ final class Newspack_Newsletters_Mailchimp extends \Newspack_Newsletters_Service
 		if ( is_wp_error( $contact ) ) {
 			return [];
 		}
-		return array_keys(
+		$audience_lists = array_keys(
 			array_filter(
 				$contact['lists'],
 				function( $list ) {
@@ -1124,6 +1165,15 @@ final class Newspack_Newsletters_Mailchimp extends \Newspack_Newsletters_Service
 				}
 			)
 		);
+		$groups_lists   = [];
+		foreach ( $contact['interests'] as $list_id => $interests ) {
+			foreach ( $interests as $group_id => $active ) {
+				if ( $active ) {
+					$groups_lists[] = $this->create_group_list_id( $group_id, $list_id );
+				}
+			}
+		}
+		return array_merge( $audience_lists, $groups_lists );
 	}
 
 	/**
@@ -1148,6 +1198,16 @@ final class Newspack_Newsletters_Mailchimp extends \Newspack_Newsletters_Service
 		$mc = new Mailchimp( $this->api_key() );
 		try {
 			foreach ( $lists_to_add as $list_id ) {
+				$list = $this->maybe_extract_group_list( $list_id );
+				// If this is a group list, check if the contact is already subscribed to the group, so we don't make an unnecessary call.
+				if ( $list ) {
+					if ( ! empty( $contact['interests'][ $list['list_id'] ] ) ) {
+						if ( isset( $contact['interests'][ $list['list_id'] ][ $list['group_id'] ] ) && $contact['interests'][ $list['list_id'] ][ $list['group_id'] ] ) {
+							continue;
+						}
+					}
+					// If the group doesn't exits, the regular add_contact call below will take care of adding it.
+				}
 				if ( ! isset( $contact['lists'][ $list_id ] ) ) {
 					$this->add_contact( [ 'email' => $email ], $list_id );
 				} else {
@@ -1155,6 +1215,11 @@ final class Newspack_Newsletters_Mailchimp extends \Newspack_Newsletters_Service
 				}
 			}
 			foreach ( $lists_to_remove as $list_id ) {
+				$list = $this->maybe_extract_group_list( $list_id );
+				if ( $list ) {
+					$this->remove_group_from_contact( $email, $list['group_id'], $list['list_id'] );
+					continue;
+				}
 				if ( ! isset( $contact['lists'][ $list_id ] ) ) {
 					continue;
 				}
@@ -1189,15 +1254,21 @@ final class Newspack_Newsletters_Mailchimp extends \Newspack_Newsletters_Service
 			return new WP_Error( 'newspack_newsletters_mailchimp_contact_not_found', __( 'Contact not found', 'newspack-newsletters' ) );
 		}
 
-		$keys = [ 'full_name', 'email_address', 'id', 'tags', 'interests' ];
-		$data = [ 'lists' => [] ];
+		$keys = [ 'full_name', 'email_address', 'id' ];
+		$data = [
+			'lists'     => [],
+			'tags'      => [],
+			'interests' => [],
+		];
 		foreach ( $found as $contact ) {
 			foreach ( $keys as $key ) {
 				if ( ! isset( $data[ $key ] ) || empty( $data[ $key ] ) ) {
 					$data[ $key ] = $contact[ $key ];
 				}
 			}
-			$data['lists'][ $contact['list_id'] ] = [
+			$data['tags'][ $contact['list_id'] ]      = $contact['tags'];
+			$data['interests'][ $contact['list_id'] ] = $contact['interests'];
+			$data['lists'][ $contact['list_id'] ]     = [
 				'id'         => $contact['id'], // md5 hash of email.
 				'contact_id' => $contact['contact_id'],
 				'status'     => $contact['status'],
@@ -1210,7 +1281,7 @@ final class Newspack_Newsletters_Mailchimp extends \Newspack_Newsletters_Service
 	 * Get the IDs of the tags associated with a contact.
 	 *
 	 * @param string $email The contact email.
-	 * @return array|WP_Error The tag IDs on success. WP_Error on failure.
+	 * @return array|WP_Error The tag IDs on success, grouped by lists. WP_Error on failure.
 	 */
 	public function get_contact_tags_ids( $email ) {
 		$contact_data = $this->get_contact_data( $email );
@@ -1218,13 +1289,47 @@ final class Newspack_Newsletters_Mailchimp extends \Newspack_Newsletters_Service
 			return $contact_data;
 		}
 
-		$contact_tags = array_map(
-			function( $tag ) {
-				return (int) $tag['id'];
-			},
-			$contact_data['tags']
-		);
+		$contact_tags = [];
+
+		foreach ( $contact_data['tags'] as $list_id => $tags ) {
+			$contact_tags[ $list_id ] = array_map(
+				function( $tag ) {
+					return (int) $tag['id'];
+				},
+				$tags
+			);
+		}
+
 		return $contact_tags;
+	}
+
+	/**
+	 * Get the contact local lists IDs
+	 *
+	 * Mailchimp has to override this method because we need to handle groups under many lists.
+	 *
+	 * In other providers, get_contact_esp_local_lists_ids returns a simple array with IDs, but in Mailchimp it returns IDs grouped by lists.
+	 *
+	 * @param string $email The contact email.
+	 * @return string[] Array of local lists IDs or error.
+	 */
+	public function get_contact_local_lists( $email ) {
+		$tags = $this->get_contact_esp_local_lists_ids( $email );
+		if ( is_wp_error( $tags ) ) {
+			return [];
+		}
+		$lists = Subscription_Lists::get_configured_for_provider( $this->service );
+		$ids   = [];
+		foreach ( $lists as $list ) {
+			$list_settings = $list->get_provider_settings( $this->service );
+			
+			if ( ! empty( $tags[ $list_settings['list'] ] ) ) {
+				if ( in_array( $list_settings['tag_id'], $tags[ $list_settings['list'] ], false ) ) { // phpcs:ignore WordPress.PHP.StrictInArray.FoundNonStrictFalse
+					$ids[] = $list->get_form_id();
+				}
+			}
+		}
+		return $ids;
 	}
 
 	/**
@@ -1232,10 +1337,11 @@ final class Newspack_Newsletters_Mailchimp extends \Newspack_Newsletters_Service
 	 *
 	 * This allows us to make reference to provider specific features in the way the user is used to see them in the provider's UI
 	 *
+	 * @param mixed $context The context in which the labels are being applied.
 	 * @return array
 	 */
-	public static function get_labels() {
-		return [
+	public static function get_labels( $context = '' ) {
+		$labels = [
 			'name'                    => 'Mailchimp', // The provider name.
 			'list'                    => __( 'audience', 'newspack-newsletters' ), // "list" in lower case singular format.
 			'lists'                   => __( 'audiences', 'newspack-newsletters' ), // "list" in lower case plural format.
@@ -1249,6 +1355,10 @@ final class Newspack_Newsletters_Mailchimp extends \Newspack_Newsletters_Service
 			// translators: %s is the name of the group category. "Newspack newsletters" by default.
 			'tag_metabox_after_save'  => sprintf( __( 'Group created for this list under %s:', 'newspack-newsletters' ), self::get_group_category_name() ),
 		];
+		if ( ! empty( $context['id'] ) && strpos( $context['id'], 'group-' ) === 0 ) {
+			$labels['list_explanation'] = __( 'Mailchimp Group', 'newspack-newsletters' );
+		}
+		return $labels;
 	}
 
 	/**
@@ -1280,5 +1390,37 @@ final class Newspack_Newsletters_Mailchimp extends \Newspack_Newsletters_Service
 			'Error sending test email. This campaign cannot be tested:" A From Name must be entered on the Setup step."' => __( 'Error sending test email. Please enter a name and email in the "FROM" section.', 'newspack-newsletters' ),
 		];
 		return isset( $known_errors[ $message ] ) ? $known_errors[ $message ] : $message;
+	}
+
+	/**
+	 * Creates a group list ID based on the group ID and the list ID
+	 *
+	 * In Mailchimp, we offer both Audiences and Groups as Subscription Lists. We modify the groups IDs so we can differentiate them from the Audiences IDs.
+	 *
+	 * Also, when working with groups, we need to know the list ID, so we add it to the group ID.
+	 *
+	 * @param string $group_id The Group ID.
+	 * @param string $list_id The List/Audience ID.
+	 * @return string
+	 */
+	public function create_group_list_id( $group_id, $list_id ) {
+		return 'group-' . $group_id . '-' . $list_id;
+	}
+
+	/**
+	 * Extract the group and list ID from an ID created with create_group_list_id
+	 *
+	 * @param string $list_id The list ID.
+	 * @return array|false Array with the group ID and the list ID or false if the ID is not a group list ID.
+	 */
+	public function maybe_extract_group_list( $list_id ) {
+		$pattern = '/^group-([^-]+)-([^-]+)$/';
+		if ( preg_match( $pattern, $list_id, $matches ) ) {
+			return [
+				'group_id' => $matches[1],
+				'list_id'  => $matches[2],
+			];
+		}
+		return false;
 	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

This PR offers Groups as Subscriptions Lists, just like Audiences. See pamTN9-6Zt-p2

### How to test the changes in this Pull Request:

1. Start with a fresh site and connect it to a Mailchimp account (item 9856 on secret store is a good option as it has 3 Audiences)
2. Visit the Mailchimp dashboard and see the Groups that already exist there
3. Go to the plugin Settings page (both on Newsletter > Settings and on Newspack > Engagement > Newsletters) and confirm you see the Audiences and their groups
4. Enable some of the groups
5. Add a subscription form with these groups somewhere
6. As a reader, subscribe to those newsletters
7. In the Mailchimp dashboard, confirm you see the new contact was added to each of the groups, in each of the Audience the groups belong to
8. Log in with the user (verify the email) and go to My Account > Newsletters
9. Play with enabling and disabling newsletters and confirm the changes are persisted. Confirm in the Mailchimp dashboard that the changes are applied.
10. Back to wp-admin, create a new Subscription List from the admin dashboard
11. Confirm a "Newspack Newsletters" group category was created in the Audience you chose
12. Try adding this to the form and subscribing de-subscribing to it to confirm it works
13. Try any other combination

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
