### PR TITLE
fix(activecampaign): prevent fatal error when fetching contact fields

### DIFF
--- a/includes/service-providers/active_campaign/class-newspack-newsletters-active-campaign.php
+++ b/includes/service-providers/active_campaign/class-newspack-newsletters-active-campaign.php
@@ -1221,7 +1221,11 @@ final class Newspack_Newsletters_Active_Campaign extends \Newspack_Newsletters_S
 		$result     = $response['fields'];
 		$new_offset = count( $result ) + $offset;
 		if ( $new_offset < $response['meta']['total'] ) {
-			$result = array_merge( $result, $this->get_all_contact_fields( $new_offset ) );
+			$fields = $this->get_all_contact_fields( $new_offset );
+			if ( \is_wp_error( $fields ) ) {
+				return $fields;
+			}
+			$result = array_merge( $result, $fields );
 		}
 		return $result;
 	}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Small tweak to AC's `get_all_contact_fields()` method so it doesn't cause a fatal error if the fetch returns a `WP_Error`. Makes sure to return the error instead of attempting to `array_merge()` it.

### How to test the changes in this Pull Request:

No visible change should take place

1. With your site connected to AC, open your site shell
2. Instantiate the provider class in the shell:  `$provider = new Newspack_Newsletters_Active_Campaign();`
3. Fetch an existing contact and confirm there's no error: `$contact = $provider->get_contact_data( 'existing@email.com' );`

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
