### PR TITLE
feat(mailchimp): support double opt-in subscription

### DIFF
--- a/includes/class-newspack-newsletters-blocks.php
+++ b/includes/class-newspack-newsletters-blocks.php
@@ -31,10 +31,12 @@ final class Newspack_Newsletters_Blocks {
 			filemtime( NEWSPACK_NEWSLETTERS_PLUGIN_FILE . 'dist/blocks.js' ),
 			true
 		);
+		$provider = Newspack_Newsletters::get_service_provider();
 		wp_localize_script(
 			$handle,
 			'newspack_newsletters_blocks',
 			[
+				'provider'           => $provider ? $provider->service : '',
 				'settings_url'       => Newspack_Newsletters_Settings::get_settings_url(),
 				'supports_recaptcha' => class_exists( 'Newspack\Recaptcha' ),
 				'has_recaptcha'      => class_exists( 'Newspack\Recaptcha' ) && \Newspack\Recaptcha::can_use_captcha(),

--- a/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp.php
+++ b/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp.php
@@ -32,6 +32,14 @@ final class Newspack_Newsletters_Mailchimp extends \Newspack_Newsletters_Service
 	public $name = 'Mailchimp';
 
 	/**
+	 * Cache of contact added on execution. Control to avoid adding the same
+	 * contact multiple times due to optimistic nature of RAS.
+	 *
+	 * @var array[]
+	 */
+	private static $contacts_added = [];
+
+	/**
 	 * Class constructor.
 	 */
 	public function __construct() {
@@ -448,12 +456,12 @@ final class Newspack_Newsletters_Mailchimp extends \Newspack_Newsletters_Service
 			// In addition to Audiences, we also automatically fetch all groups and offer them as Subscription Lists.
 			// Build the final list inside the loop so groups are added after the list they belong to and we can then represent the hierarchy in the UI.
 			foreach ( $lists_response['lists'] as $list ) {
-				
+
 				$lists[]        = $list;
 				$all_categories = $this->get_all_categories( $list['id'] );
-				
+
 				foreach ( $all_categories as $found_category ) {
-					
+
 					// Do not include groups under the category we use to store "Local" lists.
 					if ( $this->get_group_category_name() === $found_category['title'] ) {
 						continue;
@@ -1029,18 +1037,27 @@ final class Newspack_Newsletters_Mailchimp extends \Newspack_Newsletters_Service
 		if ( false === $list_id ) {
 			return new WP_Error( 'newspack_newsletters_mailchimp_list_id', __( 'Missing list id.' ) );
 		}
+		$email_address  = $contact['email'];
+
+		// If contact was added in this execution, we can return the previous
+		// result and bail.
+		if ( ! empty( self::$contacts_added[ $list_id . $email_address ] ) ) {
+			return self::$contacts_added[ $list_id . $email_address ];
+		}
+
 		$list = $this->maybe_extract_group_list( $list_id );
 		if ( $list ) {
 			$list_id  = $list['list_id'];
 			$group_id = $list['group_id'];
 		}
+		$new_contact_status = 'subscribed';
+		if ( isset( $contact['metadata'] ) && ! empty( $contact['metadata']['status'] ) ) {
+			$new_contact_status = $contact['metadata']['status'];
+			unset( $contact['metadata']['status'] );
+		}
 		try {
 			$mc             = new Mailchimp( $this->api_key() );
-			$email_address  = $contact['email'];
-			$update_payload = [
-				'email_address' => $email_address,
-				'status'        => 'subscribed',
-			];
+			$update_payload = [ 'email_address' => $email_address ];
 			$merge_fields   = [];
 			if ( isset( $contact['name'] ) ) {
 				$name_fragments = explode( ' ', $contact['name'], 2 );
@@ -1090,6 +1107,7 @@ final class Newspack_Newsletters_Mailchimp extends \Newspack_Newsletters_Service
 			// Create or update a list member.
 			$existing_contact = self::get_contact_data( $email_address );
 			if ( is_wp_error( $existing_contact ) ) {
+				$update_payload['status'] = $new_contact_status ?? 'subscribed';
 				$result = $mc->post( "lists/$list_id/members", $update_payload );
 			} else {
 				$member_id = $existing_contact['id'];
@@ -1097,7 +1115,7 @@ final class Newspack_Newsletters_Mailchimp extends \Newspack_Newsletters_Service
 			}
 			if (
 				! $result ||
-				( ! isset( $result['status'] ) || 'subscribed' !== $result['status'] ) ||
+				! isset( $result['status'] ) ||
 				( isset( $result['errors'] ) && count( $result['errors'] ) )
 			) {
 				return new WP_Error(
@@ -1115,6 +1133,7 @@ final class Newspack_Newsletters_Mailchimp extends \Newspack_Newsletters_Service
 				$e->getMessage()
 			);
 		}
+		self::$contacts_added[ $list_id . $email_address ] = $result;
 		return $result;
 	}
 
@@ -1322,7 +1341,7 @@ final class Newspack_Newsletters_Mailchimp extends \Newspack_Newsletters_Service
 		$ids   = [];
 		foreach ( $lists as $list ) {
 			$list_settings = $list->get_provider_settings( $this->service );
-			
+
 			if ( ! empty( $tags[ $list_settings['list'] ] ) ) {
 				if ( in_array( $list_settings['tag_id'], $tags[ $list_settings['list'] ], false ) ) { // phpcs:ignore WordPress.PHP.StrictInArray.FoundNonStrictFalse
 					$ids[] = $list->get_form_id();

--- a/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp.php
+++ b/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp.php
@@ -1037,7 +1037,7 @@ final class Newspack_Newsletters_Mailchimp extends \Newspack_Newsletters_Service
 		if ( false === $list_id ) {
 			return new WP_Error( 'newspack_newsletters_mailchimp_list_id', __( 'Missing list id.' ) );
 		}
-		$email_address  = $contact['email'];
+		$email_address = $contact['email'];
 
 		// If contact was added in this execution, we can return the previous
 		// result and bail.
@@ -1108,7 +1108,7 @@ final class Newspack_Newsletters_Mailchimp extends \Newspack_Newsletters_Service
 			$existing_contact = self::get_contact_data( $email_address );
 			if ( is_wp_error( $existing_contact ) ) {
 				$update_payload['status'] = $new_contact_status ?? 'subscribed';
-				$result = $mc->post( "lists/$list_id/members", $update_payload );
+				$result                   = $mc->post( "lists/$list_id/members", $update_payload );
 			} else {
 				$member_id = $existing_contact['id'];
 				$result    = $mc->put( "lists/$list_id/members/$member_id", $update_payload );

--- a/src/blocks/subscribe/block.json
+++ b/src/blocks/subscribe/block.json
@@ -58,6 +58,10 @@
 				"type": "string"
 			}
 		},
+		"mailchimpDoubleOptIn": {
+			"type": "boolean",
+			"default": false
+		},
 		"successMessage": {
 			"type": "string",
 			"default": "Thank you for signing up!"

--- a/src/blocks/subscribe/edit.js
+++ b/src/blocks/subscribe/edit.js
@@ -12,7 +12,14 @@ import { intersection } from 'lodash';
 import apiFetch from '@wordpress/api-fetch';
 import { __, sprintf } from '@wordpress/i18n';
 import { useState, useEffect } from '@wordpress/element';
-import { TextControl, ToggleControl, PanelBody, Notice, Spinner } from '@wordpress/components';
+import {
+	TextControl,
+	ToggleControl,
+	CheckboxControl,
+	PanelBody,
+	Notice,
+	Spinner,
+} from '@wordpress/components';
 import { useBlockProps, InspectorControls, RichText } from '@wordpress/block-editor';
 
 /**
@@ -42,6 +49,7 @@ export default function SubscribeEdit( {
 		successMessage,
 		lists,
 		displayDescription,
+		mailchimpDoubleOptIn,
 	},
 } ) {
 	const blockProps = useBlockProps();
@@ -151,6 +159,19 @@ export default function SubscribeEdit( {
 						</a>
 					</p>
 				</PanelBody>
+				{ newspack_newsletters_blocks.provider === 'mailchimp' && (
+					<PanelBody title={ __( 'Mailchimp Settings', 'newspack-newsletters' ) }>
+						<CheckboxControl
+							label={ __( 'Enable double opt-in', 'newspack-newsletters' ) }
+							help={ __(
+								'Whether the new contact will have its status as "pending" until email confirmation',
+								'newspack-newsletters'
+							) }
+							checked={ mailchimpDoubleOptIn }
+							onChange={ value => setAttributes( { mailchimpDoubleOptIn: value } ) }
+						/>
+					</PanelBody>
+				) }
 				{ newspack_newsletters_blocks.supports_recaptcha && (
 					<PanelBody title={ __( 'Spam protection', 'newspack' ) }>
 						<p>

--- a/src/blocks/subscribe/index.php
+++ b/src/blocks/subscribe/index.php
@@ -97,6 +97,8 @@ function render_block( $attrs ) {
 		$available_lists = [ $lists[0] ];
 	}
 
+	$provider = \Newspack_Newsletters::get_service_provider();
+
 	// Enqueue scripts.
 	enqueue_scripts();
 
@@ -235,6 +237,9 @@ function render_block( $attrs ) {
 						placeholder="<?php echo \esc_attr( $attrs['placeholder'] ); ?>"
 						value=""
 					/>
+					<?php if ( $provider && 'mailchimp' === $provider->service && $attrs['mailchimpDoubleOptIn'] ) : ?>
+						<input type="hidden" name="double_optin" value="1" />
+					<?php endif; ?>
 					<input type="submit" value="<?php echo \esc_attr( $attrs['label'] ); ?>" />
 				</div>
 			</form>
@@ -358,6 +363,12 @@ function process_form() {
 		'newspack_popup_id'               => $popup_id,
 		'newsletters_subscription_method' => 'newsletters-subscription-block',
 	];
+
+	// Handle Mailchimp double opt-in option.
+	$provider = \Newspack_Newsletters::get_service_provider();
+	if ( $provider && 'mailchimp' === $provider->service && isset( $_REQUEST['double_optin'] ) && '1' === $_REQUEST['double_optin'] ) {
+		$metadata['status'] = 'pending';
+	}
 
 	$result = \Newspack_Newsletters_Subscription::add_contact(
 		[


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<img width="282" alt="image" src="https://user-images.githubusercontent.com/820752/236314833-351064b4-6e65-4e1b-b839-c82e9ebcac14.png">

Implements Mailchimp's double opt-in support in the Newsletters Subscription Form block.

Also implements an improvement to the `add_contact` logic to prevent the same execution from adding the contact twice. This can happen with RAS's optimistic way of updating ESP data. It doesn't communicate well with Mailchimp's double opt-in because the API handles a "pending" contact differently. For that reason, we need to prevent this double run.

### How to test the changes in this Pull Request:

1. Check out this branch and make sure you have a Mailchimp setup
2. Add a Newsletters Subscription Form block to a page and confirm you see the new panel as above
3. Without checking the box, save the page
4. Visit the page and subscribe a new email to multiple lists
5. Confirm in Mailchimp's dashboard that the contact is subscribed to all lists
6. Edit the block and check the "double opt-in" option
7. Visit the page and subscribe another email
8. Confirm the contact is not added yet and you receive a confirmation email from Mailchimp
9. Click the email link and confirm the contact is subscribed

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
