### PR TITLE
feat: conditional content tags

### DIFF
--- a/includes/class-newspack-newsletters-editor.php
+++ b/includes/class-newspack-newsletters-editor.php
@@ -296,12 +296,18 @@ final class Newspack_Newsletters_Editor {
 			// Remove the Ads CPT - it does not need MJML handling since ads
 			// will be injected into email content before it's converted to MJML.
 			$mjml_handling_post_types = array_values( array_diff( self::get_email_editor_cpts(), [ Newspack_Newsletters_Ads::NEWSPACK_NEWSLETTERS_ADS_CPT ] ) );
+			$provider                 = Newspack_Newsletters::get_service_provider();
+			$conditional_tag_support  = false;
+			if ( $provider ) {
+				$conditional_tag_support = $provider::get_conditional_tag_support();
+			}
 			wp_localize_script(
 				'newspack-newsletters-editor',
 				'newspack_email_editor_data',
 				[
 					'email_html_meta'          => Newspack_Newsletters::EMAIL_HTML_META,
 					'mjml_handling_post_types' => $mjml_handling_post_types,
+					'conditional_tag_support'  => $conditional_tag_support,
 				]
 			);
 

--- a/includes/class-newspack-newsletters-renderer.php
+++ b/includes/class-newspack-newsletters-renderer.php
@@ -351,6 +351,26 @@ final class Newspack_Newsletters_Renderer {
 		$block_mjml_markup = '';
 		$attrs             = self::process_attributes( array_merge( $default_attrs, $attrs ) );
 
+		$conditionals = [];
+		if ( ! empty( $attrs['conditionalBefore'] ) && ! empty( $attrs['conditionalAfter'] ) ) {
+			$conditionals = [
+				'before' => $attrs['conditionalBefore'],
+				'after'  => $attrs['conditionalAfter'],
+			];
+		}
+
+		// Remove attributes that are not supported by MJML.
+		$unsupported_attrs = [
+			'newsletterVisibility',
+			'conditionalBefore',
+			'conditionalAfter',
+		];
+		foreach ( $unsupported_attrs as $attr ) {
+			if ( isset( $attrs[ $attr ] ) ) {
+				unset( $attrs[ $attr ] );
+			}
+		}
+
 		// Default attributes for the section which will envelop the mj-column.
 		$section_attrs = array_merge(
 			$attrs,
@@ -878,12 +898,16 @@ final class Newspack_Newsletters_Renderer {
 			$column_attrs['width'] = '100%';
 			$block_mjml_markup     = '<mj-column ' . self::array_to_attributes( $column_attrs ) . '>' . $block_mjml_markup . '</mj-column>';
 		}
-		if ( $is_in_column || $is_in_list_or_quote || $is_posts_inserter_block ) {
-			// Render a nested block without a wrapping section.
-			return $block_mjml_markup;
-		} else {
-			return '<mj-section ' . self::array_to_attributes( $section_attrs ) . '>' . $block_mjml_markup . '</mj-section>';
+
+		if ( ! $is_in_column && ! $is_in_list_or_quote && ! $is_posts_inserter_block ) {
+			$block_mjml_markup = '<mj-section ' . self::array_to_attributes( $section_attrs ) . '>' . $block_mjml_markup . '</mj-section>';
 		}
+
+		if ( ! empty( $conditionals ) ) {
+			$block_mjml_markup = '<mj-raw>' . $conditionals['before'] . '</mj-raw>' . $block_mjml_markup . '<mj-raw>' . $conditionals['after'] . '</mj-raw>';
+		}
+
+		return $block_mjml_markup;
 	}
 
 	/**

--- a/includes/service-providers/active_campaign/class-newspack-newsletters-active-campaign.php
+++ b/includes/service-providers/active_campaign/class-newspack-newsletters-active-campaign.php
@@ -63,6 +63,21 @@ final class Newspack_Newsletters_Active_Campaign extends \Newspack_Newsletters_S
 	}
 
 	/**
+	 * Get configuration for conditional tag support.
+	 *
+	 * @return array
+	 */
+	public static function get_conditional_tag_support() {
+		return [
+			'support_url' => 'https://help.activecampaign.com/hc/en-us/articles/220358207-Use-Conditional-Content',
+			'example'     => [
+				'before' => '%IF in_array(\'Interested in cameras\', $TAGS)%',
+				'after'  => '%/IF%',
+			],
+		];
+	}
+
+	/**
 	 * Perform v3 API request.
 	 *
 	 * @param string $resource Resource path.

--- a/includes/service-providers/campaign_monitor/class-newspack-newsletters-campaign-monitor.php
+++ b/includes/service-providers/campaign_monitor/class-newspack-newsletters-campaign-monitor.php
@@ -35,6 +35,21 @@ final class Newspack_Newsletters_Campaign_Monitor extends \Newspack_Newsletters_
 	}
 
 	/**
+	 * Get configuration for conditional tag support.
+	 *
+	 * @return array
+	 */
+	public static function get_conditional_tag_support() {
+		return [
+			'support_url' => 'https://www.campaignmonitor.com/create/dynamic-content/',
+			'example'     => [
+				'before' => '[ifmemberof:"My list|VIP segment"]',
+				'after'  => '[endif]',
+			],
+		];
+	}
+
+	/**
 	 * Get API credentials for service provider.
 	 *
 	 * @return Object Stored API credentials for the service provider.

--- a/includes/service-providers/class-newspack-newsletters-service-provider.php
+++ b/includes/service-providers/class-newspack-newsletters-service-provider.php
@@ -67,6 +67,21 @@ abstract class Newspack_Newsletters_Service_Provider implements Newspack_Newslet
 	}
 
 	/**
+	 * Get configuration for conditional tag support.
+	 *
+	 * @return array
+	 */
+	public static function get_conditional_tag_support() {
+		return [
+			'support_url' => '',
+			'example'     => [
+				'before' => '',
+				'after'  => '',
+			],
+		];
+	}
+
+	/**
 	 * Manage singleton instances of all descendant service provider classes.
 	 */
 	public static function instance() {
@@ -422,7 +437,7 @@ abstract class Newspack_Newsletters_Service_Provider implements Newspack_Newslet
 		if ( Subscription_List::is_form_id( $list_id ) ) {
 			try {
 				$list = new Subscription_List( $list_id );
-				
+
 				if ( ! $list->is_configured_for_provider( $this->service ) ) {
 					return new WP_Error( 'List not properly configured for the provider' );
 				}
@@ -496,7 +511,7 @@ abstract class Newspack_Newsletters_Service_Provider implements Newspack_Newslet
 			if ( Subscription_List::is_form_id( $list_id ) ) {
 				try {
 					$list = new Subscription_List( $list_id );
-					
+
 					if ( ! $list->is_configured_for_provider( $this->service ) ) {
 						return new WP_Error( 'List not properly configured for the provider' );
 					}
@@ -507,7 +522,7 @@ abstract class Newspack_Newsletters_Service_Provider implements Newspack_Newslet
 					} elseif ( 'remove' === $action ) {
 						$this->remove_esp_local_list_from_contact( $email, $list_settings['tag_id'], $list_settings['list'] );
 					}
-					
+
 					unset( $lists[ $key ] );
 
 				} catch ( \InvalidArgumentException $e ) {

--- a/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp.php
+++ b/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp.php
@@ -49,6 +49,21 @@ final class Newspack_Newsletters_Mailchimp extends \Newspack_Newsletters_Service
 	}
 
 	/**
+	 * Get configuration for conditional tag support.
+	 *
+	 * @return array
+	 */
+	public static function get_conditional_tag_support() {
+		return [
+			'support_url' => 'https://mailchimp.com/help/use-conditional-merge-tag-blocks/',
+			'example'     => [
+				'before' => '*|IF:FNAME|*',
+				'after'  => '*|END:IF|*',
+			],
+		];
+	}
+
+	/**
 	 * Get API credentials for service provider.
 	 *
 	 * @return Object Stored API credentials for the service provider.
@@ -448,12 +463,12 @@ final class Newspack_Newsletters_Mailchimp extends \Newspack_Newsletters_Service
 			// In addition to Audiences, we also automatically fetch all groups and offer them as Subscription Lists.
 			// Build the final list inside the loop so groups are added after the list they belong to and we can then represent the hierarchy in the UI.
 			foreach ( $lists_response['lists'] as $list ) {
-				
+
 				$lists[]        = $list;
 				$all_categories = $this->get_all_categories( $list['id'] );
-				
+
 				foreach ( $all_categories as $found_category ) {
-					
+
 					// Do not include groups under the category we use to store "Local" lists.
 					if ( $this->get_group_category_name() === $found_category['title'] ) {
 						continue;
@@ -1322,7 +1337,7 @@ final class Newspack_Newsletters_Mailchimp extends \Newspack_Newsletters_Service
 		$ids   = [];
 		foreach ( $lists as $list ) {
 			$list_settings = $list->get_provider_settings( $this->service );
-			
+
 			if ( ! empty( $tags[ $list_settings['list'] ] ) ) {
 				if ( in_array( $list_settings['tag_id'], $tags[ $list_settings['list'] ], false ) ) { // phpcs:ignore WordPress.PHP.StrictInArray.FoundNonStrictFalse
 					$ids[] = $list->get_form_id();

--- a/src/editor/blocks/conditional-content/index.js
+++ b/src/editor/blocks/conditional-content/index.js
@@ -1,0 +1,147 @@
+/**
+ * External dependencies
+ */
+import { assign } from 'lodash';
+import classnames from 'classnames';
+
+/**
+ * WordPress dependencies
+ */
+import { Fragment } from '@wordpress/element';
+import { createHigherOrderComponent } from '@wordpress/compose';
+import { InspectorControls } from '@wordpress/block-editor';
+import { PanelBody, TextControl } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import './style.scss';
+
+const addConditionalContentAttributes = settings => {
+	settings.attributes = assign( settings.attributes, {
+		conditionalBefore: {
+			type: 'string',
+			default: '',
+		},
+		conditionalAfter: {
+			type: 'string',
+			default: '',
+		},
+	} );
+	return settings;
+};
+
+const withConditionalContentControl = createHigherOrderComponent(
+	BlockEdit => props => {
+		const { attributes, setAttributes } = props;
+		return (
+			<Fragment>
+				<BlockEdit { ...props } />
+				<InspectorControls>
+					<PanelBody title={ __( 'Conditional Content', 'newspack-newsletters' ) }>
+						<p>
+							{ __(
+								'Use conditional tags provided by your email service provider to control who sees what in your email.',
+								'newspack-newsletters'
+							) }
+						</p>
+						<TextControl
+							label={ __( 'Opening tag', 'newspack-newsletters' ) }
+							value={ attributes.conditionalBefore }
+							onChange={ value => setAttributes( { conditionalBefore: value } ) }
+							help={ __(
+								'Opening tag for conditional content. E.g.: *|IF:AGE >= 21|*',
+								'newspack-newsletters'
+							) }
+						/>
+						<TextControl
+							label={ __( 'Closing tag', 'newspack-newsletters' ) }
+							value={ attributes.conditionalAfter }
+							onChange={ value => setAttributes( { conditionalAfter: value } ) }
+							help={ __(
+								'Closing tag for conditional content. E.g.: *|END:IF|*',
+								'newspack-newsletters'
+							) }
+						/>
+					</PanelBody>
+				</InspectorControls>
+			</Fragment>
+		);
+	},
+	'withConditionalContentControl'
+);
+
+const withConditionalContentNotice = createHigherOrderComponent(
+	BlockListBlock => props => {
+		const { conditionalBefore, conditionalAfter } = props.attributes;
+		if ( ! conditionalBefore && ! conditionalAfter ) {
+			return <BlockListBlock { ...props } />;
+		}
+		return (
+			<div
+				className={ classnames( {
+					'wp-block': true,
+					'newspack-newsletters__editor-block': true,
+					'newsletters-block__conditional-content': true,
+					'newsletters-block__conditional-content--selected': props.isSelected,
+					'newsletters-block__conditional-content--error': ! conditionalAfter,
+				} ) }
+				data-align={ props.attributes?.align || null }
+			>
+				<span className="newsletters-block__conditional-content__label newsletters-block__conditional-content__label__before">
+					{ ! conditionalBefore ? (
+						<>
+							{ __( 'Missing opening tag for conditional content.', 'newspack-newsletters' ) }
+							<button
+								onClick={ () => {
+									props.setAttributes( { conditionalAfter: '' } );
+								} }
+							>
+								{ __( 'Clear conditional', 'newspack-newsletters' ) }
+							</button>
+						</>
+					) : (
+						conditionalBefore
+					) }
+				</span>
+				<span className="newsletters-block__conditional-content__label newsletters-block__conditional-content__label__after">
+					{ ! conditionalAfter ? (
+						<>
+							{ __( 'Missing closing tag for conditional content.', 'newspack-newsletters' ) }
+							<button
+								onClick={ () => {
+									props.setAttributes( { conditionalBefore: '' } );
+								} }
+							>
+								{ __( 'Clear conditional', 'newspack-newsletters' ) }
+							</button>
+						</>
+					) : (
+						conditionalAfter
+					) }
+				</span>
+				<BlockListBlock { ...props } />
+			</div>
+		);
+	},
+	'withConditionalContentNotice'
+);
+
+export default () => {
+	wp.hooks.addFilter(
+		'blocks.registerBlockType',
+		'newspack-newsletters/conditional-content-attributes',
+		addConditionalContentAttributes
+	);
+	wp.hooks.addFilter(
+		'editor.BlockEdit',
+		'newspack-newsletters/conditional-content-control',
+		withConditionalContentControl
+	);
+	wp.hooks.addFilter(
+		'editor.BlockListBlock',
+		'newspack-newsletters/conditional-content-notice',
+		withConditionalContentNotice
+	);
+};

--- a/src/editor/blocks/conditional-content/index.js
+++ b/src/editor/blocks/conditional-content/index.js
@@ -1,3 +1,4 @@
+/* globals newspack_email_editor_data */
 /**
  * External dependencies
  */
@@ -11,12 +12,14 @@ import { Fragment } from '@wordpress/element';
 import { createHigherOrderComponent } from '@wordpress/compose';
 import { InspectorControls } from '@wordpress/block-editor';
 import { PanelBody, TextControl } from '@wordpress/components';
-import { __ } from '@wordpress/i18n';
+import { sprintf, __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
  */
 import './style.scss';
+
+const config = newspack_email_editor_data.conditional_tag_support;
 
 const addConditionalContentAttributes = settings => {
 	settings.attributes = assign( settings.attributes, {
@@ -50,20 +53,27 @@ const withConditionalContentControl = createHigherOrderComponent(
 							label={ __( 'Opening tag', 'newspack-newsletters' ) }
 							value={ attributes.conditionalBefore }
 							onChange={ value => setAttributes( { conditionalBefore: value } ) }
-							help={ __(
-								'Opening tag for conditional content. E.g.: *|IF:AGE >= 21|*',
-								'newspack-newsletters'
+							help={ sprintf(
+								/* translators: %s: example opening tag */
+								__( 'Opening tag for conditional content. E.g.: %s', 'newspack-newsletters' ),
+								config?.example?.before
 							) }
 						/>
 						<TextControl
 							label={ __( 'Closing tag', 'newspack-newsletters' ) }
 							value={ attributes.conditionalAfter }
 							onChange={ value => setAttributes( { conditionalAfter: value } ) }
-							help={ __(
-								'Closing tag for conditional content. E.g.: *|END:IF|*',
-								'newspack-newsletters'
+							help={ sprintf(
+								/* translators: %s: example closing tag */
+								__( 'Closing tag for conditional content. E.g.: %s', 'newspack-newsletters' ),
+								config?.example?.after
 							) }
 						/>
+						<p>
+							<a href={ config?.support_url } target="_blank" rel="external noreferrer">
+								{ __( 'Click here to learn more.', 'newspack-newsletters' ) }
+							</a>
+						</p>
 					</PanelBody>
 				</InspectorControls>
 			</Fragment>

--- a/src/editor/blocks/conditional-content/style.scss
+++ b/src/editor/blocks/conditional-content/style.scss
@@ -66,21 +66,21 @@
 			}
 		}
 
-    &__before {
-      top: 3px;
-      left: 3px;
-      .newsletters-block__conditional-content--selected & {
-        margin-top: -25px;
-      }
-    }
-    &__after {
-      top: 100%;
-      right: 3px;
-      margin-top: -23px;
-      .newsletters-block__conditional-content--selected & {
-        margin-top: 3px;
-      }
-    }
+		&__before {
+			top: 3px;
+			left: 3px;
+			.newsletters-block__conditional-content--selected & {
+				margin-top: -25px;
+			}
+		}
+		&__after {
+			top: 100%;
+			right: 3px;
+			margin-top: -23px;
+			.newsletters-block__conditional-content--selected & {
+				margin-top: 3px;
+			}
+		}
 
 		.newsletters-block__conditional-content--error & {
 			background: wp-colors.$alert-red;
@@ -91,7 +91,7 @@
 		min-height: 1.5em;
 	}
 	&--error {
-		&::after {
+		&::before {
 			box-shadow: 0 0 0 var( --wp-admin-border-width-focus ) wp-colors.$alert-red;
 		}
 	}

--- a/src/editor/blocks/conditional-content/style.scss
+++ b/src/editor/blocks/conditional-content/style.scss
@@ -1,0 +1,98 @@
+@use '~@wordpress/base-styles/colors' as wp-colors;
+
+:root {
+	/* stylelint-disable value-keyword-case */
+	--newspack-system-font: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen-Sans, Ubuntu,
+		Cantarell, 'Helvetica Neue', sans-serif;
+	/* stylelint-enable value-keyword-case */
+}
+
+.newsletters-block__conditional-content {
+	height: auto;
+	margin-bottom: 0;
+	margin-top: 0;
+	min-height: calc( 1.5em + 22px );
+	padding: 0 !important;
+	position: relative;
+	transition: min-height 0.25s ease-in-out;
+
+	&::before {
+		border-radius: 1px;
+		bottom: 1px;
+		box-shadow: 0 0 0 var( --wp-admin-border-width-focus ) wp-colors.$alert-yellow;
+		content: '';
+		left: 1px;
+		pointer-events: none;
+		position: absolute;
+		right: 1px;
+		top: 1px;
+	}
+
+	&::after {
+		clear: both;
+		content: '';
+		display: table;
+	}
+
+	&__label {
+		background: wp-colors.$alert-yellow;
+		border-radius: 2px;
+		color: wp-colors.$gray-900;
+		display: flex;
+		font-family: var( --newspack-system-font );
+		font-size: 10px;
+		line-height: 1.6;
+		padding: 2px 4px;
+		pointer-events: none;
+		position: absolute;
+		transition: margin 0.25s ease-in-out;
+		z-index: 22;
+		button {
+			border: 0;
+			background: transparent;
+			color: inherit;
+			cursor: pointer;
+			display: inline-block;
+			font-family: inherit;
+			font-size: inherit;
+			line-height: inherit;
+			margin-left: 0.25em;
+			padding: 0;
+			pointer-events: all;
+			text-decoration: underline;
+
+			&:focus {
+				outline: 1px solid;
+			}
+		}
+
+    &__before {
+      top: 3px;
+      left: 3px;
+      .newsletters-block__conditional-content--selected & {
+        margin-top: -25px;
+      }
+    }
+    &__after {
+      top: 100%;
+      right: 3px;
+      margin-top: -23px;
+      .newsletters-block__conditional-content--selected & {
+        margin-top: 3px;
+      }
+    }
+
+		.newsletters-block__conditional-content--error & {
+			background: wp-colors.$alert-red;
+			color: white;
+		}
+	}
+	&--selected {
+		min-height: 1.5em;
+	}
+	&--error {
+		&::after {
+			box-shadow: 0 0 0 var( --wp-admin-border-width-focus ) wp-colors.$alert-red;
+		}
+	}
+}

--- a/src/editor/index.js
+++ b/src/editor/index.js
@@ -1,3 +1,4 @@
+/* globals newspack_email_editor_data */
 /**
  * WordPress dependencies
  */
@@ -32,7 +33,13 @@ registerShareBlock();
 registerEmbedBlockEdit();
 registerMergeTagsFilters();
 registerVisibilityFilters();
-registerConditionalContent();
+
+if (
+	newspack_email_editor_data.conditional_tag_support &&
+	newspack_email_editor_data.conditional_tag_support.support_url
+) {
+	registerConditionalContent();
+}
 
 domReady( () => {
 	/* Unregister core block styles that are unsupported in emails */

--- a/src/editor/index.js
+++ b/src/editor/index.js
@@ -20,6 +20,7 @@ import registerShareBlock from './blocks/share';
 import registerEmbedBlockEdit from './blocks/embed';
 import registerMergeTagsFilters from './blocks/mailchimp-merge-tags';
 import registerVisibilityFilters from './blocks/visibility-attribute';
+import registerConditionalContent from './blocks/conditional-content';
 import { addBlocksValidationFilter } from './blocks-validation/blocks-filters';
 import { NestedColumnsDetection } from './blocks-validation/nesting-detection';
 import './api';
@@ -31,6 +32,7 @@ registerShareBlock();
 registerEmbedBlockEdit();
 registerMergeTagsFilters();
 registerVisibilityFilters();
+registerConditionalContent();
 
 domReady( () => {
 	/* Unregister core block styles that are unsupported in emails */


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Implements custom attributes to support conditional content from ESP-provided tags.

<img width="664" alt="image" src="https://github.com/Automattic/newspack-newsletters/assets/820752/02b88de3-25d9-4ce8-a055-acdd7691dd88">

<img width="1148" alt="image" src="https://user-images.githubusercontent.com/820752/236923639-e3ddbf14-3093-4b8e-9d5d-8f6600f7e38c.png">

### How to test the changes in this Pull Request:

1. Check out this branch and setup a Mailchimp connection
2. Start a new blank newsletter and add a paragraph
3. Confirm the new panel for settings conditional content attributes with Mailchimp-related instructions
4. To a segment, add a contact with "First Name" and another without (you must have access to both mailboxes or use `+` to send to the same gmail inbox)
5. Copy the setup from the first image above, with a paragraph using `*|IFNOT:FNAME|*` and another using `*|IF:FNAME|*`
6. Send the campaign and confirm both emails are sent with the appropriate greeting
7. Change your newsletter setup to use ActiveCampaign
8. Draft a new blank newsletter and add a block
9. Confirm the instructions now refer to ActiveCampaign support

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
