### PR TITLE
fix: display only Audiences in list metabox

### DIFF
--- a/includes/class-subscription-lists.php
+++ b/includes/class-subscription-lists.php
@@ -270,6 +270,13 @@ class Subscription_Lists {
 			<select name="newspack_newsletters_list" id="newspack_newsletters_list" style="width: 100%">
 				<?php foreach ( $lists as $list ) : ?>
 
+					<?php
+					// Some providers (mailchimp) register some special types of list that are not the native ESP lists. Here we want only the native lists.
+					if ( ! empty( $list['type'] ) ) {
+						continue;
+					}
+					?>
+
 					<option value="<?php echo esc_attr( $list['id'] ); ?>" <?php selected( $current_settings['list'], $list['id'] ); ?> >
 						<?php echo esc_html( $list['name'] ); ?>
 					</option>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

After https://github.com/Automattic/newspack-newsletters/pull/1156 the metabox in the creation of a Subscription List is showing groups as well as Audiences. Only Audiences should be displayed there.

### How to test the changes in this Pull Request:

1. In `master` set up a site with Mailchimp and make sure Mailchimp account have some groups
2. Go to Newspack > Settings and make sure you see Audiences and groups there
3. Click to "Add new" Subscription List
4. Confirm that in the Select box in the metabox, under "Audience:" you see all Audiences and groups
5. Checkout this PR
6. Confirm that now you only see Audiences there
7. Confirm that this also still works with other provider


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
