### PR TITLE
feat: fix SEND TO mailchimp audiences

### DIFF
--- a/src/service-providers/mailchimp/ProviderSidebar.js
+++ b/src/service-providers/mailchimp/ProviderSidebar.js
@@ -96,7 +96,10 @@ const ProviderSidebar = ( {
 	updateMeta,
 } ) => {
 	const campaign = newsletterData.campaign;
-	const lists = newsletterData.lists || [];
+	const lists =
+		newsletterData.lists && newsletterData.lists.length
+			? newsletterData.lists.filter( list => list.type !== 'mailchimp-group' )
+			: [];
 	const folders = newsletterData.folders || [];
 	const segments = newsletterData.segments || newsletterData.tags || []; // Keep .tags for backwards compatibility.
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

After https://github.com/Automattic/newspack-newsletters/pull/1156 the metabox in the creation of a Subscription List is showing groups as well as Audiences. Only Audiences should be displayed there.

### How to test the changes in this Pull Request:

1. In `master` set up a site with Mailchimp and make sure Mailchimp account have some groups
2. Go to Newspack > Settings and make sure you see Audiences and groups there
3. Click to "Add new" Newsletter
4. Confirm that in the SEND TO section, under "Audiences:" you see all Audiences and groups
5. Checkout this PR and build the plugin
6. Confirm that now you only see Audiences there



### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
