### PR TITLE
chore(lint): replace css rule to use inset

### DIFF
--- a/src/editor/blocks/conditional-content/style.scss
+++ b/src/editor/blocks/conditional-content/style.scss
@@ -18,14 +18,11 @@
 
 	&::before {
 		border-radius: 1px;
-		bottom: 1px;
 		box-shadow: 0 0 0 var( --wp-admin-border-width-focus ) wp-colors.$alert-yellow;
 		content: '';
-		left: 1px;
 		pointer-events: none;
 		position: absolute;
-		right: 1px;
-		top: 1px;
+		inset: 1px;
 	}
 
 	&::after {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

#1165 didn't account for #1162. This PR fixes the [linter error](https://app.circleci.com/pipelines/github/Automattic/newspack-newsletters/3028/workflows/4df2cee2-2049-4cbb-b86e-8e020a86dc3f/jobs/10177).

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
