### PR TITLE
feat: optional comments support

### DIFF
--- a/includes/class-newspack-newsletters-settings.php
+++ b/includes/class-newspack-newsletters-settings.php
@@ -160,6 +160,18 @@ class Newspack_Newsletters_Settings {
 				'helpURL'     => esc_url( 'https://help.tryletterhead.com/promotions-api-reference' ),
 				'onboarding'  => false,
 			),
+
+			/**
+			 * Post Comments support.
+			 */
+			array(
+				'default'           => false,
+				'description'       => esc_html__( 'Support comments in public newsletters posts', 'newspack-newsletters' ),
+				'key'               => 'newspack_newsletters_support_comments',
+				'sanitize_callback' => 'boolval',
+				'type'              => 'checkbox',
+				'onboarding'        => false,
+			),
 		);
 
 		if ( class_exists( 'Jetpack' ) && \Jetpack::is_module_active( 'related-posts' ) ) {

--- a/includes/class-newspack-newsletters-settings.php
+++ b/includes/class-newspack-newsletters-settings.php
@@ -166,7 +166,7 @@ class Newspack_Newsletters_Settings {
 			 */
 			array(
 				'default'           => false,
-				'description'       => esc_html__( 'Support comments in public newsletters posts', 'newspack-newsletters' ),
+				'description'       => esc_html__( 'Allow comments to be enabled for public Newsletters', 'newspack-newsletters' ),
 				'key'               => 'newspack_newsletters_support_comments',
 				'sanitize_callback' => 'boolval',
 				'type'              => 'checkbox',

--- a/includes/class-newspack-newsletters.php
+++ b/includes/class-newspack-newsletters.php
@@ -410,6 +410,12 @@ final class Newspack_Newsletters {
 			'item_link_description'    => __( 'A link to a newsletter.', 'newspack-newsletters' ),
 		];
 
+		$supports = [ 'author', 'editor', 'title', 'custom-fields', 'newspack_blocks', 'revisions', 'thumbnail', 'excerpt' ];
+
+		if ( get_option( 'newspack_newsletters_support_comments' ) ) {
+			$supports[] = 'comments';
+		}
+
 		$cpt_args = [
 			'has_archive'      => $public_slug,
 			'labels'           => $labels,
@@ -419,7 +425,7 @@ final class Newspack_Newsletters {
 			'rewrite'          => [ 'slug' => $public_slug ],
 			'show_ui'          => true,
 			'show_in_rest'     => true,
-			'supports'         => [ 'author', 'editor', 'title', 'custom-fields', 'newspack_blocks', 'revisions', 'thumbnail', 'excerpt' ],
+			'supports'         => $supports,
 			'taxonomies'       => [ 'category', 'post_tag' ],
 			'menu_icon'        => 'data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIGhlaWdodD0iMjQiIHZpZXdCb3g9IjAgMCAyNCAyNCIgd2lkdGg9IjI0Ij48cGF0aCB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIGQ9Ik0yMS45OSA4YzAtLjcyLS4zNy0xLjM1LS45NC0xLjdMMTIgMSAyLjk1IDYuM0MyLjM4IDYuNjUgMiA3LjI4IDIgOHYxMGMwIDEuMS45IDIgMiAyaDE2YzEuMSAwIDItLjkgMi0ybC0uMDEtMTB6TTEyIDEzTDMuNzQgNy44NCAxMiAzbDguMjYgNC44NEwxMiAxM3oiIGZpbGw9IiNhMGE1YWEiLz48L3N2Zz4K',
 		];


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Implements optional comments support for public newsletters.

### How to test the changes in this Pull Request:

1. Check out this branch and visit the Newsletter tab of "Newspack -> Engagement"
2. Confirm you see the new checkbox for `Support comments in public newsletters posts`
3. Toggle it on
4. Send/publish a new newsletter set to public
5. Confirm the "Discussion" panel is available and comments can be toggled on and off
6. Toggle it on and save
7. Visit the post and confirm comments are available
8. Visit the Newsletters settings outside Newspack's wizard (Newsletters -> Settings)
9. Confirm you see the same field
10. Toggle it off and save
11. Refresh the post page and confirm comments are no longer available

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
