### PR TITLE
feat: support non-stacking on mobile

### DIFF
--- a/includes/class-newspack-newsletters-renderer.php
+++ b/includes/class-newspack-newsletters-renderer.php
@@ -717,9 +717,17 @@ final class Newspack_Newsletters_Renderer {
 				if ( isset( $attrs['color'] ) ) {
 					$default_attrs['color'] = $attrs['color'];
 				}
-				$markup = '';
+				$stack_on_mobile = ! isset( $attrs['isStackedOnMobile'] ) || true === $attrs['isStackedOnMobile'];
+				if ( ! $stack_on_mobile ) {
+					$markup = '<mj-group>';
+				} else {
+					$markup = '';
+				}
 				foreach ( $inner_blocks as $block ) {
 					$markup .= self::render_mjml_component( $block, true, false, $default_attrs );
+				}
+				if ( ! $stack_on_mobile ) {
+					$markup .= '</mj-group>';
 				}
 				$block_mjml_markup = $markup;
 				break;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

WordPress columns block supports choosing whether or not to stack the columns on mobile. The current implementation with MJML will always stack regardless of the selected block options.

This implements the support for non-stacking on mobile through a `mj-group` containing the columns.

| Editor | Rendered |
| --- | --- |
| <img width="1104" alt="image" src="https://github.com/Automattic/newspack-newsletters/assets/820752/3cf845fe-6e59-4158-a743-4cf3ee784e0f"> | <img width="342" alt="image" src="https://github.com/Automattic/newspack-newsletters/assets/820752/436eebad-5ea7-4048-bc3b-f2b4322d2fb8"> |


### How to test the changes in this Pull Request:

1. While on master draft a new newsletter and add 2-column blocks with images, like in the example above
2. Edit the columns block and make sure it's set to not stack on mobile
3. Save the draft and confirm on the ESP that it's stacking on mobile
4. Check out this branch, save the draft again
5. Confirm on the ESP that it's not stacking on mobile
6. Edit the draft to make the columns block stack on mobile and save
7. Confirm on the ESP that it's stacking on mobile

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
