### PR TITLE
feat: better feedback to the user about api error

### DIFF
--- a/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp.php
+++ b/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp.php
@@ -466,6 +466,15 @@ final class Newspack_Newsletters_Mailchimp extends \Newspack_Newsletters_Service
 					$lists_response->getMessage()
 				);
 			}
+
+			if ( ! isset( $lists_response['lists'] ) ) {
+				$error_message  = __( 'Error retrieving Mailchimp lists.', 'newspack_newsletters' );
+				$error_message .= ! empty( $lists_response['title'] ) ? ' ' . $lists_response['title'] : '';
+				return new WP_Error(
+					'newspack_newsletters_mailchimp_error',
+					$error_message
+				);
+			}
 			$lists = [];
 
 			// In addition to Audiences, we also automatically fetch all groups and offer them as Subscription Lists.


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Givers user better feedback when the API key is invalid

### How to test the changes in this Pull Request:

1. Connect a site with Mailchimp nd confirm it works
2. On `master` Set an invalid API key for Mailchimp
3. Confirm that you don't see any error messages in Newspack > Engagement > Newsletters, nor in Newspack > Settings
4. checkout this branch
5. Confirm you see an error message in Newspack > Engagement > Newsletters

![Captura de tela de 2023-05-23 16-32-15](https://github.com/Automattic/newspack-newsletters/assets/971483/87ead6d2-5146-4ca7-ad1a-61d4e6a88206)


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
