### PR TITLE
fix: avoid editor components rerenders

### DIFF
--- a/src/editor/blocks/posts-inserter/index.js
+++ b/src/editor/blocks/posts-inserter/index.js
@@ -22,7 +22,7 @@ import {
 	Toolbar,
 	ToolbarDropdownMenu,
 } from '@wordpress/components';
-import { InnerBlocks, InspectorControls, BlockControls } from '@wordpress/block-editor';
+import { InspectorControls, BlockControls } from '@wordpress/block-editor';
 import { Fragment, useEffect, useMemo, useState } from '@wordpress/element';
 import { Icon, check, pages } from '@wordpress/icons';
 
@@ -36,6 +36,8 @@ import { getTemplateBlocks, convertBlockSerializationFormat } from './utils';
 import QueryControlsSettings from './query-controls';
 import { POSTS_INSERTER_BLOCK_NAME, POSTS_INSERTER_STORE_NAME } from './consts';
 import PostsPreview from './posts-preview';
+
+const EMPTY_STRING = '';
 
 const PostsInserterBlock = ( {
 	setAttributes,
@@ -208,7 +210,7 @@ const PostsInserterBlock = ( {
 						} }
 					/>
 					<ColorPicker
-						color={ attributes.textColor || '' }
+						color={ attributes.textColor || EMPTY_STRING }
 						onChangeComplete={ value => setAttributes( { textColor: value.hex } ) }
 						disableAlpha
 					/>
@@ -220,7 +222,7 @@ const PostsInserterBlock = ( {
 						onChange={ value => setAttributes( { headingFontSize: value } ) }
 					/>
 					<ColorPicker
-						color={ attributes.headingColor || '' }
+						color={ attributes.headingColor || EMPTY_STRING }
 						onChangeComplete={ value => setAttributes( { headingColor: value.hex } ) }
 						disableAlpha
 					/>
@@ -232,7 +234,7 @@ const PostsInserterBlock = ( {
 						onChange={ value => setAttributes( { subHeadingFontSize: value } ) }
 					/>
 					<ColorPicker
-						color={ attributes.subHeadingColor || '' }
+						color={ attributes.subHeadingColor || EMPTY_STRING }
 						onChangeComplete={ value => setAttributes( { subHeadingColor: value.hex } ) }
 						disableAlpha
 					/>
@@ -411,6 +413,6 @@ export default () => {
 		title: 'Posts Inserter',
 		icon: <Icon icon={ pages } />,
 		edit: PostsInserterBlockWithSelect,
-		save: () => <InnerBlocks.Content />,
+		save: () => null,
 	} );
 };

--- a/src/editor/blocks/posts-inserter/query-controls.js
+++ b/src/editor/blocks/posts-inserter/query-controls.js
@@ -36,6 +36,7 @@ const fetchPostSuggestions = postType => search =>
 		} ) )
 	);
 
+const EMPTY_STRING = '';
 const SEPARATOR = '--';
 const encodePosts = posts => posts.map( post => [ post.id, post.title ].join( SEPARATOR ) );
 const decodePost = encodedPost => {
@@ -94,7 +95,6 @@ const QueryControlsSettings = ( { attributes, setAttributes } ) => {
 
 	const selectTags = tokens => {
 		const validTags = tokens.filter( token => !! token );
-
 		setAttributes( { tags: validTags } );
 	};
 
@@ -235,7 +235,7 @@ const QueryControlsSettings = ( { attributes, setAttributes } ) => {
 					suggestions={ encodePosts( foundPosts ) }
 					displayTransform={ string => {
 						const [ id, title ] = decodePost( string );
-						return title || id || '';
+						return title || id || EMPTY_STRING;
 					} }
 					onInputChange={ debounce( handleSpecificPostsInput, 400 ) }
 				/>

--- a/src/newsletter-editor/index.js
+++ b/src/newsletter-editor/index.js
@@ -2,8 +2,7 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { withSelect, withDispatch } from '@wordpress/data';
-import { compose } from '@wordpress/compose';
+import { useSelect, useDispatch } from '@wordpress/data';
 import { Fragment, useEffect, useState } from '@wordpress/element';
 import {
 	PluginDocumentSettingPanel,
@@ -28,12 +27,11 @@ import withApiHandler from '../components/with-api-handler';
 
 registerEditorPlugin();
 
-const NewsletterEdit = ( {
-	apiFetchWithErrorHandling,
-	setInFlightForAsync,
-	savePost,
-	layoutId,
-} ) => {
+const NewsletterEdit = ( { apiFetchWithErrorHandling, setInFlightForAsync } ) => {
+	const layoutId = useSelect(
+		select => select( 'core/editor' ).getEditedPostAttribute( 'meta' ).layout_id
+	);
+	const savePost = useDispatch( 'core/editor' ).savePost;
 	const [ shouldDisplaySettings, setShouldDisplaySettings ] = useState(
 		window?.newspack_newsletters_data?.is_service_provider_configured !== '1'
 	);
@@ -118,22 +116,7 @@ const NewsletterEdit = ( {
 	);
 };
 
-const NewsletterEditWithSelect = compose( [
-	withApiHandler(),
-	withSelect( select => {
-		const { getEditedPostAttribute } = select( 'core/editor' );
-		const meta = getEditedPostAttribute( 'meta' );
-		return { layoutId: meta.template_id };
-	} ),
-	withDispatch( dispatch => {
-		const { savePost } = dispatch( 'core/editor' );
-		return {
-			savePost,
-		};
-	} ),
-] )( NewsletterEdit );
-
 registerPlugin( 'newspack-newsletters-sidebar', {
-	render: NewsletterEditWithSelect,
+	render: withApiHandler()( NewsletterEdit ),
 	icon: null,
 } );

--- a/src/newsletter-editor/layout/index.js
+++ b/src/newsletter-editor/layout/index.js
@@ -23,6 +23,8 @@ import './style.scss';
 import { setPreventDeduplicationForPostsInserter } from '../../editor/blocks/posts-inserter/utils';
 import NewsletterPreview from '../../components/newsletter-preview';
 
+const EMPTY_OBJECT = {};
+
 export default compose( [
 	withSelect( select => {
 		const { getEditedPostAttribute, isEditedPostEmpty, getCurrentPostId } = select( 'core/editor' );
@@ -81,7 +83,7 @@ export default compose( [
 		const [ usedLayout, setUsedLayout ] = useState( {} );
 
 		useEffect( () => {
-			setUsedLayout( find( layouts, { ID: layoutId } ) || {} );
+			setUsedLayout( find( layouts, { ID: layoutId } ) || EMPTY_OBJECT );
 		}, [ layouts.length ] );
 
 		const blockPreview = useMemo( () => {

--- a/src/newsletter-editor/sidebar/index.js
+++ b/src/newsletter-editor/sidebar/index.js
@@ -21,6 +21,9 @@ import { getServiceProvider } from '../../service-providers';
 import withApiHandler from '../../components/with-api-handler';
 import './style.scss';
 
+const EMPTY_STRING = '';
+const EMPTY_OBJECT = {};
+
 const Sidebar = ( {
 	isConnected,
 	oauthUrl,
@@ -173,10 +176,10 @@ export default compose( [
 		return {
 			title: getEditedPostAttribute( 'title' ),
 			postId: getCurrentPostId(),
-			senderEmail: meta.senderEmail || '',
-			senderName: meta.senderName || '',
-			previewText: meta.preview_text || '',
-			newsletterData: meta.newsletterData || {},
+			senderEmail: meta.senderEmail || EMPTY_STRING,
+			senderName: meta.senderName || EMPTY_STRING,
+			previewText: meta.preview_text || EMPTY_STRING,
+			newsletterData: meta.newsletterData || EMPTY_OBJECT,
 			disableAds: meta.diable_ads,
 		};
 	} ),

--- a/src/newsletter-editor/styling/index.js
+++ b/src/newsletter-editor/styling/index.js
@@ -86,14 +86,17 @@ const fontOptgroups = [
 	},
 ];
 
+const EMPTY_STRING = '';
+const WHITE = '#ffffff';
+
 const customStylesSelector = select => {
 	const { getEditedPostAttribute } = select( 'core/editor' );
 	const meta = getEditedPostAttribute( 'meta' );
 	return {
 		fontBody: meta.font_body || fontOptgroups[ 1 ].options[ 0 ].value,
 		fontHeader: meta.font_header || fontOptgroups[ 0 ].options[ 0 ].value,
-		backgroundColor: meta.background_color || '#ffffff',
-		customCss: meta.custom_css || '',
+		backgroundColor: meta.background_color || WHITE,
+		customCss: meta.custom_css || EMPTY_STRING,
 	};
 };
 

--- a/src/service-providers/mailchimp/ProviderSidebar.js
+++ b/src/service-providers/mailchimp/ProviderSidebar.js
@@ -10,6 +10,8 @@ import { ExternalLink, SelectControl, Spinner, Notice } from '@wordpress/compone
  */
 import { getListInterestsSettings } from './utils';
 
+const EMPTY_STRING = '';
+
 const SegmentsSelection = ( {
 	onUpdate,
 	inFlight,
@@ -18,7 +20,7 @@ const SegmentsSelection = ( {
 	availableInterests,
 	availableSegments,
 } ) => {
-	const [ targetId, setTargetId ] = useState( chosenTarget.toString() || '' );
+	const [ targetId, setTargetId ] = useState( chosenTarget.toString() || EMPTY_STRING );
 
 	const [ isInitial, setIsInitial ] = useState( true );
 	useEffect( () => {
@@ -212,7 +214,7 @@ const ProviderSidebar = ( {
 				<Fragment>
 					<SelectControl
 						label={ __( 'Folder', 'newspack-newsletters' ) }
-						value={ campaign?.settings?.folder_id }
+						value={ campaign?.settings?.folder_id || EMPTY_STRING }
 						options={ getFolderOptions() }
 						onChange={ setFolder }
 						disabled={ inFlight }
@@ -228,7 +230,7 @@ const ProviderSidebar = ( {
 			<SelectControl
 				label={ __( 'Audience', 'newspack-newsletters' ) }
 				className="newspack-newsletters__to-selectcontrol"
-				value={ list_id }
+				value={ list_id || EMPTY_STRING }
 				options={ [
 					{
 						value: null,


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Avoid rerenders and improve editor performance by using references of default values across the codebase.

This started as an investigation to prevent the editor from prompting "Your changes may not be saved". The only case I couldn't avoid it is when the Posts Inserter block is in editing mode (not yet inserted). The strategy for building it, even though memoized, will generate new attributes on every render, and refactoring it is a much larger task.

### How to test the changes in this Pull Request:

1. Check out this branch and draft a new newsletter
2. Add the Post Inserter block and click to "insert the posts"
3. Customize the newsletter styling options in the "Newsletter Styles" sidebar
4. Set the newsletter sender info
5. Save the draft, refresh, and confirm it doesn't prompt the "unsaved changes" notice

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
