### PR TITLE
feat(subscribe-form): improve success message

### DIFF
--- a/src/blocks/subscribe/edit.js
+++ b/src/blocks/subscribe/edit.js
@@ -19,6 +19,7 @@ import {
 	PanelBody,
 	Notice,
 	Spinner,
+	Button,
 } from '@wordpress/components';
 import { useBlockProps, InspectorControls, RichText } from '@wordpress/block-editor';
 
@@ -32,6 +33,11 @@ const getListCheckboxId = listId => {
 };
 
 const settingsUrl = newspack_newsletters_blocks.settings_url;
+
+const editedStateOptions = [
+	{ label: __( 'Initial', 'newspack-newsletters' ), value: 'initial' },
+	{ label: __( 'Success', 'newspack-newsletters' ), value: 'success' },
+];
 
 export default function SubscribeEdit( {
 	setAttributes,
@@ -53,6 +59,7 @@ export default function SubscribeEdit( {
 	},
 } ) {
 	const blockProps = useBlockProps();
+	const [ editedState, setEditedState ] = useState( editedStateOptions[ 0 ].value );
 	const [ inFlight, setInFlight ] = useState( false );
 	const [ listConfig, setListConfig ] = useState( {} );
 	const fetchLists = () => {
@@ -110,11 +117,6 @@ export default function SubscribeEdit( {
 							) }
 						</>
 					) }
-					<TextControl
-						label={ __( 'Success message', 'newspack-newsletters' ) }
-						value={ successMessage }
-						onChange={ value => setAttributes( { successMessage: value } ) }
-					/>
 					{ lists.length > 1 && (
 						<ToggleControl
 							label={ __( 'Display list description', 'newspack-newsletters' ) }
@@ -200,6 +202,21 @@ export default function SubscribeEdit( {
 				) }
 			</InspectorControls>
 			<div { ...blockProps }>
+				<div className="newspack-newsletters-subscribe__state-bar">
+					<span>{ __( 'Edited State', 'newspack-newsletters' ) }</span>
+					<div>
+						{ editedStateOptions.map( option => (
+							<Button
+								key={ option.value }
+								data-is-active={ editedState === option.value }
+								onClick={ () => setEditedState( option.value ) }
+							>
+								{ option.label }
+							</Button>
+						) ) }
+					</div>
+				</div>
+
 				{ inFlight ? (
 					<Spinner />
 				) : (
@@ -208,90 +225,108 @@ export default function SubscribeEdit( {
 							'newspack-newsletters-subscribe': true,
 							'multiple-lists': lists.length > 1,
 						} ) }
+						data-status="200"
 					>
-						<form onSubmit={ ev => ev.preventDefault() }>
-							{ lists.length > 1 && (
-								<div className="newspack-newsletters-lists">
-									<ul>
-										{ lists.map( listId => (
-											<li key={ listId }>
-												<span className="list-checkbox">
-													<input
-														id={ getListCheckboxId( listId ) }
-														type="checkbox"
-														checked
-														readOnly
-													/>
-												</span>
-												<span className="list-details">
-													<label htmlFor={ getListCheckboxId( listId ) }>
-														<span className="list-title">{ listConfig[ listId ]?.title }</span>
-														{ displayDescription && (
-															<span className="list-description">
-																{ listConfig[ listId ]?.description }
-															</span>
-														) }
-													</label>
-												</span>
-											</li>
-										) ) }
-									</ul>
-								</div>
-							) }
-							{ displayNameField && (
-								<div className="newspack-newsletters-name-input">
-									<div className="newspack-newsletters-name-input-item">
-										<label>
-											{ displayInputLabels && (
-												<RichText
-													onChange={ value => setAttributes( { nameLabel: value } ) }
-													placeholder={ __( 'Name', 'newspack' ) }
-													value={ nameLabel }
-													tagName="span"
-												/>
-											) }
-										</label>
-										<input type="text" placeholder={ namePlaceholder } />
+						{ editedState === 'initial' && (
+							<form onSubmit={ ev => ev.preventDefault() }>
+								{ lists.length > 1 && (
+									<div className="newspack-newsletters-lists">
+										<ul>
+											{ lists.map( listId => (
+												<li key={ listId }>
+													<span className="list-checkbox">
+														<input
+															id={ getListCheckboxId( listId ) }
+															type="checkbox"
+															checked
+															readOnly
+														/>
+													</span>
+													<span className="list-details">
+														<label htmlFor={ getListCheckboxId( listId ) }>
+															<span className="list-title">{ listConfig[ listId ]?.title }</span>
+															{ displayDescription && (
+																<span className="list-description">
+																	{ listConfig[ listId ]?.description }
+																</span>
+															) }
+														</label>
+													</span>
+												</li>
+											) ) }
+										</ul>
 									</div>
-									{ displayLastNameField && (
+								) }
+								{ displayNameField && (
+									<div className="newspack-newsletters-name-input">
 										<div className="newspack-newsletters-name-input-item">
 											<label>
 												{ displayInputLabels && (
 													<RichText
-														onChange={ value => setAttributes( { lastNameLabel: value } ) }
-														placeholder={ __( 'Last Name', 'newspack' ) }
-														value={ lastNameLabel }
+														onChange={ value => setAttributes( { nameLabel: value } ) }
+														placeholder={ __( 'Name', 'newspack' ) }
+														value={ nameLabel }
 														tagName="span"
 													/>
 												) }
 											</label>
-											<input type="text" placeholder={ lastNamePlaceholder } />
+											<input type="text" placeholder={ namePlaceholder } />
 										</div>
-									) }
-								</div>
-							) }
-							<div className="newspack-newsletters-email-input">
-								<label>
-									{ displayInputLabels && (
+										{ displayLastNameField && (
+											<div className="newspack-newsletters-name-input-item">
+												<label>
+													{ displayInputLabels && (
+														<RichText
+															onChange={ value => setAttributes( { lastNameLabel: value } ) }
+															placeholder={ __( 'Last Name', 'newspack' ) }
+															value={ lastNameLabel }
+															tagName="span"
+														/>
+													) }
+												</label>
+												<input type="text" placeholder={ lastNamePlaceholder } />
+											</div>
+										) }
+									</div>
+								) }
+								<div className="newspack-newsletters-email-input">
+									<label>
+										{ displayInputLabels && (
+											<RichText
+												onChange={ value => setAttributes( { emailLabel: value } ) }
+												placeholder={ __( 'Email Address', 'newspack' ) }
+												value={ emailLabel }
+												tagName="span"
+											/>
+										) }
+									</label>
+									<input type="email" placeholder={ placeholder } />
+									<button type="submit">
 										<RichText
-											onChange={ value => setAttributes( { emailLabel: value } ) }
-											placeholder={ __( 'Email Address', 'newspack' ) }
-											value={ emailLabel }
+											onChange={ value => setAttributes( { label: value } ) }
+											placeholder={ __( 'Sign up', 'newspack' ) }
+											value={ label }
 											tagName="span"
 										/>
-									) }
-								</label>
-								<input type="email" placeholder={ placeholder } />
-								<button type="submit">
+									</button>
+								</div>
+							</form>
+						) }
+						{ editedState === 'success' && (
+							<div className="newspack-newsletters-subscribe__response">
+								<div className="newspack-newsletters-subscribe__icon" />
+								<div className="newspack-newsletters-subscribe__message">
 									<RichText
-										onChange={ value => setAttributes( { label: value } ) }
-										placeholder={ __( 'Sign up', 'newspack' ) }
-										value={ label }
-										tagName="span"
+										onChange={ value => setAttributes( { successMessage: value } ) }
+										placeholder={ __( 'Success message', 'newspack-newsletters' ) }
+										value={ successMessage }
+										tagName="p"
+										className="message status-200"
+										allowedFormats={ [ 'core/bold', 'core/italic' ] }
 									/>
-								</button>
+								</div>
 							</div>
-						</form>
+						) }
 					</div>
 				) }
 			</div>

--- a/src/blocks/subscribe/editor.scss
+++ b/src/blocks/subscribe/editor.scss
@@ -1,4 +1,5 @@
 @use 'style.scss';
+@use '~@wordpress/base-styles/colors' as wp-colors;
 
 .newspack-newsletters-subscribe {
 	form {
@@ -31,6 +32,40 @@
 			padding: 0.76rem 1rem;
 			text-decoration: none;
 			vertical-align: bottom;
+		}
+	}
+	&__state-bar {
+		align-items: center;
+		border: 1px solid wp-colors.$gray-900;
+		border-radius: 2px;
+		display: flex;
+		font-family: -apple-system, blinkmacsystemfont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell,
+			'Fira Sans', 'Droid Sans', 'Helvetica Neue', sans-serif;
+		flex-wrap: wrap;
+		font-size: 13px;
+		gap: 8px;
+		justify-content: space-between;
+		line-height: 1.4;
+		margin-bottom: 12px;
+		padding: 7px 8px;
+		button {
+			box-shadow: none !important;
+			color: wp-colors.$gray-900 !important;
+			height: 32px !important;
+			&[data-is-active='true'] {
+				background-color: wp-colors.$gray-900;
+				color: white !important;
+			}
+			&:hover:not( [data-is-active='true'] ) {
+				color: var( --wp-admin-theme-color ) !important;
+			}
+		}
+		span {
+			font-weight: 500;
+		}
+		div {
+			display: flex;
+			gap: 4px;
 		}
 	}
 }

--- a/src/blocks/subscribe/index.php
+++ b/src/blocks/subscribe/index.php
@@ -137,10 +137,9 @@ function render_block( $attrs ) {
 	<div
 		class="newspack-newsletters-subscribe <?php echo esc_attr( get_block_classes( $attrs ) ); ?>"
 		data-success-message="<?php echo \esc_attr( $attrs['successMessage'] ); ?>"
+		<?php echo $subscribed ? 'data-status="200"' : ''; ?>
 	>
-		<?php if ( $subscribed ) : ?>
-			<p class="message"><?php echo \esc_html( $attrs['successMessage'] ); ?></p>
-		<?php else : ?>
+		<?php if ( ! $subscribed ) : ?>
 			<form id="<?php echo esc_attr( get_form_id() ); ?>">
 				<?php \wp_nonce_field( FORM_ACTION, FORM_ACTION ); ?>
 				<?php
@@ -243,12 +242,15 @@ function render_block( $attrs ) {
 					<input type="submit" value="<?php echo \esc_attr( $attrs['label'] ); ?>" />
 				</div>
 			</form>
-			<div class="newspack-newsletters-subscribe-response">
-				<?php if ( ! empty( $message ) ) : ?>
-					<p><?php echo \esc_html( $message ); ?></p>
+		<?php endif; ?>
+		<div class="newspack-newsletters-subscribe__response">
+			<div class="newspack-newsletters-subscribe__icon"></div>
+			<div class="newspack-newsletters-subscribe__message">
+				<?php if ( ! empty( $message ) || $subscribed ) : ?>
+					<p><?php echo $subscribed ? \wp_kses_post( $attrs['successMessage'] ) : \esc_html( $message ); ?></p>
 				<?php endif; ?>
 			</div>
-		<?php endif; ?>
+		</div>
 	</div>
 	<?php
 	return ob_get_clean();

--- a/src/blocks/subscribe/style.scss
+++ b/src/blocks/subscribe/style.scss
@@ -109,20 +109,44 @@
 		}
 	}
 
-	.newspack-newsletters-subscribe-response {
-		font-size: 0.8rem;
-		color: wp-colors.$alert-red;
-
-		p {
-			margin: 0.5rem 0 0;
+	&__response {
+		.newspack-newsletters-subscribe[data-status='200'] & {
+			p {
+				text-align: center;
+				font-size: 0.8em;
+				margin: 0.5rem 0 0;
+			}
 		}
 	}
-	.message.status-200 {
-		color: wp-colors.$alert-green;
+
+	&__icon {
+		align-items: center;
+		animation: fadein 125ms ease-in;
+		background: wp-colors.$alert-green;
+		border-radius: 50%;
+		display: flex;
+		height: 40px;
+		justify-content: center;
+		margin: 0 auto 0.8rem;
+		width: 40px;
+
+		.newspack-newsletters-subscribe:not( [data-status='200'] ) & {
+			display: none;
+		}
+
+		&::before {
+			animation: bounce 125ms ease-in;
+			animation-delay: 500ms;
+			animation-fill-mode: forwards;
+			background-image: url( "data:image/svg+xml,%3Csvg viewBox='0 0 24 24' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M16.7 7.1l-6.3 8.5-3.3-2.5-.9 1.2 4.5 3.4L17.9 8z' fill='white'/%3E%3C/svg%3E" );
+			content: '';
+			display: block;
+			height: 24px;
+			transform: scale( 0 );
+			width: 24px;
+		}
 	}
-	.message.status-400 {
-		color: wp-colors.$alert-red;
-	}
+
 	.nphp {
 		border: 0;
 		clip: rect( 1px, 1px, 1px, 1px );

--- a/src/blocks/subscribe/view.js
+++ b/src/blocks/subscribe/view.js
@@ -63,28 +63,30 @@ domReady( function () {
 		if ( ! form ) {
 			return;
 		}
-		const messageContainer = container.querySelector( '.newspack-newsletters-subscribe-response' );
+		const responseContainer = container.querySelector(
+			'.newspack-newsletters-subscribe__response'
+		);
+		const messageContainer = container.querySelector( '.newspack-newsletters-subscribe__message' );
 		const emailInput = container.querySelector( 'input[type="email"]' );
 		const submit = container.querySelector( 'input[type="submit"]' );
 		form.endFlow = ( message, status = 500, wasSubscribed = false ) => {
+			container.setAttribute( 'data-status', status );
 			const messageNode = document.createElement( 'p' );
 			emailInput.removeAttribute( 'disabled' );
 			submit.removeAttribute( 'disabled' );
 			messageNode.innerHTML = wasSubscribed
 				? container.getAttribute( 'data-success-message' )
 				: message;
+			messageContainer.appendChild( messageNode );
 			messageNode.className = `message status-${ status }`;
 			if ( status === 200 ) {
-				container.replaceChild( messageNode, form );
-			} else {
-				messageContainer.appendChild( messageNode );
+				container.replaceChild( responseContainer, form );
 			}
 		};
 		form.addEventListener( 'submit', ev => {
 			ev.preventDefault();
 			messageContainer.innerHTML = '';
 			submit.disabled = true;
-			submit.setAttribute( 'disabled', 'true' );
 
 			if ( ! form.npe?.value ) {
 				return form.endFlow( newspack_newsletters_subscribe_block.invalid_email, 400 );
@@ -112,8 +114,9 @@ domReady( function () {
 					if ( ! body.has( 'npe' ) || ! body.get( 'npe' ) ) {
 						return form.endFlow( newspack_newsletters_subscribe_block.invalid_email, 400 );
 					}
-					emailInput.disabled = true;
 					emailInput.setAttribute( 'disabled', 'true' );
+					submit.setAttribute( 'disabled', 'true' );
+
 					fetch( form.getAttribute( 'action' ) || window.location.pathname, {
 						method: 'POST',
 						headers: {
@@ -121,8 +124,6 @@ domReady( function () {
 						},
 						body,
 					} ).then( res => {
-						emailInput.disabled = false;
-						submit.disabled = false;
 						res.json().then( ( { message, newspack_newsletters_subscribed: wasSubscribed } ) => {
 							form.endFlow( message, res.status, wasSubscribed );
 						} );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

The success message of the Subscription Form Block should render and be edited like RAS' Reader Registration Block:

<img width="867" alt="image" src="https://github.com/Automattic/newspack-newsletters/assets/820752/232eb85b-16e3-4686-9a4f-3e96b0a78570">

<img width="859" alt="image" src="https://github.com/Automattic/newspack-newsletters/assets/820752/1098d162-434a-453b-8307-b16740346ce3">

### How to test the changes in this Pull Request:

1. While on the master branch, add a subscription form block to a new page
2. Check out this branch and without editing the block, subscribe using the block and confirm the new UI works
3. Edit the page, customize the message in the "Success" state, and confirm the custom message works as expected

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
