### PR TITLE
fix: remove important flag from font size rules

### DIFF
--- a/includes/class-newspack-newsletters-editor.php
+++ b/includes/class-newspack-newsletters-editor.php
@@ -197,7 +197,9 @@ final class Newspack_Newsletters_Editor {
 	 */
 	public static function newspack_font_sizes() {
 		global $pagenow;
-		if ( 'post.php' !== $pagenow || ! isset( $_GET['post'] ) || ! self::is_editing_email( absint( $_GET['post'] ) ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		$is_editing_email  = 'post.php' === $pagenow && isset( $_GET['post'] ) && self::is_editing_email( absint( $_GET['post'] ) ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		$is_creating_email = 'post-new.php' === $pagenow && isset( $_GET['post_type'] ) && Newspack_Newsletters::NEWSPACK_NEWSLETTERS_CPT === $_GET['post_type']; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		if ( ! $is_editing_email && ! $is_creating_email ) {
 			return;
 		}
 		add_theme_support(

--- a/includes/class-newspack-newsletters-editor.php
+++ b/includes/class-newspack-newsletters-editor.php
@@ -91,9 +91,12 @@ final class Newspack_Newsletters_Editor {
 
 	/**
 	 * Is the editor editing an email?
+	 *
+	 * @param int $post_id Optional post ID to check.
 	 */
-	private static function is_editing_email() {
-		return in_array( get_post_type(), self::get_email_editor_cpts() );
+	private static function is_editing_email( $post_id = null ) {
+		$post_id = empty( $post_id ) ? get_the_ID() : $post_id;
+		return in_array( get_post_type( $post_id ), self::get_email_editor_cpts() );
 	}
 
 	/**
@@ -193,7 +196,8 @@ final class Newspack_Newsletters_Editor {
 	 * Define Editor Font Sizes.
 	 */
 	public static function newspack_font_sizes() {
-		if ( ! self::is_editing_email() ) {
+		global $pagenow;
+		if ( 'post' === $pagenow && isset( $_GET['post'] ) && ! self::is_editing_email( absint( $_GET['post'] ) ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 			return;
 		}
 		add_theme_support(

--- a/includes/class-newspack-newsletters-editor.php
+++ b/includes/class-newspack-newsletters-editor.php
@@ -197,8 +197,9 @@ final class Newspack_Newsletters_Editor {
 	 */
 	public static function newspack_font_sizes() {
 		global $pagenow;
+		$email_editor_cpts = self::get_email_editor_cpts();
 		$is_editing_email  = 'post.php' === $pagenow && isset( $_GET['post'] ) && self::is_editing_email( absint( $_GET['post'] ) ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
-		$is_creating_email = 'post-new.php' === $pagenow && isset( $_GET['post_type'] ) && Newspack_Newsletters::NEWSPACK_NEWSLETTERS_CPT === $_GET['post_type']; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		$is_creating_email = 'post-new.php' === $pagenow && isset( $_GET['post_type'] ) && in_array( $_GET['post_type'], $email_editor_cpts ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 		if ( ! $is_editing_email && ! $is_creating_email ) {
 			return;
 		}

--- a/includes/class-newspack-newsletters-editor.php
+++ b/includes/class-newspack-newsletters-editor.php
@@ -197,7 +197,7 @@ final class Newspack_Newsletters_Editor {
 	 */
 	public static function newspack_font_sizes() {
 		global $pagenow;
-		if ( 'post' === $pagenow && isset( $_GET['post'] ) && ! self::is_editing_email( absint( $_GET['post'] ) ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		if ( 'post' !== $pagenow || ! isset( $_GET['post'] ) || ! self::is_editing_email( absint( $_GET['post'] ) ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 			return;
 		}
 		add_theme_support(

--- a/includes/class-newspack-newsletters-editor.php
+++ b/includes/class-newspack-newsletters-editor.php
@@ -197,7 +197,7 @@ final class Newspack_Newsletters_Editor {
 	 */
 	public static function newspack_font_sizes() {
 		global $pagenow;
-		if ( 'post' !== $pagenow || ! isset( $_GET['post'] ) || ! self::is_editing_email( absint( $_GET['post'] ) ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		if ( 'post.php' !== $pagenow || ! isset( $_GET['post'] ) || ! self::is_editing_email( absint( $_GET['post'] ) ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 			return;
 		}
 		add_theme_support(

--- a/includes/class-newspack-newsletters-editor.php
+++ b/includes/class-newspack-newsletters-editor.php
@@ -209,11 +209,6 @@ final class Newspack_Newsletters_Editor {
 					'slug' => 'small',
 				],
 				[
-					'name' => _x( 'Normal', 'font size name', 'newspack-newsletters' ),
-					'size' => 16,
-					'slug' => 'normal',
-				],
-				[
 					'name' => _x( 'Medium', 'font size name', 'newspack-newsletters' ),
 					'size' => 16,
 					'slug' => 'medium',
@@ -227,11 +222,6 @@ final class Newspack_Newsletters_Editor {
 					'name' => _x( 'Extra Large', 'font size name', 'newspack-newsletters' ),
 					'size' => 36,
 					'slug' => 'x-large',
-				],
-				[
-					'name' => _x( 'Huge', 'font size name', 'newspack-newsletters' ),
-					'size' => 36,
-					'slug' => 'huge',
 				],
 			]
 		);

--- a/src/editor/style.scss
+++ b/src/editor/style.scss
@@ -341,22 +341,22 @@
 			}
 		}
 		.has-small-font-size {
-			font-size: var( --wp--preset--font-size--small ) !important;
+			font-size: var( --wp--preset--font-size--small );
 		}
 		.has-normal-font-size {
-			font-size: var( --wp--preset--font-size--normal ) !important;
+			font-size: var( --wp--preset--font-size--normal );
 		}
 		.has-medium-font-size {
-			font-size: var( --wp--preset--font-size--medium ) !important;
+			font-size: var( --wp--preset--font-size--medium );
 		}
 		.has-large-font-size {
-			font-size: var( --wp--preset--font-size--large ) !important;
+			font-size: var( --wp--preset--font-size--large );
 		}
 		.has-x-large-font-size {
-			font-size: var( --wp--preset--font-size--x-large ) !important;
+			font-size: var( --wp--preset--font-size--x-large );
 		}
 		.has-huge-font-size {
-			font-size: var( --wp--preset--font-size--huge ) !important;
+			font-size: var( --wp--preset--font-size--huge );
 		}
 	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

The use of `!important` in the font size rules is enforcing the fixed size of `20px` to be replaced with `font-size: var( --wp--preset--font-size--normal );`, which renders 16px.

This PR removes the flag from all the font-size rules. cbc25b074c4ddcc8d1166a7769a62f2b880efbd9 also fixes the reason the rules were added in #1144. `after_setup_theme` is executed too early and the global post is not available for the `self::is_editing_email()` check. The font sizes were never registered.

### How to test the changes in this Pull Request:

1. Check out this branch and draft a new newsletter
2. With 5 paragraphs, change their font sizes to S, M, L, XL, and a custom fixed of 20px 
3. Confirm they render 12px, 16px, 24px, 36px, and 20px respectively
4. Send the newsletter and confirm the sizes persist

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
