### PR TITLE
feat: pixel and click-tracking

### DIFF
--- a/includes/class-newspack-newsletters-renderer.php
+++ b/includes/class-newspack-newsletters-renderer.php
@@ -273,10 +273,10 @@ final class Newspack_Newsletters_Renderer {
 	 * Append UTM param to links.
 	 *
 	 * @param string   $html Input HTML.
-	 * @param \WP_Post $post Post object.
+	 * @param \WP_Post $post Optional post object.
 	 * @return string HTML with processed links.
 	 */
-	public static function process_links( $html, $post ) {
+	public static function process_links( $html, $post = null ) {
 		preg_match_all( '/href="([^"]*)"/', $html, $matches );
 		$href_params = $matches[0];
 		$urls        = $matches[1];

--- a/includes/class-newspack-newsletters-renderer.php
+++ b/includes/class-newspack-newsletters-renderer.php
@@ -272,10 +272,11 @@ final class Newspack_Newsletters_Renderer {
 	/**
 	 * Append UTM param to links.
 	 *
-	 * @param string $html input HTML.
+	 * @param string   $html Input HTML.
+	 * @param \WP_Post $post Post object.
 	 * @return string HTML with processed links.
 	 */
-	public static function process_links( $html ) {
+	public static function process_links( $html, $post ) {
 		preg_match_all( '/href="([^"]*)"/', $html, $matches );
 		$href_params = $matches[0];
 		$urls        = $matches[1];
@@ -290,7 +291,8 @@ final class Newspack_Newsletters_Renderer {
 					[
 						'utm_medium' => 'email',
 					],
-					$url
+					$url,
+					$post
 				),
 				$url
 			);
@@ -1229,7 +1231,7 @@ final class Newspack_Newsletters_Renderer {
 			$body = self::insert_ads( $body, INF );
 		}
 
-		return self::process_links( $body );
+		return self::process_links( $body, $post );
 	}
 
 	/**

--- a/includes/class-newspack-newsletters-renderer.php
+++ b/includes/class-newspack-newsletters-renderer.php
@@ -291,10 +291,10 @@ final class Newspack_Newsletters_Renderer {
 					[
 						'utm_medium' => 'email',
 					],
-					$url,
-					$post
+					$url
 				),
-				$url
+				$url,
+				$post
 			);
 
 			$html = str_replace( $href_params[ $index ], 'href="' . $url_with_params . '"', $html );

--- a/includes/email-template.mjml.php
+++ b/includes/email-template.mjml.php
@@ -18,7 +18,7 @@
 
 			echo esc_html( $css );
 			echo Newspack_Newsletters_Editor::get_color_palette_css();
-			do_action( 'newspack_newsletters_editor_mjml_head' );
+			do_action( 'newspack_newsletters_editor_mjml_head', $post );
 		?>
 		</mj-style>
 		<?php if ( isset( $preview_text ) ): ?>
@@ -27,5 +27,6 @@
 	</mj-head>
 	<mj-body background-color="<?php echo $background_color; ?>">
 		<?php echo $body; ?>
+		<?php do_action( 'newspack_newsletters_editor_mjml_body', $post ); ?>
 	</mj-body>
 </mjml>

--- a/includes/tracking/class-admin.php
+++ b/includes/tracking/class-admin.php
@@ -72,7 +72,7 @@ final class Admin {
 
 		$orderby = $query->get( 'orderby' );
 		if ( 'opened' === $orderby ) {
-			$query->set( 'meta_key', 'newspack_newsletters_tracking_pixel_seen' );
+			$query->set( 'meta_key', 'tracking_pixel_seen' );
 			$query->set( 'orderby', 'meta_value_num' );
 		} elseif ( 'clicks' === $orderby ) {
 			$query->set( 'meta_key', 'tracking_clicks' );

--- a/includes/tracking/class-admin.php
+++ b/includes/tracking/class-admin.php
@@ -17,6 +17,8 @@ final class Admin {
 	public static function init() {
 		add_action( 'manage_' . \Newspack_Newsletters::NEWSPACK_NEWSLETTERS_CPT . '_posts_columns', [ __CLASS__, 'manage_columns' ] );
 		add_action( 'manage_' . \Newspack_Newsletters::NEWSPACK_NEWSLETTERS_CPT . '_posts_custom_column', [ __CLASS__, 'custom_column' ], 10, 2 );
+		add_action( 'manage_edit-' . \Newspack_Newsletters::NEWSPACK_NEWSLETTERS_CPT . '_sortable_columns', [ __CLASS__, 'sortable_columns' ] );
+		add_action( 'pre_get_posts', [ __CLASS__, 'handle_sorting' ] );
 	}
 
 	/**
@@ -41,6 +43,40 @@ final class Admin {
 			echo intval( get_post_meta( $post_id, 'newspack_newsletters_tracking_pixel_seen', true ) );
 		} elseif ( 'clicks' === $column_name ) {
 			echo intval( get_post_meta( $post_id, 'tracking_clicks', true ) );
+		}
+	}
+
+	/**
+	 * Sortable columns.
+	 *
+	 * @param array $columns Columns.
+	 */
+	public static function sortable_columns( $columns ) {
+		$columns['opened'] = 'opened';
+		$columns['clicks'] = 'clicks';
+		return $columns;
+	}
+
+	/**
+	 * Handle sorting.
+	 *
+	 * @param \WP_Query $query Query.
+	 */
+	public static function handle_sorting( $query ) {
+		if ( ! is_admin() || ! $query->is_main_query() ) {
+			return;
+		}
+		if ( \Newspack_Newsletters::NEWSPACK_NEWSLETTERS_CPT !== $query->get( 'post_type' ) ) {
+			return;
+		}
+
+		$orderby = $query->get( 'orderby' );
+		if ( 'opened' === $orderby ) {
+			$query->set( 'meta_key', 'newspack_newsletters_tracking_pixel_seen' );
+			$query->set( 'orderby', 'meta_value_num' );
+		} elseif ( 'clicks' === $orderby ) {
+			$query->set( 'meta_key', 'tracking_clicks' );
+			$query->set( 'orderby', 'meta_value_num' );
 		}
 	}
 }

--- a/includes/tracking/class-admin.php
+++ b/includes/tracking/class-admin.php
@@ -8,7 +8,7 @@
 namespace Newspack_Newsletters\Tracking;
 
 /**
- * Tracking Data Events Class.
+ * Tracking Admin Class.
  */
 final class Admin {
 	/**
@@ -26,6 +26,7 @@ final class Admin {
 	 */
 	public static function manage_columns( $columns ) {
 		$columns['opened'] = __( 'Opened', 'newspack-newsletters' );
+		$columns['clicks'] = __( 'Clicks', 'newspack-newsletters' );
 		return $columns;
 	}
 
@@ -36,10 +37,11 @@ final class Admin {
 	 * @param int   $post_id     Post ID.
 	 */
 	public static function custom_column( $column_name, $post_id ) {
-		if ( 'opened' !== $column_name ) {
-			return;
+		if ( 'opened' === $column_name ) {
+			echo intval( get_post_meta( $post_id, 'newspack_newsletters_tracking_pixel_seen', true ) );
+		} elseif ( 'clicks' === $column_name ) {
+			echo intval( get_post_meta( $post_id, 'tracking_clicks', true ) );
 		}
-		echo intval( get_post_meta( $post_id, 'newspack_newsletters_tracking_pixel_seen', true ) );
 	}
 }
 Admin::init();

--- a/includes/tracking/class-admin.php
+++ b/includes/tracking/class-admin.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * Newspack Newsletters Tracking Admin UI Tweaks.
+ *
+ * @package Newspack
+ */
+
+namespace Newspack_Newsletters\Tracking;
+
+/**
+ * Tracking Data Events Class.
+ */
+final class Admin {
+	/**
+	 * Initialize hooks.
+	 */
+	public static function init() {
+		add_action( 'manage_' . \Newspack_Newsletters::NEWSPACK_NEWSLETTERS_CPT . '_posts_columns', [ __CLASS__, 'manage_columns' ] );
+		add_action( 'manage_' . \Newspack_Newsletters::NEWSPACK_NEWSLETTERS_CPT . '_posts_custom_column', [ __CLASS__, 'custom_column' ], 10, 2 );
+	}
+
+	/**
+	 * Manage columns.
+	 *
+	 * @param array $columns Columns.
+	 */
+	public static function manage_columns( $columns ) {
+		$columns['opened'] = __( 'Opened', 'newspack-newsletters' );
+		return $columns;
+	}
+
+	/**
+	 * Custom column content.
+	 *
+	 * @param array $column_name Column name.
+	 * @param int   $post_id     Post ID.
+	 */
+	public static function custom_column( $column_name, $post_id ) {
+		if ( 'opened' !== $column_name ) {
+			return;
+		}
+		echo intval( get_post_meta( $post_id, 'newspack_newsletters_tracking_pixel_seen', true ) );
+	}
+}
+Admin::init();

--- a/includes/tracking/class-admin.php
+++ b/includes/tracking/class-admin.php
@@ -40,7 +40,7 @@ final class Admin {
 	 */
 	public static function custom_column( $column_name, $post_id ) {
 		if ( 'opened' === $column_name ) {
-			echo intval( get_post_meta( $post_id, 'newspack_newsletters_tracking_pixel_seen', true ) );
+			echo intval( get_post_meta( $post_id, 'tracking_pixel_seen', true ) );
 		} elseif ( 'clicks' === $column_name ) {
 			echo intval( get_post_meta( $post_id, 'tracking_clicks', true ) );
 		}

--- a/includes/tracking/class-click.php
+++ b/includes/tracking/class-click.php
@@ -20,7 +20,7 @@ final class Click {
 		\add_action( 'init', [ __CLASS__, 'rewrite_rule' ] );
 		\add_filter( 'query_vars', [ __CLASS__, 'query_vars' ] );
 		\add_action( 'template_redirect', [ __CLASS__, 'handle_url' ] );
-		\add_filter( 'newspack_newsletters_process_link', [ __CLASS__, 'process_link' ], 10, 2 );
+		\add_filter( 'newspack_newsletters_process_link', [ __CLASS__, 'process_link' ], 10, 3 );
 	}
 
 	/**
@@ -74,16 +74,17 @@ final class Click {
 	/**
 	 * Process link.
 	 *
-	 * @param string $url URL.
-	 * @param int    $newsletter_id Newsletter ID.
+	 * @param string   $url           Processed URL.
+	 * @param string   $original_url  Original URL.
+	 * @param \WP_Post $post          Newsletter post object.
 	 *
 	 * @return string
 	 */
-	public static function process_link( $url, $newsletter_id ) {
-		if ( ! $newsletter_id ) {
+	public static function process_link( $url, $original_url, $post ) {
+		if ( ! $post ) {
 			return $url;
 		}
-		return self::get_proxied_url( $newsletter_id, $url );
+		return self::get_proxied_url( $post->ID, $url );
 	}
 
 	/**

--- a/includes/tracking/class-click.php
+++ b/includes/tracking/class-click.php
@@ -29,6 +29,11 @@ final class Click {
 	public static function rewrite_rule() {
 		\add_rewrite_rule( 'np-newsletters-click', 'index.php?' . self::QUERY_VAR . '=1', 'top' );
 		\add_rewrite_tag( '%' . self::QUERY_VAR . '%', '1' );
+		$check_option_name = 'newspack_newsletters_tracking_click_has_rewrite_rule';
+		if ( ! \get_option( $check_option_name ) ) {
+			\flush_rewrite_rules(); // phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.flush_rewrite_rules_flush_rewrite_rules
+			\update_option( $check_option_name, true );
+		}
 	}
 
 	/**

--- a/includes/tracking/class-click.php
+++ b/includes/tracking/class-click.php
@@ -95,9 +95,11 @@ final class Click {
 			return;
 		}
 
-		$newsletter_id = \intval( $_GET['id'] ?? 0 ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
-		$email_address = \sanitize_email( $_GET['em'] ?? '' ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
-		$url           = \sanitize_text_field( \wp_unslash( $_GET['url'] ?? '' ) ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		// phpcs:disable WordPress.Security.NonceVerification.Recommended
+		$newsletter_id = \intval( $_GET['id'] ?? 0 );
+		$email_address = \sanitize_email( $_GET['em'] ?? '' );
+		$url           = \sanitize_text_field( \wp_unslash( $_GET['url'] ?? '' ) );
+		// phpcs:enable
 
 		if ( ! $url || ! \wp_http_validate_url( $url ) ) {
 			\wp_die( 'Invalid URL' );

--- a/includes/tracking/class-click.php
+++ b/includes/tracking/class-click.php
@@ -123,7 +123,7 @@ final class Click {
 		 */
 		do_action( 'newspack_newsletters_tracking_click', $newsletter_id, $email_address, $url );
 
-		\wp_safe_redirect( $url );
+		\wp_redirect( $url ); // phpcs:ignore WordPress.Security.SafeRedirect.wp_redirect_wp_redirect
 		exit;
 	}
 }

--- a/includes/tracking/class-click.php
+++ b/includes/tracking/class-click.php
@@ -19,7 +19,7 @@ final class Click {
 	public static function init() {
 		\add_action( 'init', [ __CLASS__, 'rewrite_rule' ] );
 		\add_filter( 'query_vars', [ __CLASS__, 'query_vars' ] );
-		\add_action( 'template_redirect', [ __CLASS__, 'handle_url' ] );
+		\add_action( 'template_redirect', [ __CLASS__, 'handle_click' ] );
 		\add_filter( 'newspack_newsletters_process_link', [ __CLASS__, 'process_link' ], 10, 3 );
 	}
 
@@ -88,9 +88,9 @@ final class Click {
 	}
 
 	/**
-	 * Handle proxied URL and redirect to destination.
+	 * Handle proxied URL click and redirect to destination.
 	 */
-	public static function handle_url() {
+	public static function handle_click() {
 		if ( ! \get_query_var( self::QUERY_VAR ) ) {
 			return;
 		}
@@ -106,7 +106,7 @@ final class Click {
 			exit;
 		}
 
-		if ( $newsletter_id ) {
+		if ( $newsletter_id && $email_address ) {
 			$clicks = \get_post_meta( $newsletter_id, 'tracking_clicks', true );
 			if ( ! $clicks ) {
 				$clicks = 0;

--- a/includes/tracking/class-click.php
+++ b/includes/tracking/class-click.php
@@ -110,7 +110,7 @@ final class Click {
 				$clicks = 0;
 			}
 			$clicks++;
-			\update_post_meta( $newsletter_id, 'tracking_pixel_seen', $clicks );
+			\update_post_meta( $newsletter_id, 'tracking_clicks', $clicks );
 		}
 
 		/**

--- a/includes/tracking/class-click.php
+++ b/includes/tracking/class-click.php
@@ -1,0 +1,127 @@
+<?php
+/**
+ * Newspack Newsletters Click-Tracking.
+ *
+ * @package Newspack
+ */
+
+namespace Newspack_Newsletters\Tracking;
+
+/**
+ * Tracking Click-Tracking Class.
+ */
+final class Click {
+	const QUERY_VAR = 'np_newsletters_click';
+
+	/**
+	 * Initialize hooks.
+	 */
+	public static function init() {
+		\add_action( 'init', [ __CLASS__, 'rewrite_rule' ] );
+		\add_filter( 'query_vars', [ __CLASS__, 'query_vars' ] );
+		\add_action( 'template_redirect', [ __CLASS__, 'handle_url' ] );
+		\add_filter( 'newspack_newsletters_process_link', [ __CLASS__, 'process_link' ], 10, 2 );
+	}
+
+	/**
+	 * Add rewrite rule for tracking url.
+	 */
+	public static function rewrite_rule() {
+		\add_rewrite_rule( 'np-newsletters-click', 'index.php?' . self::QUERY_VAR . '=1', 'top' );
+		\add_rewrite_tag( '%' . self::QUERY_VAR . '%', '1' );
+	}
+
+	/**
+	 * Add query vars.
+	 *
+	 * @param array $vars Query vars.
+	 *
+	 * @return array
+	 */
+	public static function query_vars( $vars = [] ) {
+		$vars[] = self::QUERY_VAR;
+		return $vars;
+	}
+
+	/**
+	 * Get tracking URL.
+	 *
+	 * @return string
+	 */
+	public static function get_tracking_url() {
+		return \home_url( 'np-newsletters-click' );
+	}
+
+	/**
+	 * Get proxied URL.
+	 *
+	 * @param int    $newsletter_id Newsletter ID.
+	 * @param string $url           Destination URL.
+	 *
+	 * @return string Proxied URL.
+	 */
+	public static function get_proxied_url( $newsletter_id, $url ) {
+		return add_query_arg(
+			[
+				'id'  => $newsletter_id,
+				'url' => urlencode( $url ),
+				'em'  => Utils::get_email_address_tag(),
+			],
+			self::get_tracking_url()
+		);
+	}
+
+	/**
+	 * Process link.
+	 *
+	 * @param string $url URL.
+	 * @param int    $newsletter_id Newsletter ID.
+	 *
+	 * @return string
+	 */
+	public static function process_link( $url, $newsletter_id ) {
+		if ( ! $newsletter_id ) {
+			return $url;
+		}
+		return self::get_proxied_url( $newsletter_id, $url );
+	}
+
+	/**
+	 * Handle proxied URL and redirect to destination.
+	 */
+	public static function handle_url() {
+		if ( ! \get_query_var( self::QUERY_VAR ) ) {
+			return;
+		}
+
+		$newsletter_id = \intval( $_GET['id'] ?? 0 ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		$email_address = \sanitize_email( $_GET['em'] ?? '' ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		$url           = \sanitize_text_field( \wp_unslash( $_GET['url'] ?? '' ) ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+
+		if ( ! $url || ! \wp_http_validate_url( $url ) ) {
+			\wp_die( 'Invalid URL' );
+			exit;
+		}
+
+		if ( $newsletter_id ) {
+			$clicks = \get_post_meta( $newsletter_id, 'tracking_clicks', true );
+			if ( ! $clicks ) {
+				$clicks = 0;
+			}
+			$clicks++;
+			\update_post_meta( $newsletter_id, 'tracking_pixel_seen', $clicks );
+		}
+
+		/**
+		 * Fires when a click is tracked.
+		 *
+		 * @param int    $newsletter_id Newsletter ID.
+		 * @param string $url           Destination URL.
+		 */
+		do_action( 'newspack_newsletters_tracking_click', $newsletter_id, $email_address, $url );
+
+		\wp_safe_redirect( $url );
+		exit;
+	}
+}
+Click::init();

--- a/includes/tracking/class-click.php
+++ b/includes/tracking/class-click.php
@@ -88,6 +88,36 @@ final class Click {
 	}
 
 	/**
+	 * Track click.
+	 *
+	 * @param int    $newsletter_id Newsletter ID.
+	 * @param string $email_address Email address.
+	 * @param string $url           Destination URL.
+	 *
+	 * @return void
+	 */
+	public static function track_click( $newsletter_id, $email_address, $url ) {
+		if ( ! $newsletter_id || ! $email_address ) {
+			return;
+		}
+
+		$clicks = \get_post_meta( $newsletter_id, 'tracking_clicks', true );
+		if ( ! $clicks ) {
+			$clicks = 0;
+		}
+		$clicks++;
+		\update_post_meta( $newsletter_id, 'tracking_clicks', $clicks );
+
+		/**
+		 * Fires when a click is tracked.
+		 *
+		 * @param int    $newsletter_id Newsletter ID.
+		 * @param string $url           Destination URL.
+		 */
+		do_action( 'newspack_newsletters_tracking_click', $newsletter_id, $email_address, $url );
+	}
+
+	/**
 	 * Handle proxied URL click and redirect to destination.
 	 */
 	public static function handle_click() {
@@ -106,22 +136,7 @@ final class Click {
 			exit;
 		}
 
-		if ( $newsletter_id && $email_address ) {
-			$clicks = \get_post_meta( $newsletter_id, 'tracking_clicks', true );
-			if ( ! $clicks ) {
-				$clicks = 0;
-			}
-			$clicks++;
-			\update_post_meta( $newsletter_id, 'tracking_clicks', $clicks );
-		}
-
-		/**
-		 * Fires when a click is tracked.
-		 *
-		 * @param int    $newsletter_id Newsletter ID.
-		 * @param string $url           Destination URL.
-		 */
-		do_action( 'newspack_newsletters_tracking_click', $newsletter_id, $email_address, $url );
+		self::track_click( $newsletter_id, $email_address, $url );
 
 		\wp_redirect( $url ); // phpcs:ignore WordPress.Security.SafeRedirect.wp_redirect_wp_redirect
 		exit;

--- a/includes/tracking/class-data-events.php
+++ b/includes/tracking/class-data-events.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * Newspack Newsletters Tracking Data Events Integration.
+ *
+ * @package Newspack
+ */
+
+namespace Newspack_Newsletters\Tracking;
+
+/**
+ * Tracking Data Events Class.
+ */
+final class Data_Events {
+	/**
+	 * Initialize hooks.
+	 */
+	public static function init() {
+		add_action( 'init', [ __CLASS__, 'register_listeners' ] );
+	}
+
+	/**
+	 * Register listeners.
+	 */
+	public static function register_listeners() {
+		if ( ! method_exists( 'Newspack\Data_Events', 'register_listener' ) ) {
+			return;
+		}
+		\Newspack\Data_Events::register_listener(
+			'newspack_newsletters_tracking_pixel_seen',
+			'newsletter_opened',
+			[ 'newsletter_id', 'email_address' ]
+		);
+	}
+}
+Data_Events::init();

--- a/includes/tracking/class-data-events.php
+++ b/includes/tracking/class-data-events.php
@@ -25,10 +25,17 @@ final class Data_Events {
 		if ( ! method_exists( 'Newspack\Data_Events', 'register_listener' ) ) {
 			return;
 		}
+		// Pixel seen.
 		\Newspack\Data_Events::register_listener(
 			'newspack_newsletters_tracking_pixel_seen',
 			'newsletter_opened',
 			[ 'newsletter_id', 'email_address' ]
+		);
+		// Click.
+		\Newspack\Data_Events::register_listener(
+			'newspack_newsletters_tracking_click',
+			'newsletter_clicked',
+			[ 'newsletter_id', 'email_address', 'url' ]
 		);
 	}
 }

--- a/includes/tracking/class-pixel.php
+++ b/includes/tracking/class-pixel.php
@@ -14,6 +14,13 @@ final class Pixel {
 	const QUERY_VAR = 'np_newsletters_pixel';
 
 	/**
+	 * Store whether the tracking pixel has been added to the newsletter.
+	 *
+	 * @var bool
+	 */
+	protected static $pixel_added = false;
+
+	/**
 	 * Initialize hooks.
 	 */
 	public static function init() {
@@ -30,10 +37,14 @@ final class Pixel {
 	 * @param WP_Post $post Post object.
 	 */
 	public static function add_tracking_pixel( $post ) {
+		if ( self::$pixel_added ) {
+			return;
+		}
 		printf(
 			'<mj-raw><img src="%s" width="1" height="1" alt="" style="display: block; width: 1px; height: 1px; border: none; margin: 0; padding: 0;" /></mj-raw>',
 			esc_url( self::get_pixel_url( $post->ID ) )
 		);
+		self::$pixel_added = true;
 	}
 
 	/**

--- a/includes/tracking/class-pixel.php
+++ b/includes/tracking/class-pixel.php
@@ -16,9 +16,9 @@ final class Pixel {
 	/**
 	 * Store whether the tracking pixel has been added to the newsletter.
 	 *
-	 * @var bool
+	 * @var bool[] Whether the tracking pixel has been by newsletter ID.
 	 */
-	protected static $pixel_added = false;
+	protected static $pixel_added = [];
 
 	/**
 	 * Initialize hooks.
@@ -37,14 +37,14 @@ final class Pixel {
 	 * @param WP_Post $post Post object.
 	 */
 	public static function add_tracking_pixel( $post ) {
-		if ( self::$pixel_added ) {
+		if ( ! empty( self::$pixel_added[ $post->ID ] ) ) {
 			return;
 		}
 		printf(
 			'<mj-raw><img src="%s" width="1" height="1" alt="" style="display: block; width: 1px; height: 1px; border: none; margin: 0; padding: 0;" /></mj-raw>',
 			esc_url( self::get_pixel_url( $post->ID ) )
 		);
-		self::$pixel_added = true;
+		self::$pixel_added[ $post->ID ] = true;
 	}
 
 	/**

--- a/includes/tracking/class-pixel.php
+++ b/includes/tracking/class-pixel.php
@@ -5,12 +5,12 @@
  * @package Newspack
  */
 
-namespace Newspack_Newsletters;
+namespace Newspack_Newsletters\Tracking;
 
 /**
  * Tracking Pixel Class.
  */
-final class Tracking_Pixel {
+final class Pixel {
 	const QUERY_VAR = 'np_newsletters_pixel';
 
 	/**
@@ -140,6 +140,13 @@ final class Tracking_Pixel {
 			exit;
 		}
 
+		$pixel_seen = get_post_meta( $newsletter_id, 'tracking_pixel_seen', true );
+		if ( ! $pixel_seen ) {
+			$pixel_seen = 0;
+		}
+		$pixel_seen++;
+		update_post_meta( $newsletter_id, 'tracking_pixel_seen', $pixel_seen );
+
 		/**
 		 * Fires when the tracking pixel is seen and valid.
 		 *
@@ -150,4 +157,4 @@ final class Tracking_Pixel {
 		exit;
 	}
 }
-Tracking_Pixel::init();
+Pixel::init();

--- a/includes/tracking/class-pixel.php
+++ b/includes/tracking/class-pixel.php
@@ -106,11 +106,12 @@ final class Pixel {
 		// Output a transparent 1x1 pixel image.
 		echo base64_decode( 'R0lGODlhAQABAIAAAAUEBAAAACwAAAAAAQABAAACAkQBADs=' ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 
-		// Process tracking.
-		$newsletter_id          = isset( $_GET['id'] ) ? intval( $_GET['id'] ) : 0; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
-		$tracking_id            = isset( $_GET['tid'] ) ? \sanitize_text_field( $_GET['tid'] ) : 0; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
-		$email_address          = isset( $_GET['em'] ) ? \sanitize_email( $_GET['em'] ) : ''; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		// phpcs:disable WordPress.Security.NonceVerification.Recommended
+		$newsletter_id          = isset( $_GET['id'] ) ? intval( $_GET['id'] ) : 0;
+		$tracking_id            = isset( $_GET['tid'] ) ? \sanitize_text_field( $_GET['tid'] ) : 0;
+		$email_address          = isset( $_GET['em'] ) ? \sanitize_email( $_GET['em'] ) : '';
 		$newsletter_tracking_id = \get_post_meta( $newsletter_id, 'tracking_id', true );
+		// phpcs:enable
 
 		// Tracking ID mismatch.
 		if ( $newsletter_tracking_id !== $tracking_id ) {

--- a/includes/tracking/class-pixel.php
+++ b/includes/tracking/class-pixel.php
@@ -153,6 +153,7 @@ final class Pixel {
 		if ( ! $newsletter_id || ! $tracking_id || ! $email_address ) {
 			return;
 		}
+
 		self::track_seen( $newsletter_id, $tracking_id, $email_address );
 		exit;
 	}

--- a/includes/tracking/class-pixel.php
+++ b/includes/tracking/class-pixel.php
@@ -17,11 +17,11 @@ final class Pixel {
 	 * Initialize hooks.
 	 */
 	public static function init() {
-		add_action( 'newspack_newsletters_editor_mjml_body', [ __CLASS__, 'add_tracking_pixel' ], 100 );
-		add_action( 'init', [ __CLASS__, 'rewrite_rule' ] );
-		add_filter( 'redirect_canonical', [ __CLASS__, 'redirect_canonical' ], 10, 2 );
-		add_filter( 'query_vars', [ __CLASS__, 'query_vars' ] );
-		add_action( 'template_redirect', [ __CLASS__, 'render' ] );
+		\add_action( 'newspack_newsletters_editor_mjml_body', [ __CLASS__, 'add_tracking_pixel' ], 100 );
+		\add_action( 'init', [ __CLASS__, 'rewrite_rule' ] );
+		\add_filter( 'redirect_canonical', [ __CLASS__, 'redirect_canonical' ], 10, 2 );
+		\add_filter( 'query_vars', [ __CLASS__, 'query_vars' ] );
+		\add_action( 'template_redirect', [ __CLASS__, 'render' ] );
 	}
 
 	/**
@@ -40,8 +40,8 @@ final class Pixel {
 	 * Add rewrite rule for tracking pixel.
 	 */
 	public static function rewrite_rule() {
-		add_rewrite_rule( 'np-newsletters.gif', 'index.php?' . self::QUERY_VAR . '=1', 'top' );
-		add_rewrite_tag( '%' . self::QUERY_VAR . '%', '1' );
+		\add_rewrite_rule( 'np-newsletters.gif', 'index.php?' . self::QUERY_VAR . '=1', 'top' );
+		\add_rewrite_tag( '%' . self::QUERY_VAR . '%', '1' );
 	}
 
 	/**
@@ -67,31 +67,8 @@ final class Pixel {
 	 * @return array
 	 */
 	public static function query_vars( $vars = [] ) {
-		$vars[] = 'np_newsletters_pixel';
+		$vars[] = self::QUERY_VAR;
 		return $vars;
-	}
-
-	/**
-	 * Get the email address tag for the tracking pixel.
-	 */
-	private static function get_email_address_tag() {
-		$provider = \Newspack_Newsletters::get_service_provider();
-		if ( empty( $provider ) ) {
-			return '';
-		}
-		$provider_name = $provider->service;
-		switch ( $provider_name ) {
-			case 'mailchimp':
-				return '*|EMAIL|*';
-			case 'campaign_monitor':
-				return '[email]';
-			case 'constant_contact':
-				return '[[emailAddress]]';
-			case 'active_campaign':
-				return '%EMAIL%';
-			default:
-				return '';
-		}
 	}
 
 	/**
@@ -100,18 +77,18 @@ final class Pixel {
 	 * @param int $post_id ID of the newsletter.
 	 */
 	public static function get_pixel_url( $post_id ) {
-		$tracking_id = get_post_meta( $post_id, 'tracking_id', true );
+		$tracking_id = \get_post_meta( $post_id, 'tracking_id', true );
 		if ( ! $tracking_id ) {
-			$tracking_id = wp_generate_password( 32, false );
-			update_post_meta( $post_id, 'tracking_id', $tracking_id );
+			$tracking_id = \wp_generate_password( 32, false );
+			\update_post_meta( $post_id, 'tracking_id', $tracking_id );
 		}
-		$url = add_query_arg(
+		$url = \add_query_arg(
 			[
 				'id'  => $post_id,
 				'tid' => $tracking_id,
-				'em'  => self::get_email_address_tag(),
+				'em'  => Utils::get_email_address_tag(),
 			],
-			home_url( 'np-newsletters.gif' )
+			\home_url( 'np-newsletters.gif' )
 		);
 		return $url;
 	}
@@ -120,7 +97,7 @@ final class Pixel {
 	 * Render the tracking pixel.
 	 */
 	public static function render() {
-		if ( ! get_query_var( self::QUERY_VAR ) ) {
+		if ( ! \get_query_var( self::QUERY_VAR ) ) {
 			return;
 		}
 
@@ -131,21 +108,21 @@ final class Pixel {
 
 		// Process tracking.
 		$newsletter_id          = isset( $_GET['id'] ) ? intval( $_GET['id'] ) : 0; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
-		$tracking_id            = isset( $_GET['tid'] ) ? sanitize_text_field( $_GET['tid'] ) : 0; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
-		$email_address          = isset( $_GET['em'] ) ? sanitize_email( $_GET['em'] ) : ''; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
-		$newsletter_tracking_id = get_post_meta( $newsletter_id, 'tracking_id', true );
+		$tracking_id            = isset( $_GET['tid'] ) ? \sanitize_text_field( $_GET['tid'] ) : 0; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		$email_address          = isset( $_GET['em'] ) ? \sanitize_email( $_GET['em'] ) : ''; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		$newsletter_tracking_id = \get_post_meta( $newsletter_id, 'tracking_id', true );
 
 		// Tracking ID mismatch.
 		if ( $newsletter_tracking_id !== $tracking_id ) {
 			exit;
 		}
 
-		$pixel_seen = get_post_meta( $newsletter_id, 'tracking_pixel_seen', true );
+		$pixel_seen = \get_post_meta( $newsletter_id, 'tracking_pixel_seen', true );
 		if ( ! $pixel_seen ) {
 			$pixel_seen = 0;
 		}
 		$pixel_seen++;
-		update_post_meta( $newsletter_id, 'tracking_pixel_seen', $pixel_seen );
+		\update_post_meta( $newsletter_id, 'tracking_pixel_seen', $pixel_seen );
 
 		/**
 		 * Fires when the tracking pixel is seen and valid.
@@ -153,7 +130,7 @@ final class Pixel {
 		 * @param int    $newsletter_id ID of the newsletter.
 		 * @param string $email_address Email address of the recipient.
 		 */
-		do_action( 'newspack_newsletters_tracking_pixel_seen', $newsletter_id, $email_address );
+		\do_action( 'newspack_newsletters_tracking_pixel_seen', $newsletter_id, $email_address );
 		exit;
 	}
 }

--- a/includes/tracking/class-pixel.php
+++ b/includes/tracking/class-pixel.php
@@ -139,6 +139,38 @@ final class Pixel {
 			return;
 		}
 
+		// Disable caching.
+		header( 'Cache-Control: no-cache, no-store, must-revalidate' );
+		header( 'Pragma: no-cache' );
+		header( 'Expires: 0' );
+
+		// phpcs:disable WordPress.Security.ValidatedSanitizedInput.InputNotSanitized, WordPressVIPMinimum.Variables.RestrictedVariables.cache_constraints___SERVER__HTTP_USER_AGENT__
+		// Skip bots.
+		if (
+			! empty( $_SERVER['HTTP_USER_AGENT'] ) &&
+			preg_match( '/bot|crawl|slurp|spider|mediapartners/i', $_SERVER['HTTP_USER_AGENT'] )
+		) {
+			return;
+		}
+		// Skip prefetching and previews.
+		if (
+			! empty( $_SERVER['HTTP_X_PURPOSE'] ) &&
+			in_array( $_SERVER['HTTP_X_PURPOSE'], [ 'preview', 'instant' ], true )
+		) {
+			return;
+		}
+		if ( ! empty( $_SERVER['HTTP_X_MOZ'] ) && 'prefetch' === $_SERVER['HTTP_X_MOZ'] ) {
+			return;
+		}
+		// Skip Google Image Pre-Fetch.
+		if (
+			! empty( $_SERVER['HTTP_USER_AGENT'] ) &&
+			'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/42.0.2311.135 Safari/537.36 Edge/12.246 Mozilla/5.0' === $_SERVER['HTTP_USER_AGENT']
+		) {
+			return;
+		}
+		// phpcs:enable
+
 		// Set the appropriate content type header.
 		header( 'Content-Type: image/gif' );
 		// Output a transparent 1x1 pixel image.

--- a/includes/tracking/class-pixel.php
+++ b/includes/tracking/class-pixel.php
@@ -42,6 +42,11 @@ final class Pixel {
 	public static function rewrite_rule() {
 		\add_rewrite_rule( 'np-newsletters.gif', 'index.php?' . self::QUERY_VAR . '=1', 'top' );
 		\add_rewrite_tag( '%' . self::QUERY_VAR . '%', '1' );
+		$check_option_name = 'newspack_newsletters_tracking_pixel_has_rewrite_rule';
+		if ( ! \get_option( $check_option_name ) ) {
+			\flush_rewrite_rules(); // phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.flush_rewrite_rules_flush_rewrite_rules
+			\update_option( $check_option_name, true );
+		}
 	}
 
 	/**

--- a/includes/tracking/class-utils.php
+++ b/includes/tracking/class-utils.php
@@ -14,7 +14,7 @@ final class Utils {
 	/**
 	 * Get the email address tag for the tracking pixel.
 	 */
-	private static function get_email_address_tag() {
+	public static function get_email_address_tag() {
 		$provider = \Newspack_Newsletters::get_service_provider();
 		if ( empty( $provider ) ) {
 			return '';

--- a/includes/tracking/class-utils.php
+++ b/includes/tracking/class-utils.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * Newspack Newsletters Tracking Utils.
+ *
+ * @package Newspack
+ */
+
+namespace Newspack_Newsletters\Tracking;
+
+/**
+ * Tracking Utils Class.
+ */
+final class Utils {
+	/**
+	 * Get the email address tag for the tracking pixel.
+	 */
+	private static function get_email_address_tag() {
+		$provider = \Newspack_Newsletters::get_service_provider();
+		if ( empty( $provider ) ) {
+			return '';
+		}
+		$provider_name = $provider->service;
+		switch ( $provider_name ) {
+			case 'mailchimp':
+				return '*|EMAIL|*';
+			case 'campaign_monitor':
+				return '[email]';
+			case 'constant_contact':
+				return '[[emailAddress]]';
+			case 'active_campaign':
+				return '%EMAIL%';
+			default:
+				return '';
+		}
+	}
+}

--- a/newspack-newsletters.php
+++ b/newspack-newsletters.php
@@ -58,7 +58,9 @@ require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/class-newspack-newsle
 require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/class-newspack-newsletters-bulk-actions.php';
 require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/class-newspack-newsletters-quick-edit.php';
 require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/class-newspack-newsletters-embed.php';
+require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/tracking/class-utils.php';
 require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/tracking/class-pixel.php';
+require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/tracking/class-click.php';
 require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/tracking/class-data-events.php';
 require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/tracking/class-admin.php';
 require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/class-newspack-newsletters.php';

--- a/newspack-newsletters.php
+++ b/newspack-newsletters.php
@@ -56,7 +56,9 @@ require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/class-newspack-newsle
 require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/class-newspack-newsletters-bulk-actions.php';
 require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/class-newspack-newsletters-quick-edit.php';
 require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/class-newspack-newsletters-embed.php';
-require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/tracking/class-tracking-pixel.php';
+require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/tracking/class-pixel.php';
+require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/tracking/class-data-events.php';
+require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/tracking/class-admin.php';
 require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/class-newspack-newsletters.php';
 
 // This MUST be initialized after Newspack_Newsletter class.

--- a/newspack-newsletters.php
+++ b/newspack-newsletters.php
@@ -56,6 +56,7 @@ require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/class-newspack-newsle
 require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/class-newspack-newsletters-bulk-actions.php';
 require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/class-newspack-newsletters-quick-edit.php';
 require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/class-newspack-newsletters-embed.php';
+require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/tracking/class-tracking-pixel.php';
 require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/class-newspack-newsletters.php';
 
 // This MUST be initialized after Newspack_Newsletter class.

--- a/tests/test-tracking.php
+++ b/tests/test-tracking.php
@@ -1,0 +1,98 @@
+<?php
+/**
+ * Test Tracking.
+ *
+ * @package Newspack_Newsletters
+ */
+
+use Newspack_Newsletters\Tracking;
+
+/**
+ * Newsletters Tracking Test.
+ */
+class Newsletters_Tracking_Test extends WP_UnitTestCase {
+	/**
+	 * Test rendering the tracking pixel.
+	 */
+	public function test_tracking_pixel_render() {
+		$post_id = self::factory->post->create( [ 'post_type' => \Newspack_Newsletters::NEWSPACK_NEWSLETTERS_CPT ] );
+		$post    = \get_post( $post_id );
+		ob_start();
+		do_action( 'newspack_newsletters_editor_mjml_body', $post );
+		$mjml_body = ob_get_clean();
+		$this->assertContains( 'np-newsletters.gif?id=' . $post_id, $mjml_body );
+	}
+
+	/**
+	 * Test tracking pixel seen.
+	 */
+	public function test_tracking_pixel_seen() {
+		$post_id = self::factory->post->create( [ 'post_type' => \Newspack_Newsletters::NEWSPACK_NEWSLETTERS_CPT ] );
+		$post    = \get_post( $post_id );
+		ob_start();
+		do_action( 'newspack_newsletters_editor_mjml_body', $post );
+		$mjml_body = ob_get_clean();
+
+		// Fetch the tracking pixel URL from body.
+		$pattern = '/src="([^"]*np-newsletters\.gif[^"]*)"/i';
+		$matches = [];
+		preg_match( $pattern, $mjml_body, $matches );
+		$pixel_url  = $matches[1];
+		$parsed_url = \wp_parse_url( $pixel_url );
+		$args       = \wp_parse_args( $parsed_url['query'] );
+
+		// Call the tracking pixel.
+		Pixel::track_seen( $args['id'], $args['tid'], $args['em'] );
+
+		// Assert seen once.
+		$seen = \get_post_meta( $post_id, 'newspack_newsletters_tracking_pixel_seen', true );
+		$this->assertEquals( 1, $seen );
+
+		// Call the tracking pixel again.
+		Pixel::track_seen( $args['id'], $args['tid'], $args['em'] );
+
+		// Assert seen twice.
+		$seen = \get_post_meta( $post_id, 'newspack_newsletters_tracking_pixel_seen', true );
+		$this->assertEquals( 2, $seen );
+	}
+
+	/**
+	 * Test tracking click render.
+	 */
+	public function test_tracking_click_render() {
+		$post_id  = self::factory->post->create(
+			[
+				'post_type'    => \Newspack_Newsletters::NEWSPACK_NEWSLETTERS_CPT,
+				'post_title'   => 'A newsletter with link.',
+				'post_content' => "<!-- wp:paragraph -->\n<p><a href=\"https://google.com\">Link</a><\/p>\n<!-- \/wp:paragraph -->",
+			]
+		);
+		$post     = \get_post( $post_id );
+		$rendered = Newspack_Newsletters_Renderer::post_to_mjml_components( $post );
+
+		// Fetch the link URL from body.
+		$pattern = '/href="([^"]*)"/i';
+		$matches = [];
+		preg_match( $pattern, $rendered, $matches );
+		$link_url   = $matches[1];
+		$parsed_url = \wp_parse_url( $link_url );
+		$args       = \wp_parse_args( $parsed_url['query'] );
+
+		$this->assertEquals( $post_id, intval( $args['id'] ) );
+		$this->assertEquals( 'https://google.com', $args['url'] );
+
+		// Call the tracking pixel.
+		Click::track_click( $args['id'], 'fake@email.com', $args['url'] );
+
+		// Assert clicked once.
+		$clicks = \get_post_meta( $post_id, 'tracking_clicks', true );
+		$this->assertEquals( 1, $clicks );
+
+		// Call the tracking pixel again.
+		Click::track_click( $args['id'], 'fake@email.com', $args['url'] );
+
+		// Assert clicked twice.
+		$clicks = \get_post_meta( $post_id, 'tracking_clicks', true );
+		$this->assertEquals( 2, $clicks );
+	}
+}

--- a/tests/test-tracking.php
+++ b/tests/test-tracking.php
@@ -15,7 +15,7 @@ class Newsletters_Tracking_Test extends WP_UnitTestCase {
 	 * Test rendering the tracking pixel.
 	 */
 	public function test_tracking_pixel_render() {
-		$post_id = self::factory->post->create( [ 'post_type' => \Newspack_Newsletters::NEWSPACK_NEWSLETTERS_CPT ] );
+		$post_id = $this->factory->post->create( [ 'post_type' => \Newspack_Newsletters::NEWSPACK_NEWSLETTERS_CPT ] );
 		$post    = \get_post( $post_id );
 		ob_start();
 		do_action( 'newspack_newsletters_editor_mjml_body', $post );
@@ -27,7 +27,7 @@ class Newsletters_Tracking_Test extends WP_UnitTestCase {
 	 * Test tracking pixel seen.
 	 */
 	public function test_tracking_pixel_seen() {
-		$post_id = self::factory->post->create( [ 'post_type' => \Newspack_Newsletters::NEWSPACK_NEWSLETTERS_CPT ] );
+		$post_id = $this->factory->post->create( [ 'post_type' => \Newspack_Newsletters::NEWSPACK_NEWSLETTERS_CPT ] );
 		$post    = \get_post( $post_id );
 		ob_start();
 		do_action( 'newspack_newsletters_editor_mjml_body', $post );
@@ -57,10 +57,10 @@ class Newsletters_Tracking_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test tracking click render.
+	 * Test tracking click.
 	 */
-	public function test_tracking_click_render() {
-		$post_id  = self::factory->post->create(
+	public function test_tracking_click() {
+		$post_id  = $this->factory->post->create(
 			[
 				'post_type'    => \Newspack_Newsletters::NEWSPACK_NEWSLETTERS_CPT,
 				'post_title'   => 'A newsletter with link.',
@@ -81,14 +81,14 @@ class Newsletters_Tracking_Test extends WP_UnitTestCase {
 		$this->assertEquals( $post_id, intval( $args['id'] ) );
 		$this->assertEquals( 'https://google.com', $args['url'] );
 
-		// Call the tracking pixel.
+		// Manually track the click.
 		Click::track_click( $args['id'], 'fake@email.com', $args['url'] );
 
 		// Assert clicked once.
 		$clicks = \get_post_meta( $post_id, 'tracking_clicks', true );
 		$this->assertEquals( 1, $clicks );
 
-		// Call the tracking pixel again.
+		// Manually track the click again.
 		Click::track_click( $args['id'], 'fake@email.com', $args['url'] );
 
 		// Assert clicked twice.

--- a/tests/test-tracking.php
+++ b/tests/test-tracking.php
@@ -5,7 +5,8 @@
  * @package Newspack_Newsletters
  */
 
-use Newspack_Newsletters\Tracking;
+use Newspack_Newsletters\Tracking\Pixel;
+use Newspack_Newsletters\Tracking\Click;
 
 /**
  * Newsletters Tracking Test.
@@ -20,7 +21,7 @@ class Newsletters_Tracking_Test extends WP_UnitTestCase {
 		ob_start();
 		do_action( 'newspack_newsletters_editor_mjml_body', $post );
 		$mjml_body = ob_get_clean();
-		$this->assertContains( 'np-newsletters.gif?id=' . $post_id, $mjml_body );
+		$this->assertRegexp( '/np-newsletters\.gif\?id=' . $post_id . '/', $mjml_body );
 	}
 
 	/**
@@ -79,7 +80,10 @@ class Newsletters_Tracking_Test extends WP_UnitTestCase {
 		$args       = \wp_parse_args( $parsed_url['query'] );
 
 		$this->assertEquals( $post_id, intval( $args['id'] ) );
-		$this->assertEquals( 'https://google.com', $args['url'] );
+
+		$parsed_destination_url = \wp_parse_url( $args['url'] );
+		$this->assertEquals( 'https', $parsed_destination_url['scheme'] );
+		$this->assertEquals( 'google.com', $parsed_destination_url['host'] );
 
 		// Manually track the click.
 		Click::track_click( $args['id'], 'fake@email.com', $args['url'] );

--- a/tests/test-tracking.php
+++ b/tests/test-tracking.php
@@ -27,7 +27,7 @@ class Newsletters_Tracking_Test extends WP_UnitTestCase {
 		$pattern = '/src="([^"]*np-newsletters\.gif[^"]*)"/i';
 		$matches = [];
 		preg_match( $pattern, $mjml_body, $matches );
-		$pixel_url  = $matches[1];
+		$pixel_url  = html_entity_decode( $matches[1] );
 		$parsed_url = \wp_parse_url( $pixel_url );
 		$args       = \wp_parse_args( $parsed_url['query'] );
 

--- a/tests/test-tracking.php
+++ b/tests/test-tracking.php
@@ -39,14 +39,14 @@ class Newsletters_Tracking_Test extends WP_UnitTestCase {
 		Pixel::track_seen( $args['id'], $args['tid'], 'fake@email.com' );
 
 		// Assert seen once.
-		$seen = \get_post_meta( $post_id, 'newspack_newsletters_tracking_pixel_seen', true );
+		$seen = \get_post_meta( $post_id, 'tracking_pixel_seen', true );
 		$this->assertEquals( 1, $seen );
 
 		// Call the tracking pixel again.
 		Pixel::track_seen( $args['id'], $args['tid'], 'fake@email.com' );
 
 		// Assert seen twice.
-		$seen = \get_post_meta( $post_id, 'newspack_newsletters_tracking_pixel_seen', true );
+		$seen = \get_post_meta( $post_id, 'tracking_pixel_seen', true );
 		$this->assertEquals( 2, $seen );
 	}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Implements pixel and click-tracking for sent newsletters.

The pixel is appended to the body of every sent email and increments a post meta as well as sends out a [data event](https://github.com/Automattic/newspack-plugin/blob/08e53ff639ffe3c58573b4f368f1db7285ff4055/includes/data-events/README.md) called `newsletter_opened` with the newsletter ID and email address.

The click tracker filters the existing `newspack_newsletters_process_link` to replace the URL with a proxied version. The redirection handler increments a post meta and sends a data event named `newsletter_clicked` with the newsletter ID, email address, and destination URL.

Both data events should be listed in the Connections -> Webhooks while editing/adding a webhook. (with `define( 'NEWSPACK_EXPERIMENTAL_WEBHOOKS', true );`)

Opens and clicks are also added as sortable columns in the dashboard's newsletters table:

<img width="1540" alt="image" src="https://github.com/Automattic/newspack-newsletters/assets/820752/3dfe56ec-61ec-4ee2-ae8a-cff75d434816">

**NOTE: This branch will be merged to `epic/revenue-optimizations` to be released along with other enhancements.**

### How to test the changes in this Pull Request:

Written tests should pass

1. Check out this branch and send a newsletter with a link to `https://newspack.com/learn-more/?v=2#post-3415` and another to any other destination
2. Open the newsletter in your email client (make sure to allow images to load), visit the dashboard, and confirm "Opened" column shows `1` for this newsletter
3. Click on a link from the newsletter and confirm you are redirected to the correct destination (with hash and parameters)
4. Refresh the dashboard and confirm the "Clicks" count is 1
5. Click on the other link and confirm it's now 2
6. Click again on the same link and confirm it's 3 (clicks are not uniquely identified)
7. Send another newsletter, open and click on links as well
8. Refresh the dashboard and confirm you are able to sort by opens and clicks

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
