### PR TITLE
Newsletter Block: add a width to the email inputs to prevent overflow

### DIFF
--- a/src/blocks/subscribe/style.scss
+++ b/src/blocks/subscribe/style.scss
@@ -47,7 +47,6 @@
 
 		@media ( min-width: 782px ) {
 			flex-basis: auto;
-			width: auto;
 		}
 
 		&[aria-hidden='true'] {

--- a/src/blocks/subscribe/style.scss
+++ b/src/blocks/subscribe/style.scss
@@ -43,9 +43,11 @@
 	input[type='text'],
 	input[type='email'] {
 		flex: 1 1 100%;
+		width: 100%;
 
 		@media ( min-width: 782px ) {
 			flex-basis: auto;
+			width: auto;
 		}
 
 		&[aria-hidden='true'] {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

In very extreme cases -- like on smaller screens, or in narrower/super padded containers, the Newsletter Subscription block's input field can push out of the container.

This PR adds a width to the text container, which seems to fix it 🤞 

See: 1200550061930446-as-1203833168966390

### How to test the changes in this Pull Request:

1. Add a few Newsletter Subscription blocks to your content, with a mix of settings: with and without names fields, inside of groups, inside of columns. You can also copy-paste this starter content (though it'd be good to add at least one weird setting of your own):

<details>
<summary><strong>Newsletter Block text code</strong></summary>

```
<!-- wp:columns -->
<div class="wp-block-columns"><!-- wp:column -->
<div class="wp-block-column"><!-- wp:newspack-newsletters/subscribe {"displayNameField":true,"lists":["3363aba3d5"]} /--></div>
<!-- /wp:column -->

<!-- wp:column -->
<div class="wp-block-column"><!-- wp:newspack-newsletters/subscribe {"displayNameField":true,"displayLastNameField":true,"lists":["3363aba3d5"]} /--></div>
<!-- /wp:column -->

<!-- wp:column -->
<div class="wp-block-column"><!-- wp:newspack-newsletters/subscribe {"lists":["3363aba3d5"]} /--></div>
<!-- /wp:column --></div>
<!-- /wp:columns -->

<!-- wp:columns -->
<div class="wp-block-columns"><!-- wp:column -->
<div class="wp-block-column"><!-- wp:newspack-newsletters/subscribe {"displayNameField":true,"lists":["3363aba3d5"]} /--></div>
<!-- /wp:column -->

<!-- wp:column -->
<div class="wp-block-column"><!-- wp:newspack-newsletters/subscribe {"displayNameField":true,"displayLastNameField":true,"lists":["3363aba3d5"]} /--></div>
<!-- /wp:column -->

<!-- wp:column -->
<div class="wp-block-column"><!-- wp:newspack-newsletters/subscribe {"lists":["3363aba3d5"]} /--></div>
<!-- /wp:column -->

<!-- wp:column -->
<div class="wp-block-column"><!-- wp:newspack-newsletters/subscribe {"lists":["3363aba3d5"]} /--></div>
<!-- /wp:column --></div>
<!-- /wp:columns -->

<!-- wp:newspack-newsletters/subscribe {"displayNameField":true,"displayLastNameField":true,"lists":["3363aba3d5"]} /-->

<!-- wp:group {"backgroundColor":"light-gray","layout":{"type":"constrained"}} -->
<div class="wp-block-group has-light-gray-background-color has-background"><!-- wp:newspack-newsletters/subscribe {"displayNameField":true,"displayLastNameField":true,"lists":["3363aba3d5"]} /--></div>
<!-- /wp:group -->

<!-- wp:columns -->
<div class="wp-block-columns"><!-- wp:column -->
<div class="wp-block-column"><!-- wp:newspack-newsletters/subscribe {"lists":["3363aba3d5"]} /--></div>
<!-- /wp:column -->

<!-- wp:column -->
<div class="wp-block-column"><!-- wp:group {"backgroundColor":"light-gray","layout":{"type":"constrained"}} -->
<div class="wp-block-group has-light-gray-background-color has-background"><!-- wp:newspack-newsletters/subscribe {"displayInputLabels":true,"displayNameField":true,"lists":["3363aba3d5"]} /--></div>
<!-- /wp:group --></div>
<!-- /wp:column --></div>
<!-- /wp:columns -->
```

</details>

2. Scale down your browser window; note that some of the inputs in the blocks peek out of their containing elements: 

![image](https://github.com/Automattic/newspack-newsletters/assets/177561/8791a385-91a3-4f5f-99e5-11ae93caf5f1)

You can also see this in some campaigns, if you want to try to add a sign up to one of those -- adding an extra group block can mess with the spacing enough that you get the inputs peeking out

![image](https://github.com/Automattic/newspack-newsletters/assets/177561/cb0c4064-1d2b-45b8-a09d-1107d1ff6f2c)

3. Apply the PR and run `npm run build`.
4. Confirm the appearance of the inputs on desktop doesn't change, and that the breakpoint where the button goes full width is still 782px. 
5. Confirm that fields don't stick out of their containers in the narrower cases above:

![image](https://github.com/Automattic/newspack-newsletters/assets/177561/a4cb3a6d-1bfc-474b-a639-baaa8f5d6359)

![image](https://github.com/Automattic/newspack-newsletters/assets/177561/381b4420-e85a-4bce-8c91-1d23afac0e2c)


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
