### PR TITLE
fix: allow public newsletters in author archives

### DIFF
--- a/includes/class-newspack-newsletters.php
+++ b/includes/class-newspack-newsletters.php
@@ -1214,7 +1214,7 @@ final class Newspack_Newsletters {
 		if ( is_admin() || ! $query->is_main_query() ) {
 			return;
 		}
-		if ( $query->is_tag() || $query->is_category() ) {
+		if ( $query->is_tag() || $query->is_category() || $query->is_author() ) {
 			$post_type = $query->get( 'post_type' );
 			if ( empty( $post_type ) ) {
 				$post_type = [ 'post' ];


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR includes author archives in the list of archives the public newsletters can appear on. The archives originally functioned this way, but it was accidentally changed as part of #1138. 

See: 1200550061930446-as-1204818298347108

### How to test the changes in this Pull Request:

1. Create at least one newsletter on your test site; assign it a category or tag, and set it to publish publicly; send.
2. View your author archive page; note that none of your newsletters appear there.
3. View the archive for the matching category/tag archive; note it does appear there. 
4. Apply this PR.
5. Confirm that the public newsletters now appear in your author archive. 
6. Confirm that the public newsletters still appear on their assigned category/tag archive pages, too. 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
