### PR TITLE
fix(subscribe-block): allow spaces in submit button

### DIFF
--- a/src/blocks/subscribe/edit.js
+++ b/src/blocks/subscribe/edit.js
@@ -301,7 +301,7 @@ export default function SubscribeEdit( {
 										) }
 									</label>
 									<input type="email" placeholder={ placeholder } />
-									<div className="submit">
+									<div className="submit-button">
 										<RichText
 											onChange={ value => setAttributes( { label: value } ) }
 											placeholder={ __( 'Sign up', 'newspack' ) }

--- a/src/blocks/subscribe/edit.js
+++ b/src/blocks/subscribe/edit.js
@@ -301,14 +301,14 @@ export default function SubscribeEdit( {
 										) }
 									</label>
 									<input type="email" placeholder={ placeholder } />
-									<button type="submit">
+									<div className="submit">
 										<RichText
 											onChange={ value => setAttributes( { label: value } ) }
 											placeholder={ __( 'Sign up', 'newspack' ) }
 											value={ label }
 											tagName="span"
 										/>
-									</button>
+									</div>
 								</div>
 							</form>
 						) }

--- a/src/blocks/subscribe/editor.scss
+++ b/src/blocks/subscribe/editor.scss
@@ -16,7 +16,7 @@
 			font-size: 1rem;
 		}
 		[type='submit'],
-		.submit {
+		.submit-button {
 			transition: background 150ms ease-in-out;
 			background: #d33;
 			border: none;

--- a/src/blocks/subscribe/editor.scss
+++ b/src/blocks/subscribe/editor.scss
@@ -15,7 +15,8 @@
 			border-radius: 0;
 			font-size: 1rem;
 		}
-		[type='submit'] {
+		[type='submit'],
+		.submit {
 			transition: background 150ms ease-in-out;
 			background: #d33;
 			border: none;
@@ -23,9 +24,8 @@
 			box-sizing: border-box;
 			display: inline-block;
 			color: #fff;
-			font-family: -apple-system, blinkmacsystemfont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell,
-				'Fira Sans', 'Droid Sans', 'Helvetica Neue', sans-serif;
-			font-size: 0.8rem;
+			font-family: var( --newspack-theme-font-heading );
+			font-size: 1rem;
 			font-weight: 700;
 			line-height: 1.2;
 			outline: none;

--- a/src/blocks/subscribe/style.scss
+++ b/src/blocks/subscribe/style.scss
@@ -47,6 +47,7 @@
 
 		@media ( min-width: 782px ) {
 			flex-basis: auto;
+			width: auto;
 		}
 
 		&[aria-hidden='true'] {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes a minor but annoying bug in which the `RichText` component for the submit button in the editor for Subscription Form blocks doesn't allow spaces if it's nested inside a `button` element. This fix changes the `button` element to a `div` with the same styles, in the editor only. See also https://github.com/Automattic/newspack-blocks/pull/1479

Closes `1204751246381643/1204483195828260`.

### How to test the changes in this Pull Request:

1. On `master`, add a Subscription Form block to a post or page.
2. Observe that you can edit the submit button labels but can't add spaces in either case.
3. Check out this branch, repeat step 2 and confirm that you can now add spaces, and that both editor and front-end styles and behavior are otherwise unchanged.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
