### PR TITLE
fix: preserve list order on subscribe block

### DIFF
--- a/src/blocks/subscribe/index.php
+++ b/src/blocks/subscribe/index.php
@@ -91,7 +91,7 @@ function render_block( $attrs ) {
 	$email           = '';
 	$lists           = array_keys( $list_config );
 	$list_map        = array_flip( $lists );
-	$available_lists = array_values( array_intersect( $lists, $attrs['lists'] ) );
+	$available_lists = array_values( array_intersect( $attrs['lists'], $lists ) );
 
 	if ( empty( $available_lists ) ) {
 		$available_lists = [ $lists[0] ];


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Even though there's not a proper UI yet for determining the order to display newsletter subscription lists in the "Newsletter Subscription Form" block, the stored array order should be preserved.

### How to test the changes in this Pull Request:

1. While on the `release` branch, select different lists on a "Newsletter Subscription Form" block
2. Make sure to select a list on the bottom first, and another at the top
3. Confirm that the bottom list is rendered first in the editor
4. Visit the page and confirm it's not reflected on the page
5. Check out this branch, refresh, and confirm it's rendering in the expected order.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
