### PR TITLE
fix: preserve Lists order when rendering the block

### DIFF
--- a/src/blocks/subscribe/index.php
+++ b/src/blocks/subscribe/index.php
@@ -91,7 +91,7 @@ function render_block( $attrs ) {
 	$email           = '';
 	$lists           = array_keys( $list_config );
 	$list_map        = array_flip( $lists );
-	$available_lists = array_values( array_intersect( $lists, $attrs['lists'] ) );
+	$available_lists = array_values( array_intersect( $attrs['lists'], $lists ) );
 
 	if ( empty( $available_lists ) ) {
 		$available_lists = [ $lists[0] ];


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Preserves the lists order as they were selected in the block.

Closes # .

### How to test the changes in this Pull Request:

1.
2.
3.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
