### PR TITLE
feat: refactor how we store lists configuration

### DIFF
--- a/includes/class-newspack-newsletters-subscription.php
+++ b/includes/class-newspack-newsletters-subscription.php
@@ -229,7 +229,7 @@ class Newspack_Newsletters_Subscription {
 	 * @param array[] $lists {
 	 *    Array of list configuration.
 	 *
-	 *    @type string  id          The list id.
+	 *    @type string  id          The list id in the ESP (not the ID in the DB)
 	 *    @type boolean active      Whether the list is available for subscription.
 	 *    @type string  title       The list title.
 	 *    @type string  description The list description.

--- a/includes/class-newspack-newsletters-subscription.php
+++ b/includes/class-newspack-newsletters-subscription.php
@@ -157,12 +157,19 @@ class Newspack_Newsletters_Subscription {
 			return new WP_Error( 'newspack_newsletters_invalid_provider', __( 'Provider is not set.' ) );
 		}
 		try {
+			/**
+			 * Here we always fetch the lists from the ESP, because we want to make sure we have the latest data.
+			 */
 			$lists = $provider->get_lists();
 			if ( is_wp_error( $lists ) ) {
 				return $lists;
 			}
 			$saved_lists = Subscription_Lists::get_configured_for_current_provider();
 
+			/**
+			 * We loop through the lists returned by the ESP.
+			 * Only remote lists that still exist in the ESP will be returned.
+			 */
 			$return_lists = array_map(
 				function( $list ) {
 					if ( ! isset( $list['id'], $list['name'] ) || empty( $list['id'] ) || empty( $list['name'] ) ) {

--- a/includes/class-newspack-newsletters-subscription.php
+++ b/includes/class-newspack-newsletters-subscription.php
@@ -164,10 +164,13 @@ class Newspack_Newsletters_Subscription {
 			$saved_lists = Subscription_Lists::get_configured_for_current_provider();
 
 			$return_lists = array_map(
-				function( $list ) use ( $config, $provider ) {
+				function( $list ) {
 					if ( ! isset( $list['id'], $list['name'] ) || empty( $list['id'] ) || empty( $list['name'] ) ) {
 						return;
 					}
+					
+					// This is messy, when the ESP returns lists, it's name, when we get it from our UIs, it's title... we need both.
+					$list['title'] = $list['name'];
 
 					$stored_list = Subscription_Lists::get_remote_list( $list );
 
@@ -175,7 +178,7 @@ class Newspack_Newsletters_Subscription {
 						return;
 					}
 
-					return $item->to_array();
+					return $stored_list->to_array();
 				},
 				$lists
 			);
@@ -244,7 +247,7 @@ class Newspack_Newsletters_Subscription {
 			return new WP_Error( 'newspack_newsletters_invalid_lists', __( 'Invalid list configuration.' ) );
 		}
 
-		return Subscription_List::update_lists( $lists );
+		return Subscription_Lists::update_lists( $lists );
 	}
 
 	/**
@@ -260,7 +263,8 @@ class Newspack_Newsletters_Subscription {
 			if ( ! isset( $list['id'], $list['title'] ) || empty( $list['id'] ) || empty( $list['title'] ) ) {
 				continue;
 			}
-			$sanitized[ $list['id'] ] = [
+			$sanitized[] = [
+				'id'          => $list['id'],
 				'active'      => isset( $list['active'] ) ? (bool) $list['active'] : false,
 				'title'       => $list['title'],
 				'description' => isset( $list['description'] ) ? (string) $list['description'] : '',

--- a/includes/class-newspack-newsletters-subscription.php
+++ b/includes/class-newspack-newsletters-subscription.php
@@ -179,7 +179,7 @@ class Newspack_Newsletters_Subscription {
 					// This is messy, when the ESP returns lists, it's name, when we get it from our UIs, it's title... we need both.
 					$list['title'] = $list['name'];
 
-					$stored_list = Subscription_Lists::get_remote_list( $list );
+					$stored_list = Subscription_Lists::get_or_create_remote_list( $list );
 
 					if ( is_wp_error( $stored_list ) ) {
 						return;

--- a/includes/class-subscription-list.php
+++ b/includes/class-subscription-list.php
@@ -53,14 +53,14 @@ class Subscription_List {
 	const REMOTE_ID_META = '_remote_id';
 
 	/**
-	 * Checks if a string $id is in the format of a Subscription List Form ID
+	 * Checks if a string $id is in the format of a local Subscription List Form ID
 	 *
 	 * @see self::get_form_id
 	 * @param string $id The ID to be checked.
 	 * @return boolean
 	 */
-	public static function is_form_id( $id ) {
-		return (bool) self::get_id_from_form_id( $id );
+	public static function is_local_form_id( $id ) {
+		return (bool) self::get_id_from_local_form_id( $id );
 	}
 
 	/**
@@ -70,7 +70,7 @@ class Subscription_List {
 	 * @param string $form_id The Form id.
 	 * @return ?int The ID on success, NULL on failure
 	 */
-	public static function get_id_from_form_id( $form_id ) {
+	public static function get_id_from_local_form_id( $form_id ) {
 		if ( ! is_string( $form_id ) ) {
 			return;
 		}
@@ -92,8 +92,8 @@ class Subscription_List {
 	 */
 	public function __construct( $post_or_id ) {
 		if ( ! $post_or_id instanceof WP_Post ) {
-			if ( self::is_form_id( $post_or_id ) ) {
-				$post_or_id = self::get_id_from_form_id( $post_or_id );
+			if ( self::is_local_form_id( $post_or_id ) ) {
+				$post_or_id = self::get_id_from_local_form_id( $post_or_id );
 			}
 			$post_or_id = get_post( (int) $post_or_id );
 			if ( ! $post_or_id instanceof WP_Post ) {
@@ -234,7 +234,7 @@ class Subscription_List {
 	}
 
 	/**
-	 * Gets the link to edit this list
+	 * Gets the link to edit this list. Only local lists can be edited locally.
 	 *
 	 * In some rest requests, the post type is not registered, so we can't use get_edit_post_link
 	 *

--- a/includes/class-subscription-list.php
+++ b/includes/class-subscription-list.php
@@ -447,14 +447,14 @@ class Subscription_List {
 	 */
 	public function to_array() {
 		return [
-			'id'          => $this->get_id(),
+			'id'          => $this->get_form_id(),
+			'db_id'       => $this->get_id(),
 			'title'       => $this->get_title(),
 			'name'        => $this->get_title(),
 			'description' => $this->get_description(),
 			'type'        => $this->get_type(),
 			'type_label'  => $this->get_type_label(),
 			'edit_link'   => $this->get_edit_link(),
-			'form_id'     => $this->get_form_id(),
 			'active'      => $this->is_active(),
 		];
 	}

--- a/includes/class-subscription-list.php
+++ b/includes/class-subscription-list.php
@@ -449,6 +449,7 @@ class Subscription_List {
 		return [
 			'id'          => $this->get_id(),
 			'title'       => $this->get_title(),
+			'name'        => $this->get_title(),
 			'description' => $this->get_description(),
 			'type'        => $this->get_type(),
 			'type_label'  => $this->get_type_label(),

--- a/includes/class-subscription-lists.php
+++ b/includes/class-subscription-lists.php
@@ -10,6 +10,7 @@ namespace Newspack\Newsletters;
 use Newspack_Newsletters;
 use Newspack_Newsletters_Settings;
 use Newspack_Newsletters_Subscription;
+use WP_Error;
 use WP_Post;
 
 defined( 'ABSPATH' ) || exit;
@@ -34,18 +35,14 @@ class Subscription_Lists {
 	 * @return void
 	 */
 	public static function init() {
-		if ( ! self::should_initialize_lists() ) {
+		add_action( 'init', [ __CLASS__, 'register_post_type' ] );
+
+		if ( ! self::should_initialize_local_lists() ) {
 			return;
 		}
-		add_action( 'init', [ __CLASS__, 'register_post_type' ] );
 		add_filter( 'wp_editor_settings', [ __CLASS__, 'filter_editor_settings' ], 10, 2 );
 		add_action( 'save_post', [ __CLASS__, 'save_post' ] );
-		add_filter( 'manage_' . self::CPT . '_posts_columns', [ __CLASS__, 'posts_columns' ] );
-		add_action( 'manage_' . self::CPT . '_posts_custom_column', [ __CLASS__, 'posts_columns_values' ], 10, 2 );
 		add_action( 'admin_enqueue_scripts', [ __CLASS__, 'admin_enqueue_scripts' ] );
-
-		add_action( 'delete_post', [ __CLASS__, 'delete_post' ] );
-		add_action( 'wp_trash_post', [ __CLASS__, 'delete_post' ] );
 
 		add_action( 'edit_form_before_permalink', [ __CLASS__, 'edit_form_before_permalink' ] );
 		add_action( 'edit_form_top', [ __CLASS__, 'edit_form_top' ] );
@@ -70,7 +67,7 @@ class Subscription_Lists {
 	 *
 	 * @return boolean
 	 */
-	public static function should_initialize_lists() {
+	public static function should_initialize_local_lists() {
 		// We only need this on admin.
 		if ( ! is_admin() ) {
 			return false;
@@ -174,46 +171,6 @@ class Subscription_Lists {
 			'side',
 			'high'
 		);
-	}
-
-	/**
-	 * Modify columns on post type table
-	 *
-	 * @param array $columns Registered columns.
-	 * @return array
-	 */
-	public static function posts_columns( $columns ) {
-		unset( $columns['date'] );
-		unset( $columns['stats'] );
-		$columns['active_providers'] = __( 'Service Providers', 'newspack-newsletters' );
-		return $columns;
-
-	}
-
-	/**
-	 * Add content to the custom column
-	 *
-	 * @param string $column The current column.
-	 * @param int    $post_id The current post ID.
-	 * @return void
-	 */
-	public static function posts_columns_values( $column, $post_id ) {
-		if ( 'active_providers' === $column ) {
-			$list = new Subscription_List( $post_id );
-			foreach ( $list->get_configured_providers() as $provider ) {
-				$settings     = $list->get_provider_settings( $provider );
-				$provider_obj = Newspack_Newsletters::get_service_provider_instance( $provider );
-				?>
-				<p>
-					<?php echo esc_html( $provider_obj::label( 'name' ) ); ?>:
-					<span class="subscription-list-tag">
-						<?php echo esc_html( $settings['tag_name'] ); ?>
-					</span>
-				</p>
-				<?php
-
-			}
-		}
 	}
 
 	/**
@@ -353,7 +310,12 @@ class Subscription_Lists {
 			return;
 		}
 
-		$list = sanitize_text_field( $_POST['newspack_newsletters_list'] ?? '' );
+		$list              = sanitize_text_field( $_POST['newspack_newsletters_list'] ?? '' );
+		$subscription_list = new Subscription_List( $post_id );
+
+		// All lists created via UI are local lists.
+		// Regular lists are created via Subscription_Lists::create_remote_list().
+		$subscription_list->set_type( 'local' );
 
 		if ( empty( $list ) ) {
 			return;
@@ -361,7 +323,6 @@ class Subscription_Lists {
 
 		$provider            = Newspack_Newsletters::get_service_provider();
 		$tag_prefix          = $provider::label( 'tag_prefix' );
-		$subscription_list   = new Subscription_List( $post_id );
 		$new_tag_name        = $subscription_list->generate_tag_name( $tag_prefix );
 		$current_settings    = $subscription_list->get_current_provider_settings();
 		$tag_id              = $current_settings['tag_id'] ?? false;
@@ -427,7 +388,7 @@ class Subscription_Lists {
 			[
 				'post_type'      => self::CPT,
 				'posts_per_page' => -1,
-				'post_status'    => 'publish',
+				'post_status'    => 'any',
 			]
 		);
 		$objects = [];
@@ -483,47 +444,159 @@ class Subscription_Lists {
 	}
 
 	/**
-	 * Callback for the delete_post and wp_trash_post actions. Will remove the deleted/trashed list from the config.
+	 * Gets the list object from a list definition fetched from the ESP. If not found, the list will be created in the database
 	 *
-	 * @param int           $post_id The Post ID.
-	 * @param false|WP_Post $post Informed by the delete_post action, but not by the wp_trash_post action. The deleted post object.
-	 * @return void
+	 * @param array[] $list {
+	 *    Array of list configuration. Fields are required.
+	 *
+	 *    @type string  id         The list id in the ESP.
+	 *    @type string  name       The list name.
+	 * }
+	 * @throws \Exception If the list is invalid.
+	 * @return Subscription_List
 	 */
-	public static function delete_post( $post_id, $post = false ) {
-		if ( ! $post ) {
-			$post = get_post( $post_id );
-		}
-		if ( ! $post instanceof WP_Post ) {
-			return;
-		}
-		if ( self::CPT !== $post->post_type ) {
-			return;
-		}
-		$list_config = Newspack_Newsletters_Subscription::get_lists_config();
-		if ( empty( $list_config ) || \is_wp_error( $list_config ) ) {
-			return;
+	public static function get_remote_list( $list ) {
+		if ( empty( $list['id'] ) || empty( $list['name'] ) ) {
+			throw new \Exception( 'Invalid list' );
 		}
 
-		$id = Subscription_List::FORM_ID_PREFIX . $post_id;
-		
-		if ( ! isset( $list_config[ $id ] ) ) {
-			return;
-		}
-		
-		unset( $list_config[ $id ] );
+		$saved = self::get_list_by_remote_id( $list['id'] );
 
-		$new_list_config = [];
-		// generate a new list config without the deleted list.
-		foreach ( $list_config as $list_id => $list ) {
-			$new_list_config[] = [
-				'id'          => $list_id,
-				'active'      => $list['active'],
-				'title'       => $list['title'],
-				'description' => $list['description'],
-			];
+		if ( $saved ) {
+			return $saved;
 		}
 
-		Newspack_Newsletters_Subscription::update_lists( $new_list_config );
+		return self::create_remote_list( $list['id'], $list['name'] );
+	}
+
+	/**
+	 * Gets a Subscription_List object by its remote ID
+	 *
+	 * @param string $remote_id The remote ID. The ID of the list in the ESP.
+	 * @return ?Subscription_List
+	 */
+	public static function get_list_by_remote_id( $remote_id ) {
+		$posts = get_posts(
+			[
+				'post_type'      => self::CPT,
+				'posts_per_page' => 1,
+				'post_status'    => 'any',
+				'meta_query'     => [ // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
+					[
+						'key'   => Subscription_List::REMOTE_ID_META,
+						'value' => $remote_id,
+					],
+				],
+			]
+		);
+		if ( 1 === count( $posts ) ) {
+			return new Subscription_List( $posts[0] );
+		}
+	}
+
+	/**
+	 * Creates a remote list
+	 *
+	 * @param string $remote_id The ID of the list in the ESP.
+	 * @param string $name The name of the list.
+	 * @return Subscription_List|WP_Error
+	 */
+	public static function create_remote_list( $remote_id, $name ) {
+		$post_id = wp_insert_post(
+			[
+				'post_type'   => self::CPT,
+				'post_status' => 'draft',
+				'post_title'  => $name,
+			]
+		);
+
+		if ( is_wp_error( $post_id ) ) {
+			return $post_id;
+		}
+
+		$list = new Subscription_List( $post_id );
+		$list->set_remote_id( $remote_id );
+		$list->set_type( 'remote' );
+		$provider = Newspack_Newsletters::get_service_provider();
+		if ( ! empty( $provider ) ) {
+			$list->set_provider( $provider->service );
+		}
+		return $list;
+	}
+
+	/**
+	 * Update the lists settings.
+	 *
+	 * This function retrieves the list of lists configured in the site and updates them all at once.
+	 *
+	 * Remote Lists that are not part of the provided array will be deleted.
+	 * Local lists that are not part of the array will be disabled.
+	 *
+	 * @param array[] $lists {
+	 *    Array of list configuration.
+	 *
+	 *    @type string  id          The list id.
+	 *    @type boolean active      Whether the list is available for subscription.
+	 *    @type string  title       The list title.
+	 *    @type string  description The list description.
+	 * }
+	 *
+	 * @return boolean|WP_Error Whether the lists were updated or error.
+	 */
+	public static function update_lists( $lists ) {
+		$provider = Newspack_Newsletters::get_service_provider();
+		if ( empty( $provider ) ) {
+			return new WP_Error( 'newspack_newsletters_invalid_provider', __( 'Provider is not set.' ) );
+		}
+		$lists = Newspack_Newsletters_Subscription::sanitize_lists( $lists );
+		if ( empty( $lists ) ) {
+			return new WP_Error( 'newspack_newsletters_invalid_lists', __( 'Invalid list configuration.' ) );
+		}
+
+		$existing_ids = [];
+
+		foreach ( $lists as $list ) {
+			try {
+				// Local lists will be fetched here.
+				$stored_list = new Subscription_List( $list['id'] );
+			} catch ( \Exception $e ) {
+				// Remote lists will be either fetched or created here.
+				$stored_list = self::get_remote_list( $list );
+			}
+
+			if ( ! $stored_list instanceof Subscription_List ) {
+				continue;
+			}
+
+			$existing_ids[] = $stored_list->get_id();
+
+			$stored_list->update( $list );
+
+		}
+
+		// Clean up. Lists that are not in the new config will be deleted.
+		$all_lists = self::get_all();
+		foreach ( $all_lists as $list ) {
+			if ( ! in_array( $list->get_id(), $existing_ids, true ) ) {
+				if ( $list->is_local() ) {
+					$list->update( [ 'active' => false ] );
+				} else {
+					self::delete_list( $list );
+				}
+			}
+		}
+
+		return true;
+	}
+
+	/**
+	 * Deletes a list from the database
+	 *
+	 * @param Subscription_List $list The list to be deleted.
+	 * @return bool
+	 */
+	public static function delete_list( Subscription_List $list ) {
+		return wp_delete_post( $list->get_id() );
 	}
 
 	/**
@@ -532,7 +605,7 @@ class Subscription_Lists {
 	 * @return ?string
 	 */
 	public static function get_add_new_url() {
-		if ( self::should_initialize_lists() ) {
+		if ( self::should_initialize_local_lists() ) {
 			return admin_url( 'post-new.php?post_type=' . self::CPT );
 		}
 	}

--- a/includes/class-subscription-lists.php
+++ b/includes/class-subscription-lists.php
@@ -450,13 +450,13 @@ class Subscription_Lists {
 	 *    Array of list configuration. Fields are required.
 	 *
 	 *    @type string  id         The list id in the ESP.
-	 *    @type string  name       The list name.
+	 *    @type string  title       The list title.
 	 * }
 	 * @throws \Exception If the list is invalid.
 	 * @return Subscription_List
 	 */
 	public static function get_remote_list( $list ) {
-		if ( empty( $list['id'] ) || empty( $list['name'] ) ) {
+		if ( empty( $list['id'] ) || empty( $list['title'] ) ) {
 			throw new \Exception( 'Invalid list' );
 		}
 
@@ -466,7 +466,7 @@ class Subscription_Lists {
 			return $saved;
 		}
 
-		return self::create_remote_list( $list['id'], $list['name'] );
+		return self::create_remote_list( $list['id'], $list['title'] );
 	}
 
 	/**

--- a/includes/class-subscription-lists.php
+++ b/includes/class-subscription-lists.php
@@ -556,7 +556,7 @@ class Subscription_Lists {
 		$existing_ids = [];
 
 		foreach ( $lists as $list ) {
-			if ( Subscription_List::is_form_id( $list['id'] ) ) {
+			if ( Subscription_List::is_local_form_id( $list['id'] ) ) {
 				// Local lists will be fetched here.
 				$stored_list = new Subscription_List( $list['id'] );
 			} else {

--- a/includes/service-providers/class-newspack-newsletters-service-provider.php
+++ b/includes/service-providers/class-newspack-newsletters-service-provider.php
@@ -434,7 +434,7 @@ abstract class Newspack_Newsletters_Service_Provider implements Newspack_Newslet
 	 * @return array|WP_Error Contact data if it was added, or error otherwise.
 	 */
 	public function add_contact_handling_local_lists( $contact, $list_id ) {
-		if ( Subscription_List::is_form_id( $list_id ) ) {
+		if ( Subscription_List::is_local_form_id( $list_id ) ) {
 			try {
 				$list = new Subscription_List( $list_id );
 
@@ -508,7 +508,7 @@ abstract class Newspack_Newsletters_Service_Provider implements Newspack_Newslet
 	 */
 	public function update_contact_local_lists( $email, $lists = [], $action = 'add' ) {
 		foreach ( $lists as $key => $list_id ) {
-			if ( Subscription_List::is_form_id( $list_id ) ) {
+			if ( Subscription_List::is_local_form_id( $list_id ) ) {
 				try {
 					$list = new Subscription_List( $list_id );
 

--- a/includes/service-providers/class-newspack-newsletters-service-provider.php
+++ b/includes/service-providers/class-newspack-newsletters-service-provider.php
@@ -436,7 +436,7 @@ abstract class Newspack_Newsletters_Service_Provider implements Newspack_Newslet
 	public function add_contact_handling_local_lists( $contact, $list_id ) {
 		if ( Subscription_List::is_local_form_id( $list_id ) ) {
 			try {
-				$list = new Subscription_List( $list_id );
+				$list = Subscription_List::from_form_id( $list_id );
 
 				if ( ! $list->is_configured_for_provider( $this->service ) ) {
 					return new WP_Error( 'List not properly configured for the provider' );
@@ -510,7 +510,7 @@ abstract class Newspack_Newsletters_Service_Provider implements Newspack_Newslet
 		foreach ( $lists as $key => $list_id ) {
 			if ( Subscription_List::is_local_form_id( $list_id ) ) {
 				try {
-					$list = new Subscription_List( $list_id );
+					$list = Subscription_List::from_form_id( $list_id );
 
 					if ( ! $list->is_configured_for_provider( $this->service ) ) {
 						return new WP_Error( 'List not properly configured for the provider' );

--- a/includes/service-providers/class-newspack-newsletters-service-provider.php
+++ b/includes/service-providers/class-newspack-newsletters-service-provider.php
@@ -547,6 +547,9 @@ abstract class Newspack_Newsletters_Service_Provider implements Newspack_Newslet
 		$lists = Subscription_Lists::get_configured_for_provider( $this->service );
 		$ids   = [];
 		foreach ( $lists as $list ) {
+			if ( ! $list->is_local() ) {
+				continue;
+			}
 			$list_settings = $list->get_provider_settings( $this->service );
 			if ( in_array( $list_settings['tag_id'], $tags, false ) ) { // phpcs:ignore WordPress.PHP.StrictInArray.FoundNonStrictFalse
 				$ids[] = $list->get_form_id();

--- a/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp.php
+++ b/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp.php
@@ -1380,7 +1380,7 @@ final class Newspack_Newsletters_Mailchimp extends \Newspack_Newsletters_Service
 	 *
 	 * This allows us to make reference to provider specific features in the way the user is used to see them in the provider's UI
 	 *
-	 * @param mixed $context The context in which the labels are being applied.
+	 * @param string $context The context in which the labels are being applied.
 	 * @return array
 	 */
 	public static function get_labels( $context = '' ) {
@@ -1398,7 +1398,7 @@ final class Newspack_Newsletters_Mailchimp extends \Newspack_Newsletters_Service
 			// translators: %s is the name of the group category. "Newspack newsletters" by default.
 			'tag_metabox_after_save'  => sprintf( __( 'Group created for this list under %s:', 'newspack-newsletters' ), self::get_group_category_name() ),
 		];
-		if ( ! empty( $context['id'] ) && strpos( $context['id'], 'group-' ) === 0 ) {
+		if ( ! empty( $context ) && strpos( $context, 'group-' ) === 0 ) {
 			$labels['list_explanation'] = __( 'Mailchimp Group', 'newspack-newsletters' );
 		}
 		return $labels;

--- a/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp.php
+++ b/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp.php
@@ -1364,6 +1364,9 @@ final class Newspack_Newsletters_Mailchimp extends \Newspack_Newsletters_Service
 		$lists = Subscription_Lists::get_configured_for_provider( $this->service );
 		$ids   = [];
 		foreach ( $lists as $list ) {
+			if ( ! $list->is_local() ) {
+				continue;
+			}
 			$list_settings = $list->get_provider_settings( $this->service );
 
 			if ( ! empty( $tags[ $list_settings['list'] ] ) ) {

--- a/tests/test-subscription-list.php
+++ b/tests/test-subscription-list.php
@@ -6,7 +6,6 @@
  */
 
 use Newspack\Newsletters\Subscription_List;
-use Newspack_Newsletters;
 
 /**
  * Tests the Subscription_List class

--- a/tests/test-subscription-list.php
+++ b/tests/test-subscription-list.php
@@ -502,6 +502,16 @@ class Subscription_List_Test extends WP_UnitTestCase {
 		$this->assertSame( false, $list->is_local() );
 		$this->assertSame( 'mailchimp', $list->get_provider() );
 		$this->assertSame( 'xyz-' . $list->get_id(), $list->get_remote_id() );
+
+		$list = new Subscription_List( self::$posts['remote_active_campaign'] );
+		$this->assertTrue( $list->is_configured_for_provider( 'active_campaign' ) );
+		$this->assertFalse( $list->is_configured_for_provider( 'mailchimp' ) );
+		$this->assertSame( 'remote', $list->get_type() );
+		$this->assertSame( (string) self::$conflicting_post_id, $list->get_form_id() );
+		$this->assertSame( true, $list->is_active() );
+		$this->assertSame( false, $list->is_local() );
+		$this->assertSame( 'active_campaign', $list->get_provider() );
+		$this->assertSame( (string) self::$conflicting_post_id, $list->get_remote_id() );
 	}
 
 	/**

--- a/tests/test-subscription-list.php
+++ b/tests/test-subscription-list.php
@@ -89,14 +89,14 @@ class Subscription_List_Test extends WP_UnitTestCase {
 	 * Tests the form ID static methods
 	 *
 	 * @param mixed $input The input for the methods.
-	 * @param mixed $is_form_id The expected result of is_form_id.
-	 * @param mixed $extracted_id The expected result of get_id_from_form_id.
+	 * @param mixed $is_local_form_id The expected result of is_local_form_id.
+	 * @param mixed $extracted_id The expected result of get_id_from_local_form_id.
 	 * @return void
 	 * @dataProvider static_methods_data
 	 */
-	public function test_static_methods( $input, $is_form_id, $extracted_id ) {
-		$this->assertSame( $is_form_id, Subscription_List::is_form_id( $input ) );
-		$this->assertSame( $extracted_id, Subscription_List::get_id_from_form_id( $input ) );
+	public function test_static_methods( $input, $is_local_form_id, $extracted_id ) {
+		$this->assertSame( $is_local_form_id, Subscription_List::is_local_form_id( $input ) );
+		$this->assertSame( $extracted_id, Subscription_List::get_id_from_local_form_id( $input ) );
 	}
 
 	/**

--- a/tests/test-subscription-list.php
+++ b/tests/test-subscription-list.php
@@ -123,10 +123,36 @@ class Subscription_List_Test extends WP_UnitTestCase {
 	 * Tests constructor with form_id
 	 */
 	public function test_constructor_with_form_id() {
-		$list = new Subscription_List( Subscription_List::FORM_ID_PREFIX . self::$posts['without_settings'] );
+		$list = Subscription_List::from_form_id( Subscription_List::FORM_ID_PREFIX . self::$posts['without_settings'] );
 		$this->assertInstanceOf( Subscription_List::class, $list );
 		$this->assertSame( self::$posts['without_settings'], $list->get_id() );
 		$this->assertSame( 'Description 1', $list->get_description() );
+	}
+
+	/**
+	 * Tests constructor with form_id
+	 */
+	public function test_constructor_with_non_existent_form_id() {
+		$list = Subscription_List::from_form_id( 'asdqwe' );
+		$this->assertNull( $list );
+	}
+
+	/**
+	 * Tests constructor with remote_id
+	 */
+	public function test_constructor_with_remote_id() {
+		$list = Subscription_List::from_remote_id( 'xyz-' . self::$posts['remote_mailchimp'] );
+		$this->assertInstanceOf( Subscription_List::class, $list );
+		$this->assertSame( self::$posts['remote_mailchimp'], $list->get_id() );
+		$this->assertSame( 'Description 5', $list->get_description() );
+	}
+
+	/**
+	 * Tests constructor with remote_id
+	 */
+	public function test_constructor_with_non_existent_remote_id() {
+		$list = Subscription_List::from_remote_id( 'asdqwe' );
+		$this->assertNull( $list );
 	}
 
 	/**

--- a/tests/test-subscription-lists.php
+++ b/tests/test-subscription-lists.php
@@ -230,4 +230,77 @@ class Subscription_Lists_Test extends WP_UnitTestCase {
 
 	}
 
+	/**
+	 * Test the migration method
+	 */
+	public function test_migration() {
+		$active_campaign = [
+			'123' => [
+				'active'      => true,
+				'title'       => 'AC1',
+				'description' => 'ac 1',
+			],
+			'456' => [
+				'active'      => false,
+				'title'       => 'AC2',
+				'description' => 'ac 2',
+			],
+		];
+		$mailchimp       = [
+			'950aaf1a98'                  => [
+				'active'      => true,
+				'title'       => 'MC1',
+				'description' => 'mc 1',
+			],
+			'group-6a822fca1c-950aaf1a98' => [
+				'active'      => false,
+				'title'       => 'MC2',
+				'description' => 'mc 2',
+			],
+			'120aaf1a12'                  => [
+				'active'      => true,
+				'title'       => 'MC3',
+				'description' => 'mc 3',
+			],
+		];
+
+		update_option( '_newspack_newsletters_mailchimp_lists', $mailchimp );
+		update_option( '_newspack_newsletters_active_campaign_lists', $active_campaign );
+
+		delete_option( '_newspack_newsletters_lists_migrated' );
+
+		Subscription_Lists::migrate_lists();
+
+		$list = Subscription_Lists::get_list_by_remote_id( '123' );
+		$this->assertSame( 'AC1', $list->get_title() );
+		$this->assertSame( 'ac 1', $list->get_description() );
+		$this->assertTrue( $list->is_active() );
+		$this->assertSame( 'active_campaign', $list->get_provider() );
+
+		$list = Subscription_Lists::get_list_by_remote_id( '456' );
+		$this->assertSame( 'AC2', $list->get_title() );
+		$this->assertSame( 'ac 2', $list->get_description() );
+		$this->assertFalse( $list->is_active() );
+		$this->assertSame( 'active_campaign', $list->get_provider() );
+
+		$list = Subscription_Lists::get_list_by_remote_id( '950aaf1a98' );
+		$this->assertSame( 'MC1', $list->get_title() );
+		$this->assertSame( 'mc 1', $list->get_description() );
+		$this->assertTrue( $list->is_active() );
+		$this->assertSame( 'mailchimp', $list->get_provider() );
+
+		$list = Subscription_Lists::get_list_by_remote_id( 'group-6a822fca1c-950aaf1a98' );
+		$this->assertSame( 'MC2', $list->get_title() );
+		$this->assertSame( 'mc 2', $list->get_description() );
+		$this->assertFalse( $list->is_active() );
+		$this->assertSame( 'mailchimp', $list->get_provider() );
+
+		$list = Subscription_Lists::get_list_by_remote_id( '120aaf1a12' );
+		$this->assertSame( 'MC3', $list->get_title() );
+		$this->assertSame( 'mc 3', $list->get_description() );
+		$this->assertTrue( $list->is_active() );
+		$this->assertSame( 'mailchimp', $list->get_provider() );
+
+	}
+
 }

--- a/tests/test-subscription-lists.php
+++ b/tests/test-subscription-lists.php
@@ -21,7 +21,7 @@ class Subscription_Lists_Test extends WP_UnitTestCase {
 	 */
 	public function test_get_all() {
 		$all = Subscription_Lists::get_all();
-		$this->assertSame( 4, count( $all ) );
+		$this->assertSame( 6, count( $all ) );
 	}
 
 	/**
@@ -29,7 +29,7 @@ class Subscription_Lists_Test extends WP_UnitTestCase {
 	 */
 	public function test_get_configured_for_provider() {
 		$all = Subscription_Lists::get_configured_for_provider( 'mailchimp' );
-		$this->assertSame( 2, count( $all ) );
+		$this->assertSame( 4, count( $all ) );
 		foreach ( $all as $list ) {
 			$this->assertInstanceOf( Subscription_List::class, $list );
 			$this->assertTrue( $list->is_configured_for_provider( 'mailchimp' ) );
@@ -52,7 +52,7 @@ class Subscription_Lists_Test extends WP_UnitTestCase {
 	public function test_get_configured_for_current_provider() {
 		Newspack_Newsletters::set_service_provider( 'mailchimp' );
 		$all = Subscription_Lists::get_configured_for_current_provider();
-		$this->assertSame( 2, count( $all ) );
+		$this->assertSame( 4, count( $all ) );
 		foreach ( $all as $list ) {
 			$this->assertInstanceOf( Subscription_List::class, $list );
 			$this->assertTrue( $list->is_configured_for_provider( 'mailchimp' ) );
@@ -85,6 +85,132 @@ class Subscription_Lists_Test extends WP_UnitTestCase {
 		$this->assertSame( 1, count( $all ) );
 		$this->assertSame( $id, $all[0]->get_id() );
 		
+	}
+
+	/**
+	 * Test get_list_by_remote_id
+	 */
+	public function test_get_list_by_remote_id() {
+		$existing = 'xyz-' . self::$posts['remote_mailchimp'];
+		$found    = Subscription_Lists::get_list_by_remote_id( $existing );
+		$this->assertSame( self::$posts['remote_mailchimp'], $found->get_id() );
+		$this->assertSame( 'mailchimp', $found->get_provider() );
+		$this->assertSame( $existing, $found->get_remote_id() );
+
+		$non_existing = 'asdqwe';
+		$found        = Subscription_Lists::get_list_by_remote_id( $non_existing );
+		$this->assertNull( $found );
+	}
+
+	/**
+	 * Test create_remote_list
+	 */
+	public function test_create_remote_list() {
+		$current_provider = Newspack_Newsletters::get_service_provider();
+		$remote_id        = 'xyz-123';
+		$title            = 'Test Remote List';
+		$list             = Subscription_Lists::create_remote_list( $remote_id, $title );
+		$this->assertSame( $remote_id, $list->get_remote_id() );
+		$this->assertSame( $title, $list->get_title() );
+		$this->assertSame( 'remote', $list->get_type() );
+		$this->assertSame( $current_provider->service, $list->get_provider() );
+
+		$check = Subscription_Lists::get_list_by_remote_id( $remote_id );
+		$this->assertSame( $check->get_id(), $list->get_id() );
+	}
+
+	/**
+	 * Test get_remote_list
+	 */
+	public function test_get_remote_list() {
+
+		$count = count( Subscription_Lists::get_all() );
+
+		// existing.
+		$existing = [
+			'id'   => 'xyz-' . self::$posts['remote_mailchimp'],
+			'name' => 'Remote mailchimp new title',
+		];
+		$list     = Subscription_Lists::get_remote_list( $existing );
+		$this->assertSame( self::$posts['remote_mailchimp'], $list->get_id() );
+		$this->assertSame( 'Test List 5', $list->get_title() );
+
+		$count_after_existing = count( Subscription_Lists::get_all() );
+		$this->assertSame( $count, $count_after_existing );
+
+		
+		// new.
+		Newspack_Newsletters::set_service_provider( 'active_campaign' );
+		$new  = [
+			'id'   => 'xyz-abcde',
+			'name' => 'New random list',
+		];
+		$list = Subscription_Lists::get_remote_list( $new );
+		$this->assertSame( 'New random list', $list->get_title() );
+		$this->assertSame( 'xyz-abcde', $list->get_remote_id() );
+		$this->assertSame( 'active_campaign', $list->get_provider() );
+
+		$count_after_new = count( Subscription_Lists::get_all() );
+		$this->assertSame( $count + 1, $count_after_new );
+	}
+
+	/**
+	 * Test update_lists method
+	 *
+	 * @return void
+	 */
+	public function test_update() {
+		
+		$new_lists = [
+			[
+				'id'   => self::$posts['only_mailchimp'],
+				'name' => 'New title',
+			],
+			[
+				'id'     => 'xyz-' . self::$posts['remote_mailchimp'],
+				'name'   => 'Remote mailchimp new title',
+				'active' => false,
+			],
+			[
+				'id'   => 'xyz-abcde',
+				'name' => 'New random list',
+			],
+		];
+
+		Subscription_Lists::update_lists( $new_lists );
+
+		$count = count( Subscription_Lists::get_all() );
+
+		// 3 local lists should be marked as deactivated.
+		// 1 remote list should be deleted and one should be added.
+		$this->assertSame( 6, $count );
+
+		$list = new Subscription_List( self::$posts['without_settings'] );
+		$this->assertSame( false, $list->is_active() );
+
+		$list = new Subscription_List( self::$posts['two_settings'] );
+		$this->assertSame( false, $list->is_active() );
+
+		$list = new Subscription_List( self::$posts['mc_invalid'] );
+		$this->assertSame( false, $list->is_active() );
+
+		$list = new Subscription_List( self::$posts['only_mailchimp'] );
+		$this->assertSame( true, $list->is_active() );
+		$this->assertSame( 'New title', $list->get_title() );
+		$this->assertSame( self::$posts['only_mailchimp'], $list->get_id() );
+
+		$list = Subscription_Lists::get_list_by_remote_id( 'xyz-' . self::$posts['remote_mailchimp'] );
+		$this->assertSame( false, $list->is_active() );
+		$this->assertSame( 'Remote mailchimp new title', $list->get_title() );
+		$this->assertSame( self::$posts['remote_mailchimp'], $list->get_id() );
+
+		$list = Subscription_Lists::get_list_by_remote_id( 'xyz-' . self::$posts['remote_mailchimp_inactive'] );
+		$this->assertNull( $list );
+
+		$list = Subscription_Lists::get_list_by_remote_id( 'xyz-abcde' );
+		$this->assertSame( true, $list->is_active() );
+		$this->assertSame( 'New random list', $list->get_title() );
+
 	}
 
 }

--- a/tests/test-subscription-lists.php
+++ b/tests/test-subscription-lists.php
@@ -7,7 +7,6 @@
 
 use Newspack\Newsletters\Subscription_List;
 use Newspack\Newsletters\Subscription_Lists;
-use Newspack_Newsletters;
 
 /**
  * Tests the Subscription_List class
@@ -128,8 +127,8 @@ class Subscription_Lists_Test extends WP_UnitTestCase {
 
 		// existing.
 		$existing = [
-			'id'   => 'xyz-' . self::$posts['remote_mailchimp'],
-			'name' => 'Remote mailchimp new title',
+			'id'    => 'xyz-' . self::$posts['remote_mailchimp'],
+			'title' => 'Remote mailchimp new title',
 		];
 		$list     = Subscription_Lists::get_remote_list( $existing );
 		$this->assertSame( self::$posts['remote_mailchimp'], $list->get_id() );
@@ -142,8 +141,8 @@ class Subscription_Lists_Test extends WP_UnitTestCase {
 		// new.
 		Newspack_Newsletters::set_service_provider( 'active_campaign' );
 		$new  = [
-			'id'   => 'xyz-abcde',
-			'name' => 'New random list',
+			'id'    => 'xyz-abcde',
+			'title' => 'New random list',
 		];
 		$list = Subscription_Lists::get_remote_list( $new );
 		$this->assertSame( 'New random list', $list->get_title() );
@@ -160,20 +159,23 @@ class Subscription_Lists_Test extends WP_UnitTestCase {
 	 * @return void
 	 */
 	public function test_update() {
-		
+
+		Newspack_Newsletters::set_service_provider( 'mailchimp' );
+
 		$new_lists = [
 			[
-				'id'   => self::$posts['only_mailchimp'],
-				'name' => 'New title',
+				'id'    => self::$posts['only_mailchimp'],
+				'title' => 'New title',
 			],
 			[
 				'id'     => 'xyz-' . self::$posts['remote_mailchimp'],
-				'name'   => 'Remote mailchimp new title',
+				'title'  => 'Remote mailchimp new title',
 				'active' => false,
 			],
 			[
-				'id'   => 'xyz-abcde',
-				'name' => 'New random list',
+				'id'     => 'xyz-abcde',
+				'title'  => 'New random list',
+				'active' => true,
 			],
 		];
 
@@ -195,7 +197,7 @@ class Subscription_Lists_Test extends WP_UnitTestCase {
 		$this->assertSame( false, $list->is_active() );
 
 		$list = new Subscription_List( self::$posts['only_mailchimp'] );
-		$this->assertSame( true, $list->is_active() );
+		$this->assertSame( false, $list->is_active(), 'If active is not informed it should be set to false' );
 		$this->assertSame( 'New title', $list->get_title() );
 		$this->assertSame( self::$posts['only_mailchimp'], $list->get_id() );
 

--- a/tests/test-subscription-lists.php
+++ b/tests/test-subscription-lists.php
@@ -91,13 +91,13 @@ class Subscription_Lists_Test extends WP_UnitTestCase {
 	 */
 	public function test_get_list_by_remote_id() {
 		$existing = 'xyz-' . self::$posts['remote_mailchimp'];
-		$found    = Subscription_Lists::get_list_by_remote_id( $existing );
+		$found    = Subscription_List::from_form_id( $existing );
 		$this->assertSame( self::$posts['remote_mailchimp'], $found->get_id() );
 		$this->assertSame( 'mailchimp', $found->get_provider() );
 		$this->assertSame( $existing, $found->get_remote_id() );
 
 		$non_existing = 'asdqwe';
-		$found        = Subscription_Lists::get_list_by_remote_id( $non_existing );
+		$found        = Subscription_List::from_form_id( $non_existing );
 		$this->assertNull( $found );
 	}
 
@@ -114,14 +114,14 @@ class Subscription_Lists_Test extends WP_UnitTestCase {
 		$this->assertSame( 'remote', $list->get_type() );
 		$this->assertSame( $current_provider->service, $list->get_provider() );
 
-		$check = Subscription_Lists::get_list_by_remote_id( $remote_id );
+		$check = Subscription_List::from_form_id( $remote_id );
 		$this->assertSame( $check->get_id(), $list->get_id() );
 	}
 
 	/**
-	 * Test get_remote_list
+	 * Test get_or_create_remote_list
 	 */
-	public function test_get_remote_list() {
+	public function test_get_or_create_remote_list() {
 
 		$count = count( Subscription_Lists::get_all() );
 
@@ -130,7 +130,7 @@ class Subscription_Lists_Test extends WP_UnitTestCase {
 			'id'    => 'xyz-' . self::$posts['remote_mailchimp'],
 			'title' => 'Remote mailchimp new title',
 		];
-		$list     = Subscription_Lists::get_remote_list( $existing );
+		$list     = Subscription_Lists::get_or_create_remote_list( $existing );
 		$this->assertSame( self::$posts['remote_mailchimp'], $list->get_id() );
 		$this->assertSame( 'Test List 5', $list->get_title() );
 
@@ -144,7 +144,7 @@ class Subscription_Lists_Test extends WP_UnitTestCase {
 			'id'    => 'xyz-abcde',
 			'title' => 'New random list',
 		];
-		$list = Subscription_Lists::get_remote_list( $new );
+		$list = Subscription_Lists::get_or_create_remote_list( $new );
 		$this->assertSame( 'New random list', $list->get_title() );
 		$this->assertSame( 'xyz-abcde', $list->get_remote_id() );
 		$this->assertSame( 'active_campaign', $list->get_provider() );
@@ -210,20 +210,20 @@ class Subscription_Lists_Test extends WP_UnitTestCase {
 		$this->assertSame( 'New title', $list->get_title() );
 		$this->assertSame( self::$posts['only_mailchimp'], $list->get_id() );
 
-		$list = Subscription_Lists::get_list_by_remote_id( 'xyz-' . self::$posts['remote_mailchimp'] );
+		$list = Subscription_List::from_form_id( 'xyz-' . self::$posts['remote_mailchimp'] );
 		$this->assertSame( false, $list->is_active() );
 		$this->assertSame( 'Remote mailchimp new title', $list->get_title() );
 		$this->assertSame( self::$posts['remote_mailchimp'], $list->get_id() );
 
-		$list = Subscription_Lists::get_list_by_remote_id( 'xyz-' . self::$posts['remote_mailchimp_inactive'] );
+		$list = Subscription_List::from_form_id( 'xyz-' . self::$posts['remote_mailchimp_inactive'] );
 		$this->assertSame( false, $list->is_active() );
 		$this->assertSame( self::$posts['remote_mailchimp_inactive'], $list->get_id() );
 
-		$list = Subscription_Lists::get_list_by_remote_id( 'xyz-abcde' );
+		$list = Subscription_List::from_form_id( 'xyz-abcde' );
 		$this->assertSame( true, $list->is_active() );
 		$this->assertSame( 'New random list', $list->get_title() );
 
-		$list = Subscription_Lists::get_list_by_remote_id( self::$conflicting_post_id );
+		$list = Subscription_List::from_form_id( self::$conflicting_post_id );
 		$this->assertSame( true, $list->is_active() );
 		$this->assertSame( 'New title for AC', $list->get_title() );
 		$this->assertSame( self::$posts['remote_active_campaign'], $list->get_id() );
@@ -271,31 +271,31 @@ class Subscription_Lists_Test extends WP_UnitTestCase {
 
 		Subscription_Lists::migrate_lists();
 
-		$list = Subscription_Lists::get_list_by_remote_id( '123' );
+		$list = Subscription_List::from_form_id( '123' );
 		$this->assertSame( 'AC1', $list->get_title() );
 		$this->assertSame( 'ac 1', $list->get_description() );
 		$this->assertTrue( $list->is_active() );
 		$this->assertSame( 'active_campaign', $list->get_provider() );
 
-		$list = Subscription_Lists::get_list_by_remote_id( '456' );
+		$list = Subscription_List::from_form_id( '456' );
 		$this->assertSame( 'AC2', $list->get_title() );
 		$this->assertSame( 'ac 2', $list->get_description() );
 		$this->assertFalse( $list->is_active() );
 		$this->assertSame( 'active_campaign', $list->get_provider() );
 
-		$list = Subscription_Lists::get_list_by_remote_id( '950aaf1a98' );
+		$list = Subscription_List::from_form_id( '950aaf1a98' );
 		$this->assertSame( 'MC1', $list->get_title() );
 		$this->assertSame( 'mc 1', $list->get_description() );
 		$this->assertTrue( $list->is_active() );
 		$this->assertSame( 'mailchimp', $list->get_provider() );
 
-		$list = Subscription_Lists::get_list_by_remote_id( 'group-6a822fca1c-950aaf1a98' );
+		$list = Subscription_List::from_form_id( 'group-6a822fca1c-950aaf1a98' );
 		$this->assertSame( 'MC2', $list->get_title() );
 		$this->assertSame( 'mc 2', $list->get_description() );
 		$this->assertFalse( $list->is_active() );
 		$this->assertSame( 'mailchimp', $list->get_provider() );
 
-		$list = Subscription_Lists::get_list_by_remote_id( '120aaf1a12' );
+		$list = Subscription_List::from_form_id( '120aaf1a12' );
 		$this->assertSame( 'MC3', $list->get_title() );
 		$this->assertSame( 'mc 3', $list->get_description() );
 		$this->assertTrue( $list->is_active() );

--- a/tests/trait-lists-setup.php
+++ b/tests/trait-lists-setup.php
@@ -76,7 +76,20 @@ trait Lists_Setup {
 			]
 		);
 
-		self::$posts = compact( 'without_settings', 'only_mailchimp', 'two_settings', 'mc_invalid' );
+		$remote_mailchimp      = self::create_post( 5 );
+		$remote_mailchimp_list = new Subscription_List( $remote_mailchimp );
+		$remote_mailchimp_list->set_remote_id( 'xyz-' . $remote_mailchimp );
+		$remote_mailchimp_list->set_type( 'remote' );
+		$remote_mailchimp_list->set_provider( 'mailchimp' );
+
+		$remote_mailchimp_inactive      = self::create_post( 6 );
+		$remote_mailchimp_inactive_list = new Subscription_List( $remote_mailchimp_inactive );
+		$remote_mailchimp_inactive_list->set_remote_id( 'xyz-' . $remote_mailchimp_inactive );
+		$remote_mailchimp_inactive_list->set_type( 'remote' );
+		$remote_mailchimp_inactive_list->set_provider( 'mailchimp' );
+		$remote_mailchimp_inactive_list->update( [ 'active' => false ] );
+
+		self::$posts = compact( 'without_settings', 'only_mailchimp', 'two_settings', 'mc_invalid', 'remote_mailchimp', 'remote_mailchimp_inactive' );
 	}
 
 	/**

--- a/tests/trait-lists-setup.php
+++ b/tests/trait-lists-setup.php
@@ -21,6 +21,13 @@ trait Lists_Setup {
 	public static $posts;
 
 	/**
+	 * Testing a post that could conlfict with the ID of a list
+	 *
+	 * @var int
+	 */
+	public static $conflicting_post_id;
+
+	/**
 	 * Sets up testing data
 	 *
 	 * @return void
@@ -89,7 +96,23 @@ trait Lists_Setup {
 		$remote_mailchimp_inactive_list->set_provider( 'mailchimp' );
 		$remote_mailchimp_inactive_list->update( [ 'active' => false ] );
 
-		self::$posts = compact( 'without_settings', 'only_mailchimp', 'two_settings', 'mc_invalid', 'remote_mailchimp', 'remote_mailchimp_inactive' );
+		/**
+		 * The list and post below make sure that the remote list ID is not confused with the post ID when it is an integer and matches with an existing post.
+		 */
+		self::$conflicting_post_id   = wp_insert_post(
+			[
+				'post_title'  => 'Simple Post',
+				'post_type'   => 'post',
+				'post_status' => 'publish',
+			]
+		);
+		$remote_active_campaign      = self::create_post( 7 );
+		$remote_active_campaign_list = new Subscription_List( $remote_active_campaign );
+		$remote_active_campaign_list->set_remote_id( self::$conflicting_post_id ); // Active campaign has integer IDs, lets make sure they dont get messed up with post IDs.
+		$remote_active_campaign_list->set_type( 'remote' );
+		$remote_active_campaign_list->set_provider( 'active_campaign' );
+
+		self::$posts = compact( 'without_settings', 'only_mailchimp', 'two_settings', 'mc_invalid', 'remote_mailchimp', 'remote_mailchimp_inactive', 'remote_active_campaign' );
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

This PR refactors how we store the lists configuration.

Instead of saving the lists configuration as an option in the database, we now create a custom post for each list. We are using the same post type used to store "local" lists, but it has been extended so it now also serves to store "remote" lists.

"local" lists are those lists that are created via wp-admin. When we create a local list, the plugin creates a tag (or group) in the ESP
"remote" lists are the lists that are dynamically fetched from the ESP. Those lists are always managed in the ESP. Users can set an alternate title and description for them, but this information is used only in the site and is not sent to the ESP.

Everytime a user visits the admin page:
* we fetch all the lists from the ESP
* we get a post that represents that list in the local database (the custom post). If the post doesn't exist yet, we create it
* We store the ID the list has in the ESP as a metadata called "remote_id"
* We allow lists to be enabled or disabled, represented by the post status publish or draft

Test migration:
* On master, select a provider and set up a couple of lists
* Make sure the migration flag does not exist `wp option delete _newspack_newsletters_lists_migrated`
* Checkout this branch and confirm the lists configuration is still the same
* Repeat with a couple of providers and with some local lists in the mix

Local lists are still treated the same. The difference is that we now handle the activation/deactivation by changing the post status. Same thing we do with the remote lists.

We don't use the configuration options we used to have any more.

### How to test the changes in this Pull Request:

Test everything related to list management:

1. Set up the provider as Mailchimp
2. Enable a couple of lists and customize their titles and descriptions
3. Set up a subscription block and confirm it works
4. Check that both the Newsletters > Settings UI and the Newspack wizard UI work the same way
5. Create a local list and confirm it works as expected
6. Try activating and deactivating different lists
7. Change to Active Campaign
8. Do all the tests again, inlcuding local lists
9. Switch back to Mailchimp
10. Confirm that the title customizations and the local lists you had created before a back
11. Test Campaign Monitor and confirm it works (provider that don't support local lists)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
