### PR TITLE
fix: allow multiple subscribe forms to be submitted on one page

### DIFF
--- a/src/blocks/subscribe/index.php
+++ b/src/blocks/subscribe/index.php
@@ -322,8 +322,12 @@ function send_form_response( $data ) {
  * Process newsletter signup form.
  */
 function process_form() {
-	if ( ! isset( $_REQUEST[ FORM_ACTION ] ) || ! \wp_verify_nonce( \sanitize_text_field( $_REQUEST[ FORM_ACTION ] ), FORM_ACTION ) ) {
+	if ( ! isset( $_REQUEST[ FORM_ACTION ] ) ) {
 		return;
+	}
+
+	if ( ! \wp_verify_nonce( \sanitize_text_field( $_REQUEST[ FORM_ACTION ] ), FORM_ACTION ) ) {
+		return send_form_response( new \WP_Error( 'invalid_nonce', __( 'Invalid request.', 'newspack-newsletters' ) ) );
 	}
 
 	// Honeypot trap.
@@ -397,6 +401,9 @@ function process_form() {
 	 * @param array          $metadata Some metadata about the subscription. Always contains `current_page_url`, `newspack_popup_id` and `newsletters_subscription_method` keys.
 	 */
 	\do_action( 'newspack_newsletters_subscribe_form_processed', $email, $result, $metadata );
+
+	// Generate a new nonce for subsequent form submissions.
+	$result[ FORM_ACTION ] = \wp_create_nonce( FORM_ACTION );
 
 	return send_form_response( $result );
 }

--- a/src/blocks/subscribe/style.scss
+++ b/src/blocks/subscribe/style.scss
@@ -149,6 +149,18 @@
 		}
 	}
 
+	&__message {
+		p {
+			font-size: 0.8em;
+			margin-top: 8px;
+
+			&.status-400,
+			&.status-500 {
+				color: wp-colors.$alert-red;
+			}
+		}
+	}
+
 	.nphp {
 		border: 0;
 		clip: rect( 1px, 1px, 1px, 1px );

--- a/src/blocks/subscribe/view.js
+++ b/src/blocks/subscribe/view.js
@@ -4,6 +4,8 @@
  */
 import './style.scss';
 
+let nonce;
+
 /**
  * Specify a function to execute when the DOM is fully loaded.
  *
@@ -115,6 +117,9 @@ domReady( function () {
 					if ( ! body.has( 'npe' ) || ! body.get( 'npe' ) ) {
 						return form.endFlow( newspack_newsletters_subscribe_block.invalid_email, 400 );
 					}
+					if ( nonce ) {
+						body.set( 'newspack_newsletters_subscribe', nonce );
+					}
 					emailInput.setAttribute( 'disabled', 'true' );
 					submit.setAttribute( 'disabled', 'true' );
 
@@ -125,9 +130,18 @@ domReady( function () {
 						},
 						body,
 					} ).then( res => {
-						res.json().then( ( { message, newspack_newsletters_subscribed: wasSubscribed } ) => {
-							form.endFlow( message, res.status, wasSubscribed );
-						} );
+						res
+							.json()
+							.then(
+								( {
+									message,
+									newspack_newsletters_subscribed: wasSubscribed,
+									newspack_newsletters_subscribe,
+								} ) => {
+									nonce = newspack_newsletters_subscribe;
+									form.endFlow( message, res.status, wasSubscribed );
+								}
+							);
 					} );
 				} );
 		} );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes a bug where if more than one Newsletter Subscription Form block exists on a single page, and signing up for one form results in a new reader account registration, submissions of other form instances will fail due to the initial nonce value being invalidated by the first form submission.

Closes `1200550061930446/1205129530451151`.

### How to test the changes in this Pull Request:

1. On `master`, using a RAS-enabled site, create a post or page that contains more than one Newsletter Subscription form, each one pointing to a different list or group in your ESP.
2. In a new session, sign up for a newsletter using a new email address. Then, without refreshing the page, sign up for another newsletter using a different form but the same email address and observe a JS console error and a hanging "disabled" state in the form:

```
Uncaught (in promise) SyntaxError: Unexpected token '<', "<!doctype "... is not valid JSON
```

3. Check out this branch and repeat step 2 with a new email address. Confirm that you're able to submit both forms without refreshing the page.
4. Repeat step 3 again in a new browser session but using the same email address (to test that it also works with pre-existing registered accounts).
5. Also confirm that the reader account is actually signed up for all of the newsletters (and only the ones) you signed up for via the different forms.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
