### PR TITLE
Add API-KEY to header in Active Campaign api_v1_request

### DIFF
--- a/includes/service-providers/active_campaign/class-newspack-newsletters-active-campaign.php
+++ b/includes/service-providers/active_campaign/class-newspack-newsletters-active-campaign.php
@@ -169,6 +169,7 @@ final class Newspack_Newsletters_Active_Campaign extends \Newspack_Newsletters_S
 			'headers' => [
 				'Content-Type' => $content_type,
 				'Accept'       => 'application/json',
+				'API-TOKEN'	   => $credentials['key'],
 			],
 			'body'    => $body,
 		];


### PR DESCRIPTION
Active Campaign has started returning 403 forbidden if the API-KEY is not in the header of the request. This fixes the issue.

### All Submissions:

* [X] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [X] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

The Active Campaign V1 API has started returning a 403 forbidden error when the API key is passed in the body of the request, but it works if it's in the header. 

See: 
https://community.activecampaign.com/t/acces-suddenly-refuses/21272
https://community.activecampaign.com/t/activecampaign-api-v1-403-error/21273

This PR adds the API-KEY to the header of the request in api_v1_request.

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes # .

### How to test the changes in this Pull Request:

Current version:
1. Create a new newsletter using Active Campaign as the ESP
2. Attempt to send a test email. Observe the returned "undefined" error.

This version
3. Create a new newsletter using Active Campaign as the ESP
4. Attempt to send a test email. Observe the a test email is successfully sent.

Closes issue #1239 

### Other information:

* [X] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [X] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
