### PR TITLE
feat: preview html

### DIFF
--- a/src/components/send-button/index.js
+++ b/src/components/send-button/index.js
@@ -21,20 +21,22 @@ import { getServiceProvider } from '../../service-providers';
 import './style.scss';
 
 function PreviewHTML() {
-	const { meta, isSavingPost } = useSelect( select => {
+	const { meta, isSavingPost, isAutoSavingPost } = useSelect( select => {
 		return {
 			meta: select( 'core/editor' ).getCurrentPostAttribute( 'meta' ),
 			isSavingPost: select( 'core/editor' ).isSavingPost(),
+			isAutoSavingPost: select( 'core/editor' ).isAutosavingPost(),
 		};
 	} );
+	const showSpinner = isSavingPost && ! isAutoSavingPost;
 	return (
 		<div className="newsletter-preview-html">
-			{ isSavingPost && (
+			{ showSpinner && (
 				<div className="newsletter-preview-html__spinner">
 					<Spinner />
 				</div>
 			) }
-			{ ! isSavingPost && meta?.newspack_email_html ? (
+			{ ! showSpinner ? (
 				<iframe
 					title={ __( 'Preview email', 'newspack-newsletters' ) }
 					srcDoc={ meta.newspack_email_html }

--- a/src/components/send-button/index.js
+++ b/src/components/send-button/index.js
@@ -234,11 +234,13 @@ export default compose( [
 								<div className="newspack-newsletters__modal__content">
 									<DisableAutoAds saveOnToggle />
 									<hr />
-									<Testing
-										testEmail={ testEmail }
-										onChangeEmail={ setTestEmail }
-										disabled={ isSaving }
-									/>
+									{ 'manual' !== serviceProviderName && (
+										<Testing
+											testEmail={ testEmail }
+											onChangeEmail={ setTestEmail }
+											disabled={ isSaving }
+										/>
+									) }
 									<hr />
 									{ renderPostUpdateInfo( newsletterData ) }
 								</div>
@@ -279,11 +281,13 @@ export default compose( [
 							<div className="newspack-newsletters__modal__content">
 								<DisableAutoAds saveOnToggle />
 								<hr />
-								<Testing
-									testEmail={ testEmail }
-									onChangeEmail={ setTestEmail }
-									disabled={ isSaving }
-								/>
+								{ 'manual' !== serviceProviderName && (
+									<Testing
+										testEmail={ testEmail }
+										onChangeEmail={ setTestEmail }
+										disabled={ isSaving }
+									/>
+								) }
 								<div className="newspack-newsletters__modal__spacer" />
 								{ renderPreSendInfo( newsletterData ) }
 								<div className="modal-buttons">

--- a/src/components/send-button/index.js
+++ b/src/components/send-button/index.js
@@ -241,6 +241,7 @@ export default compose( [
 											testEmail={ testEmail }
 											onChangeEmail={ setTestEmail }
 											disabled={ isSaving }
+											inlineNotifications
 										/>
 									) }
 									<hr />
@@ -288,6 +289,7 @@ export default compose( [
 										testEmail={ testEmail }
 										onChangeEmail={ setTestEmail }
 										disabled={ isSaving }
+										inlineNotifications
 									/>
 								) }
 								<div className="newspack-newsletters__modal__spacer" />

--- a/src/components/send-button/style.scss
+++ b/src/components/send-button/style.scss
@@ -1,4 +1,20 @@
 .newspack-newsletters__modal {
+	&__container {
+		display: flex;
+		width: 100%;
+		height: 100%;
+		justify-content: baseline;
+	}
+	&__preview {
+		flex: 1 1 100%;
+		display: flex;
+		flex-direction: column;
+	}
+	&__content {
+		flex: 0 1 0;
+		margin-left: 2em;
+		min-width: 300px;
+	}
 	.components-notice {
 		margin: 0 0 1em;
 		ul {
@@ -20,7 +36,9 @@
 	margin-right: 8px;
 }
 
-.newsletter-preview-html-modal {
+.newsletter-preview-html {
+	width: 100%;
+	height: 100%;
 	&__iframe {
 		border: 0;
 		width: 100%;
@@ -34,16 +52,17 @@
 		justify-content: center;
 		align-items: center;
 	}
-	.components-modal {
-		&__content {
-			display: flex;
-			flex-direction: column;
-			justify-content: center;
-			> div {
-				flex-grow: 1;
-				&.components-modal__header {
-					flex-grow: 0;
-				}
+}
+
+.components-modal {
+	&__content {
+		display: flex;
+		flex-direction: column;
+		justify-content: center;
+		> div {
+			flex-grow: 1;
+			&.components-modal__header {
+				flex-grow: 0;
 			}
 		}
 	}

--- a/src/components/send-button/style.scss
+++ b/src/components/send-button/style.scss
@@ -15,3 +15,35 @@
 		}
 	}
 }
+
+.newsletter-preview-html-button {
+	margin-right: 8px;
+}
+
+.newsletter-preview-html-modal {
+	&__iframe {
+		border: 0;
+		width: 100%;
+		height: 100%;
+		margin: 0 auto;
+		overflow: auto;
+	}
+	&__spinner {
+		display: flex;
+		justify-content: center;
+		align-items: center;
+	}
+	.components-modal {
+		&__content {
+			display: flex;
+			flex-direction: column;
+			justify-content: center;
+			> div {
+				flex-grow: 1;
+				&.components-modal__header {
+					flex-grow: 0;
+				}
+			}
+		}
+	}
+}

--- a/src/components/send-button/style.scss
+++ b/src/components/send-button/style.scss
@@ -30,6 +30,7 @@
 	}
 	&__spinner {
 		display: flex;
+		height: 100%;
 		justify-content: center;
 		align-items: center;
 	}

--- a/src/components/send-button/style.scss
+++ b/src/components/send-button/style.scss
@@ -14,6 +14,17 @@
 		flex: 0 1 0;
 		margin-left: 2em;
 		min-width: 300px;
+		display: flex;
+		flex-direction: column;
+		height: 100%;
+		hr {
+			margin: 1em 0;
+			border: 0;
+			border-bottom: 1px solid #eaeaea;
+		}
+	}
+	&__spacer {
+		flex: 1 1 100%;
 	}
 	.components-notice {
 		margin: 0 0 1em;

--- a/src/newsletter-editor/testing/index.js
+++ b/src/newsletter-editor/testing/index.js
@@ -1,10 +1,11 @@
 /**
  * WordPress dependencies
  */
+import apiFetch from '@wordpress/api-fetch';
 import { __ } from '@wordpress/i18n';
 import { withSelect, withDispatch } from '@wordpress/data';
 import { compose } from '@wordpress/compose';
-import { Fragment } from '@wordpress/element';
+import { useState, Fragment } from '@wordpress/element';
 import { Button, Spinner, TextControl } from '@wordpress/components';
 import { hasValidEmail } from '../utils';
 
@@ -36,13 +37,20 @@ export default compose( [
 		testEmail,
 		onChangeEmail,
 		disabled,
+		inlineNotifications,
 	} ) => {
+		const [ localInFlight, setLocalInFlight ] = useState( false );
+		const [ localMessage, setLocalMessage ] = useState( '' );
 		const sendTestEmail = async () => {
 			const serviceProvider =
 				window &&
 				window.newspack_newsletters_data &&
 				window.newspack_newsletters_data.service_provider;
-			setInFlightForAsync();
+			if ( inlineNotifications ) {
+				setLocalInFlight( true );
+			} else {
+				setInFlightForAsync();
+			}
 			await savePost();
 			const params = {
 				path: `/newspack-newsletters/v1/${ serviceProvider }/${ postId }/test`,
@@ -51,7 +59,24 @@ export default compose( [
 				},
 				method: 'POST',
 			};
-			apiFetchWithErrorHandling( params );
+			if ( inlineNotifications ) {
+				apiFetch( params )
+					.then( res => {
+						setLocalMessage( res?.message || __( 'Test email sent.', 'newspack-newsletters' ) );
+					} )
+					.catch( err => {
+						setLocalMessage(
+							err?.message ||
+								err?.data?.message ||
+								__( 'Error sending test email.', 'newspack-newsletters' )
+						);
+					} )
+					.finally( () => {
+						setLocalInFlight( false );
+					} );
+			} else {
+				apiFetchWithErrorHandling( params );
+			}
 		};
 		return (
 			<Fragment>
@@ -60,20 +85,24 @@ export default compose( [
 					value={ testEmail }
 					type="email"
 					onChange={ onChangeEmail }
+					disabled={ localInFlight || inFlight }
 					help={ __( 'Use commas to separate multiple emails.', 'newspack-newsletters' ) }
 				/>
 				<div className="newspack-newsletters__testing-controls">
 					<Button
 						variant="secondary"
 						onClick={ sendTestEmail }
-						disabled={ disabled || inFlight || ! hasValidEmail( testEmail ) }
+						disabled={ disabled || localInFlight || inFlight || ! hasValidEmail( testEmail ) }
 					>
-						{ inFlight
+						{ inFlight || localInFlight
 							? __( 'Sending Test Email…', 'newspack-newsletters' )
 							: __( 'Send a Test Email', 'newspack-newsletters' ) }
 					</Button>
-					{ inFlight && <Spinner /> }
+					{ ( inFlight || localInFlight ) && <Spinner /> }
 				</div>
+				{ localMessage ? (
+					<p className="newspack-newsletters__testing-message">{ localMessage }</p>
+				) : null }
 			</Fragment>
 		);
 	}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

1205078412187623-as-1205078412187635

Implements HTML preview before sending the newsletter:

### With provider

<img width="1325" alt="image" src="https://github.com/Automattic/newspack-newsletters/assets/820752/e2cb0ff3-d4fa-4b2f-96b7-83dce264e9f8">

### With "Manual" provider

<img width="1294" alt="image" src="https://github.com/Automattic/newspack-newsletters/assets/820752/50cef1ca-3218-4da7-bf14-6bfe56553ba5">

The editor should also be able to change the ad settings or send a test email in this modal screen.

A new "Preview Email" button also renders the HTML in a modal, but without the sending functionality:

<img width="495" alt="image" src="https://github.com/Automattic/newspack-newsletters/assets/820752/a04b429e-6d89-4dc7-a0dc-f4fd3bb0d585">

<img width="1285" alt="image" src="https://github.com/Automattic/newspack-newsletters/assets/820752/bda52797-768f-4f2d-b816-aea80e356fef">

### How to test the changes in this Pull Request:

1. Make sure you have active newsletters ads configured
2. Set your newsletter provider as "Manual" and draft a new newsletter
3. Click "Preview email" and confirm the modal renders with injected ads
4. Close the modal and click to Send
5. Toggle the "Disable automatic insertion of ads" on and confirm it updates the HTML
6. Back to Newsletters settings, change your provider to a supported ESP
7. Repeat steps 3-5
8. Send a test newsletter and confirm you receive the expected content
9. Send the newsletter and confirm you receive the expected content

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
