### PR TITLE
fix(subscription-form): return if unable to add contact

### DIFF
--- a/src/blocks/subscribe/index.php
+++ b/src/blocks/subscribe/index.php
@@ -385,6 +385,10 @@ function process_form() {
 		$lists
 	);
 
+	if ( \is_wp_error( $result ) ) {
+		return send_form_response( $result );
+	}
+
 	if ( ! \is_user_logged_in() && \class_exists( '\Newspack\Reader_Activation' ) && \Newspack\Reader_Activation::is_enabled() ) {
 		$metadata = array_merge( $metadata, [ 'registration_method' => 'newsletters-subscription' ] );
 		if ( $popup_id ) {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Prevents the subscription form logic from continuing if unable to create contact.

#1231 introduced a new captcha token as part of the returned payload but the `$result` might be a `WP_Error`, which should be handled.

### How to test the changes in this Pull Request:

1. While on the `release` branch force the `Newspack_Newsletters_Subscription::add_contact()` to return an error by adding `return new WP_Error( 'custom_error', 'My custom error' );` on line 346 of `includes/class-newspack-newsletters-subscription.php`
2. Subscribe using a Newsletter Subscription Form block
3. Confirm the unhandled error
4. Check out this branch, repeat step 2, and confirm the correct error message is rendered

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
