### PR TITLE
fix: register before adding contact

### DIFF
--- a/src/blocks/subscribe/index.php
+++ b/src/blocks/subscribe/index.php
@@ -376,6 +376,14 @@ function process_form() {
 		$metadata['status'] = 'pending';
 	}
 
+	if ( ! \is_user_logged_in() && \class_exists( '\Newspack\Reader_Activation' ) && \Newspack\Reader_Activation::is_enabled() ) {
+		$metadata = array_merge( $metadata, [ 'registration_method' => 'newsletters-subscription' ] );
+		if ( $popup_id ) {
+			$metadata['registration_method'] = 'newsletters-subscription-popup';
+		}
+		\Newspack\Reader_Activation::register_reader( $email, $name, true, $metadata );
+	}
+
 	$result = \Newspack_Newsletters_Subscription::add_contact(
 		[
 			'name'     => $name ?? null,
@@ -387,14 +395,6 @@ function process_form() {
 
 	if ( \is_wp_error( $result ) ) {
 		return send_form_response( $result );
-	}
-
-	if ( ! \is_user_logged_in() && \class_exists( '\Newspack\Reader_Activation' ) && \Newspack\Reader_Activation::is_enabled() ) {
-		$metadata = array_merge( $metadata, [ 'registration_method' => 'newsletters-subscription' ] );
-		if ( $popup_id ) {
-			$metadata['registration_method'] = 'newsletters-subscription-popup';
-		}
-		\Newspack\Reader_Activation::register_reader( $email, $name, true, $metadata );
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes the order of events when signing up for newsletters via the Subscription Form block.

### How to test the changes in this Pull Request:

1. On `master`, sign up for a newsletter via the Subscription Form block.
2. Continue navigating the site and observe that you're not segmented as a newsletter subscriber.
3. Check out this branch, repeat in a new session. Confirm you're now segmented properly and have the `np_reader_1_is_newsletter_subscriber` set in `localStorage`.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
