### PR TITLE
fix(subscription-form): register before adding contact

### DIFF
--- a/src/blocks/subscribe/index.php
+++ b/src/blocks/subscribe/index.php
@@ -376,6 +376,14 @@ function process_form() {
 		$metadata['status'] = 'pending';
 	}
 
+	if ( ! \is_user_logged_in() && \class_exists( '\Newspack\Reader_Activation' ) && \Newspack\Reader_Activation::is_enabled() ) {
+		$metadata = array_merge( $metadata, [ 'registration_method' => 'newsletters-subscription' ] );
+		if ( $popup_id ) {
+			$metadata['registration_method'] = 'newsletters-subscription-popup';
+		}
+		\Newspack\Reader_Activation::register_reader( $email, $name, true, $metadata );
+	}
+
 	$result = \Newspack_Newsletters_Subscription::add_contact(
 		[
 			'name'     => $name ?? null,
@@ -387,14 +395,6 @@ function process_form() {
 
 	if ( \is_wp_error( $result ) ) {
 		return send_form_response( $result );
-	}
-
-	if ( ! \is_user_logged_in() && \class_exists( '\Newspack\Reader_Activation' ) && \Newspack\Reader_Activation::is_enabled() ) {
-		$metadata = array_merge( $metadata, [ 'registration_method' => 'newsletters-subscription' ] );
-		if ( $popup_id ) {
-			$metadata['registration_method'] = 'newsletters-subscription-popup';
-		}
-		\Newspack\Reader_Activation::register_reader( $email, $name, true, $metadata );
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Reader data events benefits from having a user ID when a reader subscribes to a newsletter. In order to make that user available on subscription, this PR registers the reader before adding the contact.

### How to test the changes in this Pull Request:

1. On a fresh session and new email, subscribe using the block and confirm it works without issues
2. Confirm you have `is_newsleter_subscriber` data item in the browser local storage

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
