### PR TITLE
feat: add filters to support additional blocks

### DIFF
--- a/includes/class-newspack-newsletters-editor.php
+++ b/includes/class-newspack-newsletters-editor.php
@@ -240,7 +240,7 @@ final class Newspack_Newsletters_Editor {
 		if ( ! self::is_editing_email() ) {
 			return $allowed_block_types;
 		}
-		return array(
+		$allowed_block_types = array(
 			'core/spacer',
 			'core/block',
 			'core/group',
@@ -264,6 +264,13 @@ final class Newspack_Newsletters_Editor {
 			'newspack-newsletters/posts-inserter',
 			'newspack-newsletters/share',
 		);
+		/**
+		 * Filters the allowed block types for the Newsletter CPT.
+		 *
+		 * @param array   $allowed_block_types default block types.
+		 * @param WP_Post $post the post to consider.
+		 */
+		return apply_filters( 'newspack_newsletters_allowed_block_types', $allowed_block_types, $post );
 	}
 
 	/**

--- a/includes/class-newspack-newsletters-renderer.php
+++ b/includes/class-newspack-newsletters-renderer.php
@@ -333,6 +333,23 @@ final class Newspack_Newsletters_Renderer {
 	 * @return string MJML component.
 	 */
 	public static function render_mjml_component( $block, $is_in_column = false, $is_in_group = false, $default_attrs = [], $is_in_list_or_quote = false ) {
+		/**
+		 * Filter to short-circuit the markup generation for a block.
+		 *
+		 * @param string|null $markup The markup to return. If null, the default markup will be generated.
+		 * @param WP_Block    $block The block.
+		 * @param bool        $is_in_column Whether the component is a child of a column component.
+		 * @param bool        $is_in_group Whether the component is a child of a group component.
+		 * @param array       $default_attrs Default attributes for the component.
+		 * @param bool        $is_in_list_or_quote Whether the component is a child of a list or quote block.
+		 *
+		 * @return string|null The markup to return. If null, the default markup will be generated.
+		 */
+		$markup = apply_filters( 'newspack_newsletters_render_mjml_component', null, $block, $is_in_column, $is_in_group, $default_attrs, $is_in_list_or_quote );
+		if ( null !== $markup ) {
+			return $markup;
+		}
+
 		$block_name    = $block['blockName'];
 		$attrs         = $block['attrs'];
 		$inner_blocks  = $block['innerBlocks'];


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Implements two new filters to allow additional blocks to render in an email:

- `newspack_newsletters_allowed_block_types`: Filters the list of allowed block types in the newsletter editor.
- `newspack_newsletters_render_mjml_component`: Filters the block MJML markup for email rendering.

### How to test the changes in this Pull Request:

1. Check out this branch and paste the following code at the end of the `newspack-newsletters.php` file to test the filters usage:
```php
/**
 * Allow the Table block in the editor.
 */
add_filter(
	'newspack_newsletters_allowed_block_types',
	function( $allowed_block_types ) {
		$allowed_block_types[] = 'core/table';
		return $allowed_block_types;
	}
);

/**
 * Render the Table block as an MJML table.
 */
add_filter(
	'newspack_newsletters_render_mjml_component',
	function( $markup, $block, $is_in_column, $is_in_group, $default_attrs, $is_in_list_or_quote ) {
		if ( 'core/table' === $block['blockName'] ) {
			$markup = '<mj-raw>TABLE MARKUP HERE</mj-raw>';
		}
		return $markup;
	},
	10,
	6
);
```

2. Draft a new newsletter and confirm the table block is available
3. Add some paragraphs and a table with some cells filled
4. Send the newsletter and confirm "TABLE MARKUP HERE" is rendered on the email

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
