### PR TITLE
fix: reverse the auto ads meta field

### DIFF
--- a/includes/class-newspack-newsletters-ads.php
+++ b/includes/class-newspack-newsletters-ads.php
@@ -60,7 +60,6 @@ final class Newspack_Newsletters_Ads {
 				'show_in_rest'   => true,
 				'type'           => 'string',
 				'single'         => true,
-				'auth_callback'  => '__return_true',
 			]
 		);
 		\register_meta(
@@ -71,7 +70,6 @@ final class Newspack_Newsletters_Ads {
 				'show_in_rest'   => true,
 				'type'           => 'integer',
 				'single'         => true,
-				'auth_callback'  => '__return_true',
 			]
 		);
 	}
@@ -82,13 +80,13 @@ final class Newspack_Newsletters_Ads {
 	public static function register_newsletter_meta() {
 		\register_meta(
 			'post',
-			'disable_auto_ads',
+			'enable_auto_ads',
 			[
 				'object_subtype' => Newspack_Newsletters::NEWSPACK_NEWSLETTERS_CPT,
 				'show_in_rest'   => true,
 				'type'           => 'boolean',
 				'single'         => true,
-				'auth_callback'  => '__return_true',
+				'default'        => 'true',
 			]
 		);
 	}
@@ -176,13 +174,13 @@ final class Newspack_Newsletters_Ads {
 	 * @param bool   $single  Whether to return only the first value of the specified $key.
 	 */
 	public static function migrate_diable_ads( $value, $post_id, $key, $single ) {
-		if ( 'disable_auto_ads' !== $key ) {
+		if ( 'enable_auto_ads' !== $key ) {
 			return $value;
 		}
 		remove_filter( 'get_post_metadata', [ __CLASS__, 'migrate_diable_ads' ], 10, 4 );
 		if ( get_post_meta( $post_id, 'diable_ads', true ) ) {
 			delete_post_meta( $post_id, 'diable_ads' );
-			update_post_meta( $post_id, 'disable_auto_ads', true );
+			update_post_meta( $post_id, 'enable_auto_ads', false );
 			$value = true;
 			if ( ! $single ) {
 				$value = [ $value ];
@@ -203,7 +201,7 @@ final class Newspack_Newsletters_Ads {
 		/**
 		 * Disable automated ads insertion.
 		 */
-		if ( get_post_meta( $post_id, 'disable_auto_ads', true ) ) {
+		if ( false === get_post_meta( $post_id, 'enable_auto_ads', true ) ) {
 			$should_render_ads = false;
 		}
 

--- a/src/ads/newsletter-editor/index.js
+++ b/src/ads/newsletter-editor/index.js
@@ -12,10 +12,10 @@ import apiFetch from '@wordpress/api-fetch';
 import { NEWSLETTER_AD_CPT_SLUG } from '../../utils/consts';
 
 function NewslettersAdsSettings() {
-	const { disableAutoAds, date } = useSelect( select => {
+	const { enableAutoAds, date } = useSelect( select => {
 		const { getEditedPostAttribute } = select( 'core/editor' );
 		const meta = getEditedPostAttribute( 'meta' );
-		return { disableAutoAds: meta.disable_auto_ads, date: getEditedPostAttribute( 'date' ) };
+		return { enableAutoAds: meta.enable_auto_ads, date: getEditedPostAttribute( 'date' ) };
 	} );
 	const { editPost } = useDispatch( 'core/editor' );
 	const [ adsCount, setAdsCount ] = useState( {
@@ -45,9 +45,9 @@ function NewslettersAdsSettings() {
 				title={ __( 'Ads Settings', 'newspack-newsletters' ) }
 			>
 				<ToggleControl
-					label={ __( 'Disable automatic insertion of ads', 'newspack-newsletters' ) }
-					checked={ disableAutoAds }
-					onChange={ disable_auto_ads => editPost( { meta: { disable_auto_ads } } ) }
+					label={ __( 'Enable automatic insertion of ads', 'newspack-newsletters' ) }
+					checked={ enableAutoAds }
+					onChange={ enable_auto_ads => editPost( { meta: { enable_auto_ads } } ) }
 				/>
 				{ ! inFlight ? (
 					<>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Reverses the logic for toggling automatic ad insertion.

### How to test the changes in this Pull Request:

1. Check out the master branch and draft a newsletter with `Disable ads for this newsletter` toggled on and another with `Disable ads for this newsletter` toggled off
2. Check out this branch, edit the first newsletter and confirm the `Enable automatic insertion of ads` is off
3. Edit the second newsletter and confirm `Enable automatic insertion of ads` is toggled on
4. Send both newsletters and confirm the ads are inserted only for the newsletter with the option toggled on

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
