### PR TITLE
feat: ad tracking

### DIFF
--- a/includes/class-newspack-newsletters-ads.php
+++ b/includes/class-newspack-newsletters-ads.php
@@ -46,6 +46,7 @@ final class Newspack_Newsletters_Ads {
 		add_action( 'save_post_' . self::NEWSPACK_NEWSLETTERS_ADS_CPT, [ __CLASS__, 'ad_default_fields' ], 10, 3 );
 		add_action( 'admin_menu', [ __CLASS__, 'add_ads_page' ] );
 		add_filter( 'get_post_metadata', [ __CLASS__, 'migrate_diable_ads' ], 10, 4 );
+		add_action( 'newspack_newsletters_tracking_pixel_seen', [ __CLASS__, 'track_ad_impression' ], 10, 2 );
 	}
 
 	/**
@@ -214,6 +215,36 @@ final class Newspack_Newsletters_Ads {
 		 * @param int  $post_id           ID of the newsletter post.
 		 */
 		return apply_filters( 'newspack_newsletters_should_render_ads', $should_render_ads, $post_id );
+	}
+
+	/**
+	 * Track ad impression.
+	 *
+	 * @param int    $newsletter_id Newsletter ID.
+	 * @param string $email_address Email address.
+	 */
+	public static function track_ad_impression( $newsletter_id, $email_address ) {
+		$inserted_ads = get_post_meta( $newsletter_id, 'inserted_ads', true );
+		if ( empty( $inserted_ads ) ) {
+			return;
+		}
+		foreach ( $inserted_ads as $ad_id ) {
+			$impressions = get_post_meta( $ad_id, 'tracking_impressions', true );
+			if ( ! $impressions ) {
+				$impressions = 0;
+			}
+			$impressions++;
+			update_post_meta( $ad_id, 'tracking_impressions', $impressions );
+
+			/**
+			 * Fires when an ad impression is tracked.
+			 *
+			 * @param int    $ad_id         Ad ID.
+			 * @param int    $newsletter_id Newsletter ID.
+			 * @param string $email_address Email address.
+			 */
+			do_action( 'newspack_newsletters_tracking_ad_impression', $ad_id, $newsletter_id, $email_address );
+		}
 	}
 }
 Newspack_Newsletters_Ads::instance();

--- a/includes/class-newspack-newsletters-renderer.php
+++ b/includes/class-newspack-newsletters-renderer.php
@@ -1063,7 +1063,7 @@ final class Newspack_Newsletters_Renderer {
 			$precise_position = self::get_ad_placement_precise_position( $positioning, $total_length_of_content );
 
 			return [
-				'ad_id'            => $ad_id,
+				'id'               => $ad_id,
 				'is_inserted'      => false,
 				'markup'           => self::post_to_mjml_components( $ad, false ),
 				'percentage'       => $positioning,
@@ -1270,7 +1270,7 @@ final class Newspack_Newsletters_Renderer {
 		$inserted_ads = [];
 		foreach ( self::$ads_to_insert as $ad_to_insert ) {
 			if ( $ad_to_insert['is_inserted'] ) {
-				$inserted_ads[] = $ad_to_insert['ad_id'];
+				$inserted_ads[] = $ad_to_insert['id'];
 			}
 		}
 		update_post_meta( $post->ID, 'inserted_ads', $inserted_ads );

--- a/includes/class-newspack-newsletters-renderer.php
+++ b/includes/class-newspack-newsletters-renderer.php
@@ -1063,6 +1063,7 @@ final class Newspack_Newsletters_Renderer {
 			$precise_position = self::get_ad_placement_precise_position( $positioning, $total_length_of_content );
 
 			return [
+				'ad_id'            => $ad_id,
 				'is_inserted'      => false,
 				'markup'           => self::post_to_mjml_components( $ad, false ),
 				'percentage'       => $positioning,
@@ -1264,6 +1265,15 @@ final class Newspack_Newsletters_Renderer {
 		if ( ! $background_color ) {
 			$background_color = '#ffffff';
 		}
+
+		// Get all the inserted ads.
+		$inserted_ads = [];
+		foreach ( self::$ads_to_insert as $ad_to_insert ) {
+			if ( $ad_to_insert['is_inserted'] ) {
+				$inserted_ads[] = $ad_to_insert['ad_id'];
+			}
+		}
+		update_post_meta( $post->ID, 'inserted_ads', $inserted_ads );
 
 		ob_start();
 		include dirname( __FILE__ ) . '/email-template.mjml.php';

--- a/includes/tracking/class-admin.php
+++ b/includes/tracking/class-admin.php
@@ -17,7 +17,7 @@ final class Admin {
 	public static function init() {
 		add_action( 'admin_menu', [ __CLASS__, 'add_settings_page' ] );
 		add_action( 'admin_init', [ __CLASS__, 'register_settings' ] );
-    
+
 		// Newsletters columns.
 		add_action( 'manage_' . \Newspack_Newsletters::NEWSPACK_NEWSLETTERS_CPT . '_posts_columns', [ __CLASS__, 'manage_columns' ] );
 		add_action( 'manage_' . \Newspack_Newsletters::NEWSPACK_NEWSLETTERS_CPT . '_posts_custom_column', [ __CLASS__, 'custom_column' ], 10, 2 );

--- a/includes/tracking/class-admin.php
+++ b/includes/tracking/class-admin.php
@@ -15,9 +15,17 @@ final class Admin {
 	 * Initialize hooks.
 	 */
 	public static function init() {
+		// Newsletters columns.
 		add_action( 'manage_' . \Newspack_Newsletters::NEWSPACK_NEWSLETTERS_CPT . '_posts_columns', [ __CLASS__, 'manage_columns' ] );
 		add_action( 'manage_' . \Newspack_Newsletters::NEWSPACK_NEWSLETTERS_CPT . '_posts_custom_column', [ __CLASS__, 'custom_column' ], 10, 2 );
 		add_action( 'manage_edit-' . \Newspack_Newsletters::NEWSPACK_NEWSLETTERS_CPT . '_sortable_columns', [ __CLASS__, 'sortable_columns' ] );
+
+		// Newsletters Ads columns.
+		add_action( 'manage_' . \Newspack_Newsletters_Ads::NEWSPACK_NEWSLETTERS_ADS_CPT . '_posts_columns', [ __CLASS__, 'manage_ads_columns' ] );
+		add_action( 'manage_' . \Newspack_Newsletters_Ads::NEWSPACK_NEWSLETTERS_ADS_CPT . '_posts_custom_column', [ __CLASS__, 'custom_ads_column' ], 10, 2 );
+		add_action( 'manage_edit-' . \Newspack_Newsletters_Ads::NEWSPACK_NEWSLETTERS_ADS_CPT . '_sortable_columns', [ __CLASS__, 'sortable_ads_columns' ] );
+
+		// Sorting.
 		add_action( 'pre_get_posts', [ __CLASS__, 'handle_sorting' ] );
 	}
 
@@ -29,6 +37,17 @@ final class Admin {
 	public static function manage_columns( $columns ) {
 		$columns['opened'] = __( 'Opened', 'newspack-newsletters' );
 		$columns['clicks'] = __( 'Clicks', 'newspack-newsletters' );
+		return $columns;
+	}
+
+	/**
+	 * Manage ads columns.
+	 *
+	 * @param array $columns Columns.
+	 */
+	public static function manage_ads_columns( $columns ) {
+		$columns['impressions'] = __( 'Impressions', 'newspack-newsletters' );
+		$columns['clicks']      = __( 'Clicks', 'newspack-newsletters' );
 		return $columns;
 	}
 
@@ -47,6 +66,20 @@ final class Admin {
 	}
 
 	/**
+	 * Custom ads column content.
+	 *
+	 * @param array $column_name Column name.
+	 * @param int   $post_id     Post ID.
+	 */
+	public static function custom_ads_column( $column_name, $post_id ) {
+		if ( 'impressions' === $column_name ) {
+			echo intval( get_post_meta( $post_id, 'tracking_impressions', true ) );
+		} elseif ( 'clicks' === $column_name ) {
+			echo intval( get_post_meta( $post_id, 'tracking_clicks', true ) );
+		}
+	}
+
+	/**
 	 * Sortable columns.
 	 *
 	 * @param array $columns Columns.
@@ -54,6 +87,17 @@ final class Admin {
 	public static function sortable_columns( $columns ) {
 		$columns['opened'] = 'opened';
 		$columns['clicks'] = 'clicks';
+		return $columns;
+	}
+
+	/**
+	 * Sortable ads columns.
+	 *
+	 * @param array $columns Columns.
+	 */
+	public static function sortable_ads_columns( $columns ) {
+		$columns['impressions'] = 'impressions';
+		$columns['clicks']      = 'clicks';
 		return $columns;
 	}
 
@@ -66,17 +110,26 @@ final class Admin {
 		if ( ! is_admin() || ! $query->is_main_query() ) {
 			return;
 		}
-		if ( \Newspack_Newsletters::NEWSPACK_NEWSLETTERS_CPT !== $query->get( 'post_type' ) ) {
-			return;
+		if ( \Newspack_Newsletters::NEWSPACK_NEWSLETTERS_CPT === $query->get( 'post_type' ) ) {
+			$orderby = $query->get( 'orderby' );
+			if ( 'opened' === $orderby ) {
+				$query->set( 'meta_key', 'tracking_pixel_seen' );
+				$query->set( 'orderby', 'meta_value_num' );
+			} elseif ( 'clicks' === $orderby ) {
+				$query->set( 'meta_key', 'tracking_clicks' );
+				$query->set( 'orderby', 'meta_value_num' );
+			}
 		}
 
-		$orderby = $query->get( 'orderby' );
-		if ( 'opened' === $orderby ) {
-			$query->set( 'meta_key', 'tracking_pixel_seen' );
-			$query->set( 'orderby', 'meta_value_num' );
-		} elseif ( 'clicks' === $orderby ) {
-			$query->set( 'meta_key', 'tracking_clicks' );
-			$query->set( 'orderby', 'meta_value_num' );
+		if ( \Newspack_Newsletters_Ads::NEWSPACK_NEWSLETTERS_ADS_CPT === $query->get( 'post_type' ) ) {
+			$orderby = $query->get( 'orderby' );
+			if ( 'impressions' === $orderby ) {
+				$query->set( 'meta_key', 'tracking_impressions' );
+				$query->set( 'orderby', 'meta_value_num' );
+			} elseif ( 'clicks' === $orderby ) {
+				$query->set( 'meta_key', 'clicks' );
+				$query->set( 'orderby', 'meta_value_num' );
+			}
 		}
 	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Implements impression and click tracking to newsletter ads.

<img width="1114" alt="image" src="https://github.com/Automattic/newspack-newsletters/assets/820752/03a8bae0-28f9-49b4-b771-1321b1206a0c">

### How to test the changes in this Pull Request:

1. Check out this branch and send a newsletter ensuring that ads will be inserted
2. Open the email, make sure to allow the images to render, and click the ad
3. Confirm the count updates in the Newsletters -> Ads dashboard table

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
