### PR TITLE
feat: Newspack Sponsors integration

### DIFF
--- a/includes/class-newspack-newsletters-editor.php
+++ b/includes/class-newspack-newsletters-editor.php
@@ -312,6 +312,8 @@ final class Newspack_Newsletters_Editor {
 					'email_html_meta'          => Newspack_Newsletters::EMAIL_HTML_META,
 					'mjml_handling_post_types' => $mjml_handling_post_types,
 					'conditional_tag_support'  => $conditional_tag_support,
+					'sponsors_flag_hex'        => get_theme_mod( 'sponsored_flag_hex', '#FED850' ),
+					'sponsors_flag_text_color' => function_exists( 'newspack_get_color_contrast' ) ? newspack_get_color_contrast( \get_theme_mod( 'sponsored_flag_hex', '#FED850' ) ) : 'black',
 				]
 			);
 
@@ -411,7 +413,7 @@ final class Newspack_Newsletters_Editor {
 	 * Append author info to the posts REST response so we can append Coauthors, if they exist.
 	 */
 	public static function add_newspack_author_info() {
-		/* Add author info source */
+		// Add author info source.
 		register_rest_field(
 			'post',
 			'newspack_author_info',
@@ -425,6 +427,23 @@ final class Newspack_Newsletters_Editor {
 				],
 			]
 		);
+
+		// Add sponsor info.
+		if ( function_exists( '\Newspack_Sponsors\get_all_sponsors' ) ) {
+			register_rest_field(
+				'post',
+				'newspack_sponsors_info',
+				[
+					'get_callback' => [ __CLASS__, 'newspack_get_sponsors_info' ],
+					'schema'       => [
+						'context' => [
+							'edit',
+						],
+						'type'    => 'array',
+					],
+				]
+			);
+		}
 	}
 
 	/**
@@ -537,6 +556,16 @@ final class Newspack_Newsletters_Editor {
 
 		/* Return the author data */
 		return $author_data;
+	}
+
+	/**
+	 * Append sponsor data to the REST /posts response.
+	 *
+	 * @param object $post Post object for the post being returned.
+	 * @return object Formatted data for all sponsors associated with the post.
+	 */
+	public static function newspack_get_sponsors_info( $post ) {
+		return \Newspack_Sponsors\get_all_sponsors( $post['id'], null, 'post' );
 	}
 }
 Newspack_Newsletters_Editor::instance();

--- a/src/editor/blocks/posts-inserter/block.json
+++ b/src/editor/blocks/posts-inserter/block.json
@@ -45,6 +45,10 @@
 			"type": "boolean",
 			"default": false
 		},
+		"displaySponsoredPosts": {
+			"type": "boolean",
+			"default": true
+		},
 		"innerBlocksToInsert": {
 			"type": "array",
 			"default": []

--- a/src/editor/blocks/posts-inserter/index.js
+++ b/src/editor/blocks/posts-inserter/index.js
@@ -329,6 +329,7 @@ const PostsInserterBlockWithSelect = compose( [
 			tagExclusions,
 			categoryExclusions,
 			excerptLength,
+			displaySponsoredPosts,
 		} = props.attributes;
 		const { getEntityRecords, getMedia } = select( 'core' );
 		const { getSelectedBlock, getBlocks, getSettings } = select( 'core/block-editor' );
@@ -339,24 +340,23 @@ const PostsInserterBlockWithSelect = compose( [
 
 		let posts = [];
 		const isHandlingSpecificPosts = isDisplayingSpecificPosts && specificPosts.length > 0;
+		const query = {
+			categories: catIds,
+			tags,
+			order,
+			orderby: orderBy,
+			per_page: postsToShow,
+			exclude: preventDeduplication ? [] : exclude,
+			categories_exclude: categoryExclusions,
+			tags_exclude: tagExclusions,
+			excerpt_length: excerptLength,
+			exclude_sponsors: displaySponsoredPosts ? 0 : 1,
+		};
 
 		if ( ! isDisplayingSpecificPosts || isHandlingSpecificPosts ) {
 			const postListQuery = isDisplayingSpecificPosts
 				? { include: specificPosts.map( post => post.id ) }
-				: pickBy(
-						{
-							categories: catIds,
-							tags,
-							order,
-							orderby: orderBy,
-							per_page: postsToShow,
-							exclude: preventDeduplication ? [] : exclude,
-							categories_exclude: categoryExclusions,
-							tags_exclude: tagExclusions,
-							excerpt_length: excerptLength,
-						},
-						value => ! isUndefined( value )
-				  );
+				: pickBy( query, value => ! isUndefined( value ) );
 
 			posts = getEntityRecords( 'postType', postType, postListQuery ) || [];
 		}

--- a/src/editor/blocks/posts-inserter/query-controls.js
+++ b/src/editor/blocks/posts-inserter/query-controls.js
@@ -218,6 +218,11 @@ const QueryControlsSettings = ( { attributes, setAttributes } ) => {
 				onChange={ postType => setAttributes( { postType } ) }
 			/>
 			<ToggleControl
+				label={ __( 'Display sponsored posts', 'newspack-newsletters' ) }
+				checked={ attributes.displaySponsoredPosts }
+				onChange={ value => setAttributes( { displaySponsoredPosts: value } ) }
+			/>
+			<ToggleControl
 				label={ __( 'Display specific posts', 'newspack-newsletters' ) }
 				checked={ attributes.isDisplayingSpecificPosts }
 				onChange={ value => setAttributes( { isDisplayingSpecificPosts: value } ) }

--- a/src/editor/blocks/posts-inserter/utils.js
+++ b/src/editor/blocks/posts-inserter/utils.js
@@ -1,3 +1,5 @@
+/* globals newspack_email_editor_data */
+
 /**
  * External dependencies
  */
@@ -115,13 +117,97 @@ const getAuthorBlockTemplate = ( post, { textFontSize, textColor } ) => {
 	return null;
 };
 
+const getSponsorFlagBlockTemplate = ( content, { textFontSize } ) => {
+	return [
+		'core/paragraph',
+		assignFontSize( textFontSize, {
+			className: 'newspack-sponsors-flag',
+			content: `<span style="background-color:${ newspack_email_editor_data.sponsors_flag_hex };color:${ newspack_email_editor_data.sponsors_flag_text_color };font-weight:700;padding:2px 4px;text-transform:uppercase">${ content }</span>`,
+			fontSize: 'small',
+		} ),
+	];
+};
+
+const getSponsorAttributionTemplate = ( sponsors, { textFontSize, textColor } ) => {
+	const sponsorsToShow = sponsors.filter( sponsor => 'native' === sponsor.sponsor_scope );
+	if ( ! sponsorsToShow.length ) {
+		return [];
+	}
+
+	const sponsorNames = [];
+
+	sponsorsToShow.forEach( sponsor => {
+		const sponsorName = sponsor.sponsor_url
+			? `<a href="${ sponsor.sponsor_url }">${ sponsor.sponsor_name }</a>`
+			: sponsor.sponsor_name;
+		sponsorNames.push( sponsorName );
+	} );
+
+	return [
+		'core/heading',
+		assignFontSize( textFontSize, {
+			content: sponsorsToShow[ 0 ].sponsor_byline + ' ' + sponsorNames.join( ', ' ),
+			fontSize: 'normal',
+			level: 6,
+			style: { color: { text: textColor } },
+		} ),
+	];
+};
+
 const createBlockTemplatesForSinglePost = ( post, attributes ) => {
-	const postContentBlocks = [ getHeadingBlockTemplate( post, attributes ) ];
+	const postContentBlocks = [];
+	let displayAuthor = attributes.displayAuthor;
+
+	const hasSponsors = post.newspack_sponsors_info && 0 < post.newspack_sponsors_info.length;
+	if ( hasSponsors ) {
+		// If the post is set to show sponsors with native sponsor styling, OR at least one sponsor is a native sponsor, show the "sponsored" flag.
+		const showSponsorFlag =
+			'native' === post.meta.newspack_sponsor_sponsorship_scope ||
+			post.newspack_sponsors_info.reduce( ( acc, sponsor ) => {
+				if ( 'native' === sponsor.sponsor_scope ) {
+					return true;
+				}
+				return acc;
+			}, false );
+
+		if ( showSponsorFlag ) {
+			const sponsorFlag = post.newspack_sponsors_info[ 0 ].sponsor_flag;
+			postContentBlocks.push( getSponsorFlagBlockTemplate( sponsorFlag, attributes ) );
+		}
+	}
+
+	postContentBlocks.push( getHeadingBlockTemplate( post, attributes ) );
 
 	if ( attributes.displayPostSubtitle && post.meta?.newspack_post_subtitle ) {
 		postContentBlocks.push( getSubtitleBlockTemplate( post, attributes ) );
 	}
-	if ( attributes.displayAuthor ) {
+
+	if ( hasSponsors && 'underwritten' !== post.meta.newspack_sponsor_sponsorship_scope ) {
+		// If the post is set to show only sponsor, OR set to inherit and all sponsors are set to show only sponsor, hide the byline.
+		if (
+			'sponsor' === post.meta.newspack_sponsor_native_byline_display ||
+			( 'inherit' === post.meta.newspack_sponsor_native_byline_display &&
+				false ===
+					post.newspack_sponsors_info.reduce( ( acc, sponsor ) => {
+						if ( 'author' === sponsor.sponsor_byline_display ) {
+							return true;
+						}
+						return acc;
+					}, false ) )
+		) {
+			displayAuthor = false;
+		}
+
+		const sponsorAttributions = getSponsorAttributionTemplate(
+			post.newspack_sponsors_info,
+			attributes
+		);
+		if ( sponsorAttributions ) {
+			postContentBlocks.push( sponsorAttributions );
+		}
+	}
+
+	if ( displayAuthor ) {
 		const author = getAuthorBlockTemplate( post, attributes );
 
 		if ( author ) {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Adds sponsor attributions and styles to sponsored posts in the Posts Inserter. Also allows toggling on and off of sponsored posts.

Closes `1205103340481511/1203366842368233`.

### How to test the changes in this Pull Request:

#### Sponsor attributions and styles

1. Create a native sponsor using Newspack Sponsors and assign it directly to a post, or to a category.
2. Create a newsletter and add a Posts Inserter block. Set the query controls to display the sponsored post or category.
3. Confirm that the post appears in the preview with the sponsor flag and attribution. Note that the sponsor logo isn't shown because for some reason, the post editor had a really hard time rendering the image in the preview. We can look into adding the logos in a future PR if we really need them.

<img width="608" alt="Screenshot 2023-08-28 at 4 44 10 PM" src="https://github.com/Automattic/newspack-newsletters/assets/2230142/7a108ceb-7b0e-4316-9e08-e26b6efa6977">

4. Insert the posts and then send the email. Confirm that the flag and attribution appear with the sponsored post(s) in the sent email as well.
5. Play with different sponsor settings such as changing the color of the flag in the Customizer, changing the attribution text in the sponsor's settings, and setting override settings in the sponsored post itself. Try adding multiple sponsors to a single post. Confirm that the various settings are displayed as expected in the Posts Inserter.

#### Show/hide sponsored posts

1. Create a newsletter and add a Posts Inserter block. In the block settings, confirm there's a new toggle to display sponsored posts, on by default:

<img width="274" alt="Screenshot 2023-08-28 at 5 35 04 PM" src="https://github.com/Automattic/newspack-newsletters/assets/2230142/8ea9b331-3bae-4a9e-ad5a-0203c886606d">

2. Toggle off the setting and confirm that the results shown don't include any sponsored posts.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
