### PR TITLE
feat: ads taxonomies and fields

### DIFF
--- a/includes/class-newspack-newsletters-ads.php
+++ b/includes/class-newspack-newsletters-ads.php
@@ -11,10 +11,10 @@ defined( 'ABSPATH' ) || exit;
  * Newspack Newsletters Ads Class.
  */
 final class Newspack_Newsletters_Ads {
-	/**
-	 * CPT for Newsletter ads.
-	 */
-	const NEWSPACK_NEWSLETTERS_ADS_CPT = 'newspack_nl_ads_cpt';
+
+	const CPT = 'newspack_nl_ads_cpt';
+
+	const ADVERTISER_TAX = 'newspack_nl_advertiser';
 
 	/**
 	 * The single instance of the class.
@@ -43,7 +43,7 @@ final class Newspack_Newsletters_Ads {
 		add_action( 'init', [ __CLASS__, 'register_ads_cpt' ] );
 		add_action( 'init', [ __CLASS__, 'register_meta' ] );
 		add_action( 'init', [ __CLASS__, 'register_newsletter_meta' ] );
-		add_action( 'save_post_' . self::NEWSPACK_NEWSLETTERS_ADS_CPT, [ __CLASS__, 'ad_default_fields' ], 10, 3 );
+		add_action( 'save_post_' . self::CPT, [ __CLASS__, 'ad_default_fields' ], 10, 3 );
 		add_action( 'admin_menu', [ __CLASS__, 'add_ads_page' ] );
 		add_filter( 'get_post_metadata', [ __CLASS__, 'migrate_diable_ads' ], 10, 4 );
 	}
@@ -56,7 +56,7 @@ final class Newspack_Newsletters_Ads {
 			'post',
 			'expiry_date',
 			[
-				'object_subtype' => self::NEWSPACK_NEWSLETTERS_ADS_CPT,
+				'object_subtype' => self::CPT,
 				'show_in_rest'   => true,
 				'type'           => 'string',
 				'single'         => true,
@@ -67,7 +67,7 @@ final class Newspack_Newsletters_Ads {
 			'post',
 			'position_in_content',
 			[
-				'object_subtype' => self::NEWSPACK_NEWSLETTERS_ADS_CPT,
+				'object_subtype' => self::CPT,
 				'show_in_rest'   => true,
 				'type'           => 'integer',
 				'single'         => true,
@@ -102,7 +102,7 @@ final class Newspack_Newsletters_Ads {
 			__( 'Newsletters Ads', 'newspack-newsletters' ),
 			__( 'Ads', 'newspack-newsletters' ),
 			'edit_others_posts',
-			'/edit.php?post_type=' . self::NEWSPACK_NEWSLETTERS_ADS_CPT,
+			'/edit.php?post_type=' . self::CPT,
 			null,
 			2
 		);
@@ -146,9 +146,42 @@ final class Newspack_Newsletters_Ads {
 			'show_in_menu' => false,
 			'show_in_rest' => true,
 			'supports'     => [ 'editor', 'title', 'custom-fields' ],
-			'taxonomies'   => [],
+			'taxonomies'   => [ 'category' ],
 		];
-		\register_post_type( self::NEWSPACK_NEWSLETTERS_ADS_CPT, $cpt_args );
+		register_post_type( self::CPT, $cpt_args );
+
+		register_taxonomy(
+			self::ADVERTISER_TAX,
+			[ self::CPT, Newspack_Newsletters::NEWSPACK_NEWSLETTERS_CPT ],
+			[
+				'labels'            => [
+					'name'                     => __( 'Advertisers', 'newspack-newsletters' ),
+					'singular_name'            => __( 'Advertiser', 'newspack-newsletters' ),
+					'search_items'             => __( 'Search Advertisers', 'newspack-newsletters' ),
+					'popular_items'            => __( 'Popular Advertisers', 'newspack-newsletters' ),
+					'all_items'                => __( 'All Advertisers', 'newspack-newsletters' ),
+					'parent_items'             => __( 'Parent Advertisers', 'newspack-newsletters' ),
+					'parent_item'              => __( 'Parent Advertiser', 'newspack-newsletters' ),
+					'name_field_description'   => __( 'The advertiser name', 'newspack-newsletters' ),
+					'slug_field_description'   => '', // There's no advertiser URL so let's skip slug field description.
+					'parent_field_description' => __( 'Assign a parent advertiser', 'newspack-newsletters' ),
+					'desc_field_description'   => __( 'Optional description for this advertiser', 'newspack-newsletters' ),
+					'edit_item'                => __( 'Edit Advertiser', 'newspack-newsletters' ),
+					'view_item'                => __( 'View Advertiser', 'newspack-newsletters' ),
+					'update_item'              => __( 'Update Advertiser', 'newspack-newsletters' ),
+					'add_new_item'             => __( 'Add New Advertiser', 'newspack-newsletters' ),
+					'new_item_name'            => __( 'New Advertiser Name', 'newspack-newsletters' ),
+					'not_found'                => __( 'No advertisers found', 'newspack-newsletters' ),
+					'no_terms'                 => __( 'No advertisers', 'newspack-newsletters' ),
+					'filter_by_item'           => __( 'Filter by advertiser', 'newspack-newsletters' ),
+				],
+				'description'       => __( 'Newspack Newsletters Ads Advertisers', 'newspack-newsletters' ),
+				'public'            => true,
+				'hierarchical'      => true,
+				'show_in_rest'      => true,
+				'show_admin_column' => true,
+			]
+		);
 	}
 
 	/**

--- a/includes/class-newspack-newsletters-ads.php
+++ b/includes/class-newspack-newsletters-ads.php
@@ -345,7 +345,12 @@ final class Newspack_Newsletters_Ads {
 				echo '—';
 			}
 		} elseif ( 'price' === $column_name ) {
-			echo floatval( get_post_meta( $post_id, 'price', true ) );
+			$price = get_post_meta( $post_id, 'price', true );
+			if ( ! empty( $price ) ) {
+				echo esc_html( $price );
+			} else {
+				echo '—';
+			}
 		}
 	}
 

--- a/includes/class-newspack-newsletters-ads.php
+++ b/includes/class-newspack-newsletters-ads.php
@@ -315,7 +315,11 @@ final class Newspack_Newsletters_Ads {
 	 * @param array $columns Columns.
 	 */
 	public static function manage_columns( $columns ) {
-		$columns['price'] = __( 'Price', 'newspack-newsletters' );
+		$columns['start_date']  = __( 'Start Date', 'newspack-newsletters' );
+		$columns['expiry_date'] = __( 'Expiry Date', 'newspack-newsletters' );
+		$columns['price']       = __( 'Price', 'newspack-newsletters' );
+		unset( $columns['date'] );
+		unset( $columns['stats'] );
 		return $columns;
 	}
 
@@ -326,7 +330,12 @@ final class Newspack_Newsletters_Ads {
 	 * @param int   $post_id     Post ID.
 	 */
 	public static function custom_column( $column_name, $post_id ) {
-		if ( 'price' === $column_name ) {
+		if ( 'start_date' === $column_name ) {
+			// Echo date in readable format.
+			echo esc_html( wp_date( get_option( 'date_format' ), strtotime( get_post_meta( $post_id, 'start_date', true ) ) ) );
+		} elseif ( 'expiry_date' === $column_name ) {
+			echo esc_html( wp_date( get_option( 'date_format' ), strtotime( get_post_meta( $post_id, 'expiry_date', true ) ) ) );
+		} elseif ( 'price' === $column_name ) {
 			echo floatval( get_post_meta( $post_id, 'price', true ) );
 		}
 	}
@@ -337,7 +346,9 @@ final class Newspack_Newsletters_Ads {
 	 * @param array $columns Columns.
 	 */
 	public static function sortable_columns( $columns ) {
-		$columns['price'] = 'price';
+		$columns['start_date']  = 'start_date';
+		$columns['expiry_date'] = 'expiry_date';
+		$columns['price']       = 'price';
 		return $columns;
 	}
 
@@ -355,6 +366,12 @@ final class Newspack_Newsletters_Ads {
 			if ( 'price' === $orderby ) {
 				$query->set( 'meta_key', 'price' );
 				$query->set( 'orderby', 'meta_value_num' );
+			} elseif ( 'start_date' === $orderby ) {
+				$query->set( 'meta_key', 'start_date' );
+				$query->set( 'orderby', 'meta_value' );
+			} elseif ( 'expiry_date' === $orderby ) {
+				$query->set( 'meta_key', 'expiry_date' );
+				$query->set( 'orderby', 'meta_value' );
 			}
 		}
 	}

--- a/includes/class-newspack-newsletters-ads.php
+++ b/includes/class-newspack-newsletters-ads.php
@@ -54,6 +54,17 @@ final class Newspack_Newsletters_Ads {
 	public static function register_meta() {
 		\register_meta(
 			'post',
+			'start_date',
+			[
+				'object_subtype' => self::CPT,
+				'show_in_rest'   => true,
+				'type'           => 'string',
+				'single'         => true,
+				'auth_callback'  => '__return_true',
+			]
+		);
+		\register_meta(
+			'post',
 			'expiry_date',
 			[
 				'object_subtype' => self::CPT,

--- a/includes/class-newspack-newsletters-ads.php
+++ b/includes/class-newspack-newsletters-ads.php
@@ -316,7 +316,7 @@ final class Newspack_Newsletters_Ads {
 	 */
 	public static function manage_columns( $columns ) {
 		$columns['start_date']  = __( 'Start Date', 'newspack-newsletters' );
-		$columns['expiry_date'] = __( 'Expiry Date', 'newspack-newsletters' );
+		$columns['expiry_date'] = __( 'Expiration Date', 'newspack-newsletters' );
 		$columns['price']       = __( 'Price', 'newspack-newsletters' );
 		unset( $columns['date'] );
 		unset( $columns['stats'] );
@@ -331,10 +331,19 @@ final class Newspack_Newsletters_Ads {
 	 */
 	public static function custom_column( $column_name, $post_id ) {
 		if ( 'start_date' === $column_name ) {
-			// Echo date in readable format.
-			echo esc_html( wp_date( get_option( 'date_format' ), strtotime( get_post_meta( $post_id, 'start_date', true ) ) ) );
+			$start_date = get_post_meta( $post_id, 'start_date', true );
+			if ( ! empty( $start_date ) ) {
+				echo esc_html( wp_date( get_option( 'date_format' ), strtotime( $start_date ) ) );
+			} else {
+				echo '—';
+			}
 		} elseif ( 'expiry_date' === $column_name ) {
-			echo esc_html( wp_date( get_option( 'date_format' ), strtotime( get_post_meta( $post_id, 'expiry_date', true ) ) ) );
+			$expiry_date = get_post_meta( $post_id, 'expiry_date', true );
+			if ( ! empty( $expiry_date ) ) {
+				echo esc_html( wp_date( get_option( 'date_format' ), strtotime( $expiry_date ) ) );
+			} else {
+				echo '—';
+			}
 		} elseif ( 'price' === $column_name ) {
 			echo floatval( get_post_meta( $post_id, 'price', true ) );
 		}

--- a/includes/class-newspack-newsletters-ads.php
+++ b/includes/class-newspack-newsletters-ads.php
@@ -62,7 +62,7 @@ final class Newspack_Newsletters_Ads {
 	 */
 	public static function rest_api_init() {
 		\register_rest_route(
-			'wp/v2/' . self::NEWSPACK_NEWSLETTERS_ADS_CPT,
+			'wp/v2/' . self::CPT,
 			'config',
 			[
 				'callback'            => [ __CLASS__, 'get_ads_config' ],
@@ -323,7 +323,7 @@ final class Newspack_Newsletters_Ads {
 		$letterhead                 = new Newspack_Newsletters_Letterhead();
 		$has_letterhead_credentials = $letterhead->has_api_credentials();
 		$post_date                  = $request->get_param( 'date' );
-		$newspack_ad_type           = self::NEWSPACK_NEWSLETTERS_ADS_CPT;
+		$newspack_ad_type           = self::CPT;
 
 		$url_to_manage_promotions   = 'https://app.tryletterhead.com/promotions';
 		$url_to_manage_newspack_ads = "/wp-admin/edit.php?post_type={$newspack_ad_type}";

--- a/includes/class-newspack-newsletters-editor.php
+++ b/includes/class-newspack-newsletters-editor.php
@@ -84,7 +84,7 @@ final class Newspack_Newsletters_Editor {
 	private static function get_email_editor_cpts() {
 		$email_cpts = [
 			Newspack_Newsletters::NEWSPACK_NEWSLETTERS_CPT,
-			Newspack_Newsletters_Ads::NEWSPACK_NEWSLETTERS_ADS_CPT,
+			Newspack_Newsletters_Ads::CPT,
 		];
 		return apply_filters( 'newspack_newsletters_email_editor_cpts', $email_cpts );
 	}
@@ -292,7 +292,7 @@ final class Newspack_Newsletters_Editor {
 
 			// Remove the Ads CPT - it does not need MJML handling since ads
 			// will be injected into email content before it's converted to MJML.
-			$mjml_handling_post_types = array_values( array_diff( self::get_email_editor_cpts(), [ Newspack_Newsletters_Ads::NEWSPACK_NEWSLETTERS_ADS_CPT ] ) );
+			$mjml_handling_post_types = array_values( array_diff( self::get_email_editor_cpts(), [ Newspack_Newsletters_Ads::CPT ] ) );
 			$provider                 = Newspack_Newsletters::get_service_provider();
 			$conditional_tag_support  = false;
 			if ( $provider ) {
@@ -386,7 +386,7 @@ final class Newspack_Newsletters_Editor {
 	 * Is editing a newsletter ad?
 	 */
 	private static function is_editing_newsletter_ad() {
-		return Newspack_Newsletters_Ads::NEWSPACK_NEWSLETTERS_ADS_CPT === get_post_type();
+		return Newspack_Newsletters_Ads::CPT === get_post_type();
 	}
 
 	/**

--- a/includes/class-newspack-newsletters-renderer.php
+++ b/includes/class-newspack-newsletters-renderer.php
@@ -1136,46 +1136,35 @@ final class Newspack_Newsletters_Renderer {
 
 
 	/**
-	 * Whether the newspack native ad is active or expired.
+	 * Whether the newspack native ad is active.
 	 *
-	 * @param int $ad_id ID of the Ad post type.
+	 * @param int $ad_id ID of the Ad post.
+	 *
 	 * @return bool
 	 */
 	private static function is_published_ad_active( $ad_id ) {
-		$expiration_date = self::get_ad_expiration_date( $ad_id );
 
-		if ( ! $expiration_date ) {
+		$start_date  = get_post_meta( $ad_id, 'start_date', true );
+		$expiry_date = get_post_meta( $ad_id, 'expiry_date', true );
+
+		if ( ! $start_date && ! $expiry_date ) {
 			return true;
 		}
 
-		return self::is_ad_unexpired( $expiration_date );
-	}
+		$date_format = 'Y-m-d';
+		$today       = gmdate( $date_format );
 
-	/**
-	 * Determines whetherthe newspack native ad is expired.
-	 *
-	 * @param string $expiration_date_as_datetime The expiration date as datetime.
-	 * @return bool
-	 */
-	private static function is_ad_unexpired( $expiration_date_as_datetime ) {
-		$date_format               = 'Y-m-d';
-		$formatted_expiration_date = $expiration_date_as_datetime->format( $date_format );
-		$today                     = gmdate( $date_format );
+		if ( $start_date ) {
+			$formatted_start_date = ( new DateTime( $start_date ) )->format( $date_format );
+			return $formatted_start_date <= $today;
+		}
 
-		return $formatted_expiration_date >= $today;
-	}
+		if ( $expiry_date ) {
+			$formatted_expiry_date = ( new DateTime( $expiry_date ) )->format( $date_format );
+			return $formatted_expiry_date >= $today;
+		}
 
-	/**
-	 * Returns the ad expiration date of a native Ad post type from the post meta.
-	 *
-	 * @param int $ad_id The ad id.
-	 * @return DateTime
-	 */
-	private static function get_ad_expiration_date( $ad_id ) {
-		$expiration_date_meta_key   = 'expiry_date';
-		$expiration_date_meta_value = get_post_meta( $ad_id, $expiration_date_meta_key, true );
-
-		return new DateTime( $expiration_date_meta_value );
+		return true;
 	}
 
 	/** Convert a WP post to an array of non-empty blocks.

--- a/includes/class-newspack-newsletters-renderer.php
+++ b/includes/class-newspack-newsletters-renderer.php
@@ -954,7 +954,7 @@ final class Newspack_Newsletters_Renderer {
 	 */
 	private static function insert_ads( $post, $markup, $current_position ) {
 		foreach ( self::$ads_to_insert as &$ad_to_insert ) {
-			$ad_categories = wp_get_post_terms( $ad_to_insert['ad_id'], 'category' );
+			$ad_categories = wp_get_post_terms( $ad_to_insert['id'], 'category' );
 			// Skip if the ad is not in the same category as the post.
 			if ( ! empty( $ad_categories ) ) {
 				$post_categories = wp_get_post_terms( $post->ID, 'category' );
@@ -965,7 +965,7 @@ final class Newspack_Newsletters_Renderer {
 			$post_advertisers = wp_get_post_terms( $post->ID, Newspack_Newsletters_Ads::ADVERTISER_TAX );
 			// Skip if the post has an advertiser and the ad is not from the same advertiser.
 			if ( ! empty( $post_advertisers ) ) {
-				$ad_advertisers = wp_get_post_terms( $ad_to_insert['ad_id'], Newspack_Newsletters_Ads::ADVERTISER_TAX );
+				$ad_advertisers = wp_get_post_terms( $ad_to_insert['id'], Newspack_Newsletters_Ads::ADVERTISER_TAX );
 				if ( empty( array_intersect( wp_list_pluck( $post_advertisers, 'term_id' ), wp_list_pluck( $ad_advertisers, 'term_id' ) ) ) ) {
 					continue;
 				}
@@ -1081,7 +1081,7 @@ final class Newspack_Newsletters_Renderer {
 			$precise_position = self::get_ad_placement_precise_position( $positioning, $total_length_of_content );
 
 			return [
-				'ad_id'            => $ad_id,
+				'id'               => $ad_id,
 				'is_inserted'      => false,
 				'markup'           => self::post_to_mjml_components( $ad, false ),
 				'percentage'       => $positioning,

--- a/includes/class-newspack-newsletters.php
+++ b/includes/class-newspack-newsletters.php
@@ -616,7 +616,7 @@ final class Newspack_Newsletters {
 		);
 
 		\register_rest_route(
-			'wp/v2/' . Newspack_Newsletters_Ads::NEWSPACK_NEWSLETTERS_ADS_CPT,
+			'wp/v2/' . Newspack_Newsletters_Ads::CPT,
 			'count',
 			[
 				/**
@@ -965,7 +965,7 @@ final class Newspack_Newsletters {
 		$screen = get_current_screen();
 		if (
 			self::NEWSPACK_NEWSLETTERS_CPT !== $screen->post_type &&
-			Newspack_Newsletters_Ads::NEWSPACK_NEWSLETTERS_ADS_CPT !== $screen->post_type &&
+			Newspack_Newsletters_Ads::CPT !== $screen->post_type &&
 			Newspack\Newsletters\Subscription_Lists::CPT !== $screen->post_type
 		) {
 			return;
@@ -1038,7 +1038,7 @@ final class Newspack_Newsletters {
 		$letterhead                 = new Newspack_Newsletters_Letterhead();
 		$has_letterhead_credentials = $letterhead->has_api_credentials();
 		$post_date                  = $request->get_param( 'date' );
-		$newspack_ad_type           = Newspack_Newsletters_Ads::NEWSPACK_NEWSLETTERS_ADS_CPT;
+		$newspack_ad_type           = Newspack_Newsletters_Ads::CPT;
 
 		$url_to_manage_promotions   = 'https://app.tryletterhead.com/promotions';
 		$url_to_manage_newspack_ads = "/wp-admin/edit.php?post_type={$newspack_ad_type}";

--- a/includes/tracking/class-admin.php
+++ b/includes/tracking/class-admin.php
@@ -24,9 +24,9 @@ final class Admin {
 		add_action( 'manage_edit-' . \Newspack_Newsletters::NEWSPACK_NEWSLETTERS_CPT . '_sortable_columns', [ __CLASS__, 'sortable_columns' ] );
 
 		// Newsletters Ads columns.
-		add_action( 'manage_' . \Newspack_Newsletters_Ads::NEWSPACK_NEWSLETTERS_ADS_CPT . '_posts_columns', [ __CLASS__, 'manage_ads_columns' ] );
-		add_action( 'manage_' . \Newspack_Newsletters_Ads::NEWSPACK_NEWSLETTERS_ADS_CPT . '_posts_custom_column', [ __CLASS__, 'custom_ads_column' ], 10, 2 );
-		add_action( 'manage_edit-' . \Newspack_Newsletters_Ads::NEWSPACK_NEWSLETTERS_ADS_CPT . '_sortable_columns', [ __CLASS__, 'sortable_ads_columns' ] );
+		add_action( 'manage_' . \Newspack_Newsletters_Ads::CPT . '_posts_columns', [ __CLASS__, 'manage_ads_columns' ] );
+		add_action( 'manage_' . \Newspack_Newsletters_Ads::CPT . '_posts_custom_column', [ __CLASS__, 'custom_ads_column' ], 10, 2 );
+		add_action( 'manage_edit-' . \Newspack_Newsletters_Ads::CPT . '_sortable_columns', [ __CLASS__, 'sortable_ads_columns' ] );
 
 		// Sorting.
 		add_action( 'pre_get_posts', [ __CLASS__, 'handle_sorting' ] );
@@ -265,7 +265,7 @@ final class Admin {
 			}
 		}
 
-		if ( \Newspack_Newsletters_Ads::NEWSPACK_NEWSLETTERS_ADS_CPT === $query->get( 'post_type' ) ) {
+		if ( \Newspack_Newsletters_Ads::CPT === $query->get( 'post_type' ) ) {
 			$orderby = $query->get( 'orderby' );
 			if ( 'impressions' === $orderby ) {
 				$query->set( 'meta_key', 'tracking_impressions' );

--- a/src/ads/editor/index.js
+++ b/src/ads/editor/index.js
@@ -7,10 +7,16 @@ import { compose } from '@wordpress/compose';
 import { Fragment } from '@wordpress/element';
 import { PluginDocumentSettingPanel, PluginPrePublishPanel } from '@wordpress/edit-post';
 import { registerPlugin } from '@wordpress/plugins';
-import { ToggleControl, DatePicker, Notice, RangeControl } from '@wordpress/components';
+import {
+	ToggleControl,
+	TextControl,
+	DatePicker,
+	Notice,
+	RangeControl,
+} from '@wordpress/components';
 import { format, isInTheFuture } from '@wordpress/date';
 
-const AdEdit = ( { startDate, expiryDate, positionInContent, editPost } ) => {
+const AdEdit = ( { price, startDate, expiryDate, positionInContent, editPost } ) => {
 	let noticeProps;
 	if ( expiryDate ) {
 		const formattedExpiryDate = format( 'M j Y', expiryDate );
@@ -32,6 +38,15 @@ const AdEdit = ( { startDate, expiryDate, positionInContent, editPost } ) => {
 				name="newsletters-ads-settings-panel"
 				title={ __( 'Ad settings', 'newspack-newsletters' ) }
 			>
+				<TextControl
+					type="number"
+					label={ __( 'Price', 'newspack-newsletters' ) }
+					value={ price }
+					onChange={ val => editPost( { meta: { price: val } } ) }
+					min={ 0 }
+					step={ 0.01 }
+				/>
+				<hr />
 				<RangeControl
 					label={ __( 'Approximate position (in percent)' ) }
 					value={ positionInContent }
@@ -39,6 +54,7 @@ const AdEdit = ( { startDate, expiryDate, positionInContent, editPost } ) => {
 					min={ 0 }
 					max={ 100 }
 				/>
+				<hr />
 				<ToggleControl
 					label={ __( 'Custom Start Date', 'newspack-newsletters' ) }
 					checked={ !! startDate }
@@ -93,6 +109,7 @@ const AdEditWithSelect = compose( [
 		const { getEditedPostAttribute } = select( 'core/editor' );
 		const meta = getEditedPostAttribute( 'meta' );
 		return {
+			price: meta.price,
 			startDate: meta.start_date,
 			expiryDate: meta.expiry_date,
 			positionInContent: meta.position_in_content,


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<img width="1318" alt="image" src="https://github.com/Automattic/newspack-newsletters/assets/820752/25ab0c47-207e-4b46-9d4d-1e1ce0b0cbf1">

Implements the following new tax and meta fields for Newsletter Ads:
 - Start date field
 - Price field
 - Advertisers taxonomy
 - Categories taxonomy (same as posts/newsletters)

The taxonomies determine the following:
1. Newsletters associated with an advertiser should only render ads that are also associated with that same advertiser
2. Ads associated with a category should only be rendered in newsletters that are also associated with that category

That means newsletters without any advertiser association can render ads from any advertiser. That also means that ads without any categories can be rendered on any newsletter.

### How to test the changes in this Pull Request:

1. Check out this branch and create an ad with a future start date
2. Draft a new newsletter, save, click to preview, and confirm the ad doesn't render
3. Edit the ad and toggle "Custom Start Date"
4. Don't click any date, the starting date is today and should be disabled for selection (just like past dates)
5. Save, edit the newsletter, and preview
6. Confirm the ad renders
7. Edit the ad, set a future start date, and toggle the "Expiration Date"
8. Confirm you can't select a date prior to the start date
9. Select a future date, set a price, and save
10. Refresh and confirm the values persisted
11. Untoggle the Custom Start Date and save
12. Edit the newsletter, save, preview, and confirm you the ad renders
13. Edit the ad and attach it to an existing category and a new advertiser
14. Edit the newsletter, save, preview, and confirm the ad doesn't render
15. Set the category to the newsletter, save, preview, and confirm the ad renders
16. Set a different new advertiser, save, preview, and confirm the ad doesn't render

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
