### PR TITLE
feat: custom campaign name

### DIFF
--- a/includes/class-newspack-newsletters.php
+++ b/includes/class-newspack-newsletters.php
@@ -215,6 +215,21 @@ final class Newspack_Newsletters {
 	public static function register_meta() {
 		\register_meta(
 			'post',
+			'campaign_name',
+			[
+				'object_subtype' => self::NEWSPACK_NEWSLETTERS_CPT,
+				'show_in_rest'   => [
+					'schema' => [
+						'context' => [ 'edit' ],
+					],
+				],
+				'type'           => 'string',
+				'single'         => true,
+				'auth_callback'  => '__return_true',
+			]
+		);
+		\register_meta(
+			'post',
 			'template_id',
 			[
 				'object_subtype' => self::NEWSPACK_NEWSLETTERS_CPT,

--- a/includes/service-providers/active_campaign/class-newspack-newsletters-active-campaign.php
+++ b/includes/service-providers/active_campaign/class-newspack-newsletters-active-campaign.php
@@ -697,21 +697,6 @@ final class Newspack_Newsletters_Active_Campaign extends \Newspack_Newsletters_S
 	}
 
 	/**
-	 * Get campaign name.
-	 *
-	 * @param WP_Post $post Post object.
-	 *
-	 * @return string Campaign name.
-	 */
-	private function get_campaign_name( $post ) {
-		$campaign_name = get_post_meta( $post->ID, 'campaign_name', true );
-		if ( $campaign_name ) {
-			return $campaign_name;
-		}
-		return sprintf( 'Newspack Newsletter (%d)', $post->ID );
-	}
-
-	/**
 	 * Synchronize post with corresponding ESP campaign.
 	 *
 	 * @param WP_Post $post Post to synchronize.

--- a/includes/service-providers/active_campaign/class-newspack-newsletters-active-campaign.php
+++ b/includes/service-providers/active_campaign/class-newspack-newsletters-active-campaign.php
@@ -700,9 +700,14 @@ final class Newspack_Newsletters_Active_Campaign extends \Newspack_Newsletters_S
 	 * Get campaign name.
 	 *
 	 * @param WP_Post $post Post object.
-	 * @return String Campaign name.
+	 *
+	 * @return string Campaign name.
 	 */
 	private function get_campaign_name( $post ) {
+		$campaign_name = get_post_meta( $post->ID, 'campaign_name', true );
+		if ( $campaign_name ) {
+			return $campaign_name;
+		}
 		return sprintf( 'Newspack Newsletter (%d)', $post->ID );
 	}
 

--- a/includes/service-providers/class-newspack-newsletters-service-provider.php
+++ b/includes/service-providers/class-newspack-newsletters-service-provider.php
@@ -370,6 +370,21 @@ abstract class Newspack_Newsletters_Service_Provider implements Newspack_Newslet
 	}
 
 	/**
+	 * Get campaign name.
+	 *
+	 * @param WP_Post $post Post object.
+	 *
+	 * @return string Campaign name.
+	 */
+	public function get_campaign_name( $post ) {
+		$campaign_name = get_post_meta( $post->ID, 'campaign_name', true );
+		if ( $campaign_name ) {
+			return $campaign_name;
+		}
+		return sprintf( 'Newspack Newsletter (%d)', $post->ID );
+	}
+
+	/**
 	 * Update a contact lists subscription.
 	 *
 	 * @param string   $email           Contact email address.

--- a/includes/service-providers/constant_contact/class-newspack-newsletters-constant-contact.php
+++ b/includes/service-providers/constant_contact/class-newspack-newsletters-constant-contact.php
@@ -289,21 +289,6 @@ final class Newspack_Newsletters_Constant_Contact extends \Newspack_Newsletters_
 	}
 
 	/**
-	 * Get campaign name.
-	 *
-	 * @param WP_Post $post Post object.
-	 *
-	 * @return string Campaign name.
-	 */
-	private function get_campaign_name( $post ) {
-		$campaign_name = get_post_meta( $post->ID, 'campaign_name', true );
-		if ( $campaign_name ) {
-			return $campaign_name;
-		}
-		return sprintf( 'Newspack Newsletter (%d)', $post->ID );
-	}
-
-	/**
 	 * Set list for a campaign.
 	 *
 	 * A campaign can not use segments and lists at the same time, so we also unset all segments.

--- a/includes/service-providers/constant_contact/class-newspack-newsletters-constant-contact.php
+++ b/includes/service-providers/constant_contact/class-newspack-newsletters-constant-contact.php
@@ -95,7 +95,7 @@ final class Newspack_Newsletters_Constant_Contact extends \Newspack_Newsletters_
 				$credentials['api_secret'],
 				$credentials['access_token']
 			);
-	
+
 			$response = [
 				'error'    => null,
 				'valid'    => false,
@@ -292,10 +292,15 @@ final class Newspack_Newsletters_Constant_Contact extends \Newspack_Newsletters_
 	 * Get campaign name.
 	 *
 	 * @param WP_Post $post Post object.
-	 * @return String Campaign name.
+	 *
+	 * @return string Campaign name.
 	 */
 	private function get_campaign_name( $post ) {
-		return 'Newspack Newsletter #' . $post->ID;
+		$campaign_name = get_post_meta( $post->ID, 'campaign_name', true );
+		if ( $campaign_name ) {
+			return $campaign_name;
+		}
+		return sprintf( 'Newspack Newsletter (%d)', $post->ID );
 	}
 
 	/**

--- a/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp.php
+++ b/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp.php
@@ -673,21 +673,6 @@ final class Newspack_Newsletters_Mailchimp extends \Newspack_Newsletters_Service
 	}
 
 	/**
-	 * Get campaign name.
-	 *
-	 * @param WP_Post $post Post object.
-	 *
-	 * @return string Campaign name.
-	 */
-	private function get_campaign_name( $post ) {
-		$campaign_name = get_post_meta( $post->ID, 'campaign_name', true );
-		if ( $campaign_name ) {
-			return $campaign_name;
-		}
-		return sprintf( 'Newspack Newsletter (%d)', $post->ID );
-	}
-
-	/**
 	 * Synchronize post with corresponding ESP campaign.
 	 *
 	 * @param WP_Post $post Post to synchronize.

--- a/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp.php
+++ b/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp.php
@@ -673,6 +673,21 @@ final class Newspack_Newsletters_Mailchimp extends \Newspack_Newsletters_Service
 	}
 
 	/**
+	 * Get campaign name.
+	 *
+	 * @param WP_Post $post Post object.
+	 *
+	 * @return string Campaign name.
+	 */
+	private function get_campaign_name( $post ) {
+		$campaign_name = get_post_meta( $post->ID, 'campaign_name', true );
+		if ( $campaign_name ) {
+			return $campaign_name;
+		}
+		return sprintf( 'Newspack Newsletter (%d)', $post->ID );
+	}
+
+	/**
 	 * Synchronize post with corresponding ESP campaign.
 	 *
 	 * @param WP_Post $post Post to synchronize.
@@ -696,7 +711,7 @@ final class Newspack_Newsletters_Mailchimp extends \Newspack_Newsletters_Service
 				'content_type' => 'template',
 				'settings'     => [
 					'subject_line' => $post->post_title,
-					'title'        => $post->post_title,
+					'title'        => $this->get_campaign_name( $post ),
 				],
 			];
 			$mc_campaign_id = get_post_meta( $post->ID, 'mc_campaign_id', true );

--- a/src/editor/api/index.js
+++ b/src/editor/api/index.js
@@ -12,6 +12,7 @@ import { select as globalSelect } from '@wordpress/data';
 
 const POST_META_WHITELIST = [
 	'is_public',
+	'campaign_name',
 	'preview_text',
 	'disable_auto_ads',
 	'font_body',

--- a/src/newsletter-editor/editor/index.js
+++ b/src/newsletter-editor/editor/index.js
@@ -62,6 +62,7 @@ const Editor = compose( [
 			sent,
 			isPublic: meta.is_public,
 			html: meta[ window.newspack_email_editor_data.email_html_meta ],
+			campaignName: meta.campaign_name,
 		};
 	} ),
 	withDispatch( dispatch => {

--- a/src/newsletter-editor/sidebar/index.js
+++ b/src/newsletter-editor/sidebar/index.js
@@ -31,6 +31,7 @@ const Sidebar = ( {
 	title,
 	senderName,
 	senderEmail,
+	campaignName,
 	previewText,
 	newsletterData,
 	apiFetchWithErrorHandling,
@@ -45,20 +46,32 @@ const Sidebar = ( {
 			}
 		} );
 
+	const getCampaignName = () => {
+		if ( typeof campaignName === 'string' ) {
+			return campaignName;
+		}
+		return 'Newspack Newsletter (' + postId + ')';
+	};
+
+	const renderCampaignName = () => (
+		<TextControl
+			label={ __( 'Campaign Name', 'newspack-newsletters' ) }
+			className="newspack-newsletters__campaign-name-textcontrol"
+			value={ getCampaignName() }
+			placeholder={ 'Newspack Newsletter (' + postId + ')' }
+			disabled={ inFlight }
+			onChange={ value => editPost( { meta: { campaign_name: value } } ) }
+		/>
+	);
+
 	const renderSubject = () => (
-		<>
-			<strong className="newspack-newsletters__label">
-				{ __( 'Subject', 'newspack-newsletters' ) }
-			</strong>
-			<TextControl
-				label={ __( 'Subject', 'newspack-newsletters' ) }
-				className="newspack-newsletters__subject-textcontrol"
-				value={ title }
-				disabled={ inFlight }
-				onChange={ value => editPost( { title: value } ) }
-				hideLabelFromVision
-			/>
-		</>
+		<TextControl
+			label={ __( 'Subject', 'newspack-newsletters' ) }
+			className="newspack-newsletters__subject-textcontrol"
+			value={ title }
+			disabled={ inFlight }
+			onChange={ value => editPost( { title: value } ) }
+		/>
 	);
 
 	const senderEmailClasses = classnames(
@@ -142,6 +155,7 @@ const Sidebar = ( {
 				newsletterData={ newsletterData }
 				inFlight={ inFlight }
 				apiFetch={ apiFetch }
+				renderCampaignName={ renderCampaignName }
 				renderSubject={ renderSubject }
 				renderFrom={ renderFrom }
 				renderPreviewText={ renderPreviewText }
@@ -161,6 +175,7 @@ export default compose( [
 			postId: getCurrentPostId(),
 			senderEmail: meta.senderEmail || '',
 			senderName: meta.senderName || '',
+			campaignName: meta.campaign_name,
 			previewText: meta.preview_text || '',
 			newsletterData: meta.newsletterData || {},
 		};

--- a/src/service-providers/active_campaign/ProviderSidebar.js
+++ b/src/service-providers/active_campaign/ProviderSidebar.js
@@ -39,19 +39,21 @@ export const validateNewsletter = ( { from_email, from_name, list_id } ) => {
  * so that it's possible to render e.g. a loader while
  * the data is not yet available.
  *
- * @param {Object}   props                   Component props.
- * @param {number}   props.postId            ID of the edited newsletter post.
- * @param {Function} props.renderSubject     Function that renders email subject input.
- * @param {Function} props.renderPreviewText Function that renders email preview text input.
- * @param {boolean}  props.inFlight          True if the component is in a loading state.
- * @param {Object}   props.acData            ActiveCampaign data.
- * @param {Function} props.updateMetaValue   Dispatcher to update post meta.
- * @param {Object}   props.newsletterData    Newsletter data from the parent components
- * @param {Function} props.createErrorNotice Dispatcher to display an error message in the editor.
- * @param {string}   props.status            Current post status.
+ * @param {Object}   props                    Component props.
+ * @param {number}   props.postId             ID of the edited newsletter post.
+ * @param {Function} props.renderCampaignName Function that renders campaign name input.
+ * @param {Function} props.renderSubject      Function that renders email subject input.
+ * @param {Function} props.renderPreviewText  Function that renders email preview text input.
+ * @param {boolean}  props.inFlight           True if the component is in a loading state.
+ * @param {Object}   props.acData             ActiveCampaign data.
+ * @param {Function} props.updateMetaValue    Dispatcher to update post meta.
+ * @param {Object}   props.newsletterData     Newsletter data from the parent components
+ * @param {Function} props.createErrorNotice  Dispatcher to display an error message in the editor.
+ * @param {string}   props.status             Current post status.
  */
 const ProviderSidebarComponent = ( {
 	postId,
+	renderCampaignName,
 	renderSubject,
 	renderPreviewText,
 	inFlight,
@@ -114,6 +116,7 @@ const ProviderSidebarComponent = ( {
 
 	return (
 		<div className="newspack-newsletters__campaign-monitor-sidebar">
+			{ renderCampaignName() }
 			{ renderSubject() }
 			{ renderPreviewText() }
 			<hr />

--- a/src/service-providers/constant_contact/ProviderSidebar.js
+++ b/src/service-providers/constant_contact/ProviderSidebar.js
@@ -19,6 +19,7 @@ import {
 import './style.scss';
 
 const ProviderSidebar = ( {
+	renderCampaignName,
 	renderSubject,
 	renderFrom,
 	renderPreviewText,
@@ -99,6 +100,7 @@ const ProviderSidebar = ( {
 
 	return (
 		<Fragment>
+			{ renderCampaignName() }
 			{ renderSubject() }
 			{ renderPreviewText() }
 			<hr />

--- a/src/service-providers/mailchimp/ProviderSidebar.js
+++ b/src/service-providers/mailchimp/ProviderSidebar.js
@@ -86,6 +86,7 @@ const SegmentsSelection = ( {
 };
 
 const ProviderSidebar = ( {
+	renderCampaignName,
 	renderSubject,
 	renderFrom,
 	renderPreviewText,
@@ -208,6 +209,7 @@ const ProviderSidebar = ( {
 
 	return (
 		<Fragment>
+			{ renderCampaignName() }
 			{ renderSubject() }
 			{ renderPreviewText() }
 			<hr />


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Implements support for custom campaign names for Mailchimp, ActiveCampaign, and Constant Contact.

<img width="285" alt="image" src="https://github.com/Automattic/newspack-newsletters/assets/820752/52dacca0-b799-4bc0-a17d-a3f828c54037">

### How to test the changes in this Pull Request:

1. Make sure you have Mailchimp, ActiveCampaign or Constant Contact as your ESP
2. Draft a new newsletter and confirm you see the input above with the default "Newspack Newsletter (Post ID)"
3. Save the draft and confirm the draft is saved in the ESP with the expected campaign name
4. Delete the input and confirm the placeholder renders the default value, save the draft and confirm the default value persists
5. Add a custom text, save and confirm the draft is updated on the ESP

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
