### PR TITLE
fix: avoid reprocessing links

### DIFF
--- a/includes/class-newspack-newsletters-renderer.php
+++ b/includes/class-newspack-newsletters-renderer.php
@@ -40,11 +40,11 @@ final class Newspack_Newsletters_Renderer {
 	protected static $font_body = null;
 
 	/**
-	 * Ads to insert.
+	 * Cache of already processed links (avoid recursive processing).
 	 *
-	 * @var Array
+	 * @var boolean[] Map of link URLs to whether they were processed.
 	 */
-	protected static $ads_to_insert = [];
+	protected static $processed_links = [];
 
 	/**
 	 * The post permalink, if the post is public.
@@ -288,6 +288,10 @@ final class Newspack_Newsletters_Renderer {
 		$href_params = $matches[0];
 		$urls        = $matches[1];
 		foreach ( $urls as $index => $url ) {
+			/** Skip if link was already processed. */
+			if ( ! empty( self::$processed_links[ $url ] ) ) {
+				continue;
+			}
 			/** Link href content can be invalid (placeholder) so we must skip it. */
 			if ( ! wp_http_validate_url( $url ) ) {
 				continue;
@@ -303,6 +307,8 @@ final class Newspack_Newsletters_Renderer {
 				$url,
 				$post
 			);
+
+			self::$processed_links[ $url_with_params ] = true;
 
 			$html = str_replace( $href_params[ $index ], 'href="' . $url_with_params . '"', $html );
 		}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Prevents the renderer processing of links to be executed more than once for the same - already processed - link URL.

Also removes the unused `$ads_to_insert` private static variable.

### How to test the changes in this Pull Request:

1. Make sure you have a valid newsletter ad with inner link
2. Place the ad through a Newsletter Ad block on a new newsletter draft
3. Save the draft multiple times
4. Click on "Preview email" and confirm the ad link URL is correct (without multiple repeated arguments) and redirects without issues

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
