### PR TITLE
feat: add option to change subscription button block color

### DIFF
--- a/src/blocks/subscribe/block.json
+++ b/src/blocks/subscribe/block.json
@@ -65,10 +65,30 @@
 		"successMessage": {
 			"type": "string",
 			"default": "Thank you for signing up!"
+		},
+		"style": {
+			"type": "object",
+			"default": {
+				"color": {
+					"background": "#dd3333",
+					"text": "#ffffff"
+				}
+			}
+		},
+		"className": {
+			"type": "string"
 		}
 	},
 	"supports": {
 		"html": false,
-		"align": true
+		"align": true,
+		"color": {
+			"__experimentalSkipSerialization": true,
+			"gradients": true,
+			"__experimentalDefaultControls": {
+				"background": true,
+				"text": true
+			}
+		}
 	}
 }

--- a/src/blocks/subscribe/edit.js
+++ b/src/blocks/subscribe/edit.js
@@ -1,5 +1,6 @@
 /* globals newspack_newsletters_blocks */
 /* eslint jsx-a11y/label-has-for: 0 */
+/* eslint-disable @wordpress/no-unsafe-wp-apis */
 /**
  * External dependencies.
  */
@@ -21,7 +22,12 @@ import {
 	Spinner,
 	Button,
 } from '@wordpress/components';
-import { useBlockProps, InspectorControls, RichText } from '@wordpress/block-editor';
+import {
+	useBlockProps,
+	InspectorControls,
+	RichText,
+	__experimentalUseColorProps as useColorProps,
+} from '@wordpress/block-editor';
 
 /**
  * Internal dependencies
@@ -39,9 +45,9 @@ const editedStateOptions = [
 	{ label: __( 'Success', 'newspack-newsletters' ), value: 'success' },
 ];
 
-export default function SubscribeEdit( {
-	setAttributes,
-	attributes: {
+export default function SubscribeEdit( props ) {
+	const { attributes, setAttributes } = props;
+	const {
 		displayInputLabels,
 		placeholder,
 		emailLabel,
@@ -56,9 +62,10 @@ export default function SubscribeEdit( {
 		lists,
 		displayDescription,
 		mailchimpDoubleOptIn,
-	},
-} ) {
+	} = attributes;
+
 	const blockProps = useBlockProps();
+	const colorProps = useColorProps( attributes );
 	const [ editedState, setEditedState ] = useState( editedStateOptions[ 0 ].value );
 	const [ inFlight, setInFlight ] = useState( false );
 	const [ listConfig, setListConfig ] = useState( {} );
@@ -300,8 +307,14 @@ export default function SubscribeEdit( {
 											/>
 										) }
 									</label>
+
 									<input type="email" placeholder={ placeholder } />
-									<div className="submit-button">
+									<div
+										className={ classnames( 'submit-button', colorProps.className ) }
+										style={ {
+											...colorProps.style,
+										} }
+									>
 										<RichText
 											onChange={ value => setAttributes( { label: value } ) }
 											placeholder={ __( 'Sign up', 'newspack' ) }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?


### Changes proposed in this Pull Request:

This PR adds an option to change the button colour in the subscribe block; as part of this change, there's also a small theme PR to make sure the palette colours get picked up correctly: https://github.com/Automattic/newspack-theme/pull/2177

I mostly followed how this was handled for the Checkout button, with a couple bigger differences:

* I had to make some changes to get it working with the PHP output for the front-end
* In the above, I added a normally-unnecessary check for the defaults so they're not output as inline styles. This is strictly to keep existing Custom CSS working -- the styles that are already out there easily override the block's default CSS, but won't override the colours if they're inline.

I'd love feedback on any of the changes made in this PR but wanted to flag those two in particular (especially if there's a better way to go about either of them!). 

See 1200550061930446-as-1204989537763335

### How to test the changes in this Pull Request:

1. Apply this PR and https://github.com/Automattic/newspack-theme/pull/2177 to the theme and run `npm run build` for both.
2. Add the Subscription block to the editor and confirm that you now have some colour options under the Styles tab:

![image](https://github.com/Automattic/newspack-newsletters/assets/177561/467c8a39-cd5e-443e-bae6-050012714328)

3. Try changing the colours to options in your editor palette, and confirm they work in the editor and on the front-end.
4. Try changing the colours to custom colours, and confirm they work in the editor and on the front-end. 
5. Try clearing the colours (... menu in the Color panel and click 'Reset all'), and confirm the block goes back to the default red and white.
6. To test the CSS issue I mentioned above, you can try adding the following to the Additional CSS panel in the Customizer, and confirm it overrides the default styles:

```
div.newspack-newsletters-subscribe input[type="submit"] {
	background: yellow;
	color: black;
}
```

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
