### PR TITLE
fix(posts-inserter): avoid conflicting UI state

### DIFF
--- a/src/editor/blocks/posts-inserter/query-controls.js
+++ b/src/editor/blocks/posts-inserter/query-controls.js
@@ -218,15 +218,17 @@ const QueryControlsSettings = ( { attributes, setAttributes } ) => {
 				onChange={ postType => setAttributes( { postType } ) }
 			/>
 			<ToggleControl
-				label={ __( 'Display sponsored posts', 'newspack-newsletters' ) }
-				checked={ attributes.displaySponsoredPosts }
-				onChange={ value => setAttributes( { displaySponsoredPosts: value } ) }
-			/>
-			<ToggleControl
 				label={ __( 'Display specific posts', 'newspack-newsletters' ) }
 				checked={ attributes.isDisplayingSpecificPosts }
 				onChange={ value => setAttributes( { isDisplayingSpecificPosts: value } ) }
 			/>
+			{ ! attributes.isDisplayingSpecificPosts && (
+				<ToggleControl
+					label={ __( 'Display sponsored posts', 'newspack-newsletters' ) }
+					checked={ attributes.displaySponsoredPosts }
+					onChange={ value => setAttributes( { displaySponsoredPosts: value } ) }
+				/>
+			) }
 			{ attributes.isDisplayingSpecificPosts ? (
 				<FormTokenField
 					label={


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes an impossible UI state in the Posts Inserter block.

### How to test the changes in this Pull Request:

1. Make sure you have at least 1 sponsored post on your test site.
2. Create a new newsletter and add a Posts Inserter block set to display specific posts.
3. Choose the sponsored post to appear in the block. On `master`, observe that the "Display sponsored posts" option remains available in block settings, but has no effect due to the "specific posts" behavior forcing the sponsored post to be displayed.
4. Check out this branch and refresh the newsletter. Now confirm that if "Display specific posts" is turned on for the Posts Inserter block, the "Display sponsored posts" option disappears as it's no longer relevant.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
