### PR TITLE
feat: add color picker for the subscribe block button

### DIFF
--- a/src/blocks/subscribe/block.json
+++ b/src/blocks/subscribe/block.json
@@ -65,6 +65,25 @@
 		"successMessage": {
 			"type": "string",
 			"default": "Thank you for signing up!"
+		},
+		"className": {
+			"type": "string"
+		},
+		"textColor": {
+			"type": "string",
+			"default": "#ffffff"
+		},
+		"textColorName": {
+			"type": "string",
+			"default": ""
+		},
+		"backgroundColor": {
+			"type": "string",
+			"default": "#dd3333"
+		},
+		"backgroundColorName": {
+			"type": "string",
+			"default": ""
 		}
 	},
 	"supports": {

--- a/src/blocks/subscribe/edit.js
+++ b/src/blocks/subscribe/edit.js
@@ -21,7 +21,14 @@ import {
 	Spinner,
 	Button,
 } from '@wordpress/components';
-import { useBlockProps, InspectorControls, RichText } from '@wordpress/block-editor';
+import {
+	useBlockProps,
+	InspectorControls,
+	RichText,
+	PanelColorSettings,
+	getColorObjectByColorValue,
+} from '@wordpress/block-editor';
+import { select } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -38,6 +45,18 @@ const editedStateOptions = [
 	{ label: __( 'Initial', 'newspack-newsletters' ), value: 'initial' },
 	{ label: __( 'Success', 'newspack-newsletters' ), value: 'success' },
 ];
+
+function getColorName( colorvalue ) {
+	let colorName = '';
+	if ( colorvalue ) {
+		const settings = select( 'core/editor' ).getEditorSettings();
+		const colorObject = getColorObjectByColorValue( settings.colors, colorvalue );
+		if ( colorObject ) {
+			colorName = colorObject.slug;
+		}
+	}
+	return colorName;
+}
 
 export default function SubscribeEdit( {
 	setAttributes,
@@ -56,6 +75,8 @@ export default function SubscribeEdit( {
 		lists,
 		displayDescription,
 		mailchimpDoubleOptIn,
+		textColor,
+		backgroundColor,
 	},
 } ) {
 	const blockProps = useBlockProps();
@@ -77,6 +98,17 @@ export default function SubscribeEdit( {
 			setAttributes( { lists: [ Object.keys( listConfig )[ 0 ] ] } );
 		}
 	}, [ listConfig ] );
+
+	const onChangeBackgroundColor = newBackgroundColor => {
+		setAttributes( { backgroundColorName: getColorName( newBackgroundColor ) } );
+		setAttributes( { backgroundColor: newBackgroundColor } );
+	};
+
+	const onChangeTextColor = newTextColor => {
+		setAttributes( { textColorName: getColorName( newTextColor ) } );
+		setAttributes( { textColor: newTextColor } );
+	};
+
 	return (
 		<>
 			<InspectorControls>
@@ -124,6 +156,33 @@ export default function SubscribeEdit( {
 							onChange={ () => setAttributes( { displayDescription: ! displayDescription } ) }
 						/>
 					) }
+				</PanelBody>
+				<PanelBody
+					title={ __( 'Styles', 'newspack-newsletters' ) }
+					initialOpen={ false }
+					className="styles-container"
+				>
+					<p>
+						{ __(
+							"Pick a button color that will contrast against the rest of your site's color scheme.",
+							'newspack-newsletters'
+						) }
+					</p>
+					<PanelColorSettings
+						initialOpen={ true }
+						colorSettings={ [
+							{
+								value: textColor,
+								onChange: onChangeTextColor,
+								label: __( 'Text color', 'newspack-newsletters' ),
+							},
+							{
+								value: backgroundColor,
+								onChange: onChangeBackgroundColor,
+								label: __( 'Background color', 'newspack-newsletters' ),
+							},
+						] }
+					/>
 				</PanelBody>
 				<PanelBody title={ __( 'Subscription Lists', 'newspack-newsletters' ) }>
 					{ inFlight && <Spinner /> }
@@ -301,7 +360,7 @@ export default function SubscribeEdit( {
 										) }
 									</label>
 									<input type="email" placeholder={ placeholder } />
-									<div className="submit-button">
+									<div className="submit-button" style={ { backgroundColor, color: textColor } }>
 										<RichText
 											onChange={ value => setAttributes( { label: value } ) }
 											placeholder={ __( 'Sign up', 'newspack' ) }

--- a/src/blocks/subscribe/edit.js
+++ b/src/blocks/subscribe/edit.js
@@ -157,11 +157,7 @@ export default function SubscribeEdit( {
 						/>
 					) }
 				</PanelBody>
-				<PanelBody
-					title={ __( 'Styles', 'newspack-newsletters' ) }
-					initialOpen={ false }
-					className="styles-container"
-				>
+				<PanelBody title={ __( 'Styles', 'newspack-newsletters' ) } className="styles-container">
 					<p>
 						{ __(
 							"Make sure to pick a color that will contrast against the rest of your site's color scheme, to help this block stand out!",

--- a/src/blocks/subscribe/edit.js
+++ b/src/blocks/subscribe/edit.js
@@ -164,7 +164,7 @@ export default function SubscribeEdit( {
 				>
 					<p>
 						{ __(
-							"Pick a button color that will contrast against the rest of your site's color scheme.",
+							"Make sure to pick a color that will contrast against the rest of your site's color scheme, to help this block stand out!",
 							'newspack-newsletters'
 						) }
 					</p>

--- a/src/blocks/subscribe/editor.scss
+++ b/src/blocks/subscribe/editor.scss
@@ -79,3 +79,9 @@
 	// stylelint-disable-next-line no-invalid-position-at-import-rule,import-notation
 	@import 'style';
 }
+
+// Remove padding around the nested Color Palette
+.components-panel__body.styles-container .components-tools-panel {
+	border: 0;
+	padding: 0;
+}

--- a/src/blocks/subscribe/index.php
+++ b/src/blocks/subscribe/index.php
@@ -251,7 +251,8 @@ function render_block( $attrs ) {
 					<?php if ( $provider && 'mailchimp' === $provider->service && $attrs['mailchimpDoubleOptIn'] ) : ?>
 						<input type="hidden" name="double_optin" value="1" />
 					<?php endif; ?>
-					<input type="submit" value="<?php echo \esc_attr( $attrs['label'] ); ?>" />
+
+					<input class="<?php echo \esc_attr( get_block_button_classes( $attrs ) ); ?>"type="submit" value="<?php echo \esc_attr( $attrs['label'] ); ?>" style="<?php echo \esc_attr( get_block_button_styles( $attrs ) ); ?>" />
 				</div>
 			</form>
 		<?php endif; ?>
@@ -287,6 +288,83 @@ function get_block_classes( $attrs = [] ) {
 		$classes[] = 'multiple-lists';
 	}
 	return implode( ' ', $classes );
+}
+
+/**
+ * Check if button text is set to the default color.
+ *
+ * @param array $attrs Block attributes.
+ *
+ * @return bool Whether text color is default.
+ */
+function is_button_text_default( $attrs = [] ) {
+	if ( '#ffffff' === $attrs['textColor'] ) {
+		return true;
+	}
+	return false;
+}
+
+/**
+ * Check if button background is set to the default color.
+ *
+ * @param array $attrs Block attributes.
+ *
+ * @return bool Whether background color is default.
+ */
+function is_button_background_default( $attrs = [] ) {
+	if ( '#dd3333' === $attrs['backgroundColor'] ) {
+		return true;
+	}
+	return false;
+}
+
+/**
+ * Utility to assemble the class for a server-side rendered block button.
+ *
+ * @param array $attrs Block attributes.
+ *
+ * @return string Class list separated by spaces.
+ */
+function get_block_button_classes( $attrs = [] ) {
+	$classes[] = 'submit-button';
+
+	if ( ! is_button_text_default( $attrs ) ) {
+		$classes[] = 'has-text-color';
+	}
+
+	if ( ! is_button_background_default( $attrs ) ) {
+		$classes[] = 'has-background-color';
+	}
+
+	if ( '' !== $attrs['backgroundColorName'] ) {
+		$classes[] = 'has-' . $attrs['backgroundColorName'] . '-background-color';
+	}
+
+	if ( '' !== $attrs['textColorName'] ) {
+		$classes[] = 'has-' . $attrs['textColorName'] . '-color';
+	}
+
+	return implode( ' ', $classes );
+}
+
+/**
+ * Utility to assemble the styles for a server-side rendered block button.
+ *
+ * @param array $attrs Block attributes.
+ *
+ * @return string Class list separated by spaces.
+ */
+function get_block_button_styles( $attrs = [] ) {
+	$style = '';
+
+	if ( ! is_button_text_default( $attrs ) ) {
+		$style .= 'color: ' . $attrs['textColor'] . ';';
+	}
+
+	if ( ! is_button_background_default( $attrs ) ) {
+		$style .= 'background-color: ' . $attrs['backgroundColor'] . ';';
+	}
+	return $style;
 }
 
 /**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR adds an option to change the button colour in the subscribe block; as part of this change, there's also a small theme PR to make sure the palette colours get picked up correctly: https://github.com/Automattic/newspack-theme/pull/2177

A couple specific things to call out:

* My previous attempt (#1279) tried to copy how the Checkout button handles this, but then realized there wasn't an easy way to add text recommending using colours that stand out. So this is a bit of a franken-attempt, nesting a `PanelColorSettings` inside of a `PanelBody` 😅 and probably a couple other minor crimes. (The other option was two separate `ColorPickers`, but they ate up a lot of space!).
* I added a normally-unnecessary check for the default colours so they're not output as inline styles. This is strictly to keep existing Custom CSS working -- the styles that are already out there easily override the block's default CSS, but won't override the colours if they're inline.

I'd love feedback on any of the changes made in this PR but wanted to flag those two in particular (especially if there's a better way to go about either of them!).

See 1200550061930446-as-1204989537763335

### How to test the changes in this Pull Request:

1. Apply this PR and https://github.com/Automattic/newspack-theme/pull/2177 to the theme and run `npm run build` for both.
2. Add the Subscription block to the editor and confirm that you now have some colour options under the Styles panel.

![image](https://github.com/Automattic/newspack-newsletters/assets/177561/61a29b94-13c0-49b7-995d-fe35b6083489)

3. To test the CSS issue I mentioned above, you can try publishing the post, and adding the following to the Additional CSS panel in the Customizer, and confirm it overrides the default styles:

```
div.newspack-newsletters-subscribe input[type="submit"] {
	background: yellow;
	color: black;
}
```

4. Try changing the colours to options in your editor palette, and confirm they work in the editor and on the front-end.
5. Try changing the colours to custom colours, and confirm they work in the editor and on the front-end.
6. Review the text message displayed with the colour picker, and let me know if you have any suggestions to improve it!

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
