### PR TITLE
Declared Reader Activation

### DIFF
--- a/includes/class-newspack-newsletters-subscription.php
+++ b/includes/class-newspack-newsletters-subscription.php
@@ -8,6 +8,7 @@
 defined( 'ABSPATH' ) || exit;
 
 use Newspack\Newsletters\Subscription_Lists;
+use Newspack\Newsletters\Reader_Activation;
 
 /**
  * Manages Settings Subscription Class.


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)? [x]
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)? [x]
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?[x]

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->
One of our ProfilePress plugin users reported a critical error on their site when using your plugin with ProfilePress. We took a look and found that you did not declare the Reader_Activation class in the file newspack-newsletters/includes/class-newspack-newsletters-subscription.php although it is used on line 524.

We added the declaration and that fixed the issue.
![image](https://github.com/Automattic/newspack-newsletters/assets/32033699/65a9a952-f18f-4039-9a9a-ebfff846ba64)

Closes # .


### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?[x]
* [ ] Have you written new tests for your changes, as applicable? No
* [ ] Have you successfully ran tests with your changes locally? [x]
