### PR TITLE
fix: newsletterData handling and editor improvements

### DIFF
--- a/includes/class-newspack-newsletters.php
+++ b/includes/class-newspack-newsletters.php
@@ -156,21 +156,6 @@ final class Newspack_Newsletters {
 				],
 			],
 			[
-				'name'               => 'newsletterValidationErrors',
-				'register_meta_args' => [
-					'show_in_rest' => [
-						'schema' => [
-							'type'    => 'array',
-							'context' => [ 'edit' ],
-							'items'   => [
-								'type' => 'string',
-							],
-						],
-					],
-					'type'         => 'array',
-				],
-			],
-			[
 				'name'               => 'senderName',
 				'register_meta_args' => [
 					'show_in_rest' => [

--- a/includes/service-providers/active_campaign/class-newspack-newsletters-active-campaign.php
+++ b/includes/service-providers/active_campaign/class-newspack-newsletters-active-campaign.php
@@ -569,10 +569,12 @@ final class Newspack_Newsletters_Active_Campaign extends \Newspack_Newsletters_S
 	/**
 	 * Retrieve a campaign.
 	 *
-	 * @param integer $post_id Numeric ID of the Newsletter post.
+	 * @param int  $post_id    Numeric ID of the Newsletter post.
+	 * @param bool $skip_sync Whether to skip syncing the campaign.
+
 	 * @return array|WP_Error API Response or error.
 	 */
-	public function retrieve( $post_id ) {
+	public function retrieve( $post_id, $skip_sync = false ) {
 		if ( ! $this->has_api_credentials() ) {
 			return [];
 		}
@@ -608,7 +610,7 @@ final class Newspack_Newsletters_Active_Campaign extends \Newspack_Newsletters_S
 			'lists'       => $lists,
 			'segments'    => $segments,
 		];
-		if ( ! $campaign_id ) {
+		if ( ! $campaign_id && true !== $skip_sync ) {
 			$sync_result = $this->sync( get_post( $post_id ) );
 			if ( ! is_wp_error( $sync_result ) ) {
 				$result = wp_parse_args(
@@ -781,7 +783,7 @@ final class Newspack_Newsletters_Active_Campaign extends \Newspack_Newsletters_S
 		update_post_meta( $post->ID, 'ac_message_id', $message['id'] );
 
 		// Retrieve and store campaign data.
-		$data = $this->retrieve( $post->ID );
+		$data = $this->retrieve( $post->ID, true );
 		if ( ! is_wp_error( $data ) ) {
 			update_post_meta( $post->ID, 'newsletterData', $data );
 		}

--- a/includes/service-providers/active_campaign/class-newspack-newsletters-active-campaign.php
+++ b/includes/service-providers/active_campaign/class-newspack-newsletters-active-campaign.php
@@ -782,19 +782,22 @@ final class Newspack_Newsletters_Active_Campaign extends \Newspack_Newsletters_S
 
 		update_post_meta( $post->ID, 'ac_message_id', $message['id'] );
 
-		// Retrieve and store campaign data.
-		$data = $this->retrieve( $post->ID, true );
-		if ( ! is_wp_error( $data ) ) {
-			update_post_meta( $post->ID, 'newsletterData', $data );
-		}
-
-		return [
+		$sync_data = [
 			'campaign'   => true, // Satisfy JS API.
 			'message_id' => $message['id'],
 			'list_id'    => $list_id,
 			'from_email' => $from_email,
 			'from_name'  => $from_name,
 		];
+
+		// Retrieve and store campaign data.
+		$data = $this->retrieve( $post->ID, true );
+		if ( ! is_wp_error( $data ) ) {
+			$data = array_merge( $data, $sync_data );
+			update_post_meta( $post->ID, 'newsletterData', $data );
+		}
+
+		return $sync_data;
 	}
 
 	/**

--- a/includes/service-providers/active_campaign/class-newspack-newsletters-active-campaign.php
+++ b/includes/service-providers/active_campaign/class-newspack-newsletters-active-campaign.php
@@ -780,6 +780,12 @@ final class Newspack_Newsletters_Active_Campaign extends \Newspack_Newsletters_S
 
 		update_post_meta( $post->ID, 'ac_message_id', $message['id'] );
 
+		// Retrieve and store campaign data.
+		$data = $this->retrieve( $post->ID );
+		if ( ! is_wp_error( $data ) ) {
+			update_post_meta( $post->ID, 'newsletterData', $data );
+		}
+
 		return [
 			'campaign'   => true, // Satisfy JS API.
 			'message_id' => $message['id'],

--- a/includes/service-providers/constant_contact/class-newspack-newsletters-constant-contact.php
+++ b/includes/service-providers/constant_contact/class-newspack-newsletters-constant-contact.php
@@ -680,6 +680,11 @@ final class Newspack_Newsletters_Constant_Contact extends \Newspack_Newsletters_
 				$campaign_result = $cc->create_campaign( $campaign );
 			}
 			update_post_meta( $post->ID, 'cc_campaign_id', $campaign_result->campaign_id );
+			// Retrieve and store campaign data.
+			$data = $this->retrieve( $post->ID );
+			if ( ! is_wp_error( $data ) ) {
+				update_post_meta( $post->ID, 'newsletterData', $data );
+			}
 			return $campaign_result;
 
 		} catch ( Exception $e ) {

--- a/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp.php
+++ b/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp.php
@@ -740,6 +740,13 @@ final class Newspack_Newsletters_Mailchimp extends \Newspack_Newsletters_Service
 				$mc->put( "campaigns/$mc_campaign_id/content", $content_payload ),
 				__( 'Error updating campaign content.', 'newspack_newsletters' )
 			);
+
+			// Retrieve and store campaign data.
+			$data = $this->retrieve( $post->ID );
+			if ( ! is_wp_error( $data ) ) {
+				update_post_meta( $post->ID, 'newsletterData', $data );
+			}
+
 			return [
 				'campaign_result' => $campaign_result,
 				'content_result'  => $content_result,

--- a/src/components/send-button/index.js
+++ b/src/components/send-button/index.js
@@ -18,6 +18,7 @@ import { get } from 'lodash';
  * Internal dependencies
  */
 import { getServiceProvider } from '../../service-providers';
+import { validateNewsletter } from '../../newsletter-editor/utils';
 import './style.scss';
 
 function PreviewHTML() {
@@ -130,7 +131,9 @@ export default compose( [
 		sent,
 		isPublished,
 	} ) => {
-		const { newsletterData = {}, newsletterValidationErrors = [], is_public } = meta;
+		const { newsletterData = {}, is_public } = meta;
+
+		const newsletterValidationErrors = validateNewsletter( newsletterData );
 
 		const {
 			name: serviceProviderName,

--- a/src/editor/api/index.js
+++ b/src/editor/api/index.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { pick, omit, includes } from 'lodash';
+import { pick, includes } from 'lodash';
 import mjml2html from 'mjml-browser';
 
 /**
@@ -21,6 +21,8 @@ const POST_META_WHITELIST = [
 	'custom_css',
 	'newsletter_sent',
 ];
+
+const emailHTMLMetaName = window.newspack_email_editor_data.email_html_meta;
 
 /**
  * Use a middleware to hijack the post update request.
@@ -53,12 +55,6 @@ apiFetch.use( async ( options, next ) => {
 	// Only run if the current post type is allowed to be handled by MJML.
 	if ( ! includes( mjmlHandlingPostTypes, postType ) ) {
 		return next( options );
-	}
-
-	const emailHTMLMetaName = window.newspack_email_editor_data.email_html_meta;
-	// Strip the meta which will be updated explicitly from post update payload.
-	if ( options.data.meta ) {
-		options.data.meta = omit( options.data.meta, [ ...POST_META_WHITELIST, emailHTMLMetaName ] );
 	}
 
 	const meta = pick( editorSelector.getEditedPostAttribute( 'meta' ), POST_META_WHITELIST );

--- a/src/editor/api/index.js
+++ b/src/editor/api/index.js
@@ -61,11 +61,12 @@ apiFetch.use( async ( options, next ) => {
 		options.data.meta = omit( options.data.meta, [ ...POST_META_WHITELIST, emailHTMLMetaName ] );
 	}
 
+	const meta = pick( editorSelector.getEditedPostAttribute( 'meta' ), POST_META_WHITELIST );
+
 	// First, save post meta. It is not saved when saving a draft, so
 	// it's saved here in order for the backend to have access to these.
-	const postMeta = editorSelector.getEditedPostAttribute( 'meta' );
 	await apiFetch( {
-		data: { meta: pick( postMeta, POST_META_WHITELIST ) },
+		data: { meta },
 		method: 'POST',
 		path: `/wp/v2/${ postType }/${ data.id }`,
 	} );

--- a/src/newsletter-editor/index.js
+++ b/src/newsletter-editor/index.js
@@ -2,8 +2,7 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { withSelect, withDispatch } from '@wordpress/data';
-import { compose } from '@wordpress/compose';
+import { useSelect, useDispatch } from '@wordpress/data';
 import { Fragment, useEffect, useState } from '@wordpress/element';
 import {
 	PluginDocumentSettingPanel,
@@ -28,12 +27,12 @@ import withApiHandler from '../components/with-api-handler';
 
 registerEditorPlugin();
 
-const NewsletterEdit = ( {
-	apiFetchWithErrorHandling,
-	setInFlightForAsync,
-	savePost,
-	layoutId,
-} ) => {
+function NewsletterEdit( { apiFetchWithErrorHandling, setInFlightForAsync } ) {
+	const layoutId = useSelect(
+		select => select( 'core/editor' ).getEditedPostAttribute( 'meta' ).layout_id
+	);
+	const savePost = useDispatch( 'core/editor' ).savePost;
+
 	const [ shouldDisplaySettings, setShouldDisplaySettings ] = useState(
 		window?.newspack_newsletters_data?.is_service_provider_configured !== '1'
 	);
@@ -116,24 +115,9 @@ const NewsletterEdit = ( {
 			<ApplyStyling />
 		</Fragment>
 	);
-};
-
-const NewsletterEditWithSelect = compose( [
-	withApiHandler(),
-	withSelect( select => {
-		const { getEditedPostAttribute } = select( 'core/editor' );
-		const meta = getEditedPostAttribute( 'meta' );
-		return { layoutId: meta.template_id };
-	} ),
-	withDispatch( dispatch => {
-		const { savePost } = dispatch( 'core/editor' );
-		return {
-			savePost,
-		};
-	} ),
-] )( NewsletterEdit );
+}
 
 registerPlugin( 'newspack-newsletters-sidebar', {
-	render: NewsletterEditWithSelect,
+	render: withApiHandler()( NewsletterEdit ),
 	icon: null,
 } );

--- a/src/newsletter-editor/index.js
+++ b/src/newsletter-editor/index.js
@@ -29,7 +29,7 @@ registerEditorPlugin();
 
 function NewsletterEdit( { apiFetchWithErrorHandling, setInFlightForAsync } ) {
 	const layoutId = useSelect(
-		select => select( 'core/editor' ).getEditedPostAttribute( 'meta' ).layout_id
+		select => select( 'core/editor' ).getEditedPostAttribute( 'meta' ).template_id
 	);
 	const savePost = useDispatch( 'core/editor' ).savePost;
 

--- a/src/newsletter-editor/utils.js
+++ b/src/newsletter-editor/utils.js
@@ -4,15 +4,19 @@
 import { getServiceProvider } from '../service-providers';
 
 export const getEditPostPayload = newsletterData => {
-	const { validateNewsletter } = getServiceProvider();
 	return {
 		meta: {
-			// These meta fields do not have to be registered on the back end,
-			// as they are not used there.
-			newsletterValidationErrors: validateNewsletter( newsletterData ),
 			newsletterData,
 		},
 	};
+};
+
+export const validateNewsletter = newsletterData => {
+	const { validateNewsletter: validate } = getServiceProvider();
+	if ( ! validate ) {
+		return [];
+	}
+	return validate( newsletterData );
 };
 
 /**

--- a/src/service-providers/active_campaign/ProviderSidebar.js
+++ b/src/service-providers/active_campaign/ProviderSidebar.js
@@ -47,7 +47,6 @@ export const validateNewsletter = ( { from_email, from_name, list_id } ) => {
  * @param {boolean}  props.inFlight           True if the component is in a loading state.
  * @param {Object}   props.acData             ActiveCampaign data.
  * @param {Function} props.updateMetaValue    Dispatcher to update post meta.
- * @param {Object}   props.newsletterData     Newsletter data from the parent components
  * @param {Function} props.createErrorNotice  Dispatcher to display an error message in the editor.
  * @param {string}   props.status             Current post status.
  */
@@ -59,7 +58,6 @@ const ProviderSidebarComponent = ( {
 	inFlight,
 	acData,
 	updateMetaValue,
-	newsletterData,
 	createErrorNotice,
 	status,
 } ) => {
@@ -87,19 +85,6 @@ const ProviderSidebarComponent = ( {
 		}
 		setIsLoading( false );
 	};
-
-	useEffect( () => {
-		const updatedData = {
-			...newsletterData,
-			lists,
-			list_id: listId,
-			segment_id: segmentId,
-			from_email: senderEmail,
-			from_name: senderName,
-			campaign: true,
-		};
-		updateMetaValue( 'newsletterData', updatedData );
-	}, [ JSON.stringify( acData ), lists, status ] );
 
 	if ( ! inFlight && 'publish' === status ) {
 		return (

--- a/src/service-providers/active_campaign/ProviderSidebar.js
+++ b/src/service-providers/active_campaign/ProviderSidebar.js
@@ -98,11 +98,6 @@ const ProviderSidebarComponent = ( {
 			from_name: senderName,
 			campaign: true,
 		};
-
-		const messages = validateNewsletter( updatedData );
-
-		// Send info to parent components, for send button/validation management.
-		updateMetaValue( 'newsletterValidationErrors', messages );
 		updateMetaValue( 'newsletterData', updatedData );
 	}, [ JSON.stringify( acData ), lists, status ] );
 

--- a/src/service-providers/campaign_monitor/ProviderSidebar.js
+++ b/src/service-providers/campaign_monitor/ProviderSidebar.js
@@ -119,11 +119,6 @@ const ProviderSidebarComponent = ( {
 			from_name: senderName,
 			campaign: true,
 		};
-
-		const messages = validateNewsletter( updatedData );
-
-		// Send info to parent components, for send button/validation management.
-		updateMetaValue( 'newsletterValidationErrors', messages );
 		updateMetaValue( 'newsletterData', updatedData );
 	}, [ JSON.stringify( cmData ), lists, segments, status ] );
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Fixes the editor stuck in dirty state even after saving due to two issues:

 - The unsynced handling of `newsletterData` meta in the front-end
 - Transforming the apiFetch original payload when saving the post

You may still get an unexpected "unsaved changes" alert with the Post Inserter block when the posts are not inserted. Its editing state regenerates the block attributes on component rerenders and fixing that issue requires a bigger refactor that is not covered in this PR.

The `newsletterData` is now handled in the backend and the apiFetch original payload is no longer modified, as it doesn't impact the middleware functionality.

Other improvements were made for the sake of simplicity and readability:

 - Refactored the `NewsletterEdit` and `LayoutPicker` components to use hooks instead of hocs
 - Changed the layout selection to use `resetEditorBlocks` instead of both `insertBlocks` and `replaceBlocks`
 - Simplified the layout sidebar panel logic

These changes should improve the editor performance, experience and reliability, as it reduces the amount of browser requests and removes logic that adds additional friction to the editor state and data handling.

### How to test the changes in this Pull Request:

**The following steps should be tested for each available ESP**

1. Draft a new newsletter and select an existing layout
2. If it includes a Post Inserter block, make sure to insert the posts and save the draft
3. Refresh and confirm it doesn't alert about unsaved changes
4. Modify the newsletter body, save as a new layout and confirm the layout is saved
5. Click on "Reset layout", select a different layout and confirm the selected layout replaces the content without issues
6. Fill the required newsletter fields, send a test email and confirm the email is sent without issues
7. Send the newsletter and confirm the newsletter is sent
8. Draft a new newsletter using the custom layout created and confirm the layout is selected and renders without issues

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
