### PR TITLE
fix: fatal error from nonexistent class in main plugin

### DIFF
--- a/includes/class-newspack-newsletters-subscription.php
+++ b/includes/class-newspack-newsletters-subscription.php
@@ -8,6 +8,7 @@
 defined( 'ABSPATH' ) || exit;
 
 use Newspack\Newsletters\Subscription_Lists;
+use Newspack\Newsletters\Reader_Activation;
 
 /**
  * Manages Settings Subscription Class.
@@ -520,7 +521,7 @@ class Newspack_Newsletters_Subscription {
 	 * @return bool|WP_Error Whether the contact was deleted or error.
 	 */
 	public static function delete_user( $user_id, $reassign, $user ) {
-		if ( ! \Newspack\Reader_Activation::is_user_reader( $user ) ) {
+		if ( ! class_exists( '\Newspack\Reader_Activation' ) || ! \Newspack\Reader_Activation::is_user_reader( $user ) ) {
 			return;
 		}
 		$sync = \Newspack\Reader_Activation::get_setting( 'sync_esp' );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes a fatal error that occurs if the main Newspack plugin isn't available, due to a non-existent `\Newspack\Reader_Activation` class. 

### How to test the changes in this Pull Request:

1. On `release`, deactivate the Newspack plugin.
2. Delete any user from the Users admin page. Observe a fatal error:

```
PHP Fatal error:  Uncaught Error: Class "Newspack\Reader_Activation" not found in /newspack-repos/newspack-newsletters/includes/class-newspack-newsletters-subscription.php:523
Stack trace:
#0 /var/www/html/wp-includes/class-wp-hook.php(310): Newspack_Newsletters_Subscription::delete_user()
#1 /var/www/html/wp-includes/class-wp-hook.php(334): WP_Hook->apply_filters()
#2 /var/www/html/wp-includes/plugin.php(517): WP_Hook->do_action()
#3 /var/www/html/wp-admin/includes/user.php(380): do_action()
#4 /var/www/html/wp-admin/users.php(211): wp_delete_user()
#5 {main}
  thrown in /newspack-repos/newspack-newsletters/includes/class-newspack-newsletters-subscription.php on line 523
```

3. Check out this branch, repeat step 2, confirm that the operation succeeds without error.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
