### PR TITLE
fix: crash when adding underwritten posts to Posts Inserter

### DIFF
--- a/src/editor/blocks/posts-inserter/utils.js
+++ b/src/editor/blocks/posts-inserter/utils.js
@@ -203,7 +203,7 @@ const createBlockTemplatesForSinglePost = ( post, attributes ) => {
 			post.newspack_sponsors_info,
 			attributes
 		);
-		if ( sponsorAttributions ) {
+		if ( sponsorAttributions?.length ) {
 			postContentBlocks.push( sponsorAttributions );
 		}
 	}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes an editor crash when adding an underwritten post to the Posts Inserter block.

### How to test the changes in this Pull Request:

1. On `release`, create a sponsor with a scope of "Underwritten", apply to a post, create a new newsletter, and add a Posts Inserter block that will show the underwritten post.
2. Observe a JS error and editor crash:

```
Uncaught Error: Block type 'undefined' is not registered.
```

3. Check out this branch, refresh the newsletter and confirm that the post renders in the Posts Inserter like a regular post and without error.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
