### PR TITLE
Add newsletter_id param to newspack_newsletters_render_mjml_component

### DIFF
--- a/includes/class-newspack-newsletters-renderer.php
+++ b/includes/class-newspack-newsletters-renderer.php
@@ -393,10 +393,11 @@ final class Newspack_Newsletters_Renderer {
 		 * @param bool        $is_in_group Whether the component is a child of a group component.
 		 * @param array       $default_attrs Default attributes for the component.
 		 * @param bool        $is_in_list_or_quote Whether the component is a child of a list or quote block.
+		 * @param int         $newsletter_id The newsletter post ID.
 		 *
 		 * @return string|null The markup to return. If null, the default markup will be generated.
 		 */
-		$markup = apply_filters( 'newspack_newsletters_render_mjml_component', null, $block, $is_in_column, $is_in_group, $default_attrs, $is_in_list_or_quote );
+		$markup = apply_filters( 'newspack_newsletters_render_mjml_component', null, $block, $is_in_column, $is_in_group, $default_attrs, $is_in_list_or_quote, self::$newsletter_id );
 		if ( null !== $markup ) {
 			return $markup;
 		}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Adds the newsletter post_id to the `newspack_newsletters_render_mjml_component` filter, so it can be accessed when the filter is used.  This is helpful when you need to conditionally update a block's mjml based on the post details.  

One example where this will help CalMatters:  we have four newsletters and each one has a different image and links in the header, which is styled in a custom block.  With this update, we can use the post_id to check the newsletter category and customize the mjml for each newsletter.  

### How to test the changes in this Pull Request:

Example code to test the filter by modifying a core block:

```php
/**
 * Render a custom block.
 *
 * See https://documentation.mjml.io/ for MJML documentation.
 */
add_filter(
	'newspack_newsletters_render_mjml_component',
	function( $mjml, $block, $is_in_column, $is_in_group, $default_attrs, $is_in_list_or_quote, $newsletter_id ) {
		if ( 'core/paragraph' === $block['blockName'] ) {
		     $mjml = '<mj-text>' . $block['innerHTML'] . "Test" . '</mj-text>';
		}
		return $mjml;
	},
	10,
	7
);
```

Note:  since the filter now has seven parameters, anyone who is already using this filter will need to update the number of parameters.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?
