### PR TITLE
fix: avoid duplicate firing of add_contact

### DIFF
--- a/includes/class-newspack-newsletters-subscription.php
+++ b/includes/class-newspack-newsletters-subscription.php
@@ -481,6 +481,11 @@ class Newspack_Newsletters_Subscription {
 	 * @param array          $metadata      Metadata.
 	 */
 	public static function newspack_registered_reader( $email, $authenticate, $user_id, $existing_user, $metadata ) {
+		// Prevent double-syncing to audience if the registration method was through a Newsletter Subscription Form block.
+		if ( isset( $metadata['registration_method'] ) && 'newsletters-subscription' === $metadata['registration_method'] ) {
+			return;
+		}
+
 		if ( isset( $metadata['lists'] ) && ! empty( $metadata['lists'] ) ) {
 			$lists = $metadata['lists'];
 			unset( $metadata['lists'] );

--- a/includes/plugins/class-woocommerce-memberships.php
+++ b/includes/plugins/class-woocommerce-memberships.php
@@ -208,6 +208,11 @@ class Woocommerce_Memberships {
 				$lists_to_add[]    = $subscription_list->get_form_id();
 			}
 		}
+		
+		if ( empty( $lists_to_add ) ) {
+			return;
+		}
+
 		$provider = Newspack_Newsletters::get_service_provider();
 		$provider->update_contact_lists_handling_local( $user_email, $lists_to_add );
 		Newspack_Newsletters_Logger::log( 'Reader ' . $user_email . ' added to the following lists: ' . implode( ', ', $lists_to_add ) );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Adds some checks and early returns to avoid extraneous firings of the `add_contact` method which will result in additional requests to the connected ESP. There is no need to sync the contact to the ESP upon reader registration if the reader registration is happening as a side effect of either subscribing to a newsletter via the Newsletter Subscription Form block, or adding the user account to a Woo Memberships plan that doesn't restrict any newsletter lists.

### How to test the changes in this Pull Request:

1. On `release`, make sure your site is connected to an ESP and you've enabled at least one Group or local list in Newspack > Engagement > Newsletters.
2. Add a Newsletter Subscription Form block to a post or page. Enable a single list for that block.
3. Add `define( 'NEWSPACK_LOG_LEVEL', 2 );` to your wp-config.php so we know when the `add_contact` method is fired.
4. On the front-end, subscribe via the block. In your debug.log, observe there are multiple instances of the `[NEWSPACK-NEWSLETTERS][Newspack_Newsletters_Subscription::add_contact]: Adding contact to list(s):` event, and that at least one is fired with no list IDs.
5. Check out this branch, repeat step 4, confirm that you only see one instance of the `Adding contact to list(s)` event with the exact list/group ID you signed up for in the block.

Note that this can also happen if you have WooCommerce Memberships set up with a membership plan that will be granted to anyone who registers for an account. In this case, we shouldn't subscribe contacts for the membership unless the membership is restricting specific newsletter lists, in which case we should subscribe them to those lists.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
