### PR TITLE
fix: remove honeypot field if using reCAPTCHA

### DIFF
--- a/src/blocks/subscribe/index.php
+++ b/src/blocks/subscribe/index.php
@@ -74,6 +74,27 @@ function enqueue_scripts() {
 function get_form_id() {
 	return \wp_unique_id( 'newspack-subscribe-' );
 }
+/**
+ * Render a honeypot field to guard against bot form submissions. Note that
+ * this field is named `email` to hopefully catch more bots who might be
+ * looking for such fields, where as the "real" field is named "npe".
+ * 
+ * Not rendered if reCAPTCHA is enabled as it's a superior spam protection.
+ *
+ * @param string $placeholder Placeholder text to render in the field.
+ */
+function render_honeypot_field( $placeholder = '' ) {
+	if ( method_exists( 'Newspack\Recaptcha', 'can_use_captcha' ) && \Newspack\Recaptcha::can_use_captcha() ) {
+		return;
+	}
+
+	if ( empty( $placeholder ) ) {
+		$placeholder = __( 'Enter your email address', 'newspack-plugin' );
+	}
+	?>
+	<input class="nphp" tabindex="-1" aria-hidden="true" name="email" type="email" autocomplete="off" placeholder="<?php echo \esc_attr( $placeholder ); ?>" />
+	<?php
+}
 
 /**
  * Render Registration Block.
@@ -238,16 +259,7 @@ function render_block( $attrs ) {
 						placeholder="<?php echo \esc_attr( $attrs['placeholder'] ); ?>"
 						value="<?php echo esc_attr( $email ); ?>"
 					/>
-					<input
-						class="nphp"
-						tabindex="-1"
-						aria-hidden="true"
-						type="email"
-						name="email"
-						autocomplete="email"
-						placeholder="<?php echo \esc_attr( $attrs['placeholder'] ); ?>"
-						value=""
-					/>
+					<?php render_honeypot_field( $attrs['placeholder'] ); ?>
 					<?php if ( $provider && 'mailchimp' === $provider->service && $attrs['mailchimpDoubleOptIn'] ) : ?>
 						<input type="hidden" name="double_optin" value="1" />
 					<?php endif; ?>

--- a/src/blocks/subscribe/index.php
+++ b/src/blocks/subscribe/index.php
@@ -74,11 +74,12 @@ function enqueue_scripts() {
 function get_form_id() {
 	return \wp_unique_id( 'newspack-subscribe-' );
 }
+
 /**
  * Render a honeypot field to guard against bot form submissions. Note that
  * this field is named `email` to hopefully catch more bots who might be
  * looking for such fields, where as the "real" field is named "npe".
- * 
+ *
  * Not rendered if reCAPTCHA is enabled as it's a superior spam protection.
  *
  * @param string $placeholder Placeholder text to render in the field.
@@ -129,7 +130,7 @@ function render_block( $attrs ) {
 	if ( empty( $available_lists ) ) {
 		return;
 	}
-	
+
 	$provider = \Newspack_Newsletters::get_service_provider();
 
 	// Enqueue scripts.


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

We've seen reports from readers that the honeypot field sometimes gets autofilled by Chrome's built-in password manager, despite the `autocomplete="off"` attribute. (Probably because Chrome [intentionally ignores this attribute](https://adamsilver.io/blog/stopping-chrome-from-ignoring-autocomplete-off/)). There's not much we can do to prevent this frustrating behavior, but since the honeypot is kind of redundant/unnecessary if protecting forms with reCAPTCHA, this PR proposes we only render the honeypot if reCAPTCHA is not on, as a sort of fallback security measure. Since most Newspack sites enable reCAPTCHA to protect their form inputs, this should sidestep the autocomplete issue for most readers.

See also https://github.com/Automattic/newspack-plugin/pull/2667

### How to test the changes in this Pull Request:

1. Check out this branch.
2. With reCAPTCHA enabled in the Connections wizard, view the site on the front-end. Confirm that the Newsletter Subscription Form block doesn't contain a honeypot input field (with `name="email"` and `class="nphp"`). Confirm you can still register/login without error.
3. Disable reCAPTCHA in Connections and confirm that the block form does render the honeypot field.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->