### PR TITLE
feat: add alt attr to mj-image elements

### DIFF
--- a/includes/class-newspack-newsletters-renderer.php
+++ b/includes/class-newspack-newsletters-renderer.php
@@ -92,7 +92,7 @@ final class Newspack_Newsletters_Renderer {
 						isset( $attributes[ $key ] ) &&
 						( is_string( $attributes[ $key ] ) || is_numeric( $attributes[ $key ] ) ) // Don't convert values that can't be expressed as a string.
 					) {
-						return $key . '="' . $attributes[ $key ] . '"';
+						return $key . '="' . esc_attr( $attributes[ $key ] ) . '"';
 					} else {
 						return '';
 					}
@@ -100,6 +100,29 @@ final class Newspack_Newsletters_Renderer {
 				array_keys( $attributes )
 			)
 		);
+	}
+
+	/**
+	 * Get a value for an image alt attribute.
+	 * 
+	 * @param int $attachment_id Attachment ID of the image.
+	 * 
+	 * @return string A value for the alt attribute.
+	 */
+	private static function get_image_alt( $attachment_id ) {
+		$alt = get_post_meta( $attachment_id, '_wp_attachment_image_alt', true );
+
+		if ( empty( $alt ) ) {
+			$alt = get_the_content( $attachment_id );
+		}
+		if ( empty( $alt ) ) {
+			$alt = get_the_excerpt( $attachment_id );
+		}
+		if ( empty( $alt ) ) {
+			$alt = get_the_title( $attachment_id );
+		}
+
+		return $alt;
 	}
 
 	/**
@@ -533,6 +556,7 @@ final class Newspack_Newsletters_Renderer {
 						'src'     => $image[0],
 						'href'    => isset( $attrs['isLink'] ) && ! $attrs['isLink'] ? '' : esc_url( home_url( '/' ) ),
 						'target'  => isset( $attrs['linkTarget'] ) && '_blank' === $attrs['linkTarget'] ? '_blank' : '',
+						'alt'     => self::get_image_alt( $custom_logo_id ),
 					);
 					$markup   .= '<mj-image ' . self::array_to_attributes( $img_attrs ) . ' />';
 				}
@@ -549,12 +573,14 @@ final class Newspack_Newsletters_Renderer {
 				$dom->loadHTML( mb_convert_encoding( $inner_html, 'HTML-ENTITIES', get_bloginfo( 'charset' ) ), LIBXML_HTML_NOIMPLIED | LIBXML_HTML_NODEFDTD );
 				$img        = $dom->getElementsByTagName( 'img' )->item( 0 );
 				$img_src    = $img->getAttribute( 'src' );
+				$img_alt    = self::get_image_alt( $attrs['id'] );
 				$figcaption = $dom->getElementsByTagName( 'figcaption' )->item( 0 );
 
 				$img_attrs = array(
 					'padding' => '0',
 					'align'   => isset( $attrs['align'] ) ? $attrs['align'] : 'left',
 					'src'     => $img_src,
+					'alt'     => $img_alt,
 				);
 
 				if ( isset( $attrs['sizeSlug'] ) ) {

--- a/includes/class-newspack-newsletters-renderer.php
+++ b/includes/class-newspack-newsletters-renderer.php
@@ -110,16 +110,17 @@ final class Newspack_Newsletters_Renderer {
 	 * @return string A value for the alt attribute.
 	 */
 	private static function get_image_alt( $attachment_id ) {
-		$alt = get_post_meta( $attachment_id, '_wp_attachment_image_alt', true );
+		$alt        = get_post_meta( $attachment_id, '_wp_attachment_image_alt', true );
+		$attachment = get_post( $attachment_id );
 
 		if ( empty( $alt ) ) {
-			$alt = get_the_content( $attachment_id );
+			$alt = $attachment->post_content;
 		}
 		if ( empty( $alt ) ) {
-			$alt = get_the_excerpt( $attachment_id );
+			$alt = $attachment->post_excerpt;
 		}
 		if ( empty( $alt ) ) {
-			$alt = get_the_title( $attachment_id );
+			$alt = $attachment->post_title;
 		}
 
 		return $alt;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Populates an `alt` attribute on `mj-image` elements in the rendered email markup. Implements fallbacks to make sure something is always populated even if the expected field is empty. Given the following media library fields, the attribute is populated with the value of the first non-empty field:

- Alternative text
- Caption
- Description
- Title (all media library attachments get a title auto-generated from the filename, so this will always contain some value)

<img width="866" alt="Screenshot 2023-09-29 at 4 47 46 PM" src="https://github.com/Automattic/newspack-newsletters/assets/2230142/34e0afed-e08e-49b5-a908-2690be462ddf">

### How to test the changes in this Pull Request:

1. Add some values to a media library attachment in the fields described above.
2. Create a new newsletter. Add the attachment as an image block.
3. Send yourself a test email (or if using the "Other" ESP option, just click "Send" to render via MJML and get the HTML).
4. Confirm that the image block is always rendered with a populated `alt` attribute, according to the fallback logic described above.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
