### PR TITLE
fix: correct newsletter editor alignment with FSE

### DIFF
--- a/src/editor/style.scss
+++ b/src/editor/style.scss
@@ -5,6 +5,8 @@
 }
 
 .wp-block {
+	margin-left: auto;
+	margin-right: auto;
 	max-width: var( --newspack-max-width );
 	padding: 12px;
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR acts as a temporary fix for an issue we're seeing with the Newsletter editor + FSE themes that isn't happening with Classic themes: classic themes load a CSS file in the editor (/wp-includes/css/dist/edit-post/classic.min.css) that includes this style:
```
.editor-styles-wrapper .wp-block { 
    margin-left:auto; 
    margin-right:auto;
}
```

This CSS isn't loaded with FSE themes. In Newsletters, the max-width of 600px is still applied, but some blocks end up aligned left. This PR adds a temporary fix, adding the auto margin on the left and right to the editor. Long-term, we'll work on some more "proper" FSE support. 

See: 1200550061930446-as-1205636043694685

### How to test the changes in this Pull Request:

1. On a site running Newspack, start a new newsletter; if you use one of the premade templates with the top solid bar of colour, you should see this issue pretty immediately. Save the draft.
2. Download and activate [this theme](https://github.com/automattic/newspack-block-theme).
3. Refresh the Newsletter editor and note the mismatch.

![image](https://github.com/Automattic/newspack-newsletters/assets/177561/95714959-7f7c-4e6e-bb31-cedba71a6fdf)

4. Apply this PR and run `npm run build`.
5. Refresh the Newsletter editor and confirm the blocks are aligned correctly.

![image](https://github.com/Automattic/newspack-newsletters/assets/177561/7cc651bb-d554-4ec5-817e-54b0160fac0c)

6. Switch back to one of the classic Newspack themes and confirm there are no display issues. 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
