### PR TITLE
feat: define node 16 required in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,9 @@
 	"name": "newspack-newsletters",
 	"version": "2.1.3",
 	"description": "",
+	"engines": {
+    	"node" : ">=16.0.0 <17.0.0"
+	},
 	"scripts": {
 		"cm": "newspack-scripts commit",
 		"semantic-release": "newspack-scripts release --files=newspack-newsletters.php",


### PR DESCRIPTION
this plugin is not node 18 compatible

### All Submissions:

* [ x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [ x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes # .

### How to test the changes in this Pull Request:

1. This just lets the dev know that node 16 must be used, this isn't compatible with node 18 yet.


### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
