### PR TITLE
feat(subscription-form): custom checkbox state for lists

### DIFF
--- a/src/blocks/subscribe/block.json
+++ b/src/blocks/subscribe/block.json
@@ -58,6 +58,10 @@
 				"type": "string"
 			}
 		},
+		"listsCheckboxes": {
+			"type": "object",
+			"default": {}
+		},
 		"mailchimpDoubleOptIn": {
 			"type": "boolean",
 			"default": false

--- a/src/blocks/subscribe/edit.js
+++ b/src/blocks/subscribe/edit.js
@@ -73,6 +73,7 @@ export default function SubscribeEdit( {
 		label,
 		successMessage,
 		lists,
+		listsCheckboxes,
 		displayDescription,
 		mailchimpDoubleOptIn,
 		textColor,
@@ -107,6 +108,15 @@ export default function SubscribeEdit( {
 	const onChangeTextColor = newTextColor => {
 		setAttributes( { textColorName: getColorName( newTextColor ) } );
 		setAttributes( { textColor: newTextColor } );
+	};
+
+	const isListSelected = listId => {
+		return ! listsCheckboxes.hasOwnProperty( listId ) || listsCheckboxes[ listId ];
+	};
+	const toggleListCheckbox = listId => () => {
+		const newListsCheckboxes = { ...listsCheckboxes };
+		newListsCheckboxes[ listId ] = ! isListSelected( listId );
+		setAttributes( { listsCheckboxes: newListsCheckboxes } );
 	};
 
 	return (
@@ -293,8 +303,8 @@ export default function SubscribeEdit( {
 														<input
 															id={ getListCheckboxId( listId ) }
 															type="checkbox"
-															checked
-															readOnly
+															checked={ isListSelected( listId ) }
+															onChange={ toggleListCheckbox( listId ) }
 														/>
 													</span>
 													<span className="list-details">

--- a/src/blocks/subscribe/index.php
+++ b/src/blocks/subscribe/index.php
@@ -162,6 +162,15 @@ function render_block( $attrs ) {
 		}
 	}
 
+	// Handle checkbox checked state.
+	if ( isset( $attrs['listsCheckboxes'] ) ) {
+		foreach ( $list_map as $list_id => $list_index ) {
+			if ( isset( $attrs['listsCheckboxes'][ $list_id ] ) && false === $attrs['listsCheckboxes'][ $list_id ] ) {
+				unset( $list_map[ $list_id ] );
+			}
+		}
+	}
+
 	$display_input_label = ! empty( $attrs['displayInputLabels'] );
 	$email_label         = $display_input_label ? $attrs['emailLabel'] : '';
 	$input_id            = sprintf( 'newspack-newsletters-subscribe-block-input-%s', $block_id );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

1200550061930446-as-1205543124448992

Support toggling and storing the checkbox state for defining the initial form state:

<img width="849" alt="image" src="https://github.com/Automattic/newspack-newsletters/assets/820752/9b04a6bb-3a70-47dc-a250-3771d486f432">


### How to test the changes in this Pull Request:

1. Draft a new page and add a Newsletter Subscription Form block
2. Enable multiple lists and toggle their checkbox state in the editor
3. Save, refresh, and confirm the selected state is preserved
4. Visit the page and confirm the selected state is also reflected on the page

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
