### PR TITLE
fix: execute tracking in an earlier hook

### DIFF
--- a/includes/class-newspack-newsletters-ads.php
+++ b/includes/class-newspack-newsletters-ads.php
@@ -710,6 +710,10 @@ final class Newspack_Newsletters_Ads {
 		if ( empty( self::$inserted_ads[ $newsletter_id ] ) ) {
 			self::$inserted_ads[ $newsletter_id ] = [];
 		}
+		// Avoid duplicate.
+		if ( in_array( $ad_id, self::$inserted_ads[ $newsletter_id ], true ) ) {
+			return;
+		}
 		self::$inserted_ads[ $newsletter_id ][] = $ad_id;
 		update_post_meta( $newsletter_id, 'inserted_ads', self::$inserted_ads[ $newsletter_id ] );
 	}

--- a/includes/tracking/class-data-events.php
+++ b/includes/tracking/class-data-events.php
@@ -15,7 +15,7 @@ final class Data_Events {
 	 * Initialize hooks.
 	 */
 	public static function init() {
-		add_action( 'init', [ __CLASS__, 'register_listeners' ] );
+		add_action( 'plugins_loaded', [ __CLASS__, 'register_listeners' ] );
 	}
 
 	/**

--- a/tests/test-tracking.php
+++ b/tests/test-tracking.php
@@ -21,7 +21,7 @@ class Newsletters_Tracking_Test extends WP_UnitTestCase {
 		ob_start();
 		do_action( 'newspack_newsletters_editor_mjml_body', $post );
 		$mjml_body = ob_get_clean();
-		$this->assertMatchesRegularExpression( '\?np_newsletters_pixel=1&id=' . $post_id . '/', $mjml_body );
+		$this->assertMatchesRegularExpression( '/\?np_newsletters_pixel=1&id=' . $post_id . '/', $mjml_body );
 
 		// Fetch the tracking pixel URL from body.
 		$pattern = '/src="([^"]*np_newsletters_pixel[^"]*)"/i';

--- a/tests/test-tracking.php
+++ b/tests/test-tracking.php
@@ -21,7 +21,7 @@ class Newsletters_Tracking_Test extends WP_UnitTestCase {
 		ob_start();
 		do_action( 'newspack_newsletters_editor_mjml_body', $post );
 		$mjml_body = ob_get_clean();
-		$this->assertMatchesRegularExpression( '/\?np_newsletters_pixel=1&id=' . $post_id . '/', $mjml_body );
+		$this->assertMatchesRegularExpression( '/\?np_newsletters_pixel=1&#038;id=' . $post_id . '/', $mjml_body );
 
 		// Fetch the tracking pixel URL from body.
 		$pattern = '/src="([^"]*np_newsletters_pixel[^"]*)"/i';

--- a/tests/test-tracking.php
+++ b/tests/test-tracking.php
@@ -21,10 +21,10 @@ class Newsletters_Tracking_Test extends WP_UnitTestCase {
 		ob_start();
 		do_action( 'newspack_newsletters_editor_mjml_body', $post );
 		$mjml_body = ob_get_clean();
-		$this->assertMatchesRegularExpression( '/np-newsletters\.gif\?id=' . $post_id . '/', $mjml_body );
+		$this->assertMatchesRegularExpression( '\?np_newsletters_pixel=1&id=' . $post_id . '/', $mjml_body );
 
 		// Fetch the tracking pixel URL from body.
-		$pattern = '/src="([^"]*np-newsletters\.gif[^"]*)"/i';
+		$pattern = '/src="([^"]*np_newsletters_pixel[^"]*)"/i';
 		$matches = [];
 		preg_match( $pattern, $mjml_body, $matches );
 		$pixel_url  = html_entity_decode( $matches[1] );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

The existing approach for processing the pixel and click tracking processes the requests in the `template_redirect` hook, which can potentially be quite heavy being a hook called farther down the hook tree.

Removing the custom rewrite rule allows the hook to be executed early in `init`, which is executed much earlier, reducing the load of such requests.

The rewrite rule and the hook to `template_redirect` will continue to exist for backward compatibility, but every new newsletter sent will use a query parameter, which will be executed in the new hook.

### How to test the changes in this Pull Request:

1. While on the `release` branch, send a newsletter with links
2. Check out this branch
3. Open the newsletter in your inbox and make sure to allow images to render
4. Click on any link in the newsletter
5. Go to the newsletters dashboard table and confirm the Open and Click were tracked (backward compatibility)
6. Send a new newsletter with links
7. Open the newsletter in your inbox and make sure to allow images to render
8. Click on any link in the newsletter
5. Go to the newsletters dashboard table and confirm the Open and Click were tracked (query var approach)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
