### PR TITLE
feat(tracking): experimental pixel tracking through log files

### DIFF
--- a/includes/tracking/class-pixel.php
+++ b/includes/tracking/class-pixel.php
@@ -290,7 +290,7 @@ final class Pixel {
 				if ( ! $newsletter_id || ! $tracking_id || ! $email_address ) {
 					continue;
 				}
-				self::track_seen( $newsletter_id, $newsletter_id, $email_address );
+				self::track_seen( $newsletter_id, $tracking_id, $email_address );
 			}
 
 			// Remove the log file after processing.

--- a/includes/tracking/class-pixel.php
+++ b/includes/tracking/class-pixel.php
@@ -245,15 +245,9 @@ final class Pixel {
 	public static function log_pixel_url( $url, $post_id, $tracking_id, $email_tag ) {
 		return \add_query_arg(
 			[
-				'data' => \base64_encode(
-					\wp_json_encode(
-						[
-							'id'  => $post_id,
-							'tid' => $tracking_id,
-						]
-					)
-				),
-				'em'   => $email_tag,
+				'id'  => $post_id,
+				'tid' => $tracking_id,
+				'em'  => $email_tag,
 			],
 			\content_url( '/np-newsletters-pixel.php' )
 		);
@@ -276,17 +270,13 @@ final class Pixel {
 					continue;
 				}
 				$item = explode( '|', $item );
-				if ( 2 !== count( $item ) ) {
-					continue;
-				}
-				$data = json_decode( base64_decode( $item[1] ), true );
-				if ( ! $data || ! is_array( $data ) ) {
+				if ( 3 !== count( $item ) ) {
 					continue;
 				}
 				// Values must be sanitized as they are stored in the logs without sanitization.
-				$newsletter_id = isset( $data['id'] ) ? intval( $data['id'] ) : 0;
-				$tracking_id   = isset( $data['tid'] ) ? \sanitize_text_field( $data['tid'] ) : 0;
 				$email_address = isset( $item[0] ) ? \sanitize_email( $item[0] ) : '';
+				$newsletter_id = isset( $item[1] ) ? intval( $item[1] ) : 0;
+				$tracking_id   = isset( $item[2] ) ? \sanitize_text_field( $item[2] ) : 0;
 				if ( ! $newsletter_id || ! $tracking_id || ! $email_address ) {
 					continue;
 				}
@@ -322,9 +312,10 @@ final class Pixel {
 			exit;
 		}
 		$file = "' . $log_file_path . '";
-		$data = $_GET["data"];
+		$id = $_GET["id"];
+		$tid = $_GET["tid"];
 		$email_address = $_GET["em"];
-		file_put_contents( $file, $email_address . "|" . $data . PHP_EOL, FILE_APPEND );
+		file_put_contents( $file, $email_address . "|" . $id . "|" . $tid . PHP_EOL, FILE_APPEND );
 		header( "Cache-Control: no-cache, no-store, must-revalidate" );
 		header( "Pragma: no-cache" );
 		header( "Expires: 0" );

--- a/includes/tracking/class-pixel.php
+++ b/includes/tracking/class-pixel.php
@@ -283,6 +283,7 @@ final class Pixel {
 				if ( ! $data || ! is_array( $data ) ) {
 					continue;
 				}
+				// Values must be sanitized as they are stored in the logs without sanitization.
 				$newsletter_id = isset( $data['id'] ) ? intval( $data['id'] ) : 0;
 				$tracking_id   = isset( $data['tid'] ) ? \sanitize_text_field( $data['tid'] ) : 0;
 				$email_address = isset( $item[0] ) ? \sanitize_email( $item[0] ) : '';

--- a/includes/tracking/class-pixel.php
+++ b/includes/tracking/class-pixel.php
@@ -274,9 +274,9 @@ final class Pixel {
 					continue;
 				}
 				// Values must be sanitized as they are stored in the logs without sanitization.
-				$email_address = isset( $item[0] ) ? \sanitize_email( $item[0] ) : '';
-				$newsletter_id = isset( $item[1] ) ? intval( $item[1] ) : 0;
-				$tracking_id   = isset( $item[2] ) ? \sanitize_text_field( $item[2] ) : 0;
+				$newsletter_id = isset( $item[0] ) ? intval( $item[0] ) : 0;
+				$tracking_id   = isset( $item[1] ) ? \sanitize_text_field( $item[1] ) : 0;
+				$email_address = isset( $item[2] ) ? \sanitize_email( $item[2] ) : '';
 				if ( ! $newsletter_id || ! $tracking_id || ! $email_address ) {
 					continue;
 				}
@@ -308,14 +308,14 @@ final class Pixel {
 		if ( ! empty( $_SERVER["HTTP_USER_AGENT"] ) && "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/42.0.2311.135 Safari/537.36 Edge/12.246 Mozilla/5.0" === $_SERVER["HTTP_USER_AGENT"] ) {
 			exit;
 		}
-		if ( ! isset( $_GET["data"] ) || ! isset( $_GET["em"] ) ) {
+		if ( ! isset( $_GET["id"] ) || ! isset( $_GET["tid"] ) || ! isset( $_GET["em"] ) ) {
 			exit;
 		}
 		$file = "' . $log_file_path . '";
 		$id = $_GET["id"];
 		$tid = $_GET["tid"];
 		$email_address = $_GET["em"];
-		file_put_contents( $file, $email_address . "|" . $id . "|" . $tid . PHP_EOL, FILE_APPEND );
+		file_put_contents( $file, $id . "|" . $tid . "|" $email_address . PHP_EOL, FILE_APPEND );
 		header( "Cache-Control: no-cache, no-store, must-revalidate" );
 		header( "Pragma: no-cache" );
 		header( "Expires: 0" );

--- a/includes/tracking/class-pixel.php
+++ b/includes/tracking/class-pixel.php
@@ -35,7 +35,7 @@ final class Pixel {
 		if ( defined( 'NEWSPACK_NEWSLETTERS_PIXEL_LOG_PROCESSING' ) && NEWSPACK_NEWSLETTERS_PIXEL_LOG_PROCESSING ) {
 			\add_action( 'wp', [ __CLASS__, 'schedule_log_processing' ] );
 			\add_action( 'newspack_newsletters_tracking_pixel_process_log', [ __CLASS__, 'process_logs' ] );
-			\add_filter( 'newspack_newsletters_tracking_pixel_url', [ __ClASS__, 'log_pixel_url' ], 10, 4 );
+			\add_filter( 'newspack_newsletters_tracking_pixel_url', [ __CLASS__, 'log_pixel_url' ], 10, 4 );
 		}
 	}
 

--- a/includes/tracking/class-pixel.php
+++ b/includes/tracking/class-pixel.php
@@ -292,7 +292,7 @@ final class Pixel {
 			unlink( $current_log_file, null ); // phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.file_ops_unlink
 		}
 
-		// Generate a random log file name.
+		// Generate a new log file.
 		$log_dir       = \wp_get_upload_dir()['path'];
 		$log_file_path = tempnam( $log_dir, 'newspack_newsletters_pixel_log_' ); // phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.file_ops_tempnam
 
@@ -323,7 +323,7 @@ final class Pixel {
 		echo base64_decode( "R0lGODlhAQABAIAAAAUEBAAAACwAAAAAAQABAAACAkQBADs=" );
 		?>';
 
-		// Save the track.php file.
+		// Save the updated np-newsletters-pixel.php file.
 		file_put_contents( WP_CONTENT_DIR . '/np-newsletters-pixel.php', $pixel_code ); // phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.file_ops_file_put_contents
 
 		// Update the log file path option.

--- a/includes/tracking/class-pixel.php
+++ b/includes/tracking/class-pixel.php
@@ -30,6 +30,13 @@ final class Pixel {
 		\add_filter( 'query_vars', [ __CLASS__, 'query_vars' ] );
 		\add_action( 'init', [ __CLASS__, 'render' ], 2, 0 ); // Run on priority 2 to allow Data Events and ActionScheduler to initialize first.
 		\add_action( 'template_redirect', [ __CLASS__, 'render' ] );
+
+		// Experimental approach by processing cycled log files.
+		if ( defined( 'NEWSPACK_NEWSLETTERS_PIXEL_LOG_PROCESSING' ) && NEWSPACK_NEWSLETTERS_PIXEL_LOG_PROCESSING ) {
+			\add_action( 'wp', [ __CLASS__, 'schedule_log_processing' ] );
+			\add_action( 'newspack_newsletters_tracking_pixel_process_log', [ __CLASS__, 'process_logs' ] );
+			\add_filter( 'newspack_newsletters_tracking_pixel_url', [ __ClASS__, 'log_pixel_url' ], 10, 4 );
+		}
 	}
 
 	/**
@@ -113,7 +120,15 @@ final class Pixel {
 			],
 			\home_url()
 		);
-		return $url;
+		/**
+		 * Filters the pixel URL.
+		 *
+		 * @param string $url         Pixel URL.
+		 * @param int    $post_id     ID of the newsletter.
+		 * @param string $tracking_id Tracking ID.
+		 * @param string $email_tag   The ESP email address tag.
+		 */
+		return apply_filters( 'newspack_newsletters_tracking_pixel_url', $url, $post_id, $tracking_id, Utils::get_email_address_tag() );
 	}
 
 	/**
@@ -206,6 +221,117 @@ final class Pixel {
 
 		self::track_seen( $newsletter_id, $tracking_id, $email_address );
 		exit;
+	}
+
+	/**
+	 * Schedule log processing.
+	 */
+	public static function schedule_log_processing() {
+		if ( ! \wp_next_scheduled( 'newspack_newsletters_tracking_pixel_process_log' ) ) {
+			\wp_schedule_single_event( time() + 60, 'newspack_newsletters_tracking_pixel_process_log' );
+		}
+	}
+
+	/**
+	 * Log pixel URL.
+	 *
+	 * @param string $url         Pixel URL.
+	 * @param int    $post_id     ID of the newsletter.
+	 * @param string $tracking_id Tracking ID.
+	 * @param string $email_tag   Email address of the recipient.
+	 *
+	 * @return string
+	 */
+	public static function log_pixel_url( $url, $post_id, $tracking_id, $email_tag ) {
+		return \add_query_arg(
+			[
+				'data' => \base64_encode(
+					\wp_json_encode(
+						[
+							'id'  => $post_id,
+							'tid' => $tracking_id,
+							'em'  => $email_tag,
+						]
+					)
+				),
+			],
+			\content_url( '/np-newsletters-pixel.php' )
+		);
+	}
+
+	/**
+	 * Process logs.
+	 */
+	public static function process_logs() {
+		$current_log_file = \get_option( 'newspack_newsletters_tracking_pixel_log_file' );
+
+		if ( $current_log_file && file_exists( $current_log_file ) ) {
+			// Read the tracking data from the log file.
+			$data = file_get_contents( $current_log_file ); // phpcs:ignore WordPressVIPMinimum.Performance.FetchingRemoteData.FileGetContentsUnknown
+
+			// Process the tracking data.
+			$tracking_data = explode( PHP_EOL, $data );
+			foreach ( $tracking_data as $item ) {
+				if ( ! $item ) {
+					continue;
+				}
+				$item = json_decode( base64_decode( $item ), true );
+				if ( ! $item ) {
+					continue;
+				}
+				$newsletter_id = isset( $item['id'] ) ? intval( $item['id'] ) : 0;
+				$tracking_id   = isset( $item['tid'] ) ? \sanitize_text_field( $item['tid'] ) : 0;
+				$email_address = isset( $item['em'] ) ? \sanitize_email( $item['em'] ) : '';
+				if ( ! $newsletter_id || ! $tracking_id || ! $email_address ) {
+					continue;
+				}
+				self::track_seen( $newsletter_id, $newsletter_id, $email_address );
+			}
+
+			// Remove the log file after processing.
+			unlink( $current_log_file, null ); // phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.file_ops_unlink
+		}
+
+		// Generate a random log file name.
+		$log_dir       = \wp_get_upload_dir()['path'];
+		$log_file_path = tempnam( $log_dir, 'newspack_newsletters_pixel_log_' ); // phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.file_ops_tempnam
+
+		// Create the pixel.php file with the new log file path.
+		$pixel_code = '<?php
+		// Skip bots.
+		if ( ! empty( $_SERVER["HTTP_USER_AGENT"] ) && preg_match( \'/bot|crawl|slurp|spider|mediapartners/i\', $_SERVER["HTTP_USER_AGENT"] )
+		) {
+			exit;
+		}
+		// Skip prefetching and previews.
+		if ( ! empty( $_SERVER["HTTP_X_PURPOSE"] ) && in_array( $_SERVER["HTTP_X_PURPOSE"], [ "preview", "instant" ], true ) ) {
+			exit;
+		}
+		if ( ! empty( $_SERVER["HTTP_X_MOZ"] ) && "prefetch" === $_SERVER["HTTP_X_MOZ"] ) {
+			exit;
+		}
+		if ( ! empty( $_SERVER["HTTP_USER_AGENT"] ) && "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/42.0.2311.135 Safari/537.36 Edge/12.246 Mozilla/5.0" === $_SERVER["HTTP_USER_AGENT"] ) {
+			exit;
+		}
+		$file = "' . $log_file_path . '";
+		$data = $_GET["data"];
+		file_put_contents( $file, $data . PHP_EOL, FILE_APPEND );
+		header( "Cache-Control: no-cache, no-store, must-revalidate" );
+		header( "Pragma: no-cache" );
+		header( "Expires: 0" );
+		header( "Content-Type: image/gif" );
+		echo base64_decode( "R0lGODlhAQABAIAAAAUEBAAAACwAAAAAAQABAAACAkQBADs=" );
+		?>';
+
+		// Save the track.php file.
+		file_put_contents( WP_CONTENT_DIR . '/np-newsletters-pixel.php', $pixel_code ); // phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.file_ops_file_put_contents
+
+		// Update the log file path option.
+		update_option( 'newspack_newsletters_tracking_pixel_log_file', $log_file_path );
+
+		// Avoid notoptions bug.
+		wp_cache_delete( 'notoptions', 'options' );
+		wp_cache_delete( 'alloptions', 'options' );
 	}
 }
 Pixel::init();


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Implements an alternative strategy for pixel tracking, suggested by @claudiulodro, by storing temporary log files that are processed through cron instead of processing each on every pixel request.

The cron, executed every minute, looks for an existing log file and processes each stored request. It will, then, delete the processed file and generate a new one using [`tempnam()`](https://www.php.net/manual/en/function.tempnam.php) for a new unique file name.

When a new log file is created, the `np-newsletters-pixel.php` file is also dynamically replaced to account for the changed file name.

This PR also implements a filter to the tracking pixel URL, used by the new strategy to point to the new `np-newsletters-pixel.php`.

Cycling log files with a unique name is the security layer I'm going for since the logs are stored in the uploads directory. I am open to suggestions for alternatives or improvements to this strategy.

Due to its experimental nature, it's currently placed behind the `NEWSPACK_NEWSLETTERS_PIXEL_LOG_PROCESSING` PHP constant and the default/existing approach should continue to work without issues.

### How to test the changes in this Pull Request:

1. Without yet modifying the `NEWSPACK_NEWSLETTERS_PIXEL_LOG_PROCESSING`, send a new newsletter, open it, and confirm the pixel tracking behaves as expected (incremented "Opens" in the newsletters dashboard table)
2. Add `define( 'NEWSPACK_NEWSLETTERS_PIXEL_LOG_PROCESSING', true );` to your `wp-config.php` file
3. Also confirm you have `define( 'NEWSPACK_LOG_LEVEL', 2 );` so we can track the data event being dispatched
4. Send a new newsletter and open it
5. Navigate to your `uploads/2023/10` directory and confirm a `newspack_newsletters_pixel_log_{xxxxxx}` file exists and contains a base64 encoded line
6. Open the email again and confirm the file has now 2 lines
7. Navigate a bit on your site until the cron executes another log processing
8. Confirm the file is replaced and the server logged `[49160][NEWSPACK-DATA-EVENTS][Newspack\Data_Events::dispatch]: Dispatching action "newsletter_opened" via Action Scheduler`
9. Confirm the "Opens" column in the newsletters dashboard table also had its value increment for the sent newsletter

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
