### PR TITLE
chore: newspack.pub > newspack.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # newspack-newsletters
 Author email newsletters in WordPress
 
-Visit [the documentation]([https://newspack.pub/support/engagement/newsletters/](https://help.newspack.com/engagement/newspack-newsletters/)) for more guidance.
+Visit [the documentation](https://help.newspack.com/engagement/newspack-newsletters/) for more guidance.
 
 ## Development
 

--- a/newspack-newsletters.php
+++ b/newspack-newsletters.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Plugin Name:     Newspack Newsletters
- * Plugin URI:      https://newspack.pub
+ * Plugin URI:      https://newspack.com
  * Description:     Newsletter authoring using the Gutenberg editor.
  * Author:          Automattic
  * Author URI:      https://newspack.com/

--- a/readme.txt
+++ b/readme.txt
@@ -43,7 +43,7 @@ Before sending your campaign, you can send test emails to one or more email addr
 
 = About Newspack =
 
-The Newspack Newletters plugin is part of Newspack, a suite of tools to help small to mid-sized news organizations publish and generate revenue with WordPress. Newspack is a collaborative project by WordPress.com and the Google News Initiative. You can learn more about Newspack by [visiting our website](https://newspack.pub/).
+The Newspack Newletters plugin is part of Newspack, a suite of tools to help small to mid-sized news organizations publish and generate revenue with WordPress. Newspack is a collaborative project by WordPress.com and the Google News Initiative. You can learn more about Newspack by [visiting our website](https://newspack.com/).
 
 = Credits =
 

--- a/src/branding/index.js
+++ b/src/branding/index.js
@@ -9,7 +9,7 @@ jQuery( document ).ready( () => {
 	const wpBodyContentEl = document.getElementById( 'wpbody-content' );
 	if ( wpBodyContentEl ) {
 		const bannerEl = document.createElement( 'a' );
-		bannerEl.setAttribute( 'href', 'https://newspack.pub' );
+		bannerEl.setAttribute( 'href', 'https://newspack.com' );
 		bannerEl.setAttribute( 'target', '_blank' );
 		bannerEl.classList.add( 'newspack-newsletters__banner' );
 		wpBodyContentEl.insertBefore( bannerEl, wpBodyContentEl.children[ 0 ] );

--- a/tests/test-renderer.php
+++ b/tests/test-renderer.php
@@ -138,13 +138,13 @@ class Newsletters_Renderer_Test extends WP_UnitTestCase {
 	 */
 	public function test_aux_functions() {
 		$this->assertEquals(
-			Newspack_Newsletters_Renderer::process_links( '<a href="//newspack.pub">linky<a>' ),
-			'<a href="//newspack.pub?utm_medium=email">linky<a>',
+			Newspack_Newsletters_Renderer::process_links( '<a href="//newspack.com">linky<a>' ),
+			'<a href="//newspack.com?utm_medium=email">linky<a>',
 			'Appends utm_medium=email to links'
 		);
 		$this->assertEquals(
-			Newspack_Newsletters_Renderer::process_links( '<a href="//newspack.pub?value=1">linky<a>' ),
-			'<a href="//newspack.pub?value=1&utm_medium=email">linky<a>',
+			Newspack_Newsletters_Renderer::process_links( '<a href="//newspack.com?value=1">linky<a>' ),
+			'<a href="//newspack.com?value=1&utm_medium=email">linky<a>',
 			'Appends utm_medium=email to links with params'
 		);
 	}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Updates some lingering legacy URLs throughout the code. All instances of newspack.pub or newspack.blog should be newspack.com

### How to test the changes in this Pull Request:

No functional changes.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
