### PR TITLE
fix: init modal header misalignment

### DIFF
--- a/src/components/init-modal/screens/layout-picker/index.js
+++ b/src/components/init-modal/screens/layout-picker/index.js
@@ -60,20 +60,22 @@ export default function LayoutPicker() {
 		<Fragment>
 			<div className="newspack-newsletters-modal__content">
 				<div className="newspack-newsletters-modal__content__sidebar">
-					<p>
-						{ __( 'Choose a layout or start with a blank newsletter.', 'newspack-newsletters' ) }
-					</p>
-					<div className="newspack-newsletters-modal__content__layout-buttons">
-						{ LAYOUTS_TABS.map( ( { title }, i ) => (
-							<Button
-								key={ i }
-								disabled={ isFetchingLayouts }
-								variant={ ! isFetchingLayouts && i === activeTabIndex ? 'primary' : 'tertiary' }
-								onClick={ () => setActiveTabIndex( i ) }
-							>
-								{ title }
-							</Button>
-						) ) }
+					<div className="newspack-newsletters-modal__content__sidebar-wrapper">
+						<p>
+							{ __( 'Choose a layout or start with a blank newsletter.', 'newspack-newsletters' ) }
+						</p>
+						<div className="newspack-newsletters-modal__content__layout-buttons">
+							{ LAYOUTS_TABS.map( ( { title }, i ) => (
+								<Button
+									key={ i }
+									disabled={ isFetchingLayouts }
+									variant={ ! isFetchingLayouts && i === activeTabIndex ? 'primary' : 'tertiary' }
+									onClick={ () => setActiveTabIndex( i ) }
+								>
+									{ title }
+								</Button>
+							) ) }
+						</div>
 					</div>
 				</div>
 				<div

--- a/src/components/init-modal/style.scss
+++ b/src/components/init-modal/style.scss
@@ -100,6 +100,10 @@
 			padding: 24px;
 
 			@media only screen and ( min-width: 600px ) {
+				padding: 32px;
+			}
+
+			@media only screen and ( min-width: 783px ) {
 				border-bottom: none;
 				border-right: 1px solid wp-colors.$gray-300;
 			}
@@ -200,6 +204,10 @@
 	&__layouts {
 		max-height: 100%;
 		padding: 24px;
+
+		@media only screen and ( min-width: 600px ) {
+			padding: 32px;
+		}
 
 		@media only screen and ( min-width: 783px ) {
 			overflow-y: scroll;

--- a/src/components/init-modal/style.scss
+++ b/src/components/init-modal/style.scss
@@ -15,10 +15,6 @@
 			.is-fullscreen-mode & {
 				left: 60px;
 				top: 0;
-
-				.components-modal__header {
-					height: 60px;
-				}
 			}
 		}
 
@@ -28,6 +24,18 @@
 				left: 160px;
 			}
 		}
+
+		.components-modal__header {
+			border-color: wp-colors.$gray-300;
+			height: 60px;
+			padding-bottom: 0;
+			padding-top: 0;
+		}
+
+		.components-modal__content {
+			margin-top: 60px;
+			padding-top: 0;
+		}
 	}
 
 	&__frame {
@@ -35,6 +43,7 @@
 		border: 0;
 		box-shadow: none;
 		height: 100%;
+		margin: 0;
 		max-height: 100%;
 		max-width: 100%;
 		min-height: 100%;
@@ -62,17 +71,20 @@
 
 	&__content {
 		background: white;
-		height: calc( 100% - 36px );
-		margin: -24px -32px;
-		width: calc( 100% + 64px );
+		height: 100%;
+		left: 0;
+		margin: 0;
+		overflow-y: scroll;
+		position: fixed;
+		width: 100%;
 
 		@media only screen and ( min-width: 783px ) {
 			display: grid;
 			gap: 0;
 			grid-template-columns: 280px 1fr;
 			grid-template-rows: 1fr;
-			margin: -24px;
-			width: 100%;
+			overflow-y: hidden;
+			position: initial;
 
 			// Fullscreen mode
 			.is-fullscreen-mode & {
@@ -118,6 +130,10 @@
 		right: 24px;
 		top: 12px;
 		z-index: 11;
+
+		@media only screen and ( min-width: 600px ) {
+			right: 32px;
+		}
 
 		.components-button + .components-button {
 			margin-left: 8px;
@@ -182,9 +198,12 @@
 	}
 
 	&__layouts {
-		overflow-y: scroll;
 		max-height: 100%;
 		padding: 24px;
+
+		@media only screen and ( min-width: 783px ) {
+			overflow-y: scroll;
+		}
 
 		&--loading {
 			display: flex;

--- a/src/components/init-modal/style.scss
+++ b/src/components/init-modal/style.scss
@@ -39,7 +39,7 @@
 			@media only screen and ( min-width: 783px ) {
 				.is-fullscreen-mode & {
 					margin-left: -60px;
-					width: calc(100% + 60px);
+					width: calc( 100% + 60px );
 				}
 			}
 		}

--- a/src/components/init-modal/style.scss
+++ b/src/components/init-modal/style.scss
@@ -13,7 +13,7 @@
 
 			// Fullscreen mode
 			.is-fullscreen-mode & {
-				left: 60px;
+				left: 0;
 				top: 0;
 			}
 		}
@@ -28,13 +28,13 @@
 		.components-modal__header {
 			border-color: wp-colors.$gray-300;
 			height: 60px;
-			padding-bottom: 0;
-			padding-top: 0;
+			padding: 0 24px;
 		}
 
 		.components-modal__content {
+			justify-content: start;
 			margin-top: 60px;
-			padding-top: 0;
+			padding: 0;
 		}
 	}
 
@@ -74,8 +74,6 @@
 		height: 100%;
 		left: 0;
 		margin: 0;
-		overflow-y: scroll;
-		position: fixed;
 		width: 100%;
 
 		@media only screen and ( min-width: 783px ) {
@@ -83,29 +81,21 @@
 			gap: 0;
 			grid-template-columns: 280px 1fr;
 			grid-template-rows: 1fr;
-			overflow-y: hidden;
-			position: initial;
-
-			// Fullscreen mode
-			.is-fullscreen-mode & {
-				height: calc( 100vh - 60px );
-				position: fixed;
-				inset: 60px 0 0;
-			}
 		}
 
 		&__sidebar {
 			background: wp-colors.$gray-100;
 			border-bottom: 1px solid wp-colors.$gray-300;
-			padding: 24px;
-
-			@media only screen and ( min-width: 600px ) {
-				padding: 32px;
-			}
 
 			@media only screen and ( min-width: 783px ) {
 				border-bottom: none;
 				border-right: 1px solid wp-colors.$gray-300;
+			}
+
+			&-wrapper {
+				padding: 24px;
+				position: sticky;
+				top: 0;
 			}
 
 			p {
@@ -134,10 +124,6 @@
 		right: 24px;
 		top: 12px;
 		z-index: 11;
-
-		@media only screen and ( min-width: 600px ) {
-			right: 32px;
-		}
 
 		.components-button + .components-button {
 			margin-left: 8px;
@@ -204,10 +190,6 @@
 	&__layouts {
 		max-height: 100%;
 		padding: 24px;
-
-		@media only screen and ( min-width: 600px ) {
-			padding: 32px;
-		}
 
 		@media only screen and ( min-width: 783px ) {
 			overflow-y: scroll;

--- a/src/components/init-modal/style.scss
+++ b/src/components/init-modal/style.scss
@@ -13,7 +13,7 @@
 
 			// Fullscreen mode
 			.is-fullscreen-mode & {
-				left: 0;
+				left: 60px;
 				top: 0;
 			}
 		}
@@ -35,6 +35,13 @@
 			justify-content: start;
 			margin-top: 60px;
 			padding: 0;
+
+			@media only screen and ( min-width: 783px ) {
+				.is-fullscreen-mode & {
+					margin-left: -60px;
+					width: calc(100% + 60px);
+				}
+			}
 		}
 	}
 
@@ -52,6 +59,12 @@
 		transform: none;
 		width: 100%;
 		inset: 0;
+
+		@media only screen and ( min-width: 783px ) {
+			.is-fullscreen-mode & {
+				overflow: visible;
+			}
+		}
 
 		.components-modal__header-heading {
 			display: none;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

I'm not sure which WP version introduced the shift in the layout but the init modal looks broken. This PR fixes the issue.

__Before__

![before](https://github.com/Automattic/newspack-newsletters/assets/177929/ca6e1453-5817-437a-a463-7d917c826d07)

__After__

![after](https://github.com/Automattic/newspack-newsletters/assets/177929/32121421-5958-4e17-95b7-13e6d89e77a2)

### How to test the changes in this Pull Request:

1. Create a new newsletter, the modal should be broken
2. Switch to this branch
3. Refresh the screen with the modal.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
