### PR TITLE
feat: mailchimp usage data report

### DIFF
--- a/includes/service-providers/class-newspack-newsletters-service-provider.php
+++ b/includes/service-providers/class-newspack-newsletters-service-provider.php
@@ -517,7 +517,6 @@ abstract class Newspack_Newsletters_Service_Provider implements Newspack_Newslet
 			}
 		}
 		return $this->update_contact_lists( $email, $lists_to_add, $lists_to_remove );
-
 	}
 
 	/**
@@ -773,5 +772,14 @@ abstract class Newspack_Newsletters_Service_Provider implements Newspack_Newslet
 	 */
 	public function get_contact_esp_local_lists_ids( $email ) {
 		return $this->get_contact_tags_ids( $email );
+	}
+
+	/**
+	 * Get usage data.
+	 *
+	 * @return array|WP_Error
+	 */
+	public function get_usage_report() {
+		return new WP_Error( 'newspack_newsletters_not_implemented', __( 'Not implemented', 'newspack-newsletters' ), [ 'status' => 400 ] );
 	}
 }

--- a/includes/service-providers/class-newspack-newsletters-service-provider.php
+++ b/includes/service-providers/class-newspack-newsletters-service-provider.php
@@ -777,9 +777,11 @@ abstract class Newspack_Newsletters_Service_Provider implements Newspack_Newslet
 	/**
 	 * Get usage data.
 	 *
+	 * @param int $last_n_days Number of days to get the report for.
+	 *
 	 * @return array|WP_Error
 	 */
-	public function get_usage_report() {
+	public function get_usage_report( $last_n_days ) {
 		return new WP_Error( 'newspack_newsletters_not_implemented', __( 'Not implemented', 'newspack-newsletters' ), [ 'status' => 400 ] );
 	}
 }

--- a/includes/service-providers/interface-newspack-newsletters-esp-service.php
+++ b/includes/service-providers/interface-newspack-newsletters-esp-service.php
@@ -171,4 +171,11 @@ interface Newspack_Newsletters_ESP_API_Interface {
 	 * @return true|WP_Error
 	 */
 	public function remove_tag_from_contact( $email, $tag, $list_id = null );
+
+	/**
+	 * Get usage report (no. of subscribers etc.)
+	 *
+	 * @return array|WP_Error
+	 */
+	public function get_usage_report();
 }

--- a/includes/service-providers/interface-newspack-newsletters-esp-service.php
+++ b/includes/service-providers/interface-newspack-newsletters-esp-service.php
@@ -175,7 +175,9 @@ interface Newspack_Newsletters_ESP_API_Interface {
 	/**
 	 * Get usage report (no. of subscribers etc.)
 	 *
+	 * @param int $last_n_days Number of days to get the report for.
+	 *
 	 * @return array|WP_Error
 	 */
-	public function get_usage_report();
+	public function get_usage_report( $last_n_days );
 }

--- a/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp-groups.php
+++ b/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp-groups.php
@@ -150,7 +150,7 @@ trait Newspack_Newsletters_Mailchimp_Groups {
 				'type'  => 'checkboxes',
 			]
 		);
-		
+
 		// If there was an error creating the category, let's check if it already exists.
 		if ( ! empty( $create['status'] ) && 400 === $create['status'] ) {
 			$search = $mc->get(
@@ -169,7 +169,7 @@ trait Newspack_Newsletters_Mailchimp_Groups {
 				}
 			}
 		}
-			
+
 		if ( ! empty( $create['id'] ) ) {
 			$group_category_ids[ $list_id ] = $create['id'];
 			update_option( $option_name, $group_category_ids );
@@ -249,7 +249,6 @@ trait Newspack_Newsletters_Mailchimp_Groups {
 	 * @return array|WP_Error The group representation sent from the server on succes. WP_Error on failure.
 	 */
 	public function create_group( $group, $list_id = null ) {
-		
 		$mc      = new Mailchimp( $this->api_key() );
 		$created = $mc->post(
 			sprintf( '/lists/%s/interest-categories/%s/interests', $list_id, $this->get_groups_category_id( $list_id ) ),
@@ -276,7 +275,6 @@ trait Newspack_Newsletters_Mailchimp_Groups {
 	 * @return array|WP_Error The group representation sent from the server on succes. WP_Error on failure.
 	 */
 	public function update_group( $group_id, $group, $list_id = null ) {
-		
 		$mc      = new Mailchimp( $this->api_key() );
 		$created = $mc->patch(
 			sprintf( '/lists/%s/interest-categories/%s/interests/%s', $list_id, $this->get_groups_category_id( $list_id ), $group_id ),
@@ -382,7 +380,7 @@ trait Newspack_Newsletters_Mailchimp_Groups {
 				}
 			}
 		}
-		
+
 		return $groups;
 	}
 

--- a/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp-usage-reports.php
+++ b/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp-usage-reports.php
@@ -25,9 +25,11 @@ class Newspack_Newsletters_Mailchimp_Usage_Reports {
 	/**
 	 * Creates a usage report.
 	 *
+	 * @param int $last_n_days Number of days to get the report for.
+	 *
 	 * @return array Usage report.
 	 */
-	public static function get_usage_report() {
+	public static function get_usage_report( $last_n_days ) {
 		$mailchimp_instance = self::get_mc_instance();
 		$mc_api             = new Mailchimp( $mailchimp_instance->api_key() );
 
@@ -37,7 +39,7 @@ class Newspack_Newsletters_Mailchimp_Usage_Reports {
 			$activity_response = $mc_api->get(
 				'lists/' . $list['id'] . '/activity',
 				[
-					'count' => 1, // Last day only.
+					'count' => $last_n_days,
 				]
 			);
 			$list['activity']  = $activity_response['activity'];

--- a/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp-usage-reports.php
+++ b/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp-usage-reports.php
@@ -1,0 +1,85 @@
+<?php
+/**
+ * Service Provider: Mailchimp Usage Reports
+ *
+ * @package Newspack
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+use DrewM\MailChimp\MailChimp;
+
+/**
+ * Usage reports for Mailchimp.
+ */
+class Newspack_Newsletters_Mailchimp_Usage_Reports {
+	/**
+	 * Retrieves the main Mailchimp instance
+	 *
+	 * @return Newspack_Newsletters_Mailchimp
+	 */
+	private static function get_mc_instance() {
+		return Newspack_Newsletters_Mailchimp::instance();
+	}
+
+	/**
+	 * Creates a usage report.
+	 *
+	 * @return array Usage report.
+	 */
+	public static function get_usage_report() {
+		$mailchimp_instance = self::get_mc_instance();
+		$mc_api             = new Mailchimp( $mailchimp_instance->api_key() );
+
+		// Get daily activity for each list.
+		$lists = $mc_api->get( 'lists', [ 'count' => 1000 ] );
+		foreach ( $lists['lists'] as &$list ) {
+			$activity_response = $mc_api->get(
+				'lists/' . $list['id'] . '/activity',
+				[
+					'count' => 1, // Last day only.
+				]
+			);
+			$list['activity']  = $activity_response['activity'];
+		}
+
+		return self::process_data_to_report( $lists['lists'] );
+	}
+
+	/**
+	 * Process lists and activity data to a usage report.
+	 *
+	 * @param array $lists_with_activity Lists with activity.
+	 */
+	public static function process_data_to_report( $lists_with_activity ) {
+		$report = [];
+		foreach ( $lists_with_activity as $list ) {
+			foreach ( $list['activity'] as $day ) {
+				$date = $day['day'];
+				if ( isset( $report[ $date ] ) ) {
+					$existing_day    = $report[ $date ];
+					$report[ $date ] = array_merge(
+						$existing_day,
+						[
+							'emails_sent' => $existing_day['emails_sent'] + $day['emails_sent'],
+							'opens'       => $existing_day['opens'] + $day['unique_opens'],
+							'clicks'      => $existing_day['clicks'] + $day['recipient_clicks'],
+							'subs'        => $existing_day['subs'] + $day['subs'],
+							'unsubs'      => $existing_day['unsubs'] + $day['unsubs'],
+						]
+					);
+				} else {
+					$report[ $date ] = [
+						'date'        => $date,
+						'emails_sent' => $day['emails_sent'],
+						'opens'       => $day['unique_opens'],
+						'clicks'      => $day['recipient_clicks'],
+						'subs'        => $day['subs'],
+						'unsubs'      => $day['unsubs'],
+					];
+				}
+			}
+		}
+		return array_values( $report );
+	}
+}

--- a/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp.php
+++ b/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp.php
@@ -7,7 +7,7 @@
 
 defined( 'ABSPATH' ) || exit;
 
-use \DrewM\MailChimp\MailChimp;
+use DrewM\MailChimp\MailChimp;
 use Newspack\Newsletters\Subscription_Lists;
 
 /**
@@ -274,7 +274,6 @@ final class Newspack_Newsletters_Mailchimp extends \Newspack_Newsletters_Service
 			'newspack_newsletter_error_adding_tag_to_contact',
 			! empty( $created['errors'] ) && ! empty( $created['errors'][0]['error'] ) ? $created['errors'][0]['error'] : ''
 		);
-
 	}
 
 	/**
@@ -306,7 +305,6 @@ final class Newspack_Newsletters_Mailchimp extends \Newspack_Newsletters_Service
 			'newspack_newsletter_error_adding_tag_to_contact',
 			! empty( $created['errors'] ) && ! empty( $created['errors'][0]['error'] ) ? $created['errors'][0]['error'] : ''
 		);
-
 	}
 
 	/**
@@ -1470,8 +1468,10 @@ final class Newspack_Newsletters_Mailchimp extends \Newspack_Newsletters_Service
 
 	/**
 	 * Get usage report.
+	 *
+	 * @param int $last_n_days Number of days to get the report for.
 	 */
-	public function get_usage_report() {
-		return Newspack_Newsletters_Mailchimp_Usage_Reports::get_usage_report();
+	public function get_usage_report( $last_n_days ) {
+		return Newspack_Newsletters_Mailchimp_Usage_Reports::get_usage_report( $last_n_days );
 	}
 }

--- a/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp.php
+++ b/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp.php
@@ -1467,4 +1467,11 @@ final class Newspack_Newsletters_Mailchimp extends \Newspack_Newsletters_Service
 		}
 		return false;
 	}
+
+	/**
+	 * Get usage report.
+	 */
+	public function get_usage_report() {
+		return Newspack_Newsletters_Mailchimp_Usage_Reports::get_usage_report();
+	}
 }

--- a/newspack-newsletters.php
+++ b/newspack-newsletters.php
@@ -38,6 +38,7 @@ require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/service-providers/mai
 require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp.php';
 require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp-controller.php';
 require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp-cached-data.php';
+require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp-usage-reports.php';
 require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/service-providers/constant_contact/class-newspack-newsletters-constant-contact.php';
 require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/service-providers/constant_contact/class-newspack-newsletters-constant-contact-controller.php';
 require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/service-providers/constant_contact/class-newspack-newsletters-constant-contact-sdk.php';

--- a/tests/test-usage-reports.php
+++ b/tests/test-usage-reports.php
@@ -1,0 +1,98 @@
+<?php
+/**
+ * Class Test Usage Reports
+ *
+ * @package Newspack_Newsletters
+ */
+
+/**
+ * Usage Reports Test.
+ */
+class Newsletter_Usage_Reports_Test extends WP_UnitTestCase {
+	/**
+	 * Test set up.
+	 */
+	public function set_up() {
+		\Newspack_Newsletters::set_service_provider( 'mailchimp' );
+	}
+
+	/**
+	 * Test MC usage report processing.
+	 */
+	public function test_mailchimp_usage_report() {
+		$mailchimp_data = [
+			[
+				'id'       => 1,
+				'activity' => [
+					[
+						'day'              => '2023-01-01',
+						'emails_sent'      => 2,
+						'unique_opens'     => 3,
+						'recipient_clicks' => 4,
+						'subs'             => 5,
+						'unsubs'           => 6,
+					],
+					[
+						'day'              => '2023-01-02',
+						'emails_sent'      => 7,
+						'unique_opens'     => 8,
+						'recipient_clicks' => 9,
+						'subs'             => 10,
+						'unsubs'           => 11,
+					],
+				],
+			],
+			[
+				'id'       => 2,
+				'activity' => [
+					[
+						'day'              => '2023-01-01',
+						'emails_sent'      => 2,
+						'unique_opens'     => 3,
+						'recipient_clicks' => 4,
+						'subs'             => 5,
+						'unsubs'           => 6,
+					],
+					[
+						'day'              => '2023-01-03',
+						'emails_sent'      => 3,
+						'unique_opens'     => 3,
+						'recipient_clicks' => 3,
+						'subs'             => 3,
+						'unsubs'           => 3,
+					],
+				],
+			],
+		];
+		$result         = Newspack_Newsletters_Mailchimp_Usage_Reports::process_data_to_report( $mailchimp_data );
+		$this->assertEquals(
+			[
+				[
+					'date'        => '2023-01-01',
+					'emails_sent' => 4,
+					'opens'       => 6,
+					'clicks'      => 8,
+					'subs'        => 10,
+					'unsubs'      => 12,
+				],
+				[
+					'date'        => '2023-01-02',
+					'emails_sent' => 7,
+					'opens'       => 8,
+					'clicks'      => 9,
+					'subs'        => 10,
+					'unsubs'      => 11,
+				],
+				[
+					'date'        => '2023-01-03',
+					'emails_sent' => 3,
+					'opens'       => 3,
+					'clicks'      => 3,
+					'subs'        => 3,
+					'unsubs'      => 3,
+				],
+			],
+			$result
+		);
+	}
+}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Adds a usage report class, for retrieving ESP data. A report is an array of arrays representing days of activity. Currently it's hard-coded to retrieve the last day only, but this can be amended later. 

Currently this is only implemented for Mailchimp, handling more ESPs to come. 

### How to test the changes in this Pull Request:

1. Observe that the tests are passing.
2. With Mailchimp set as the ESP, run `wp eval "echo print_r( (\Newspack_Newsletters::get_service_provider())->get_usage_report(1) , true );"` in the console – observe an appropriate array printed
3. Switch ESP to another, run the snippet again – observe that its value is a `newspack_newsletters_not_implemented` WP Error

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->