### PR TITLE
fix: add margin to lists and list style position

### DIFF
--- a/includes/email-template-mjml.css
+++ b/includes/email-template-mjml.css
@@ -61,9 +61,9 @@ h6 {
 
 /* List */
 ul, ol {
-	margin-bottom: 0;
-	margin-top: 0;
-	padding-left: 1.3em;
+	margin: 12px 0;
+	padding: 0;
+	list-style-position: inside;
 }
 
 /* Quote */


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR adds a small bottom/top margin to lists (12px). Prior to this, lists felt very compact.
I also changed the list-style-position to inside because in some email clients, the bullet points were outside the screen.

__Before__
![1-before](https://github.com/Automattic/newspack-newsletters/assets/177929/59f56b4e-9de1-48f2-bd3f-d593d4a92f10)

__After__
![2-after](https://github.com/Automattic/newspack-newsletters/assets/177929/d8608de4-cb47-45ad-8ff7-4ae5bc98e630)

### How to test the changes in this Pull Request:

1. Send a (test) newsletter with a bunch of lists
2. Switch to this branch and refresh
3. Resend newsletter

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
