### PR TITLE
fix(tracking): make the log cycling strategy default for pixel tracking

### DIFF
--- a/includes/tracking/class-pixel.php
+++ b/includes/tracking/class-pixel.php
@@ -31,12 +31,17 @@ final class Pixel {
 		\add_action( 'init', [ __CLASS__, 'render' ], 2, 0 ); // Run on priority 2 to allow Data Events and ActionScheduler to initialize first.
 		\add_action( 'template_redirect', [ __CLASS__, 'render' ] );
 
-		// Experimental approach by processing cycled log files.
-		if ( defined( 'NEWSPACK_NEWSLETTERS_PIXEL_LOG_PROCESSING' ) && NEWSPACK_NEWSLETTERS_PIXEL_LOG_PROCESSING ) {
-			\add_action( 'wp', [ __CLASS__, 'schedule_log_processing' ] );
-			\add_action( 'newspack_newsletters_tracking_pixel_process_log', [ __CLASS__, 'process_logs' ] );
-			\add_filter( 'newspack_newsletters_tracking_pixel_url', [ __CLASS__, 'log_pixel_url' ], 10, 4 );
-		}
+		/**
+		 * Replace the default approach, which processes each request in the pixel
+		 * hit, to an approach that processes requests in batches by cycling log
+		 * files.
+		 *
+		 * The new pixel URL appends the tracking data to a log file, and then the
+		 * log file is processed in batches by the `newspack_newsletters_tracking_pixel_process_log`
+		 */
+		\add_action( 'wp', [ __CLASS__, 'schedule_log_processing' ] );
+		\add_action( 'newspack_newsletters_tracking_pixel_process_log', [ __CLASS__, 'process_logs' ] );
+		\add_filter( 'newspack_newsletters_tracking_pixel_url', [ __CLASS__, 'log_pixel_url' ], 10, 4 );
 	}
 
 	/**

--- a/includes/tracking/class-pixel.php
+++ b/includes/tracking/class-pixel.php
@@ -38,6 +38,8 @@ final class Pixel {
 		 *
 		 * The new pixel URL appends the tracking data to a log file, and then the
 		 * log file is processed in batches by the `newspack_newsletters_tracking_pixel_process_log`
+		 *
+		 * Unhooking the following restores the original approach.
 		 */
 		\add_action( 'wp', [ __CLASS__, 'schedule_log_processing' ] );
 		\add_action( 'newspack_newsletters_tracking_pixel_process_log', [ __CLASS__, 'process_logs' ] );

--- a/tests/test-tracking.php
+++ b/tests/test-tracking.php
@@ -21,10 +21,10 @@ class Newsletters_Tracking_Test extends WP_UnitTestCase {
 		ob_start();
 		do_action( 'newspack_newsletters_editor_mjml_body', $post );
 		$mjml_body = ob_get_clean();
-		$this->assertMatchesRegularExpression( '/\?np_newsletters_pixel=1&#038;id=' . $post_id . '/', $mjml_body );
+		$this->assertMatchesRegularExpression( '/\/np-newsletters.pixel.php\?id=' . $post_id . '/', $mjml_body );
 
 		// Fetch the tracking pixel URL from body.
-		$pattern = '/src="([^"]*np_newsletters_pixel[^"]*)"/i';
+		$pattern = '/src="([^"]*np-newsletters-pixel.php[^"]*)"/i';
 		$matches = [];
 		preg_match( $pattern, $mjml_body, $matches );
 		$pixel_url  = html_entity_decode( $matches[1] );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Make the cycling log files approach for pixel tracking (#1317) the default strategy.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
