### PR TITLE
fix: active ad start/end date check

### DIFF
--- a/includes/class-newspack-newsletters-ads.php
+++ b/includes/class-newspack-newsletters-ads.php
@@ -393,7 +393,7 @@ final class Newspack_Newsletters_Ads {
 	 *
 	 * @return bool
 	 */
-	private static function is_ad_active( $ad_id, $post_id = null ) {
+	public static function is_ad_active( $ad_id, $post_id = null ) {
 
 		$start_date  = get_post_meta( $ad_id, 'start_date', true );
 		$expiry_date = get_post_meta( $ad_id, 'expiry_date', true );

--- a/includes/class-newspack-newsletters-ads.php
+++ b/includes/class-newspack-newsletters-ads.php
@@ -408,17 +408,19 @@ final class Newspack_Newsletters_Ads {
 			$date = get_the_date( $date_format, $post_id );
 		}
 
+		$started = true;
 		if ( $start_date ) {
 			$formatted_start_date = ( new DateTime( $start_date ) )->format( $date_format );
-			return $formatted_start_date <= $date;
+			$started              = $formatted_start_date <= $date;
 		}
 
+		$ended = false;
 		if ( $expiry_date ) {
 			$formatted_expiry_date = ( new DateTime( $expiry_date ) )->format( $date_format );
-			return $formatted_expiry_date >= $date;
+			$ended                 = $formatted_expiry_date < $date;
 		}
 
-		return true;
+		return $started && ! $ended;
 	}
 
 	/**

--- a/tests/test-newsletter-ads.php
+++ b/tests/test-newsletter-ads.php
@@ -34,22 +34,22 @@ class Newsletters_Newsletter_Ads_Test extends WP_UnitTestCase {
 	 * Test active ad.
 	 */
 	public function test_is_active_ad() {
-		$this->assertTrue( Newspack_Newsletters_Ads::is_active_ad( self::$ad_id ) );
+		$this->assertTrue( Newspack_Newsletters_Ads::is_ad_active( self::$ad_id ) );
 
 		// Set start date to tomorrow.
 		update_post_meta( self::$ad_id, 'start_date', dgmate( 'Y-m-d', strtotime( '+1 day' ) ) );
-		$this->assertFalse( Newspack_Newsletters_Ads::is_active_ad( self::$ad_id ) );
+		$this->assertFalse( Newspack_Newsletters_Ads::is_ad_active( self::$ad_id ) );
 
 		// Set start date to yesterday.
 		update_post_meta( self::$ad_id, 'start_date', gmdate( 'Y-m-d', strtotime( '-1 day' ) ) );
-		$this->assertTrue( Newspack_Newsletters_Ads::is_active_ad( self::$ad_id ) );
+		$this->assertTrue( Newspack_Newsletters_Ads::is_ad_active( self::$ad_id ) );
 
 		// Set end date to yesterday.
 		update_post_meta( self::$ad_id, 'end_date', gmdate( 'Y-m-d', strtotime( '-1 day' ) ) );
-		$this->assertFalse( Newspack_Newsletters_Ads::is_active_ad( self::$ad_id ) );
+		$this->assertFalse( Newspack_Newsletters_Ads::is_ad_active( self::$ad_id ) );
 
 		// Set end date to tomorrow.
 		update_post_meta( self::$ad_id, 'end_date', gmdate( 'Y-m-d', strtotime( '+1 day' ) ) );
-		$this->assertTrue( Newspack_Newsletters_Ads::is_active_ad( self::$ad_id ) );
+		$this->assertTrue( Newspack_Newsletters_Ads::is_ad_active( self::$ad_id ) );
 	}
 }

--- a/tests/test-newsletter-ads.php
+++ b/tests/test-newsletter-ads.php
@@ -44,12 +44,12 @@ class Newsletters_Newsletter_Ads_Test extends WP_UnitTestCase {
 		update_post_meta( self::$ad_id, 'start_date', gmdate( 'Y-m-d', strtotime( '-1 day' ) ) );
 		$this->assertTrue( Newspack_Newsletters_Ads::is_ad_active( self::$ad_id ) );
 
-		// Set end date to yesterday.
-		update_post_meta( self::$ad_id, 'end_date', gmdate( 'Y-m-d', strtotime( '-1 day' ) ) );
+		// Set expiry date to yesterday.
+		update_post_meta( self::$ad_id, 'expiry_date', gmdate( 'Y-m-d', strtotime( '-1 day' ) ) );
 		$this->assertFalse( Newspack_Newsletters_Ads::is_ad_active( self::$ad_id ) );
 
-		// Set end date to tomorrow.
-		update_post_meta( self::$ad_id, 'end_date', gmdate( 'Y-m-d', strtotime( '+1 day' ) ) );
+		// Set expiry date to tomorrow.
+		update_post_meta( self::$ad_id, 'expiry_date', gmdate( 'Y-m-d', strtotime( '+1 day' ) ) );
 		$this->assertTrue( Newspack_Newsletters_Ads::is_ad_active( self::$ad_id ) );
 	}
 }

--- a/tests/test-newsletter-ads.php
+++ b/tests/test-newsletter-ads.php
@@ -37,7 +37,7 @@ class Newsletters_Newsletter_Ads_Test extends WP_UnitTestCase {
 		$this->assertTrue( Newspack_Newsletters_Ads::is_ad_active( self::$ad_id ) );
 
 		// Set start date to tomorrow.
-		update_post_meta( self::$ad_id, 'start_date', dgmate( 'Y-m-d', strtotime( '+1 day' ) ) );
+		update_post_meta( self::$ad_id, 'start_date', gmdate( 'Y-m-d', strtotime( '+1 day' ) ) );
 		$this->assertFalse( Newspack_Newsletters_Ads::is_ad_active( self::$ad_id ) );
 
 		// Set start date to yesterday.

--- a/tests/test-newsletter-ads.php
+++ b/tests/test-newsletter-ads.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * Test Newsletter Ads.
+ *
+ * @package Newspack_Newsletters
+ */
+
+/**
+ * Newsletters Tracking Test.
+ */
+class Newsletters_Newsletter_Ads_Test extends WP_UnitTestCase {
+	/**
+	 * Ad ID for testing.
+	 *
+	 * @var int
+	 */
+	private static $ad_id = 0;
+
+	/**
+	 * Test creating ad.
+	 */
+	public function test_creating_ad() {
+		self::$ad_id = self::factory()->post->create(
+			[
+				'post_type'    => Newspack_Newsletters_Ads::CPT,
+				'post_title'   => 'A sample ad',
+				'post_content' => '<!-- wp:paragraph -->\n<p>Ad content.<\/p>\n<!-- \/wp:paragraph -->',
+			]
+		);
+		$this->assertNotEquals( 0, self::$ad_id );
+	}
+
+	/**
+	 * Test active ad.
+	 */
+	public function test_is_active_ad() {
+		$this->assertTrue( Newspack_Newsletters_Ads::is_active_ad( self::$ad_id ) );
+
+		// Set start date to tomorrow.
+		update_post_meta( self::$ad_id, 'start_date', dgmate( 'Y-m-d', strtotime( '+1 day' ) ) );
+		$this->assertFalse( Newspack_Newsletters_Ads::is_active_ad( self::$ad_id ) );
+
+		// Set start date to yesterday.
+		update_post_meta( self::$ad_id, 'start_date', gmdate( 'Y-m-d', strtotime( '-1 day' ) ) );
+		$this->assertTrue( Newspack_Newsletters_Ads::is_active_ad( self::$ad_id ) );
+
+		// Set end date to yesterday.
+		update_post_meta( self::$ad_id, 'end_date', gmdate( 'Y-m-d', strtotime( '-1 day' ) ) );
+		$this->assertFalse( Newspack_Newsletters_Ads::is_active_ad( self::$ad_id ) );
+
+		// Set end date to tomorrow.
+		update_post_meta( self::$ad_id, 'end_date', gmdate( 'Y-m-d', strtotime( '+1 day' ) ) );
+		$this->assertTrue( Newspack_Newsletters_Ads::is_active_ad( self::$ad_id ) );
+	}
+}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

If the newsletter ad has a past start date, it will considered "active" regardless of the end date. This PR makes sure to check both start and end dates.

### How to test the changes in this Pull Request:

1. While in the `release` branch, create a new newsletter ad
2. Set its "start_date" to a past date through CLI: `wp post meta update {post_id} start_date "2023-01-01T00:00:00.000Z"`
3. Set its "expiry_date" to another past date through CLI: `wp post meta update {post_id} expiry_date "2023-02-01T00:00:00.000Z"`
4. Draft a new newsletter, preview, and confirm the ad renders even though it's supposed to be expired
5. Check out this branch, save the draft newsletter again, and preview
6. Confirm the ad no longer renders
7. Modify the ad "expiry_date" to somewhere in the future: `wp post meta update {post_id} expiry_date "2024-01-01T00:00:00.000Z"`
8. Save the draft newsletter and preview
9. Confirm the ad renders

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
