### PR TITLE
fix: restrict conditional content to newsletters

### DIFF
--- a/includes/class-newspack-newsletters-editor.php
+++ b/includes/class-newspack-newsletters-editor.php
@@ -304,7 +304,7 @@ final class Newspack_Newsletters_Editor {
 			$mjml_handling_post_types = array_values( array_diff( self::get_email_editor_cpts(), [ Newspack_Newsletters_Ads::CPT ] ) );
 			$provider                 = Newspack_Newsletters::get_service_provider();
 			$conditional_tag_support  = false;
-			if ( $provider ) {
+			if ( $provider && ( self::is_editing_newsletter() || self::is_editing_newsletter_ad() ) ) {
 				$conditional_tag_support = $provider::get_conditional_tag_support();
 			}
 			wp_localize_script(
@@ -420,7 +420,7 @@ final class Newspack_Newsletters_Editor {
 
 	/**
 	 * If Posts Inserter is set to hide sponsored content, add a tax query to exclude sponsored posts.
-	 * 
+	 *
 	 * @param array           $args Request arguments.
 	 * @param WP_REST_Request $request The original REST request params.
 	 *
@@ -428,7 +428,7 @@ final class Newspack_Newsletters_Editor {
 	 */
 	public static function maybe_exclude_sponsored_posts( $args, $request ) {
 		$params = $request->get_params();
-	
+
 		if ( ! empty( $params['exclude_sponsors'] ) && class_exists( '\Newspack_Sponsors\Core' ) ) {
 			if ( empty( $args['tax_query'] ) ) {
 				$args['tax_query'] = []; // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_tax_query


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Prevents the "Conditional Content" block feature from being rendered in other email editors. It should only be rendered for newsletters, where it can benefit from the ESP capabilities of conditional content.

### How to test the changes in this Pull Request:

1. While on the master branch, edit the "Receipt" email from "Newspack -> Reader Revenue -> Emails"
2. Edit a block and confirm you see the "Conditional Content" panel
3. Checkout this branch, refresh the page, and confirm the panel is no longer available
4.  Draft a new newsletter and confirm the "Conditional Content" panel renders

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
