### PR TITLE
fix(tracking): don't flush options cache on log processing

### DIFF
--- a/includes/tracking/class-pixel.php
+++ b/includes/tracking/class-pixel.php
@@ -335,10 +335,6 @@ final class Pixel {
 
 		// Update the log file path option.
 		update_option( 'newspack_newsletters_tracking_pixel_log_file', $log_file_path );
-
-		// Avoid notoptions bug.
-		wp_cache_delete( 'notoptions', 'options' );
-		wp_cache_delete( 'alloptions', 'options' );
 	}
 }
 Pixel::init();


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

No longer delete `notoptions` and `alloptions` from object cache as it's not ideal to have it executed every minute and can cause CPU spikes.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
