### PR TITLE
feat(subscription): support async `add_contact()`

### DIFF
--- a/includes/class-newspack-newsletters-subscription.php
+++ b/includes/class-newspack-newsletters-subscription.php
@@ -575,7 +575,8 @@ class Newspack_Newsletters_Subscription {
 					'email'    => $email,
 					'metadata' => $metadata,
 				],
-				$lists
+				$lists,
+				true // Async.
 			);
 		} catch ( \Exception $e ) {
 			// Avoid breaking the registration process.

--- a/includes/class-newspack-newsletters-subscription.php
+++ b/includes/class-newspack-newsletters-subscription.php
@@ -1124,7 +1124,7 @@ class Newspack_Newsletters_Subscription {
 							<?php
 							echo sprintf(
 								// translators: %s: Error message.
-								esc_html__( 'Error when attempting to subscribe: %s', 'newspack-newsletters' ),
+								esc_html__( 'Error while attempting to subscribe: %s', 'newspack-newsletters' ),
 								esc_html( $intent_error )
 							);
 							?>

--- a/includes/service-providers/class-newspack-newsletters-service-provider.php
+++ b/includes/service-providers/class-newspack-newsletters-service-provider.php
@@ -455,7 +455,7 @@ abstract class Newspack_Newsletters_Service_Provider implements Newspack_Newslet
 	 *
 	 * @return array|WP_Error Contact data if it was added, or error otherwise.
 	 */
-	public function add_contact_handling_local_lists( $contact, $list_id ) {
+	public function add_contact_handling_local_list( $contact, $list_id ) {
 		if ( Subscription_List::is_local_form_id( $list_id ) ) {
 			try {
 				$list = Subscription_List::from_form_id( $list_id );
@@ -499,7 +499,7 @@ abstract class Newspack_Newsletters_Service_Provider implements Newspack_Newslet
 		$contact = $this->get_contact_data( $email );
 		if ( is_wp_error( $contact ) ) {
 			// Create contact.
-			// Use  Newspack_Newsletters_Subscription::add_contact to trigger hooks and call add_contact_handling_local_lists if needed.
+			// Use  Newspack_Newsletters_Subscription::add_contact to trigger hooks and call add_contact_handling_local_list if needed.
 			$result = Newspack_Newsletters_Subscription::add_contact( [ 'email' => $email ], $lists_to_add );
 			if ( is_wp_error( $result ) ) {
 				return $result;

--- a/src/blocks/subscribe/index.php
+++ b/src/blocks/subscribe/index.php
@@ -502,7 +502,8 @@ function process_form() {
 			'email'    => $email,
 			'metadata' => $metadata,
 		],
-		$lists
+		$lists,
+		true // Async.
 	);
 
 	if ( \is_wp_error( $result ) ) {

--- a/src/blocks/subscribe/index.php
+++ b/src/blocks/subscribe/index.php
@@ -506,6 +506,11 @@ function process_form() {
 		true // Async.
 	);
 
+	// The async subscription strategy returns true.
+	if ( true === $result ) {
+		$result = [];
+	}
+
 	if ( \is_wp_error( $result ) ) {
 		return send_form_response( $result );
 	}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

When subscribing, each selected list generates one (or more) ESP API requests. When subscribing to multiple lists the form may take more than 7 seconds to resolve, which is not reasonable.

This PR implements an `async` parameter to the `Newspack_Newsletters_Subscription::add_contact` method. This parameter should be used by the Newsletter Subscription Form and Reader Registration blocks when subscribing readers.

#### Error handling

2191b5758a693994111df5d2ae9b671b7b1bff07 introduces a subscription intent system, which allows the backend to recover from server hiccups or other reasons for a subscription attempt to fail while performed asynchronously.

The subscription intent is stored and processed 3 times, once every minute, before giving up. If the subscribed email is an existing user, a user meta stores the last error so it can be displayed in the "My Account -> Newsletters" page:

<img width="833" alt="image" src="https://github.com/Automattic/newspack-newsletters/assets/820752/f2872c4a-6c86-4099-ae61-f21518d9e85d">

### How to test the changes in this Pull Request:

1. Connect Newsletters to ActiveCampaign and make sure you have multiple newsletter lists (5+) enabled
2. Add the Newsletters Subscription Form and Reader Registration blocks with all the subscription lists enabled to a page
3. Make sure you are in the **master** branch
5. Visit the page and subscribe to all lists using the Newsletters Subscription Form
6. Confirm it takes 5+ seconds to resolve the form
7. Check out this branch, make sure you have `define( 'NEWSPACK_LOG_LEVEL', 2 );` and watch the logs
8. Repeat step 5 and confirm the form resolves faster and that you have `[57058][NEWSPACK-DATA-EVENTS][Newspack\Data_Events::dispatch]: Dispatching action "newsletter_subscribed"` logged after the form is resolved
9. Visit the page anonymously, register through the Reader Registration block, and confirm it also resolves in a reasonable time and the subscription executes and is logged afterward

#### Test error handling

1. Add the following to line `999` of `includes/service-providers/active_campaign/class-newspack-newsletters-active-campaign.php`:
```php
		return new WP_Error( 'test_error', 'Some error message from the ESP' );
```

2. While authenticated as a reader, visit the page with the Newsletters Subscription Form block and subscribe to a list
3. Confirm block shows a success state
4. Visit "My Account -> Newsletters" and confirm you see the "Some error message from the ESP" notification
5. Remove the added line and wait 1 minute
6. Refresh the My Account page, confirm the error is gone and you are subscribed to the list

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
