### PR TITLE
fix: add layout styles to newsletter

### DIFF
--- a/src/components/init-modal/screens/layout-picker/index.js
+++ b/src/components/init-modal/screens/layout-picker/index.js
@@ -38,8 +38,8 @@ export default function LayoutPicker() {
 	const { layouts, isFetchingLayouts, deleteLayoutPost } = useLayoutsState();
 
 	const insertLayout = layoutId => {
-		const { post_content } = find( layouts, { ID: layoutId } ) || {};
-		editPost( { meta: { template_id: layoutId } } );
+		const { post_content, meta = {} } = find( layouts, { ID: layoutId } ) || {};
+		editPost( { meta: { template_id: layoutId, ...meta } } );
 		resetEditorBlocks( post_content ? parse( post_content ) : [] );
 		savePost();
 	};


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Fixes a regression introduced in #1287.

Layouts with custom styles (custom font, background color, or custom CSS) do not have their settings applied to newsletters when selected. This PR ensures the layout meta is applied to the newsletter.

<img width="1247" alt="image" src="https://github.com/Automattic/newspack-newsletters/assets/820752/14efd9e8-968b-4c55-ae1f-4964fa7c6cb4">


### How to test the changes in this Pull Request:

1. While in the master branch, draft a new newsletter with custom styles like the example above
2. Save this newsletter as a new layout
3. Draft a new newsletter and select the new layout
4. Confirm the styles are not applied
5. Check out this branch, refresh, and draft a new newsletter selecting the style
6. Confirm all the styles are applied

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
