### PR TITLE
fix(ras): contact syncing to mailchimp

### DIFF
--- a/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp.php
+++ b/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp.php
@@ -1054,12 +1054,7 @@ final class Newspack_Newsletters_Mailchimp extends \Newspack_Newsletters_Service
 	 * @return array|WP_Error Contact data if it was added, or error otherwise.
 	 */
 	public function add_contact( $contact, $list_id = false ) {
-		// If RAS is available and a default audience is set.
-		if ( false === $list_id && method_exists( 'Newspack\Reader_Activation', 'get_setting' ) ) {
-			$list_id = \Newspack\Reader_Activation::get_setting( 'mailchimp_audience_id' );
-		}
-
-		if ( empty( $list_id ) ) {
+		if ( false === $list_id ) {
 			return new WP_Error( 'newspack_newsletters_mailchimp_list_id', __( 'Missing list id.' ) );
 		}
 		$email_address = $contact['email'];


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

When syncing metadata fields to Mailchimp merge fields, we hit the [merge-fields endpoint](https://mailchimp.com/developer/marketing/api/list-merges/list-merge-fields/). By default, this endpoint only returns a max of 10 results. So if there are more than 10 merge fields in the audience (likely there will be), we won't see all of the available fields and will attempt to create duplicates of fields that have already been created.

### How to test the changes in this Pull Request:

1. On `master` in this plugin and Newsletters, set up RAS, connect Mailchimp as the ESP and set an audience in RAS advanced settings.
4. As a new reader, purchase a donation or non-donation product without signing up for any newsletters and observe that in Mailchimp, only a small amount of reader data is synced to the contact in Mailchimp, and few or none of the [metadata fields](https://github.com/Automattic/newspack-plugin/blob/master/includes/plugins/class-newspack-newsletters.php#L26).
5. (optional) If your Mailchimp account has 30 merge fields, observe that there may be duplicate merge fields in the audience, and that not all of the metadata fields have been created as merge fields.
6. Check out this branch.
7. In a new session, log into the account that you created in step 3. Confirm that full metadata is now synced for the contact in Mailchimp.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
