### PR TITLE
fix(editor): ensure localized variables while editing patterns

### DIFF
--- a/includes/class-newspack-newsletters-editor.php
+++ b/includes/class-newspack-newsletters-editor.php
@@ -279,6 +279,21 @@ final class Newspack_Newsletters_Editor {
 	 * Load up common JS/CSS for newsletter editor.
 	 */
 	public static function enqueue_block_editor_assets() {
+		// Remove the Ads CPT - it does not need MJML handling since ads
+		// will be injected into email content before it's converted to MJML.
+		$mjml_handling_post_types = array_values( array_diff( self::get_email_editor_cpts(), [ Newspack_Newsletters_Ads::CPT ] ) );
+		$provider                 = Newspack_Newsletters::get_service_provider();
+		$conditional_tag_support  = false;
+		if ( $provider && ( self::is_editing_newsletter() || self::is_editing_newsletter_ad() ) ) {
+			$conditional_tag_support = $provider::get_conditional_tag_support();
+		}
+		$email_editor_data = [
+			'email_html_meta'          => Newspack_Newsletters::EMAIL_HTML_META,
+			'mjml_handling_post_types' => $mjml_handling_post_types,
+			'conditional_tag_support'  => $conditional_tag_support,
+			'sponsors_flag_hex'        => get_theme_mod( 'sponsored_flag_hex', '#FED850' ),
+			'sponsors_flag_text_color' => function_exists( 'newspack_get_color_contrast' ) ? newspack_get_color_contrast( \get_theme_mod( 'sponsored_flag_hex', '#FED850' ) ) : 'black',
+		];
 		if ( self::is_editing_email() ) {
 			wp_register_style(
 				'newspack-newsletters',
@@ -298,27 +313,7 @@ final class Newspack_Newsletters_Editor {
 				filemtime( NEWSPACK_NEWSLETTERS_PLUGIN_FILE . 'dist/editor.js' ),
 				true
 			);
-
-			// Remove the Ads CPT - it does not need MJML handling since ads
-			// will be injected into email content before it's converted to MJML.
-			$mjml_handling_post_types = array_values( array_diff( self::get_email_editor_cpts(), [ Newspack_Newsletters_Ads::CPT ] ) );
-			$provider                 = Newspack_Newsletters::get_service_provider();
-			$conditional_tag_support  = false;
-			if ( $provider && ( self::is_editing_newsletter() || self::is_editing_newsletter_ad() ) ) {
-				$conditional_tag_support = $provider::get_conditional_tag_support();
-			}
-			wp_localize_script(
-				'newspack-newsletters-editor',
-				'newspack_email_editor_data',
-				[
-					'email_html_meta'          => Newspack_Newsletters::EMAIL_HTML_META,
-					'mjml_handling_post_types' => $mjml_handling_post_types,
-					'conditional_tag_support'  => $conditional_tag_support,
-					'sponsors_flag_hex'        => get_theme_mod( 'sponsored_flag_hex', '#FED850' ),
-					'sponsors_flag_text_color' => function_exists( 'newspack_get_color_contrast' ) ? newspack_get_color_contrast( \get_theme_mod( 'sponsored_flag_hex', '#FED850' ) ) : 'black',
-				]
-			);
-
+			wp_localize_script( 'newspack-newsletters-editor', 'newspack_email_editor_data', $email_editor_data );
 			do_action( 'newspack_newsletters_enqueue_block_editor_assets' );
 		}
 
@@ -383,6 +378,8 @@ final class Newspack_Newsletters_Editor {
 			);
 			wp_style_add_data( 'newspack-newsletters-editor-blocks', 'rtl', 'replace' );
 			wp_enqueue_style( 'newspack-newsletters-editor-blocks' );
+			// Localized data for the editor.
+			wp_localize_script( 'newspack-newsletters-editor-blocks', 'newspack_email_editor_data', $email_editor_data );
 		}
 	}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Ensures the editor localized variables that may be required by blocks are available when editing block patterns. Fixes the fatal crash when editing a pattern containing a Post Inserter block with sponsored posts.

### How to test the changes in this Pull Request:

1. While on the master branch, draft a new newsletter with the Post Inserter block
2. Make sure the Post Inserter block is rendering a sponsored post and save the block as a new pattern
3. Visit Posts -> Patterns and edit the recently created pattern
4. Confirm the block crashes
5. Check out this branch, refresh, and confirm the pattern renders without issues

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
