### PR TITLE
Feat/usage data ac leo

### DIFF
--- a/includes/service-providers/active_campaign/class-newspack-newsletters-active-campaign-usage-reports.php
+++ b/includes/service-providers/active_campaign/class-newspack-newsletters-active-campaign-usage-reports.php
@@ -150,7 +150,45 @@ class Newspack_Newsletters_Active_Campaign_Usage_Reports {
 	 * @param int $last_n_days Number of last days to get the data about.
 	 */
 	private function get_campaign_data( $last_n_days ) {
-		$report           = self::get_default_report();
+		$current_campaign_data = $this->get_current_campaign_data( $last_n_days );
+		$last_campaigns_data   = get_option( self::LAST_REPORT_OPTION_NAME );
+		$campaigns_data        = [
+			'emails_sent' => 0,
+			'opens'       => 0,
+			'clicks'      => 0,
+		];
+
+		update_option( self::LAST_REPORT_OPTION_NAME, $current_campaign_data );
+
+		if ( ! $last_campaigns_data ) {
+			// We don't have data about campaigns yet, we will be able to calculate the report next time.
+			return $campaigns_data;
+		}
+
+		foreach ( $current_campaign_data as $campaign_id => $current_data ) {
+			$subtract = [
+				'emails_sent' => 0,
+				'opens'       => 0,
+				'clicks'      => 0,
+			];
+			// From the current totals, we subtract the totals from the last report.
+			// Campaigns that exist in the last report but not in the current report are ignored.
+			if ( isset( $last_campaigns_data[ $campaign_id ] ) ) {
+				$subtract = $last_campaigns_data[ $campaign_id ];
+			}
+			$campaigns_data['emails_sent'] += $current_data['emails_sent'] - $subtract['emails_sent'];
+			$campaigns_data['opens']       += $current_data['opens'] - $subtract['opens'];
+			$campaigns_data['clicks']      += $current_data['clicks'] - $subtract['clicks'];
+		}
+		return $campaigns_data;
+	}
+
+	/**
+	 * Get campaign data - emails sent, opens, and clicks live from the ESP.
+	 *
+	 * @param int $last_n_days Number of last days to get the data about.
+	 */
+	private function get_current_campaign_data( $last_n_days ) {
 		$ac               = $this->ac_instance;
 		$params           = [
 			'query' => [
@@ -164,6 +202,9 @@ class Newspack_Newsletters_Active_Campaign_Usage_Reports {
 		if ( \is_wp_error( $campaigns_result ) ) {
 			return $campaigns_result;
 		}
+
+		$campaigns_data = [];
+
 		foreach ( $campaigns_result['campaigns'] as $campaign ) {
 			if (
 				! isset( $campaign['sdate'] )
@@ -176,11 +217,13 @@ class Newspack_Newsletters_Active_Campaign_Usage_Reports {
 			if ( $campaign_send_date < $cutoff_datetime ) {
 				break;
 			}
-			$report['emails_sent'] += intval( $campaign['send_amt'] );
-			$report['opens']       += intval( $campaign['uniqueopens'] );
-			$report['clicks']      += intval( $campaign['uniquelinkclicks'] );
+			$campaigns_data[ intval( $campaign['id'] ) ] = [
+				'emails_sent' => intval( $campaign['send_amt'] ),
+				'opens'       => intval( $campaign['uniqueopens'] ),
+				'clicks'      => intval( $campaign['uniquelinkclicks'] ),
+			];
 		}
-		return $report;
+		return $campaigns_data;
 	}
 
 	/**
@@ -216,15 +259,14 @@ class Newspack_Newsletters_Active_Campaign_Usage_Reports {
 		}
 
 		// Get campaign data to retrieve emails sent, opens, and clicks.
-		$campaign_data = $this->get_campaign_data( 1 );
+		$campaign_data = $this->get_campaign_data( 30 ); // We consider sents, opens and clicks for Campaigns sent up to 30 days in the past.
 		if ( \is_wp_error( $campaign_data ) ) {
 			return $campaign_data;
 		}
-		$last_report = get_option( self::LAST_REPORT_OPTION_NAME, self::get_default_report() );
 
-		$report->emails_sent = $campaign_data['emails_sent'] - $last_report['emails_sent'];
-		$report->opens       = $campaign_data['opens'] - $last_report['opens'];
-		$report->clicks      = $campaign_data['clicks'] - $last_report['clicks'];
+		$report->emails_sent = $campaign_data['emails_sent'];
+		$report->opens       = $campaign_data['opens'];
+		$report->clicks      = $campaign_data['clicks'];
 
 		$report->total_contacts = $this->get_total_active_contacts();
 
@@ -235,8 +277,6 @@ class Newspack_Newsletters_Active_Campaign_Usage_Reports {
 		if ( isset( $contacts_data[ $yesterday ], $contacts_data[ $yesterday ]['unsubs'] ) ) {
 			$report->unsubscribes = $contacts_data[ $yesterday ]['unsubs'];
 		}
-
-		update_option( self::LAST_REPORT_OPTION_NAME, $report->to_array() );
 
 		return $report;
 	}

--- a/tests/test-active-campaign-usage-report.php
+++ b/tests/test-active-campaign-usage-report.php
@@ -51,7 +51,7 @@ class Newspack_Newsletters_Active_Campaign_Test_Wrapper {
 				$response['contacts']      = $contacts;
 				break;
 			case 'campaigns':
-				$campaigns                 = [
+				$campaigns = [
 					[
 						'id'               => 1,
 						'status'           => 5,
@@ -76,6 +76,15 @@ class Newspack_Newsletters_Active_Campaign_Test_Wrapper {
 						'uniqueopens'      => 40,
 						'uniquelinkclicks' => 10,
 					],
+					// Campaign sent more than 30 days ago should be ignored.
+					[
+						'id'               => 3,
+						'status'           => 5,
+						'sdate'            => gmdate( 'Y-m-d H:i:s', strtotime( '-31 day' ) ),
+						'send_amt'         => 99,
+						'uniqueopens'      => 99,
+						'uniquelinkclicks' => 99,
+					],
 				];
 				$response['campaigns']     = $campaigns;
 				$response['meta']['total'] = count( $campaigns );
@@ -91,9 +100,9 @@ class Newspack_Newsletters_Active_Campaign_Test_Wrapper {
 class ActiveCampaignUsageReportsTest extends WP_UnitTestCase {
 	public function test_get_usage_report() { // phpcs:ignore Squiz.Commenting.FunctionComment.Missing
 		$expected_report                 = new Newspack_Newsletters_Service_Provider_Usage_Report();
-		$expected_report->emails_sent    = 15;
-		$expected_report->opens          = 8;
-		$expected_report->clicks         = 3;
+		$expected_report->emails_sent    = 0;
+		$expected_report->opens          = 0;
+		$expected_report->clicks         = 0;
 		$expected_report->subscribes     = 1;
 		$expected_report->unsubscribes   = 1;
 		$expected_report->total_contacts = 2;
@@ -107,15 +116,28 @@ class ActiveCampaignUsageReportsTest extends WP_UnitTestCase {
 		update_option(
 			Newspack_Newsletters_Active_Campaign_Usage_Reports::LAST_REPORT_OPTION_NAME,
 			[
-				'emails_sent' => 10,
-				'opens'       => 5,
-				'clicks'      => 2,
+				1   => [
+					'emails_sent' => 9,
+					'opens'       => 1,
+					'clicks'      => 1,
+				],
+				3   => [
+					'emails_sent' => 100,
+					'opens'       => 40,
+					'clicks'      => 10,
+				],
+				// A campaign present in the prior data but not in the current data should be ignored.
+				100 => [
+					'emails_sent' => 88,
+					'opens'       => 88,
+					'clicks'      => 88,
+				],
 			]
 		);
 		$expected_report                 = new Newspack_Newsletters_Service_Provider_Usage_Report();
-		$expected_report->emails_sent    = 5;
-		$expected_report->opens          = 3;
-		$expected_report->clicks         = 1;
+		$expected_report->emails_sent    = 6;
+		$expected_report->opens          = 7;
+		$expected_report->clicks         = 2;
 		$expected_report->subscribes     = 1;
 		$expected_report->unsubscribes   = 1;
 		$expected_report->total_contacts = 2;

--- a/tests/test-active-campaign-usage-report.php
+++ b/tests/test-active-campaign-usage-report.php
@@ -78,7 +78,7 @@ class Newspack_Newsletters_Active_Campaign_Test_Wrapper {
 					],
 					// Campaign sent more than 30 days ago should be ignored.
 					[
-						'id'               => 3,
+						'id'               => 4,
 						'status'           => 5,
 						'sdate'            => gmdate( 'Y-m-d H:i:s', strtotime( '-31 day' ) ),
 						'send_amt'         => 99,
@@ -98,8 +98,10 @@ class Newspack_Newsletters_Active_Campaign_Test_Wrapper {
  * Test ActiveCampaign Usage Reports.
  */
 class ActiveCampaignUsageReportsTest extends WP_UnitTestCase {
-	public function test_get_usage_report() { // phpcs:ignore Squiz.Commenting.FunctionComment.Missing
-		$expected_report                 = new Newspack_Newsletters_Service_Provider_Usage_Report();
+	public function test_get_usage_report_initial() { // phpcs:ignore Squiz.Commenting.FunctionComment.Missing
+		$expected_report = new Newspack_Newsletters_Service_Provider_Usage_Report();
+		// The initial report's campaigns data should be empty, because there is no prior data to compare the values with.
+		// The campaigns data can only be meaningful when compared with prior data.
 		$expected_report->emails_sent    = 0;
 		$expected_report->opens          = 0;
 		$expected_report->clicks         = 0;
@@ -114,7 +116,7 @@ class ActiveCampaignUsageReportsTest extends WP_UnitTestCase {
 
 	public function test_get_usage_report_with_prior_data() { // phpcs:ignore Squiz.Commenting.FunctionComment.Missing
 		update_option(
-			Newspack_Newsletters_Active_Campaign_Usage_Reports::LAST_REPORT_OPTION_NAME,
+			Newspack_Newsletters_Active_Campaign_Usage_Reports::LAST_CAMPAIGNS_DATA_OPTION_NAME,
 			[
 				1   => [
 					'emails_sent' => 9,


### PR DESCRIPTION
Here is how I see it working.

We consider sents, opens and clicks for campaigns that were sent in the last 30 days (see pamTN9-6YO-p2#comment-9637), otherwise we would always have to loop through all campaigns that were sent in history. So we might miss a few opens and clicks, but that should not be relevant.

We store the value from the campaigns today so we can subtract them tomorrow. However, we need to store their IDs because we don't want to subtract the opens and clicks from a campaign that was sent more than 30 days ago and is not part of the current response