### PR TITLE
fix(ras): fall back to RAS audience ID if not passed to add_contact method

### DIFF
--- a/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp.php
+++ b/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp.php
@@ -1054,6 +1054,10 @@ final class Newspack_Newsletters_Mailchimp extends \Newspack_Newsletters_Service
 	 * @return array|WP_Error Contact data if it was added, or error otherwise.
 	 */
 	public function add_contact( $contact, $list_id = false ) {
+		// If RAS is available and a default audience is set.
+		if ( false === $list_id && class_exists( 'Newspack\Reader_Activation' ) && method_exists( 'Newspack\Data_Events\Connectors\Mailchimp', 'get_audience_id' ) ) {
+			$list_id = \Newspack\Data_Events\Connectors\Mailchimp::get_audience_id();
+		}
 		if ( false === $list_id ) {
 			return new WP_Error( 'newspack_newsletters_mailchimp_list_id', __( 'Missing list id.' ) );
 		}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Plugs another hole in the RAS Mailchimp reader data sync. #1355 almost did it but I misunderstood and removed the line that fixed things completely in the current implementation.

For future reference, the longer-term fix should be to refactor the WP hook callbacks that are currently handling syncing upon reader login into Data Events handlers in the Mailchimp and AC Data Connector classes.

### How to test the changes in this Pull Request:

1. On `master` or `release`, set up RAS, connect Mailchimp as the ESP and set an audience in RAS advanced settings.
2. As a new reader, purchase a new non-donation subscription without signing up for any newsletter lists.
3. In Mailchimp, find the contact and observe that the [metadata fields](https://github.com/Automattic/newspack-plugin/blob/master/includes/plugins/class-newspack-newsletters.php#L26) are missing data about the subscription (start date, amount, etc.)
4. Test the login sync with error logging in a `wp shell` session. Use the following:

```bash
wp> $customer = new WC_Customer( 111 ); // use the ID of the user account created after purchasing the subscription
wp> $order = $customer->get_last_order();
wp> $contact = Newspack\WooCommerce_Connection::get_contact_from_order( $order );
wp> \Newspack_Newsletters_Subscription::add_contact( $contact );
```

6. This will log the response from the contact sync. Observe that it's an error message:

```
=> object(WP_Error)#11243 (3) {
  ["errors"]=>
  array(1) {
    ["newspack_newsletters_mailchimp_list_id"]=>
    array(1) {
      [0]=>
      string(16) "Missing list id."
    }
  }
  ["error_data"]=>
  array(0) {
  }
  ["additional_data":protected]=>
  array(0) {
  }
}
```

7. Check out this branch, repeat step 4. Confirm that it now succeeds and that the contact in Mailchimp now contains metadata about the subscription, including the following fields:
  - `NP_Total Paid`
  - `NP_Last Payment Amount`
  - `NP_Last Payment Date`
  - `NP_Next Payment Date`
  - `NP_Billing Cycle`
  - `NP_Recurring Payment`
  - `NP_Product Name`

8. Repeat steps 2-3 with a new reader/purchase and confirm that the metadata fields are now synced upon purchase to begin with.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
