### PR TITLE
fix(constant-contact): increase request timeout

### DIFF
--- a/includes/service-providers/constant_contact/class-newspack-newsletters-constant-contact-sdk.php
+++ b/includes/service-providers/constant_contact/class-newspack-newsletters-constant-contact-sdk.php
@@ -90,6 +90,7 @@ final class Newspack_Newsletters_Constant_Contact_SDK {
 			unset( $options['query'] );
 		}
 		$args = [
+			'timeout' => 30, // phpcs:ignore WordPressVIPMinimum.Performance.RemoteRequestTimeout.timeout_timeout
 			'method'  => $method,
 			'headers' => [
 				'Content-Type'  => 'application/json',
@@ -228,6 +229,7 @@ final class Newspack_Newsletters_Constant_Contact_SDK {
 			'redirect_uri' => $redirect_uri,
 		];
 		$args        = [
+			'timeout' => 30, // phpcs:ignore WordPressVIPMinimum.Performance.RemoteRequestTimeout.timeout_timeout
 			'headers' => [
 				'Content-Type'  => 'application/x-www-form-urlencoded',
 				'Accept'        => 'application/json',
@@ -766,7 +768,7 @@ final class Newspack_Newsletters_Constant_Contact_SDK {
 			[
 				'name'             => $name,
 				'segment_criteria' => wp_json_encode( $criteria ),
-				
+
 			]
 		);
 


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Avoid request timeouts by increasing the timeout to 30 seconds.

### How to test the changes in this Pull Request:

1.
2.
3.

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
