### PR TITLE
fix: store and recover lists on membership reactivation

### DIFF
--- a/includes/plugins/class-woocommerce-memberships.php
+++ b/includes/plugins/class-woocommerce-memberships.php
@@ -164,11 +164,13 @@ class Woocommerce_Memberships {
 		 * in which case we want to resubscribe them to the lists they were in.
 		 */
 		$current_user_lists = \Newspack_Newsletters_Subscription::get_contact_lists( $user_email );
+		$existing_lists     = [];
 
 		if ( is_array( $current_user_lists ) ) {
 			$existing_lists = array_values( array_intersect( $current_user_lists, $lists_to_remove ) );
-			self::update_user_lists_on_deactivation( $user->ID, $user_membership->get_id(), $existing_lists );
 		}
+
+		self::update_user_lists_on_deactivation( $user->ID, $user_membership->get_id(), $existing_lists );
 
 		if ( ! empty( $provider ) ) {
 			$provider->update_contact_lists_handling_local( $user_email, [], $lists_to_remove );

--- a/includes/plugins/class-woocommerce-memberships.php
+++ b/includes/plugins/class-woocommerce-memberships.php
@@ -167,9 +167,7 @@ class Woocommerce_Memberships {
 
 		if ( is_array( $current_user_lists ) ) {
 			$existing_lists = array_values( array_intersect( $current_user_lists, $lists_to_remove ) );
-			if ( ! empty( $existing_lists ) ) {
-				self::update_user_lists_on_deactivation( $user->ID, $user_membership->get_id(), $existing_lists );
-			}
+			self::update_user_lists_on_deactivation( $user->ID, $user_membership->get_id(), $existing_lists );
 		}
 
 		if ( ! empty( $provider ) ) {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Currently, every time a user is granted a membership, they get add to all lists behind that membership.

If a membership is paused and then restored, the user will be re-added to all lists, even if they opt out of some of the lists at some point.

We recently found out that every membership that is tied to a Subscription, will be put on pause and active again when the subscription is being renewed. This could amplify this problem.

What this PR does is:

* When a membership is deactivated, we store which of the lists behind the membership the user is actually subscribed to
* Whenever a membership is reactivated, we will only resubscribe the user to the lists they were before (which could be none)

### How to test the changes in this Pull Request:

1.Create a membership plan
2. Configure Newsletters with 2 or more lists
3. In the membership plan, configure Restricted Content, and select 2 "Subscription Lists"
4. Set the membership to be connected to a Subscription product
5. As a reader, buy the subscription
6. Confirm the reader is granted the membership
7. Confirm in the ESP that the reader was added to both lists
8. As the reader, go to My Account and unsubscribe from one of the lists
9. Confirm it worked
10. Now, process the subscription renewal (one good way of doing this, that simulates the real automatic renewal, is to find the scheduled action under Tools > Scheduled Actions and Run it - search by the subscription ID)
11. After the renewal is complete, confirm in the membership activity that it was set to paused and active again
12. Confirm that the user is still subscribed only to the one list they were subscribed before
13. Ideally, repeat the test leaving all lists selected and no lists selected


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1206093655507511