### PR TITLE
fix(renderer): ensure group blocks use conditional tags

### DIFF
--- a/includes/class-newspack-newsletters-renderer.php
+++ b/includes/class-newspack-newsletters-renderer.php
@@ -104,9 +104,9 @@ final class Newspack_Newsletters_Renderer {
 
 	/**
 	 * Get a value for an image alt attribute.
-	 * 
+	 *
 	 * @param int $attachment_id Attachment ID of the image.
-	 * 
+	 *
 	 * @return string A value for the alt attribute.
 	 */
 	private static function get_image_alt( $attachment_id ) {
@@ -712,14 +712,14 @@ final class Newspack_Newsletters_Renderer {
 					if ( ! empty( $attrs['color'] ) ) {
 						$default_button_attrs['color'] = $attrs['color'];
 					}
-					
+
 					$column_attrs['css-class'] = 'mj-column-has-width';
 					$column_attrs['width']     = $default_width . '%';
 					if ( ! empty( $attrs['width'] ) ) {
 						$column_attrs['width']         = $attrs['width'] . '%';
 						$default_button_attrs['width'] = '100%'; // Buttons with defined width should fill their column.
 					}
-					
+
 					if ( ! empty( $attrs['padding'] ) ) {
 						$default_button_attrs['inner-padding'] = $attrs['padding'];
 					}
@@ -1127,6 +1127,13 @@ final class Newspack_Newsletters_Renderer {
 			if ( 'core/group' === $block['blockName'] ) {
 				$default_attrs = [];
 				$attrs         = self::process_attributes( $block['attrs'] );
+				$conditionals  = [];
+				if ( ! empty( $attrs['conditionalBefore'] ) && ! empty( $attrs['conditionalAfter'] ) ) {
+					$conditionals = [
+						'before' => $attrs['conditionalBefore'],
+						'after'  => $attrs['conditionalAfter'],
+					];
+				}
 				if ( isset( $attrs['color'] ) ) {
 					$default_attrs['color'] = $attrs['color'];
 				}
@@ -1136,6 +1143,9 @@ final class Newspack_Newsletters_Renderer {
 					$mjml_markup        .= $inner_block_content;
 				}
 				$block_content = $mjml_markup . '</mj-wrapper>';
+				if ( ! empty( $conditionals ) ) {
+					$block_content = '<mj-raw>' . $conditionals['before'] . '</mj-raw>' . $block_content . '<mj-raw>' . $conditionals['after'] . '</mj-raw>';
+				}
 			} else {
 				$block_content = self::render_mjml_component( $block );
 			}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

1200550061930446-as-1205996773681761

Group blocks placed in the root of the body are processed outside the usual `render_mjml_component()` method so they didn't have the conditional tags properly applied.

This PR ensures the conditional tags are rendered for such blocks.

### How to test the changes in this Pull Request:

1. Make sure you have your ESP setup to Mailchimp
2. While in the master branch, draft a new newsletter
3. Add a group block with some content and set the conditional tags to any rule, like `*|IF:FNAME|*` and `*|END:IF|*`
4. Add a paragraph block below that one and apply the same rule
5. Save the draft and click to preview
6. Confirm only the paragraph is contained in the conditional tags
7. Check out this branch, save the draft and preview again
8. Confirm both blocks are contained in the conditional tags

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
