### PR TITLE
fix: memberships & "other" ESP

### DIFF
--- a/includes/plugins/class-woocommerce-memberships.php
+++ b/includes/plugins/class-woocommerce-memberships.php
@@ -29,14 +29,14 @@ class Woocommerce_Memberships {
 	 */
 	protected static $user_id_in_scope;
 
-	/** 
+	/**
 	 * Initialize the class
 	 */
 	public static function init() {
 		add_action( 'plugins_loaded', [ __CLASS__, 'init_hooks' ] );
 	}
-	
-	/** 
+
+	/**
 	 * Initialize the hooks after all plugins are loaded
 	 */
 	public static function init_hooks() {
@@ -65,7 +65,7 @@ class Woocommerce_Memberships {
 		}
 		$lists = array_filter(
 			$lists,
-			function( $list ) {
+			function ( $list ) {
 				$list_object = Subscription_List::from_form_id( $list );
 				if ( ! $list_object ) {
 					return false;
@@ -80,8 +80,7 @@ class Woocommerce_Memberships {
 				$user_id = self::$user_id_in_scope ?? get_current_user_id();
 
 				return wc_memberships_user_can( $user_id, 'view', [ 'post' => $list_object->get_id() ] );
-
-			} 
+			}
 		);
 		return array_values( $lists );
 	}
@@ -101,12 +100,11 @@ class Woocommerce_Memberships {
 
 		return array_filter(
 			$lists,
-			function( $list_id ) use ( $list_ids ) {
+			function ( $list_id ) use ( $list_ids ) {
 				return in_array( $list_id, $list_ids );
 			},
 			ARRAY_FILTER_USE_KEY
 		);
-
 	}
 
 	/**
@@ -124,7 +122,7 @@ class Woocommerce_Memberships {
 		if ( in_array( $new_status, $status_considered_active ) ) {
 			return;
 		}
-		
+
 		$lists_to_remove = [];
 		$user            = $user_membership->get_user();
 		if ( ! $user ) {
@@ -147,19 +145,19 @@ class Woocommerce_Memberships {
 			}
 		}
 		$provider = Newspack_Newsletters::get_service_provider();
-		$provider->update_contact_lists_handling_local( $user_email, [], $lists_to_remove );
-		Newspack_Newsletters_Logger::log( 'Reader ' . $user_email . ' removed from the following lists: ' . implode( ', ', $lists_to_remove ) );
-		
+		if ( ! empty( $provider ) ) {
+			$provider->update_contact_lists_handling_local( $user_email, [], $lists_to_remove );
+			Newspack_Newsletters_Logger::log( 'Reader ' . $user_email . ' removed from the following lists: ' . implode( ', ', $lists_to_remove ) );
+		}
 	}
 
 	/**
 	 * Adds user to premium lists when a membership is granted
 	 *
 	 * @param \WC_Memberships_Membership_Plan $plan the plan that user was granted access to.
-	 * @param array                           $args 
-	 * {
+	 * @param array                           $args {
 	 *     Array of User Membership arguments.
-	 * 
+	 *
 	 *     @type int $user_id the user ID the membership is assigned to.
 	 *     @type int $user_membership_id the user membership ID being saved.
 	 *     @type bool $is_update whether this is a post update or a newly created membership.
@@ -208,7 +206,7 @@ class Woocommerce_Memberships {
 				$lists_to_add[]    = $subscription_list->get_form_id();
 			}
 		}
-		
+
 		if ( empty( $lists_to_add ) ) {
 			return;
 		}
@@ -216,7 +214,6 @@ class Woocommerce_Memberships {
 		$provider = Newspack_Newsletters::get_service_provider();
 		$provider->update_contact_lists_handling_local( $user_email, $lists_to_add );
 		Newspack_Newsletters_Logger::log( 'Reader ' . $user_email . ' added to the following lists: ' . implode( ', ', $lists_to_add ) );
-		
 	}
 
 	/**
@@ -228,7 +225,6 @@ class Woocommerce_Memberships {
 	public static function deleted_membership( $user_membership ) {
 		self::remove_user_from_list( $user_membership, '', 'deleted' );
 	}
-
 }
 
 Woocommerce_Memberships::init();


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes a small issue. 

### How to test the changes in this Pull Request:

1. On `master`,
1. Create a user with a membership
2. Set ESP to "Other"
3. Try to delete the user, observe it fails
4. Switch to this branch, repeat, observe the user can be deleted

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->