### PR TITLE
fix: prevent the use of `add_contact` for data sync purposes

### DIFF
--- a/includes/class-newspack-newsletters-subscription.php
+++ b/includes/class-newspack-newsletters-subscription.php
@@ -708,17 +708,12 @@ class Newspack_Newsletters_Subscription {
 			return;
 		}
 
-		if ( isset( $metadata['lists'] ) && ! empty( $metadata['lists'] ) ) {
-			$lists = $metadata['lists'];
-			unset( $metadata['lists'] );
-		} else {
-			$lists = false;
-		}
-		/** Don't add contact if reader sync is disabled and there are no lists to subscribe to. */
-		$sync = \Newspack\Reader_Activation::get_setting( 'sync_esp' );
-		if ( ! $sync && empty( $lists ) ) {
+		if ( empty( $metadata['lists'] ) ) {
 			return;
 		}
+
+		$lists = $metadata['lists'];
+		unset( $metadata['lists'] );
 
 		$metadata['newsletters_subscription_method'] = 'reader-registration';
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Changes the newsletters' `reader_registered` hook to only `add_contact()` if there are lists to subscribe to. The `add_contact()` method should no longer be used for data sync purposes, only subscriptions.

The sync strategy is already performed through different strategies in the main plugin, where it belongs:

- https://github.com/Automattic/newspack-plugin/blob/f8d35ec6b092a2078a742a0ee04926801ef74fdc/includes/data-events/connectors/class-mailchimp.php#L36-L38
- https://github.com/Automattic/newspack-plugin/blob/f8d35ec6b092a2078a742a0ee04926801ef74fdc/includes/reader-revenue/woocommerce/class-woocommerce-connection.php#L363-L385

### How to test the changes in this Pull Request:

1. Check out this branch and confirm you have RAS enabled with Mailchimp
2. Make sure you have a data sync Mailchimp audience selected in RAS' advanced settings
3. Click to register a new account using the "Sign In" modal from the header
4. Finish the registration with a new email and without subscribing to any newsletter
5. Confirm you don't get any "Missing list ID" warning in the logs
6. Wait until the `reader_registered` data events are processed and confirm the contact is added as transactional with the correct merge fields

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
