### PR TITLE
Use custom capability_type for the CPT

### DIFF
--- a/includes/class-newspack-newsletters-ads.php
+++ b/includes/class-newspack-newsletters-ads.php
@@ -87,7 +87,8 @@ final class Newspack_Newsletters_Ads {
 	 * @return bool|WP_Error
 	 */
 	public static function permission_callback( $request ) {
-		return current_user_can( 'edit_' . self::CPT . 's' );
+		$post_type_object = get_post_type_object( self::CPT );
+		return current_user_can( $post_type_object->cap->edit_posts );
 	}
 
 	/**
@@ -186,11 +187,12 @@ final class Newspack_Newsletters_Ads {
 	 * Add ads page link.
 	 */
 	public static function add_ads_page() {
+		$post_type_object = get_post_type_object( self::CPT );
 		add_submenu_page(
 			'edit.php?post_type=' . Newspack_Newsletters::NEWSPACK_NEWSLETTERS_CPT,
 			__( 'Newsletters Ads', 'newspack-newsletters' ),
 			__( 'Ads', 'newspack-newsletters' ),
-			'edit_' . self::CPT . 's',
+			$post_type_object->cap->edit_posts,
 			'/edit.php?post_type=' . self::CPT,
 			null,
 			2
@@ -201,10 +203,6 @@ final class Newspack_Newsletters_Ads {
 	 * Register the custom post type for layouts.
 	 */
 	public static function register_ads_cpt() {
-		if ( ! \Newspack_Newsletters::can_user_edit_newsletters() ) {
-			return;
-		}
-
 		$labels = [
 			'name'                     => _x( 'Newsletter Ads', 'post type general name', 'newspack-newsletters' ),
 			'singular_name'            => _x( 'Newsletter Ad', 'post type singular name', 'newspack-newsletters' ),
@@ -240,6 +238,8 @@ final class Newspack_Newsletters_Ads {
 		];
 		register_post_type( self::CPT, $cpt_args );
 
+		$post_type_object = get_post_type_object( self::CPT );
+
 		register_taxonomy(
 			self::ADVERTISER_TAX,
 			[ self::CPT, Newspack_Newsletters::NEWSPACK_NEWSLETTERS_CPT ],
@@ -272,10 +272,10 @@ final class Newspack_Newsletters_Ads {
 				'show_admin_column' => true,
 				// Available for anyone who can edit newsletter ads.
 				'capabilities'      => [
-					'manage_terms' => 'edit_' . self::CPT . 's',
-					'edit_terms'   => 'edit_' . self::CPT . 's',
-					'delete_terms' => 'edit_' . self::CPT . 's',
-					'assign_terms' => 'edit_' . self::CPT . 's',
+					'manage_terms' => $post_type_object->cap->edit_posts,
+					'edit_terms'   => $post_type_object->cap->edit_posts,
+					'delete_terms' => $post_type_object->cap->edit_posts,
+					'assign_terms' => $post_type_object->cap->edit_posts,
 				],
 			]
 		);

--- a/includes/class-newspack-newsletters-ads.php
+++ b/includes/class-newspack-newsletters-ads.php
@@ -87,7 +87,7 @@ final class Newspack_Newsletters_Ads {
 	 * @return bool|WP_Error
 	 */
 	public static function permission_callback( $request ) {
-		return current_user_can( 'edit_posts' );
+		return current_user_can( 'edit_' . self::CPT . 's' );
 	}
 
 	/**
@@ -190,7 +190,7 @@ final class Newspack_Newsletters_Ads {
 			'edit.php?post_type=' . Newspack_Newsletters::NEWSPACK_NEWSLETTERS_CPT,
 			__( 'Newsletters Ads', 'newspack-newsletters' ),
 			__( 'Ads', 'newspack-newsletters' ),
-			'edit_others_posts',
+			'edit_' . self::CPT . 's',
 			'/edit.php?post_type=' . self::CPT,
 			null,
 			2
@@ -201,7 +201,7 @@ final class Newspack_Newsletters_Ads {
 	 * Register the custom post type for layouts.
 	 */
 	public static function register_ads_cpt() {
-		if ( ! current_user_can( 'edit_others_posts' ) ) {
+		if ( ! \Newspack_Newsletters::can_user_edit_newsletters() ) {
 			return;
 		}
 
@@ -229,13 +229,14 @@ final class Newspack_Newsletters_Ads {
 		];
 
 		$cpt_args = [
-			'public'       => false,
-			'labels'       => $labels,
-			'show_ui'      => true,
-			'show_in_menu' => false,
-			'show_in_rest' => true,
-			'supports'     => [ 'editor', 'title', 'custom-fields' ],
-			'taxonomies'   => [ 'category' ],
+			'public'          => false,
+			'labels'          => $labels,
+			'show_ui'         => true,
+			'show_in_menu'    => false,
+			'show_in_rest'    => true,
+			'supports'        => [ 'editor', 'title', 'custom-fields' ],
+			'taxonomies'      => [ 'category' ],
+			'capability_type' => self::CPT,
 		];
 		register_post_type( self::CPT, $cpt_args );
 
@@ -269,6 +270,13 @@ final class Newspack_Newsletters_Ads {
 				'hierarchical'      => true,
 				'show_in_rest'      => true,
 				'show_admin_column' => true,
+				// Available for anyone who can edit newsletter ads.
+				'capabilities'      => [
+					'manage_terms' => 'edit_' . self::CPT . 's',
+					'edit_terms'   => 'edit_' . self::CPT . 's',
+					'delete_terms' => 'edit_' . self::CPT . 's',
+					'assign_terms' => 'edit_' . self::CPT . 's',
+				],
 			]
 		);
 	}

--- a/includes/class-newspack-newsletters-layouts.php
+++ b/includes/class-newspack-newsletters-layouts.php
@@ -54,10 +54,11 @@ final class Newspack_Newsletters_Layouts {
 		}
 
 		$cpt_args = [
-			'public'       => false,
-			'show_in_rest' => true,
-			'supports'     => [ 'editor', 'title', 'custom-fields' ],
-			'taxonomies'   => [],
+			'public'          => false,
+			'show_in_rest'    => true,
+			'supports'        => [ 'editor', 'title', 'custom-fields' ],
+			'taxonomies'      => [],
+			'capability_type' => self::NEWSPACK_NEWSLETTERS_LAYOUT_CPT,
 		];
 		\register_post_type( self::NEWSPACK_NEWSLETTERS_LAYOUT_CPT, $cpt_args );
 	}

--- a/includes/class-newspack-newsletters-layouts.php
+++ b/includes/class-newspack-newsletters-layouts.php
@@ -49,7 +49,7 @@ final class Newspack_Newsletters_Layouts {
 	 * Register the custom post type for layouts.
 	 */
 	public static function register_layout_cpt() {
-		if ( ! current_user_can( 'edit_others_posts' ) ) {
+		if ( ! \Newspack_Newsletters::can_user_edit_newsletters() ) {
 			return;
 		}
 

--- a/includes/class-newspack-newsletters-quick-edit.php
+++ b/includes/class-newspack-newsletters-quick-edit.php
@@ -19,7 +19,7 @@ class Newspack_Newsletters_Quick_Edit {
 		add_action( 'quick_edit_custom_box', [ __CLASS__, 'quick_edit_box' ], 10, 2 );
 		add_action( 'save_post_newspack_nl_cpt', [ __CLASS__, 'save' ] );
 	}
-  
+
 	/**
 	 * Enqueue Quick Edit scripts used to update inputs.
 	 */
@@ -39,7 +39,7 @@ class Newspack_Newsletters_Quick_Edit {
 
 	/**
 	 * Display "Make newsletter page public" checkbox field
-	 * 
+	 *
 	 * @param string $column_name Coulumn name.
 	 * @param string $post_type   Post Type.
 	 */
@@ -67,11 +67,11 @@ class Newspack_Newsletters_Quick_Edit {
 
 	/**
 	 * Save Quick Edit action values.
-	 * 
+	 *
 	 * @param int $post_id Post ID.
 	 */
 	public static function save( $post_id ) {
-		if ( ! current_user_can( 'edit_post', $post_id ) ) {
+		if ( ! current_user_can( 'edit_' . Newspack_Newsletters::NEWSPACK_NEWSLETTERS_CPT, $post_id ) ) {
 			return;
 		}
 		if (

--- a/includes/class-newspack-newsletters-quick-edit.php
+++ b/includes/class-newspack-newsletters-quick-edit.php
@@ -71,7 +71,8 @@ class Newspack_Newsletters_Quick_Edit {
 	 * @param int $post_id Post ID.
 	 */
 	public static function save( $post_id ) {
-		if ( ! current_user_can( 'edit_' . Newspack_Newsletters::NEWSPACK_NEWSLETTERS_CPT, $post_id ) ) {
+		$post_type_object = get_post_type_object( Newspack_Newsletters::NEWSPACK_NEWSLETTERS_CPT );
+		if ( ! current_user_can( $post_type_object->cap->edit_post, $post_id ) ) {
 			return;
 		}
 		if (

--- a/includes/class-newspack-newsletters-settings.php
+++ b/includes/class-newspack-newsletters-settings.php
@@ -199,12 +199,11 @@ class Newspack_Newsletters_Settings {
 	 * Add options page
 	 */
 	public static function add_plugin_page() {
-		$post_type_object = get_post_type_object( Newspack_Newsletters::NEWSPACK_NEWSLETTERS_CPT );
 		add_submenu_page(
 			'edit.php?post_type=' . Newspack_Newsletters::NEWSPACK_NEWSLETTERS_CPT,
 			esc_html__( 'Newsletters Settings', 'newspack-newsletters' ),
 			esc_html__( 'Settings', 'newspack-newsletters' ),
-			$post_type_object->cap->edit_others_posts,
+			'manage_options',
 			'newspack-newsletters-settings-admin',
 			[ __CLASS__, 'create_admin_page' ]
 		);

--- a/includes/class-newspack-newsletters-settings.php
+++ b/includes/class-newspack-newsletters-settings.php
@@ -199,11 +199,12 @@ class Newspack_Newsletters_Settings {
 	 * Add options page
 	 */
 	public static function add_plugin_page() {
+		$post_type_object = get_post_type_object( Newspack_Newsletters::NEWSPACK_NEWSLETTERS_CPT );
 		add_submenu_page(
 			'edit.php?post_type=' . Newspack_Newsletters::NEWSPACK_NEWSLETTERS_CPT,
 			esc_html__( 'Newsletters Settings', 'newspack-newsletters' ),
 			esc_html__( 'Settings', 'newspack-newsletters' ),
-			'edit_others_' . Newspack_Newsletters::NEWSPACK_NEWSLETTERS_CPT . 's',
+			$post_type_object->cap->edit_others_posts,
 			'newspack-newsletters-settings-admin',
 			[ __CLASS__, 'create_admin_page' ]
 		);

--- a/includes/class-newspack-newsletters-settings.php
+++ b/includes/class-newspack-newsletters-settings.php
@@ -203,7 +203,7 @@ class Newspack_Newsletters_Settings {
 			'edit.php?post_type=' . Newspack_Newsletters::NEWSPACK_NEWSLETTERS_CPT,
 			esc_html__( 'Newsletters Settings', 'newspack-newsletters' ),
 			esc_html__( 'Settings', 'newspack-newsletters' ),
-			'manage_options',
+			'edit_others_' . Newspack_Newsletters::NEWSPACK_NEWSLETTERS_CPT . 's',
 			'newspack-newsletters-settings-admin',
 			[ __CLASS__, 'create_admin_page' ]
 		);

--- a/includes/class-newspack-newsletters-subscription.php
+++ b/includes/class-newspack-newsletters-subscription.php
@@ -120,7 +120,8 @@ class Newspack_Newsletters_Subscription {
 	 * @return bool Whether the current user can manage subscription lists.
 	 */
 	public static function api_permission_callback() {
-		return current_user_can( 'edit_others_' . Newspack\Newsletters\Subscription_Lists::CPT . 's' );
+		$post_type_object = get_post_type_object( Newspack_Newsletters::NEWSPACK_NEWSLETTERS_CPT );
+		return current_user_can( $post_type_object->cap->edit_others_posts );
 	}
 
 	/**

--- a/includes/class-newspack-newsletters-subscription.php
+++ b/includes/class-newspack-newsletters-subscription.php
@@ -163,8 +163,11 @@ class Newspack_Newsletters_Subscription {
 	 */
 	public static function get_lists() {
 		$provider = Newspack_Newsletters::get_service_provider();
-		if ( empty( $provider ) ) {
-			return new WP_Error( 'newspack_newsletters_invalid_provider', __( 'Provider is not set.' ) );
+		if ( ! $provider ) {
+			return new WP_Error(
+				'newspack_newsletters_esp_not_a_provider',
+				__( 'Lists not available for the current Newsletters setup.', 'newspack-newsletters' )
+			);
 		}
 		try {
 			/**
@@ -229,8 +232,11 @@ class Newspack_Newsletters_Subscription {
 	 */
 	public static function get_lists_config() {
 		$provider = Newspack_Newsletters::get_service_provider();
-		if ( empty( $provider ) ) {
-			return new WP_Error( 'newspack_newsletters_invalid_provider', __( 'Provider is not set.' ) );
+		if ( ! $provider ) {
+			return new WP_Error(
+				'newspack_newsletters_esp_not_a_provider',
+				__( 'Lists not available for the current Newsletters setup.', 'newspack-newsletters' )
+			);
 		}
 
 		$saved_lists  = Subscription_Lists::get_configured_for_current_provider();

--- a/includes/class-newspack-newsletters-subscription.php
+++ b/includes/class-newspack-newsletters-subscription.php
@@ -120,7 +120,7 @@ class Newspack_Newsletters_Subscription {
 	 * @return bool Whether the current user can manage subscription lists.
 	 */
 	public static function api_permission_callback() {
-		return current_user_can( 'manage_options' );
+		return current_user_can( 'edit_others_' . Newspack\Newsletters\Subscription_Lists::CPT . 's' );
 	}
 
 	/**

--- a/includes/class-newspack-newsletters.php
+++ b/includes/class-newspack-newsletters.php
@@ -480,6 +480,13 @@ final class Newspack_Newsletters {
 	}
 
 	/**
+	 * Can the current user edit newsletters and related entities?
+	 */
+	public static function can_user_edit_newsletters() {
+		return current_user_can( 'edit_others_' . self::NEWSPACK_NEWSLETTERS_CPT . 's' );
+	}
+
+	/**
 	 * Register blocks server-side for front-end rendering.
 	 */
 	public static function register_blocks() {
@@ -888,7 +895,7 @@ final class Newspack_Newsletters {
 	 * @return bool|WP_Error
 	 */
 	public static function api_administration_permissions_check( $request ) {
-		if ( ! current_user_can( 'edit_others_' . self::NEWSPACK_NEWSLETTERS_CPT . 's' ) ) {
+		if ( ! self::can_user_edit_newsletters() ) {
 			return new \WP_Error(
 				'newspack_rest_forbidden',
 				esc_html__( 'You cannot use this resource.', 'newspack-newsletters' ),

--- a/includes/class-newspack-newsletters.php
+++ b/includes/class-newspack-newsletters.php
@@ -454,7 +454,11 @@ final class Newspack_Newsletters {
 			return;
 		}
 		$eligible_roles = apply_filters( 'newspack_newsletters_cpt_eligible_roles', [ 'administrator', 'editor' ] );
-		$capabilities = array_merge( self::get_capabilities_list(), self::get_capabilities_list( Newspack_Newsletters_Ads::CPT ) );
+		$capabilities = array_merge(
+			self::get_capabilities_list(),
+			self::get_capabilities_list( Newspack_Newsletters_Ads::CPT ),
+			self::get_capabilities_list( \Newspack\Newsletters\Subscription_Lists::CPT )
+		);
 		foreach ( $eligible_roles as $role ) {
 			$role = get_role( $role );
 			foreach ( $capabilities as $cap ) {

--- a/includes/class-newspack-newsletters.php
+++ b/includes/class-newspack-newsletters.php
@@ -454,10 +454,11 @@ final class Newspack_Newsletters {
 			return;
 		}
 		$eligible_roles = apply_filters( 'newspack_newsletters_cpt_eligible_roles', [ 'administrator', 'editor' ] );
-		$capabilities = array_merge(
+		$capabilities   = array_merge(
 			self::get_capabilities_list(),
 			self::get_capabilities_list( Newspack_Newsletters_Ads::CPT ),
-			self::get_capabilities_list( \Newspack\Newsletters\Subscription_Lists::CPT )
+			self::get_capabilities_list( \Newspack\Newsletters\Subscription_Lists::CPT ),
+			self::get_capabilities_list( Newspack_Newsletters_Layouts::NEWSPACK_NEWSLETTERS_LAYOUT_CPT )
 		);
 		foreach ( $eligible_roles as $role ) {
 			$role = get_role( $role );

--- a/includes/class-newspack-newsletters.php
+++ b/includes/class-newspack-newsletters.php
@@ -500,7 +500,8 @@ final class Newspack_Newsletters {
 	 * Can the current user edit newsletters and related entities?
 	 */
 	public static function can_user_edit_newsletters() {
-		return current_user_can( 'edit_others_' . self::NEWSPACK_NEWSLETTERS_CPT . 's' );
+		$post_type_object = get_post_type_object( self::NEWSPACK_NEWSLETTERS_CPT );
+		return current_user_can( $post_type_object->cap->edit_others_posts );
 	}
 
 	/**
@@ -931,7 +932,8 @@ final class Newspack_Newsletters {
 	 * @return bool|WP_Error
 	 */
 	public static function api_authoring_permissions_check( $request ) {
-		if ( ! current_user_can( 'edit_' . self::NEWSPACK_NEWSLETTERS_CPT . 's' ) ) {
+		$post_type_object = get_post_type_object( self::NEWSPACK_NEWSLETTERS_CPT );
+		if ( ! current_user_can( $post_type_object->cap->edit_posts ) ) {
 			return new \WP_Error(
 				'newspack_rest_forbidden',
 				esc_html__( 'You cannot use this resource.', 'newspack-newsletters' ),

--- a/includes/class-newspack-newsletters.php
+++ b/includes/class-newspack-newsletters.php
@@ -485,7 +485,7 @@ final class Newspack_Newsletters {
 	 *
 	 * @param string $post_type Post type.
 	 */
-	private static function get_capabilities_list( $post_type = self::NEWSPACK_NEWSLETTERS_CPT ) {
+	public static function get_capabilities_list( $post_type = self::NEWSPACK_NEWSLETTERS_CPT ) {
 		$capabilities = get_post_type_capabilities(
 			(object) [
 				'map_meta_cap'    => true,

--- a/includes/class-newspack-newsletters.php
+++ b/includes/class-newspack-newsletters.php
@@ -454,9 +454,10 @@ final class Newspack_Newsletters {
 			return;
 		}
 		$eligible_roles = apply_filters( 'newspack_newsletters_cpt_eligible_roles', [ 'administrator', 'editor' ] );
+		$capabilities = array_merge( self::get_capabilities_list(), self::get_capabilities_list( Newspack_Newsletters_Ads::CPT ) );
 		foreach ( $eligible_roles as $role ) {
 			$role = get_role( $role );
-			foreach ( self::get_capabilities_list() as $cap ) {
+			foreach ( $capabilities as $cap ) {
 				$role->add_cap( $cap );
 			}
 		}
@@ -467,12 +468,14 @@ final class Newspack_Newsletters {
 	 * Get capabilities necessary to manage this CPT.
 	 *
 	 * See https://developer.wordpress.org/reference/functions/register_post_type/#capabilities.
+	 *
+	 * @param string $post_type Post type.
 	 */
-	public static function get_capabilities_list() {
+	public static function get_capabilities_list( $post_type = self::NEWSPACK_NEWSLETTERS_CPT ) {
 		$capabilities = get_post_type_capabilities(
 			(object) [
 				'map_meta_cap'    => true,
-				'capability_type' => self::NEWSPACK_NEWSLETTERS_CPT,
+				'capability_type' => $post_type,
 				'capabilities'    => [],
 			]
 		);

--- a/includes/class-newspack-newsletters.php
+++ b/includes/class-newspack-newsletters.php
@@ -1147,35 +1147,6 @@ final class Newspack_Newsletters {
 	}
 
 	/**
-	 * Get mailing lists of the configured ESP.
-	 */
-	public static function get_esp_lists() {
-		if ( self::is_service_provider_configured() ) {
-			if ( 'manual' === self::service_provider() ) {
-				return new WP_Error(
-					'newspack_newsletters_manual_lists',
-					__( 'Lists not available while using manual configuration.', 'newspack-newsletters' )
-				);
-			}
-			if ( ! self::$provider ) {
-				return new WP_Error(
-					'newspack_newsletters_esp_not_a_provider',
-					__( 'Lists not available for the current Newsletters setup.', 'newspack-newsletters' )
-				);
-			}
-			try {
-				return self::$provider->get_lists();
-			} catch ( \Exception $e ) {
-				return new WP_Error(
-					'newspack_newsletters_get_lists',
-					$e->getMessage()
-				);
-			}
-		}
-		return [];
-	}
-
-	/**
 	 * Mark newsletter as sent.
 	 *
 	 * @param int $post_id Post ID.

--- a/includes/class-subscription-list.php
+++ b/includes/class-subscription-list.php
@@ -444,7 +444,7 @@ class Subscription_List {
 				'tag_name' => $tag_name,
 			];
 		}
-		
+
 		return update_post_meta( $this->get_id(), self::META_KEY, $settings );
 	}
 

--- a/includes/class-subscription-lists.php
+++ b/includes/class-subscription-lists.php
@@ -109,7 +109,6 @@ class Subscription_Lists {
 	 * @return void
 	 */
 	public static function register_post_type() {
-
 		$labels = array(
 			'name'                  => _x( 'Subscription Lists', 'Post Type General Name', 'newspack' ),
 			'singular_name'         => _x( 'Subscription List', 'Post Type Singular Name', 'newspack' ),
@@ -152,7 +151,7 @@ class Subscription_Lists {
 			'show_ui'              => true,
 			'show_in_menu'         => false,
 			'can_export'           => false,
-			'capability_type'      => 'page',
+			'capability_type'      => self::CPT,
 			'show_in_rest'         => false,
 			'delete_with_user'     => false,
 			'register_meta_box_cb' => [ __CLASS__, 'add_metabox' ],
@@ -555,7 +554,6 @@ class Subscription_Lists {
 			$existing_ids[] = $stored_list->get_id();
 
 			$stored_list->update( $list );
-
 		}
 
 		// Clean up. Lists that are not in the new config deactivated.
@@ -618,7 +616,7 @@ class Subscription_Lists {
 			printf( '<h2>%s</h2>', esc_html__( 'Description', 'newspack-newsletters' ) );
 		}
 	}
-	
+
 	/**
 	 * Outputs a link back to the Settings page above the title in the post editor.
 	 */
@@ -654,7 +652,7 @@ class Subscription_Lists {
 			}
 
 			foreach ( $lists as $list_id => $list ) {
-				
+
 				if ( Subscription_List::is_local_form_id( $list_id ) ) {
 					continue;
 				}

--- a/includes/service-providers/class-newspack-newsletters-service-provider.php
+++ b/includes/service-providers/class-newspack-newsletters-service-provider.php
@@ -98,7 +98,7 @@ abstract class Newspack_Newsletters_Service_Provider implements Newspack_Newslet
 	 * @return bool|WP_Error
 	 */
 	public function api_authoring_permissions_check( $request ) {
-		if ( ! current_user_can( 'edit_others_posts' ) ) {
+		if ( ! \Newspack_Newsletters::can_user_edit_newsletters() ) {
 			return new \WP_Error(
 				'newspack_rest_forbidden',
 				esc_html__( 'You cannot use this resource.', 'newspack-newsletters' ),

--- a/includes/service-providers/constant_contact/class-newspack-newsletters-constant-contact.php
+++ b/includes/service-providers/constant_contact/class-newspack-newsletters-constant-contact.php
@@ -144,7 +144,7 @@ final class Newspack_Newsletters_Constant_Contact extends \Newspack_Newsletters_
 	 * Authorization code callback
 	 */
 	public function oauth_callback() {
-		if ( ! current_user_can( 'edit_others_posts' ) ) {
+		if ( ! \Newspack_Newsletters::can_user_edit_newsletters() ) {
 			return;
 		}
 		if ( ! isset( $_GET['cc_oauth2'] ) ) {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Registers the newsletter CPT with a custom `capability_type`, in order to allow granular control over access to this CPT.

Also adds a small tweak for handling "Other" provider in some methods. 

### How to test the changes in this Pull Request:

1. As an administrator or editor user, ensure that the following can all be edited:
    2. Newsletters
    3. Newsletter Ads
    4. Newsletter Ads Advertisers
    5. Subscription Lists (via Newspack's Engagement wizard UI)
    6. Layouts (via Newsletters post editor)  
2. Install the [capability-manager-enhanced plugin](https://wordpress.org/plugins/capability-manager-enhanced/) and create a new role in "Roles" submenu item
3. Go to "Capabilities" submenu item and select the new role. Select "Newspack Newsletters" group and assign all the caps

<img width="1048" alt="image" src="https://github.com/Automattic/newspack-newsletters/assets/7383192/8286e17d-4d5d-4792-b592-16a5197c8edd">

5. Due to a quirk in CME plugin, also assign these same caps in the "Editing" group:

<img width="441" alt="image" src="https://github.com/Automattic/newspack-newsletters/assets/7383192/3de8b9ed-1abb-434d-bcbd-b1ad60fb2673">

6. Select "Newspack" group and assign the engagement wizard cap:

<img width="706" alt="image" src="https://github.com/Automattic/newspack-newsletters/assets/7383192/3c940042-45a1-404f-b5d3-8485b6c60068">

8. Assign `edit_posts` (in Posts group) and `read` in Admin group caps -> this way the user will be able to log in to /wp-admin
9. Save the caps
10. Create a new user, with the newly created role, and log in as them – then redo first step of these instructions 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->