### PR TITLE
fix: get all verified domains from Mailchimp

### DIFF
--- a/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp.php
+++ b/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp.php
@@ -545,7 +545,7 @@ final class Newspack_Newsletters_Mailchimp extends \Newspack_Newsletters_Service
 			$mc = new Mailchimp( $this->api_key() );
 
 			$result = $this->validate(
-				$mc->get( 'verified-domains' ),
+				$mc->get( 'verified-domains', [ 'count' => 1000 ] ),
 				__( 'Error retrieving verified domains from Mailchimp.', 'newspack-newsletters' )
 			);
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

When checking the sender email domain, pull all verified domains from MC api. Currently we are pulling only 10, which is the default return from the api.

### How to test the changes in this Pull Request:

1. Edit a Newsletter
2. Set the sender
3. Make sure it work

If you don't have a mailchimp account with more than 10 verified domains, you can check just doing an api request and playing with the `count` argument to confirm it works

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
