### PR TITLE
fix: apply custom editor modal styles only to newspack modals

### DIFF
--- a/src/components/send-button/index.js
+++ b/src/components/send-button/index.js
@@ -73,7 +73,7 @@ function PreviewHTMLButton() {
 				<Modal
 					title={ __( 'Preview email', 'newspack-newsletters' ) }
 					onRequestClose={ () => setIsModalOpen( false ) }
-					className="newsletter-preview-html-modal"
+					className="newspack-newsletters__modal newsletter-preview-html-modal"
 					overlayClassName="newsletter-preview-html-modal__overlay"
 					shouldCloseOnClickOutside={ false }
 					isFullScreen

--- a/src/components/send-button/style.scss
+++ b/src/components/send-button/style.scss
@@ -41,6 +41,19 @@
 			margin-left: 0.7rem;
 		}
 	}
+	.components-modal {
+		&__content {
+			display: flex;
+			flex-direction: column;
+			justify-content: center;
+			> div {
+				flex-grow: 1;
+				&.components-modal__header {
+					flex-grow: 0;
+				}
+			}
+		}
+	}
 }
 
 .newsletter-preview-html-button {
@@ -62,19 +75,5 @@
 		height: 100%;
 		justify-content: center;
 		align-items: center;
-	}
-}
-
-.components-modal {
-	&__content {
-		display: flex;
-		flex-direction: column;
-		justify-content: center;
-		> div {
-			flex-grow: 1;
-			&.components-modal__header {
-				flex-grow: 0;
-			}
-		}
 	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Tweaks some newsletter editor components to isolate custom CSS only to our custom modal elements. Currently some of our custom editor styles are bleeding into core modal components as well.

Fixes `1206197591054328/1206312385969911`

### How to test the changes in this Pull Request:

1. On `master`, edit a newsletter, click the three-dots icon, then Preferences, then "Blocks" in the modal that appears.

<img width="513" alt="Screenshot 2024-01-22 at 3 09 27 PM" src="https://github.com/Automattic/newspack-newsletters/assets/2230142/4d5e518d-3c93-4aaa-8c6e-6dfc21520bd7">

3. Observe that the top of the "Blocks" preferences are not shown. The highlighted area is hidden and can't be scrolled to. (You can repeat these steps in a regular post editor to see what it should look like).

<img width="838" alt="Screenshot 2024-01-22 at 3 08 50 PM" src="https://github.com/Automattic/newspack-newsletters/assets/2230142/bfc81019-be2b-4cc6-9bdb-484c388457a3">

4. Check out this branch and repeat in the newsletter editor. Confirm that all Blocks preferences are now viewable and interactive in the Preferences modal.
5. Smoke test the custom Newsletter modals to make sure they still work as expected, too:
  - Layout selector modal when creating a new newsletter
  - Preview modal when clicking "Preview email"
  - Send modal when clicking "Send"
  - Layout modal when changing and resetting the layout for an existing newsletter

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1206312385969911