### PR TITLE
fix: Catch invalid subscription list errors

### DIFF
--- a/includes/plugins/class-woocommerce-memberships.php
+++ b/includes/plugins/class-woocommerce-memberships.php
@@ -258,8 +258,12 @@ class Woocommerce_Memberships {
 			}
 			$object_ids = $rule->get_object_ids();
 			foreach ( $object_ids as $object_id ) {
-				$subscription_list = new Subscription_List( $object_id );
-				$lists_to_add[]    = $subscription_list->get_form_id();
+				try {
+					$subscription_list = new Subscription_List( $object_id );
+					$lists_to_add[]    = $subscription_list->get_form_id();
+				} catch ( \InvalidArgumentException $e ) {
+					continue;
+				}
 			}
 		}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

This PR fixes an issue I ran into on a client site. A membership plan can reference different subscription lists, and will continue referencing a subscription list if the associated CPT post is deleted. So when a user purchases a subscription and we're giving them access to subscriptions via their membership, an uncaught exception is thrown. This PR modifies a bit of code to make it more [in line with this piece](https://github.com/Automattic/newspack-newsletters/blob/075cd033d553c029ef64e5e652f031f17456e5d1/includes/plugins/class-woocommerce-memberships.php#L168-L173). 



### How to test the changes in this Pull Request:

I'm not sure the simplest way to test this. Create a Subscription List, assign it to a Membership Plan, delete the Subscription List, observe it's still in the Membership Plan.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
