### PR TITLE
fix: activate newsletter subscribers if needed

### DIFF
--- a/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp.php
+++ b/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp.php
@@ -1156,7 +1156,8 @@ final class Newspack_Newsletters_Mailchimp extends \Newspack_Newsletters_Service
 			// If we're subscribing the contact to a newsletter, they should have some status 
 			// because 'non-subscriber' status can't receive newsletters.
 			if ( ! empty( $group_id ) || ! empty( $list_id ) ) {
-				$update_payload['status_if_new'] = $new_contact_status;
+				$update_payload['status_if_new'] = $new_contact_status ?? 'subscribed';
+				$update_payload['status']        = $new_contact_status ?? 'subscribed';
 			}
 
 			// Create or update a list member.

--- a/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp.php
+++ b/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp.php
@@ -1153,6 +1153,12 @@ final class Newspack_Newsletters_Mailchimp extends \Newspack_Newsletters_Service
 				];
 			}
 
+			// If we're subscribing the contact to a newsletter, they should have some status 
+			// because 'non-subscriber' status can't receive newsletters.
+			if ( ! empty( $group_id ) || ! empty( $list_id ) ) {
+				$update_payload['status_if_new'] = $new_contact_status;
+			}
+
 			// Create or update a list member.
 			$existing_contact = self::get_contact_data( $email_address );
 			if ( is_wp_error( $existing_contact ) ) {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes an issue recently encountered on a client site. When someone gets added to a newsletter list (premium or otherwise), they should have the Subscribed status in MailChimp. This is because MC [categorizes newsletters as a form of marketing email](https://mailchimp.com/help/about-non-subscribed-contacts/). So if someone subscribes to a list but they don't have the Subscribed status, MC won't send them the newsletter because they technically didn't opt-in to marketing emails.

The only place we currently set the status [is here](https://github.com/Automattic/newspack-newsletters/blob/trunk/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp.php#L1159), and only for new contacts. So if a contact has already been added somehow, they will never get Subscribed status and will never receive a newsletter they signed up for.

I'm not super familiar with the MC API, but my understanding is `status_if_new` is the field we want to use here. Let me know if that's not accurate!

### How to test the changes in this Pull Request:

1. Create a "Non-subscribed" contact by going into MC > All Contacts > Add Contacts > Import > Paste and paste an email address into the import. When imported if you did it right you should see they have the "Non-subscribed" status:

<img width="399" alt="Screenshot 2024-02-05 at 2 43 05 PM" src="https://github.com/Automattic/newspack-newsletters/assets/7317227/5a7d69cf-5d2f-487d-a289-ddee569a9c3b">

2. Before applying this patch, give them a membership or log in as them and change your newsletter preferences. Observe that while they do get added to the correct groups, the status stays "Non-subscribed".
3. Apply this patch. change the newsletter preferences again (or do anything else to trigger a contact sync). Observe the status is now "Subscribed"
<img width="404" alt="Screenshot 2024-02-05 at 3 03 02 PM" src="https://github.com/Automattic/newspack-newsletters/assets/7317227/0622171b-a0ed-4035-97b2-c42d1970fdd5">


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
