### PR TITLE
Revert "feat: use custom capability_type for CPTs (#1398)"

### DIFF
--- a/includes/class-newspack-newsletters-ads.php
+++ b/includes/class-newspack-newsletters-ads.php
@@ -87,8 +87,7 @@ final class Newspack_Newsletters_Ads {
 	 * @return bool|WP_Error
 	 */
 	public static function permission_callback( $request ) {
-		$post_type_object = get_post_type_object( self::CPT );
-		return current_user_can( $post_type_object->cap->edit_posts );
+		return current_user_can( 'edit_posts' );
 	}
 
 	/**
@@ -187,12 +186,11 @@ final class Newspack_Newsletters_Ads {
 	 * Add ads page link.
 	 */
 	public static function add_ads_page() {
-		$post_type_object = get_post_type_object( self::CPT );
 		add_submenu_page(
 			'edit.php?post_type=' . Newspack_Newsletters::NEWSPACK_NEWSLETTERS_CPT,
 			__( 'Newsletters Ads', 'newspack-newsletters' ),
 			__( 'Ads', 'newspack-newsletters' ),
-			$post_type_object->cap->edit_posts,
+			'edit_others_posts',
 			'/edit.php?post_type=' . self::CPT,
 			null,
 			2
@@ -203,6 +201,10 @@ final class Newspack_Newsletters_Ads {
 	 * Register the custom post type for layouts.
 	 */
 	public static function register_ads_cpt() {
+		if ( ! current_user_can( 'edit_others_posts' ) ) {
+			return;
+		}
+
 		$labels = [
 			'name'                     => _x( 'Newsletter Ads', 'post type general name', 'newspack-newsletters' ),
 			'singular_name'            => _x( 'Newsletter Ad', 'post type singular name', 'newspack-newsletters' ),
@@ -227,18 +229,15 @@ final class Newspack_Newsletters_Ads {
 		];
 
 		$cpt_args = [
-			'public'          => false,
-			'labels'          => $labels,
-			'show_ui'         => true,
-			'show_in_menu'    => false,
-			'show_in_rest'    => true,
-			'supports'        => [ 'editor', 'title', 'custom-fields' ],
-			'taxonomies'      => [ 'category' ],
-			'capability_type' => self::CPT,
+			'public'       => false,
+			'labels'       => $labels,
+			'show_ui'      => true,
+			'show_in_menu' => false,
+			'show_in_rest' => true,
+			'supports'     => [ 'editor', 'title', 'custom-fields' ],
+			'taxonomies'   => [ 'category' ],
 		];
 		register_post_type( self::CPT, $cpt_args );
-
-		$post_type_object = get_post_type_object( self::CPT );
 
 		register_taxonomy(
 			self::ADVERTISER_TAX,
@@ -270,13 +269,6 @@ final class Newspack_Newsletters_Ads {
 				'hierarchical'      => true,
 				'show_in_rest'      => true,
 				'show_admin_column' => true,
-				// Available for anyone who can edit newsletter ads.
-				'capabilities'      => [
-					'manage_terms' => $post_type_object->cap->edit_posts,
-					'edit_terms'   => $post_type_object->cap->edit_posts,
-					'delete_terms' => $post_type_object->cap->edit_posts,
-					'assign_terms' => $post_type_object->cap->edit_posts,
-				],
 			]
 		);
 	}

--- a/includes/class-newspack-newsletters-layouts.php
+++ b/includes/class-newspack-newsletters-layouts.php
@@ -49,16 +49,15 @@ final class Newspack_Newsletters_Layouts {
 	 * Register the custom post type for layouts.
 	 */
 	public static function register_layout_cpt() {
-		if ( ! \Newspack_Newsletters::can_user_edit_newsletters() ) {
+		if ( ! current_user_can( 'edit_others_posts' ) ) {
 			return;
 		}
 
 		$cpt_args = [
-			'public'          => false,
-			'show_in_rest'    => true,
-			'supports'        => [ 'editor', 'title', 'custom-fields' ],
-			'taxonomies'      => [],
-			'capability_type' => self::NEWSPACK_NEWSLETTERS_LAYOUT_CPT,
+			'public'       => false,
+			'show_in_rest' => true,
+			'supports'     => [ 'editor', 'title', 'custom-fields' ],
+			'taxonomies'   => [],
 		];
 		\register_post_type( self::NEWSPACK_NEWSLETTERS_LAYOUT_CPT, $cpt_args );
 	}

--- a/includes/class-newspack-newsletters-quick-edit.php
+++ b/includes/class-newspack-newsletters-quick-edit.php
@@ -19,7 +19,7 @@ class Newspack_Newsletters_Quick_Edit {
 		add_action( 'quick_edit_custom_box', [ __CLASS__, 'quick_edit_box' ], 10, 2 );
 		add_action( 'save_post_newspack_nl_cpt', [ __CLASS__, 'save' ] );
 	}
-
+  
 	/**
 	 * Enqueue Quick Edit scripts used to update inputs.
 	 */
@@ -39,7 +39,7 @@ class Newspack_Newsletters_Quick_Edit {
 
 	/**
 	 * Display "Make newsletter page public" checkbox field
-	 *
+	 * 
 	 * @param string $column_name Coulumn name.
 	 * @param string $post_type   Post Type.
 	 */
@@ -67,12 +67,11 @@ class Newspack_Newsletters_Quick_Edit {
 
 	/**
 	 * Save Quick Edit action values.
-	 *
+	 * 
 	 * @param int $post_id Post ID.
 	 */
 	public static function save( $post_id ) {
-		$post_type_object = get_post_type_object( Newspack_Newsletters::NEWSPACK_NEWSLETTERS_CPT );
-		if ( ! current_user_can( $post_type_object->cap->edit_post, $post_id ) ) {
+		if ( ! current_user_can( 'edit_post', $post_id ) ) {
 			return;
 		}
 		if (

--- a/includes/class-newspack-newsletters-subscription.php
+++ b/includes/class-newspack-newsletters-subscription.php
@@ -120,8 +120,7 @@ class Newspack_Newsletters_Subscription {
 	 * @return bool Whether the current user can manage subscription lists.
 	 */
 	public static function api_permission_callback() {
-		$post_type_object = get_post_type_object( Newspack_Newsletters::NEWSPACK_NEWSLETTERS_CPT );
-		return current_user_can( $post_type_object->cap->edit_others_posts );
+		return current_user_can( 'manage_options' );
 	}
 
 	/**
@@ -164,11 +163,8 @@ class Newspack_Newsletters_Subscription {
 	 */
 	public static function get_lists() {
 		$provider = Newspack_Newsletters::get_service_provider();
-		if ( ! $provider ) {
-			return new WP_Error(
-				'newspack_newsletters_esp_not_a_provider',
-				__( 'Lists not available for the current Newsletters setup.', 'newspack-newsletters' )
-			);
+		if ( empty( $provider ) ) {
+			return new WP_Error( 'newspack_newsletters_invalid_provider', __( 'Provider is not set.' ) );
 		}
 		try {
 			/**
@@ -233,11 +229,8 @@ class Newspack_Newsletters_Subscription {
 	 */
 	public static function get_lists_config() {
 		$provider = Newspack_Newsletters::get_service_provider();
-		if ( ! $provider ) {
-			return new WP_Error(
-				'newspack_newsletters_esp_not_a_provider',
-				__( 'Lists not available for the current Newsletters setup.', 'newspack-newsletters' )
-			);
+		if ( empty( $provider ) ) {
+			return new WP_Error( 'newspack_newsletters_invalid_provider', __( 'Provider is not set.' ) );
 		}
 
 		$saved_lists  = Subscription_Lists::get_configured_for_current_provider();

--- a/includes/class-newspack-newsletters.php
+++ b/includes/class-newspack-newsletters.php
@@ -7,7 +7,7 @@
 
 defined( 'ABSPATH' ) || exit;
 
-use DrewM\MailChimp\MailChimp;
+use \DrewM\MailChimp\MailChimp;
 
 /**
  * Main Newspack Newsletters Class.
@@ -77,7 +77,6 @@ final class Newspack_Newsletters {
 	 */
 	public function __construct() {
 		add_action( 'init', [ __CLASS__, 'register_cpt' ] );
-		add_action( 'admin_init', [ __CLASS__, 'add_caps' ] );
 		add_action( 'init', [ __CLASS__, 'register_meta' ] );
 		add_action( 'init', [ __CLASS__, 'register_editor_only_meta' ] );
 		add_action( 'init', [ __CLASS__, 'register_blocks' ] );
@@ -97,8 +96,6 @@ final class Newspack_Newsletters {
 		add_action( 'pre_get_posts', [ __CLASS__, 'display_newsletters_in_archives' ] );
 		add_action( 'the_post', [ __CLASS__, 'fix_public_status' ] );
 		self::set_service_provider( self::service_provider() );
-
-		add_filter( 'cme_plugin_capabilities', [ __CLASS__, 'cme_plugin_capabilities' ] );
 
 		$needs_nag = is_admin() && ! self::is_service_provider_configured() && ! get_option( 'newspack_newsletters_activation_nag_viewed', false );
 		if ( $needs_nag ) {
@@ -442,66 +439,8 @@ final class Newspack_Newsletters {
 			'supports'         => $supports,
 			'taxonomies'       => [ 'category', 'post_tag' ],
 			'menu_icon'        => 'data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIGhlaWdodD0iMjQiIHZpZXdCb3g9IjAgMCAyNCAyNCIgd2lkdGg9IjI0Ij48cGF0aCB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIGQ9Ik0yMS45OSA4YzAtLjcyLS4zNy0xLjM1LS45NC0xLjdMMTIgMSAyLjk1IDYuM0MyLjM4IDYuNjUgMiA3LjI4IDIgOHYxMGMwIDEuMS45IDIgMiAyaDE2YzEuMSAwIDItLjkgMi0ybC0uMDEtMTB6TTEyIDEzTDMuNzQgNy44NCAxMiAzbDguMjYgNC44NEwxMiAxM3oiIGZpbGw9IiNhMGE1YWEiLz48L3N2Zz4K',
-			'capability_type'  => self::NEWSPACK_NEWSLETTERS_CPT,
 		];
 		\register_post_type( self::NEWSPACK_NEWSLETTERS_CPT, $cpt_args );
-	}
-
-	/**
-	 * Get all capabilities offered by this plugin.
-	 */
-	private static function get_all_capabilities_list() {
-		return array_merge(
-			self::get_capabilities_list(),
-			self::get_capabilities_list( Newspack_Newsletters_Ads::CPT ),
-			self::get_capabilities_list( \Newspack\Newsletters\Subscription_Lists::CPT ),
-			self::get_capabilities_list( Newspack_Newsletters_Layouts::NEWSPACK_NEWSLETTERS_LAYOUT_CPT )
-		);
-	}
-
-	/**
-	 * Add capabilities for roles eligible to access this CPT.
-	 */
-	public static function add_caps() {
-		$option_name = 'newspack_newsletters_has_set_up_caps_v1';
-		if ( get_option( $option_name, false ) ) {
-			return;
-		}
-		$eligible_roles = apply_filters( 'newspack_newsletters_cpt_eligible_roles', [ 'administrator', 'editor' ] );
-		$capabilities   = self::get_all_capabilities_list();
-		foreach ( $eligible_roles as $role ) {
-			$role = get_role( $role );
-			foreach ( $capabilities as $cap ) {
-				$role->add_cap( $cap );
-			}
-		}
-		add_option( $option_name, true );
-	}
-
-	/**
-	 * Get capabilities necessary to manage this CPT.
-	 *
-	 * See https://developer.wordpress.org/reference/functions/register_post_type/#capabilities.
-	 *
-	 * @param string $post_type Post type.
-	 */
-	public static function get_capabilities_list( $post_type = self::NEWSPACK_NEWSLETTERS_CPT ) {
-		$capabilities = get_post_type_capabilities(
-			(object) [
-				'map_meta_cap'    => true,
-				'capability_type' => $post_type,
-				'capabilities'    => [],
-			]
-		);
-		return array_values( (array) $capabilities );
-	}
-
-	/**
-	 * Can the current user edit newsletters and related entities?
-	 */
-	public static function can_user_edit_newsletters() {
-		$post_type_object = get_post_type_object( self::NEWSPACK_NEWSLETTERS_CPT );
-		return current_user_can( $post_type_object->cap->edit_others_posts );
 	}
 
 	/**
@@ -913,7 +852,7 @@ final class Newspack_Newsletters {
 	 * @return bool|WP_Error
 	 */
 	public static function api_administration_permissions_check( $request ) {
-		if ( ! self::can_user_edit_newsletters() ) {
+		if ( ! current_user_can( 'manage_options' ) ) {
 			return new \WP_Error(
 				'newspack_rest_forbidden',
 				esc_html__( 'You cannot use this resource.', 'newspack-newsletters' ),
@@ -932,8 +871,7 @@ final class Newspack_Newsletters {
 	 * @return bool|WP_Error
 	 */
 	public static function api_authoring_permissions_check( $request ) {
-		$post_type_object = get_post_type_object( self::NEWSPACK_NEWSLETTERS_CPT );
-		if ( ! current_user_can( $post_type_object->cap->edit_posts ) ) {
+		if ( ! current_user_can( 'edit_others_posts' ) ) {
 			return new \WP_Error(
 				'newspack_rest_forbidden',
 				esc_html__( 'You cannot use this resource.', 'newspack-newsletters' ),
@@ -1149,6 +1087,35 @@ final class Newspack_Newsletters {
 	}
 
 	/**
+	 * Get mailing lists of the configured ESP.
+	 */
+	public static function get_esp_lists() {
+		if ( self::is_service_provider_configured() ) {
+			if ( 'manual' === self::service_provider() ) {
+				return new WP_Error(
+					'newspack_newsletters_manual_lists',
+					__( 'Lists not available while using manual configuration.', 'newspack-newsletters' )
+				);
+			}
+			if ( ! self::$provider ) {
+				return new WP_Error(
+					'newspack_newsletters_esp_not_a_provider',
+					__( 'Lists not available for the current Newsletters setup.', 'newspack-newsletters' )
+				);
+			}
+			try {
+				return self::$provider->get_lists();
+			} catch ( \Exception $e ) {
+				return new WP_Error(
+					'newspack_newsletters_get_lists',
+					$e->getMessage()
+				);
+			}
+		}
+		return [];
+	}
+
+	/**
 	 * Mark newsletter as sent.
 	 *
 	 * @param int $post_id Post ID.
@@ -1244,16 +1211,6 @@ final class Newspack_Newsletters {
 				exit;
 			}
 		}
-	}
-
-	/**
-	 * Filter the capabilities list in the capability-manager-enhanced plugin.
-	 *
-	 * @param array $capabilities_list The list of capabilities tabs.
-	 */
-	public static function cme_plugin_capabilities( $capabilities_list ) {
-		$capabilities_list['Newspack Newsletters'] = self::get_all_capabilities_list();
-		return $capabilities_list;
 	}
 }
 Newspack_Newsletters::instance();

--- a/includes/class-subscription-list.php
+++ b/includes/class-subscription-list.php
@@ -444,7 +444,7 @@ class Subscription_List {
 				'tag_name' => $tag_name,
 			];
 		}
-
+		
 		return update_post_meta( $this->get_id(), self::META_KEY, $settings );
 	}
 

--- a/includes/class-subscription-lists.php
+++ b/includes/class-subscription-lists.php
@@ -109,6 +109,7 @@ class Subscription_Lists {
 	 * @return void
 	 */
 	public static function register_post_type() {
+
 		$labels = array(
 			'name'                  => _x( 'Subscription Lists', 'Post Type General Name', 'newspack' ),
 			'singular_name'         => _x( 'Subscription List', 'Post Type Singular Name', 'newspack' ),
@@ -151,7 +152,7 @@ class Subscription_Lists {
 			'show_ui'              => true,
 			'show_in_menu'         => false,
 			'can_export'           => false,
-			'capability_type'      => self::CPT,
+			'capability_type'      => 'page',
 			'show_in_rest'         => false,
 			'delete_with_user'     => false,
 			'register_meta_box_cb' => [ __CLASS__, 'add_metabox' ],
@@ -554,6 +555,7 @@ class Subscription_Lists {
 			$existing_ids[] = $stored_list->get_id();
 
 			$stored_list->update( $list );
+
 		}
 
 		// Clean up. Lists that are not in the new config deactivated.
@@ -616,7 +618,7 @@ class Subscription_Lists {
 			printf( '<h2>%s</h2>', esc_html__( 'Description', 'newspack-newsletters' ) );
 		}
 	}
-
+	
 	/**
 	 * Outputs a link back to the Settings page above the title in the post editor.
 	 */
@@ -652,7 +654,7 @@ class Subscription_Lists {
 			}
 
 			foreach ( $lists as $list_id => $list ) {
-
+				
 				if ( Subscription_List::is_local_form_id( $list_id ) ) {
 					continue;
 				}

--- a/includes/service-providers/class-newspack-newsletters-service-provider.php
+++ b/includes/service-providers/class-newspack-newsletters-service-provider.php
@@ -98,7 +98,7 @@ abstract class Newspack_Newsletters_Service_Provider implements Newspack_Newslet
 	 * @return bool|WP_Error
 	 */
 	public function api_authoring_permissions_check( $request ) {
-		if ( ! \Newspack_Newsletters::can_user_edit_newsletters() ) {
+		if ( ! current_user_can( 'edit_others_posts' ) ) {
 			return new \WP_Error(
 				'newspack_rest_forbidden',
 				esc_html__( 'You cannot use this resource.', 'newspack-newsletters' ),

--- a/includes/service-providers/constant_contact/class-newspack-newsletters-constant-contact.php
+++ b/includes/service-providers/constant_contact/class-newspack-newsletters-constant-contact.php
@@ -144,7 +144,7 @@ final class Newspack_Newsletters_Constant_Contact extends \Newspack_Newsletters_
 	 * Authorization code callback
 	 */
 	public function oauth_callback() {
-		if ( ! \Newspack_Newsletters::can_user_edit_newsletters() ) {
+		if ( ! current_user_can( 'edit_others_posts' ) ) {
 			return;
 		}
 		if ( ! isset( $_GET['cc_oauth2'] ) ) {


### PR DESCRIPTION
This reverts commit 59403a92ae0ec2b14549dc9c72d8495fca1e926a.

### All Submissions:

* [ ] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes # .

### How to test the changes in this Pull Request:

1.
2.
3.

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
