### PR TITLE
fix: only sync once when sending newsletters

### DIFF
--- a/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp.php
+++ b/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp.php
@@ -756,13 +756,19 @@ final class Newspack_Newsletters_Mailchimp extends \Newspack_Newsletters_Service
 	 * @param boolean $update Whether this is an existing post being updated or not.
 	 */
 	public function save( $post_id, $post, $update ) {
+		if ( $update && ! wp_is_post_revision( $post_id ) ) {
+			return;
+		}
+
+		if ( wp_is_post_autosave( $post_id ) || ( defined( 'DOING_AUTOSAVE' ) && DOING_AUTOSAVE ) ) {
+			return;
+		}
+
 		$status = get_post_status( $post_id );
 		if ( 'trash' === $status ) {
 			return;
 		}
-		if ( defined( 'DOING_AUTOSAVE' ) && DOING_AUTOSAVE ) {
-			return;
-		}
+
 		$this->sync( $post );
 	}
 


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

It looks like we are syncing multiple times whenever we send a newsletter. This is because [we trigger a sync `save_post_{cpt}` hook](https://github.com/Automattic/newspack-newsletters/blob/b5cfee339d660dfe42fc6da8e52ff598b11dfeaf/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp.php#L50), but, like `save_post`, this seems to be triggered multiple times on a single save. 

In addition to this, we also [trigger a sync on status transition](https://github.com/Automattic/newspack-newsletters/blob/8bbd6f29ba3a60c31c6a3cf37d5665c64d74ac47/includes/service-providers/class-newspack-newsletters-service-provider.php#L346) when [the publisher clicks send](https://github.com/Automattic/newspack-newsletters/blob/b5cfee339d660dfe42fc6da8e52ff598b11dfeaf/src/components/send-button/index.js#L203).

So the result is a lot of syncing whenever a newsletter is saved.

### How to test the changes in this Pull Request:

1.
2.
3.

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
