### PR TITLE
fix(custom-css): code editor styling

### DIFF
--- a/src/newsletter-editor/styling/style.scss
+++ b/src/newsletter-editor/styling/style.scss
@@ -23,6 +23,9 @@
 	}
 
 	&__css-panel {
+		.components-base-control {
+			max-width: 100%;
+		}
 		.CodeMirror {
 			border: 1px solid wp-colors.$gray-700;
 		}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes custom CSS editing issue.

Before:

<img width="305" alt="image" src="https://github.com/Automattic/newspack-newsletters/assets/7383192/e850e2db-65e4-4f69-9d5e-c6a072c288fa">

After:

<img width="296" alt="image" src="https://github.com/Automattic/newspack-newsletters/assets/7383192/c131abd0-fd8a-42e3-9a74-5978c99c6545">

### How to test the changes in this Pull Request:

1. On `trunk`, create a new newsletter and open the "Custom CSS" panel in the styling settings (the half-black circle icon in the top row)
2. Paste in a bit of CSS*
3. Observe the input element is pushed out of the screen
4. Switch to this branch, observe the element is side-scrollable

\* e.g.
```
h3.wp-block-heading{
	font-family: "montserrat", sans-serif !important;
}
```

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->