### PR TITLE
 fix: dynamic class property deprecated warnings

### DIFF
--- a/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp.php
+++ b/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp.php
@@ -40,6 +40,13 @@ final class Newspack_Newsletters_Mailchimp extends \Newspack_Newsletters_Service
 	private static $contacts_added = [];
 
 	/**
+	 * Controller.
+	 *
+	 * @var Newspack_Newsletters_Mailchimp_Controller
+	 */
+	public $controller;
+
+	/**
 	 * Class constructor.
 	 */
 	public function __construct() {


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

This PR just addresses some warnings flooding the logs:

![Screenshot 2024-02-13 at 10 46 22](https://github.com/Automattic/newspack-newsletters/assets/17905991/e3f17d39-19d1-48b7-8e09-e74e7fa1097f)

### How to test the changes in this Pull Request:

Code review should be fine, but feel free to checkout these changes and verify deprecated warnings don't appear in the logs while sending MC newsletters

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
