### PR TITLE
feat: update translation strings 

### DIFF
--- a/includes/class-newspack-newsletters-editor.php
+++ b/includes/class-newspack-newsletters-editor.php
@@ -295,6 +295,8 @@ final class Newspack_Newsletters_Editor {
 			'sponsors_flag_text_color' => function_exists( 'newspack_get_color_contrast' ) ? newspack_get_color_contrast( \get_theme_mod( 'sponsored_flag_hex', '#FED850' ) ) : 'black',
 			'labels'                   => [
 				'continue_reading_label' => __( 'Continue reading…', 'newspack-newsletters' ),
+				'byline_prefix_label'    => __( 'By ', 'newspack-newsletters' ),
+				'byline_connector_label' => __( 'and ', 'newspack-newsletters' ),
 			],
 		];
 		if ( self::is_editing_email() ) {

--- a/includes/class-newspack-newsletters-editor.php
+++ b/includes/class-newspack-newsletters-editor.php
@@ -293,6 +293,9 @@ final class Newspack_Newsletters_Editor {
 			'conditional_tag_support'  => $conditional_tag_support,
 			'sponsors_flag_hex'        => get_theme_mod( 'sponsored_flag_hex', '#FED850' ),
 			'sponsors_flag_text_color' => function_exists( 'newspack_get_color_contrast' ) ? newspack_get_color_contrast( \get_theme_mod( 'sponsored_flag_hex', '#FED850' ) ) : 'black',
+			'labels'                   => [
+				'continue_reading_label' => __( 'Continue reading…', 'newspack-newsletters' ),
+			],
 		];
 		if ( self::is_editing_email() ) {
 			wp_register_style(

--- a/includes/class-newspack-newsletters.php
+++ b/includes/class-newspack-newsletters.php
@@ -80,6 +80,7 @@ final class Newspack_Newsletters {
 		add_action( 'init', [ __CLASS__, 'register_meta' ] );
 		add_action( 'init', [ __CLASS__, 'register_editor_only_meta' ] );
 		add_action( 'init', [ __CLASS__, 'register_blocks' ] );
+		add_action( 'init', [ __CLASS__, 'load_textdomain' ] );
 		add_action( 'rest_api_init', [ __CLASS__, 'rest_api_init' ] );
 		add_action( 'default_title', [ __CLASS__, 'default_title' ], 10, 2 );
 		add_action( 'wp_head', [ __CLASS__, 'public_newsletter_custom_style' ], 10, 2 );
@@ -465,6 +466,13 @@ final class Newspack_Newsletters {
 				'render_callback' => [ __CLASS__, 'render_share_block' ],
 			]
 		);
+	}
+
+	/**
+	 * Set text domain.
+	 */
+	public static function load_textdomain() {
+		load_plugin_textdomain( 'newspack-newsletters', null, NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/languages/' );
 	}
 
 	/**

--- a/includes/class-newspack-newsletters.php
+++ b/includes/class-newspack-newsletters.php
@@ -472,7 +472,7 @@ final class Newspack_Newsletters {
 	 * Set text domain.
 	 */
 	public static function load_textdomain() {
-		load_plugin_textdomain( 'newspack-newsletters', null, NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/languages/' );
+		load_plugin_textdomain( 'newspack-newsletters', false, NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/languages/' );
 	}
 
 	/**

--- a/src/editor/blocks/posts-inserter/utils.js
+++ b/src/editor/blocks/posts-inserter/utils.js
@@ -75,7 +75,7 @@ const getExcerptBlockTemplate = ( post, { excerptLength, textFontSize, textColor
 
 const getContinueReadingLinkBlockTemplate = ( post, { textFontSize, textColor } ) => {
 	const attributes = {
-		content: `<a href="${ post.link }">${ __( 'Continue reading…', 'newspack-newsletters' ) }</a>`,
+		content: `<a href="${ post.link }">${ newspack_email_editor_data?.labels?.continue_reading_label }</a>`,
 		style: { color: { text: textColor } },
 	};
 	return [ 'core/paragraph', assignFontSize( textFontSize, attributes ) ];

--- a/src/editor/blocks/posts-inserter/utils.js
+++ b/src/editor/blocks/posts-inserter/utils.js
@@ -8,7 +8,7 @@ import { omit } from 'lodash';
 /**
  * WordPress dependencies
  */
-import { __, _x } from '@wordpress/i18n';
+import { _x } from '@wordpress/i18n';
 import { createBlock, getBlockContent } from '@wordpress/blocks';
 // eslint-disable-next-line @wordpress/no-unsafe-wp-apis
 import { dateI18n, __experimentalGetSettings } from '@wordpress/date';
@@ -106,7 +106,7 @@ const getAuthorBlockTemplate = ( post, { textFontSize, textColor } ) => {
 		return [
 			'core/heading',
 			assignFontSize( textFontSize, {
-				content: newspack_email_editor_data?.labels?.byline_prefix_label  + authorLinks.join( ' ' ),
+				content: newspack_email_editor_data?.labels?.byline_prefix_label + authorLinks.join( ' ' ),
 				fontSize: 'normal',
 				level: 6,
 				style: { color: { text: textColor } },

--- a/src/editor/blocks/posts-inserter/utils.js
+++ b/src/editor/blocks/posts-inserter/utils.js
@@ -95,7 +95,7 @@ const getAuthorBlockTemplate = ( post, { textFontSize, textColor } ) => {
 						: '';
 				const and =
 					newspack_author_info.length > 1 && index === newspack_author_info.length - 1
-						? __( 'and ', 'newspack-newsletters' )
+						? newspack_email_editor_data?.labels?.byline_connector_label
 						: '';
 				acc.push( `${ and }<a href="${ author_link }">${ display_name }</a>${ comma }` );
 			}
@@ -106,7 +106,7 @@ const getAuthorBlockTemplate = ( post, { textFontSize, textColor } ) => {
 		return [
 			'core/heading',
 			assignFontSize( textFontSize, {
-				content: __( 'By ', 'newspack-newsletters' ) + authorLinks.join( ' ' ),
+				content: newspack_email_editor_data?.labels?.byline_prefix_label  + authorLinks.join( ' ' ),
 				fontSize: 'normal',
 				level: 6,
 				style: { color: { text: textColor } },


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Right now, translations aren't being pulled into the Newspack Newsletter editor. While we dig into the cause of this odd issue, this PR moves three strings -- `Continue reading...`, and the `By` and `and` from the byline into a PHP file, so they can be swapped out. 

See: 1200550061930446-as-1205587112319820

### How to test the changes in this Pull Request:

This one's a little odd to test because the translations come from WordPress.org, and won't be updated there until the plugin itself is updated. The testing steps below attempt to work around that, but don't create a 1:1 experience with what reality will be: 

1. Apply the PR and run `npm run build`.
2. Uncompress and add the attached `/languages` directory to the plugin. It should contain one `.mo` file with Spanish translations. [languages.zip](https://github.com/Automattic/newspack-newsletters/files/14305263/languages.zip)
3. Edit the /newspack-newsletters.php file, and add the following function - this makes the site load the local .mo file rather than trying to load the translations from WP.org:

```
function newspack_newsletters_load_custom_translation_file( $mofile, $domain ) {
	if ( 'newspack-newsletters' === $domain ) {
		if( 'es_ES' === get_locale() ) {
			$mofile = NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/languages/newspack-newsletters-es_ES.mo';
		}
	}
	return $mofile;
}
add_filter( 'load_textdomain_mofile', 'newspack_newsletters_load_custom_translation_file', 10, 2 );
```

4. Switch your site to Spanish.
5. Create a new newsletter.
6. Add the Posts Inserter block, and enable both the byline and 'Continue reading...' text. 
7. Confirm that both are "translated" -- by which I mean, both have the text "translated" appended to them -- this is coming from the .mo file. 

![image](https://github.com/Automattic/newspack-newsletters/assets/177561/938da6f2-4dad-4885-ba90-dcf85d53085f)

8. Send yourself a test email, and confirm that the "translations" carry over.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
