### PR TITLE
fix: add missing text domains

### DIFF
--- a/src/editor/blocks/posts-inserter/query-controls.js
+++ b/src/editor/blocks/posts-inserter/query-controls.js
@@ -293,25 +293,25 @@ const QueryControlsSettings = ( { attributes, setAttributes } ) => {
 							/>
 							<SelectControl
 								key="query-controls-order-select"
-								label={ __( 'Order by' ) }
+								label={ __( 'Order by', 'newspack-newsletters' ) }
 								value={ `${ attributes.orderBy }/${ attributes.order }` }
 								options={ [
 									{
-										label: __( 'Newest to oldest' ),
+										label: __( 'Newest to oldest', 'newspack-newsletters' ),
 										value: 'date/desc',
 									},
 									{
-										label: __( 'Oldest to newest' ),
+										label: __( 'Oldest to newest', 'newspack-newsletters' ),
 										value: 'date/asc',
 									},
 									{
 										/* translators: label for ordering posts by title in ascending order */
-										label: __( 'A → Z' ),
+										label: __( 'A → Z', 'newspack-newsletters' ),
 										value: 'title/asc',
 									},
 									{
 										/* translators: label for ordering posts by title in descending order */
-										label: __( 'Z → A' ),
+										label: __( 'Z → A', 'newspack-newsletters' ),
 										value: 'title/desc',
 									},
 								] }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR just fixes a small handful of strings that I noticed didn't have text domains while investigating general translation issues. 

### How to test the changes in this Pull Request:

1. Spot check the PR, and confirm it adds the correct text domains to strings marked for translation.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
