### PR TITLE
fix: handle inactive woocommerce

### DIFF
--- a/includes/plugins/class-woocommerce-memberships.php
+++ b/includes/plugins/class-woocommerce-memberships.php
@@ -79,6 +79,9 @@ class Woocommerce_Memberships {
 		if ( ! is_array( $lists ) || empty( $lists ) ) {
 			return $lists;
 		}
+		if ( ! function_exists( 'wc_memberships_is_post_content_restricted' ) ) {
+			return $lists;
+		}
 		$lists = array_filter(
 			$lists,
 			function ( $list ) {
@@ -87,7 +90,7 @@ class Woocommerce_Memberships {
 					return false;
 				}
 
-				$is_post_restricted = wc_memberships_is_post_content_restricted( $list_object->get_id() );
+				$is_post_restricted = \wc_memberships_is_post_content_restricted( $list_object->get_id() );
 
 				if ( ! $is_post_restricted ) {
 					return true;
@@ -95,7 +98,7 @@ class Woocommerce_Memberships {
 
 				$user_id = self::$user_id_in_scope ?? get_current_user_id();
 
-				return wc_memberships_user_can( $user_id, 'view', [ 'post' => $list_object->get_id() ] );
+				return \wc_memberships_user_can( $user_id, 'view', [ 'post' => $list_object->get_id() ] );
 			}
 		);
 		return array_values( $lists );

--- a/includes/plugins/class-woocommerce-memberships.php
+++ b/includes/plugins/class-woocommerce-memberships.php
@@ -56,7 +56,7 @@ class Woocommerce_Memberships {
 	 * Initialize the hooks after all plugins are loaded
 	 */
 	public static function init_hooks() {
-		if ( ! class_exists( 'WC_Memberships_Loader' ) ) {
+		if ( ! class_exists( 'WC_Memberships_Loader' ) || ! function_exists( 'wc_memberships_is_post_content_restricted' ) ) {
 			return;
 		}
 		add_filter( 'newspack_newsletters_contact_lists', [ __CLASS__, 'filter_lists' ] );
@@ -77,9 +77,6 @@ class Woocommerce_Memberships {
 	 */
 	public static function filter_lists( $lists ) {
 		if ( ! is_array( $lists ) || empty( $lists ) ) {
-			return $lists;
-		}
-		if ( ! function_exists( 'wc_memberships_is_post_content_restricted' ) ) {
 			return $lists;
 		}
 		$lists = array_filter(


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Add a check for WC function existence. 

### How to test the changes in this Pull Request:

Should be self-explanatory, but if testing is needed – I've encountered this after deactivating `woocommerce` and editing a post. PHP Errors are logged in this situation on `trunk`. 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->