### PR TITLE
hotfix: decode newletter tracked link before redirect

### DIFF
--- a/includes/tracking/class-click.php
+++ b/includes/tracking/class-click.php
@@ -141,7 +141,8 @@ final class Click {
 		// phpcs:disable WordPress.Security.NonceVerification.Recommended
 		$newsletter_id = \intval( $_GET['id'] ?? 0 );
 		$email_address = \sanitize_email( $_GET['em'] ?? '' );
-		$url           = \sanitize_text_field( \wp_unslash( $_GET['url'] ?? '' ) );
+		// We need to decode the URL before redirecting, as it may contain encoded characters.
+		$url = html_entity_decode( esc_url_raw( \wp_unslash( $_GET['url'] ?? '' ) ) );
 		// phpcs:enable
 
 		/**

--- a/tests/test-renderer.php
+++ b/tests/test-renderer.php
@@ -130,7 +130,7 @@ class Newsletters_Renderer_Test extends WP_UnitTestCase {
 					'innerHTML'    => $inner_html,
 				]
 			),
-			'<mj-section url="https://www.amazon.com/Learning-PHP-MySQL-JavaScript-Javascript/dp/1491978910" padding="0"><mj-column padding="12px" width="100%"><mj-text padding="0" line-height="1.5" font-size="16px" ><a href="https://www.amazon.com/Learning-PHP-MySQL-JavaScript-Javascript/dp/1491978910">Learning PHP, MySQL &amp; JavaScript: With jQuery, CSS &amp; HTML5 (Learning PHP, MYSQL, Javascript, CSS &amp; HTML5)</a></mj-text></mj-column></mj-section>',
+			'<mj-section url="https://www.amazon.com/Learning-PHP-MySQL-JavaScript-Javascript/dp/1491978910" padding="0"><mj-column padding="12px" width="100%"><mj-text padding="0" line-height="1.5" font-size="16px" ><a href="https://www.amazon.com/Learning-PHP-MySQL-JavaScript-Javascript/dp/1491978910">Learning PHP, MYSQL &amp; JavaScript: With jQuery, CSS &amp; HTML5</a></mj-text></mj-column></mj-section>',
 			'Renders invalid rich HTML as link'
 		);
 	}


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Part of [/0/1200550061930446/1206673203803226/f](https://app.asana.com/0/1200550061930446/1206673203803226/f)

This decodes tracked newsletter URLs before redirecting. Previously newsletter links that contained query parameters would be encoded whenever tracking is enabled so that the URL itself could be included as a param of the new tracking link. However, we were never decoding these links when a tracked link was clicked and so would redirect with the encoded url parameters.

This PR addresses this by decoding urls prior to redirecting.

![Screenshot 2024-02-23 at 14 38 19](https://github.com/Automattic/newspack-newsletters/assets/17905991/3533fe10-bf9d-4656-8f3f-627837f2fbd4)

### How to test the changes in this Pull Request:

1. Enable click-tracking in Newsletters (Newsletters > Tracking)
2. Create a new newsletter using any layout (Newsletters > Add New)
3. In the body of the newletter, add a link to some text that contains url params: (for example https://newspack.com?param1=test&param2=test)
4. Send a test email to yourself via the `Send a Test Email` button in the edit newsletter page
5. Wait for the email to arrive, then click the link created in step 2
6. On `release` branch you should be redirected to `https://newspack.com?param1=test&amp;param2=test&utm_medium=email`. On this branch you should be redirected to `https://newspack.com?param1=test&param2=test&utm_medium=email` (notice the first `&amp;` vs `&`)

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
