### PR TITLE
fix(mc): log MC errors when adding membership user to lists fails

### DIFF
--- a/includes/plugins/class-woocommerce-memberships.php
+++ b/includes/plugins/class-woocommerce-memberships.php
@@ -278,7 +278,13 @@ class Woocommerce_Memberships {
 		}
 
 		$provider = Newspack_Newsletters::get_service_provider();
-		$provider->update_contact_lists_handling_local( $user_email, $lists_to_add );
+		$result = $provider->update_contact_lists_handling_local( $user_email, $lists_to_add );
+
+		if ( is_wp_error( $result ) ) {
+			Newspack_Newsletters_Logger::log( 'An error occured while updating lists for ' . $user_email . ': ' . $result->get_error_message() );
+			return;
+		}
+
 		Newspack_Newsletters_Logger::log( 'Reader ' . $user_email . ' added to the following lists: ' . implode( ', ', $lists_to_add ) );
 	}
 

--- a/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp.php
+++ b/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp.php
@@ -1160,7 +1160,7 @@ final class Newspack_Newsletters_Mailchimp extends \Newspack_Newsletters_Service
 				];
 			}
 
-			// If we're subscribing the contact to a newsletter, they should have some status 
+			// If we're subscribing the contact to a newsletter, they should have some status
 			// because 'non-subscriber' status can't receive newsletters.
 			if ( ! empty( $group_id ) || ! empty( $list_id ) ) {
 				$update_payload['status_if_new'] = $new_contact_status ?? 'subscribed';
@@ -1179,6 +1179,8 @@ final class Newspack_Newsletters_Mailchimp extends \Newspack_Newsletters_Service
 			if (
 				! $result ||
 				! isset( $result['status'] ) ||
+				// See Mailchimp error code glossary: https://mailchimp.com/developer/marketing/docs/errors/#error-glossary.
+				(int) $result['status'] >= 400 ||
 				( isset( $result['errors'] ) && count( $result['errors'] ) )
 			) {
 				return new WP_Error(


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes [0/1200550061930446/1206699019683828/f](https://app.asana.com/0/1200550061930446/1206699019683828/f) 

This adds some logging to address a problem where sometimes adding a membership user to mailchimp list fails. ( Ideally we would be able to use the new Newspack Manager Logging implemented by Leo, but [this is on-hold right now](https://github.com/Automattic/newspack-newsletters/pull/1432).)

It looks like we weren't properly catching some errors from MC when adding users since we were only looking for an errors field from MC, but this is not always included in their error responses.

This PR also checks for a status of 400 or greater to account for this, and logs the output of this error message when `NEWSPACK_LOG_LEVEL` is set.

### How to test the changes in this Pull Request:

This one is a bit tricky to test. You'll have to force an error response from the api, and unfortunately providing an invalid api key doesn't do the trick since this causes the MC library to fatal. I was able to replicate by repeatedly signing up to a MC list and archiving until my email was flagged and blocked temporarily.

1. In wp-config, set `NEWSPACK_LOG_LEVEL` to 1
2. Set up memberships and subscriptions on your test site
3. Create a subscription product
4. Set up a membership plan that grants access to a MC list and is tied to the subscription product from step 2:

![Screenshot 2024-02-28 at 17 58 31](https://github.com/Automattic/newspack-newsletters/assets/17905991/05ef47c9-82cf-4936-b488-8bf2be91bfcd)

![Screenshot 2024-02-28 at 17 57 40](https://github.com/Automattic/newspack-newsletters/assets/17905991/aa422cca-b805-4278-8cfe-65b300fff4a8)

5. Log in as a reader with an email address that has been blocked by MC
6. Purchase the subscription from step 2
7. Check your site's debug log and confirm you see an entry that gives some details about the failure:

![Screenshot 2024-02-28 at 18 04 44](https://github.com/Automattic/newspack-newsletters/assets/17905991/b7584064-b26b-412d-845e-3d37e9cf3eab)

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
