### PR TITLE
fix: activate newsletter subscribers if needed

### DIFF
--- a/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp.php
+++ b/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp.php
@@ -1153,6 +1153,13 @@ final class Newspack_Newsletters_Mailchimp extends \Newspack_Newsletters_Service
 				];
 			}
 
+			// If we're subscribing the contact to a newsletter, they should have some status 
+			// because 'non-subscriber' status can't receive newsletters.
+			if ( ! empty( $group_id ) || ! empty( $list_id ) ) {
+				$update_payload['status_if_new'] = $new_contact_status ?? 'subscribed';
+				$update_payload['status']        = $new_contact_status ?? 'subscribed';
+			}
+
 			// Create or update a list member.
 			$existing_contact = self::get_contact_data( $email_address );
 			if ( is_wp_error( $existing_contact ) ) {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Hotfix version of #1421.

### How to test the changes in this Pull Request:

Same as #1421.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
