### PR TITLE
chore: active campaign dynamic property warnings

### DIFF
--- a/includes/service-providers/active_campaign/class-newspack-newsletters-active-campaign.php
+++ b/includes/service-providers/active_campaign/class-newspack-newsletters-active-campaign.php
@@ -41,13 +41,6 @@ final class Newspack_Newsletters_Active_Campaign extends \Newspack_Newsletters_S
 	public static $support_local_lists = true;
 
 	/**
-	 * Controller.
-	 *
-	 * @var Newspack_Newsletters_Active_Campaign_Controller
-	 */
-	public $controller;
-
-	/**
 	 * Provider name.
 	 *
 	 * @var string

--- a/includes/service-providers/active_campaign/class-newspack-newsletters-active-campaign.php
+++ b/includes/service-providers/active_campaign/class-newspack-newsletters-active-campaign.php
@@ -41,6 +41,13 @@ final class Newspack_Newsletters_Active_Campaign extends \Newspack_Newsletters_S
 	public static $support_local_lists = true;
 
 	/**
+	 * Controller.
+	 *
+	 * @var Newspack_Newsletters_Active_Campaign_Controller
+	 */
+	public $controller;
+
+	/**
 	 * Provider name.
 	 *
 	 * @var string

--- a/includes/service-providers/class-newspack-newsletters-service-provider.php
+++ b/includes/service-providers/class-newspack-newsletters-service-provider.php
@@ -22,7 +22,7 @@ abstract class Newspack_Newsletters_Service_Provider implements Newspack_Newslet
 	 *
 	 * @var \WP_REST_Controller.
 	 */
-	private $controller;
+	protected $controller;
 
 	/**
 	 * Name of the service.


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Removes these warnings from the log:
![Screenshot 2024-03-01 at 12 49 05](https://github.com/Automattic/newspack-newsletters/assets/17905991/e705c05a-ac82-4fcd-8f2a-4f012f3db12f)

### How to test the changes in this Pull Request:

1. Set up active campaign as ESP (Newspack > Engagement > Newsletters)
2. Tail `debug.log`
3. Go to the Newsletters menu in wp-admin
4. On `trunk` observe lots of dynamic property warnings (pictured above)
5. On this branch observe none

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
