### PR TITLE
fix: avoid fatal if no plan rules to read

### DIFF
--- a/includes/plugins/class-woocommerce-memberships.php
+++ b/includes/plugins/class-woocommerce-memberships.php
@@ -132,7 +132,20 @@ class Woocommerce_Memberships {
 	 * @return void
 	 */
 	public static function handle_membership_status_change( $user_membership, $old_status, $new_status ) {
-		Newspack_Newsletters_Logger::log( 'Membership status changed to ' . $new_status );
+		$user = $user_membership->get_user();
+		if ( ! $user ) {
+			return;
+		}
+		$user_email = $user->user_email;
+
+		Newspack_Newsletters_Logger::log(
+			sprintf(
+				'Membership status for %s changed from %s to %s',
+				$user_email,
+				$old_status,
+				$new_status
+			)
+		);
 
 		// Store the previous status so we can check it in the `add_user_to_lists` method, that runs on a later hook.
 		self::$previous_statuses[ $user_membership->get_id() ] = $old_status;
@@ -157,7 +170,12 @@ class Woocommerce_Memberships {
 			return;
 		}
 		$user_email = $user->user_email;
-		$rules      = $user_membership->get_plan()->get_content_restriction_rules();
+		$plan       = $user_membership->get_plan();
+		if ( ! $plan ) {
+			return;
+		}
+
+		$rules = $plan->get_content_restriction_rules();
 		foreach ( $rules as $rule ) {
 			if ( Subscription_Lists::CPT !== $rule->get_content_type_name() ) {
 				continue;
@@ -172,6 +190,12 @@ class Woocommerce_Memberships {
 				}
 			}
 		}
+
+		// Bail if there are no lists we need to remove.
+		if ( empty( $lists_to_remove ) ) {
+			return;
+		}
+
 		$provider = Newspack_Newsletters::get_service_provider();
 
 		/**
@@ -248,7 +272,7 @@ class Woocommerce_Memberships {
 		$user_email   = $user->user_email;
 		$rules        = $plan->get_content_restriction_rules();
 
-		Newspack_Newsletters_Logger::log( 'New membership granted to ' . $user_email );
+		Newspack_Newsletters_Logger::log( 'Membership activated for ' . $user_email );
 
 		foreach ( $rules as $rule ) {
 			if ( Subscription_Lists::CPT !== $rule->get_content_type_name() ) {
@@ -263,6 +287,16 @@ class Woocommerce_Memberships {
 					continue;
 				}
 			}
+		}
+		if ( empty( $lists_to_add ) ) {
+			return;
+		}
+
+		// No need to re-add the user to the lists they are already subscribed to.
+		$current_user_lists = \Newspack_Newsletters_Subscription::get_contact_lists( $user_email );
+		$lists_to_add      = array_diff( $lists_to_add, $current_user_lists );
+		if ( empty( $lists_to_add ) ) {
+			return;
 		}
 
 		/**

--- a/includes/plugins/class-woocommerce-memberships.php
+++ b/includes/plugins/class-woocommerce-memberships.php
@@ -171,7 +171,7 @@ class Woocommerce_Memberships {
 		}
 		$user_email = $user->user_email;
 		$plan       = $user_membership->get_plan();
-		if ( ! $plan ) {
+		if ( ! $plan instanceof \WC_Memberships_Membership_Plan ) {
 			return;
 		}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes a potential unhandled fatal error when a Membership status changes. The fatal could potentially prevent syncs from completing in our and other plugins which trigger syncs to MC.

Also refactors some of our Memberships hook callbacks to bail a bit earlier if we don't need to do anything to change list subscriptions when a membership status changes. This shouldn't technically change any behavior, but there's no reason to interact with the ESP APIs if the membership status change shouldn't result in any changes to the member's subscriptions.

Related to `1200550061930446/1206754741092185`

### How to test the changes in this Pull Request:

Hard to replicate organically, but sometimes `$user_membership->get_plan()` on [this line](https://github.com/Automattic/newspack-newsletters/blob/trunk/includes/plugins/class-woocommerce-memberships.php#L160) is `false`, which results in a fatal error like this (data IDs obfuscated):

```
2024-03-05T12:31:33+00:00 Critical Uncaught Error: Call to a member function get_content_restriction_rules() on bool in /wordpress/plugins/newspack-newsletters/2.11.0/includes/plugins/class-woocommerce-memberships.php:160 CONTEXT: {"error":{"type":1,"file":"\/wordpress\/plugins\/newspack-newsletters\/2.11.0\/includes\/plugins\/class-woocommerce-memberships.php","line":160},"backtrace":["","#0 \/wordpress\/plugins\/newspack-newsletters\/2.11.0\/includes\/plugins\/class-woocommerce-memberships.php(292): Newspack_Newsletters\\Plugins\\Woocommerce_Memberships::remove_user_from_lists(Object(WC_Memberships_User_Membership))","#1 \/wordpress\/core\/6.4.3\/wp-includes\/class-wp-hook.php(324): Newspack_Newsletters\\Plugins\\Woocommerce_Memberships::deleted_membership(Object(WC_Memberships_User_Membership))","#2 \/wordpress\/core\/6.4.3\/wp-includes\/class-wp-hook.php(348): WP_Hook->apply_filters('', Array)","#3 \/wordpress\/core\/6.4.3\/wp-includes\/plugin.php(517): WP_Hook->do_action(Array)","#4 \/srv\/htdocs\/wp-content\/plugins\/woocommerce-memberships\/src\/class-wc-memberships-user-memberships.php(1637): do_action('wc_memberships_...', Object(WC_Memberships_User_Membership))","#5 \/wordpress\/core\/6.4.3\/wp-includes\/class-wp-hook.php(326): WC_Memberships_User_Memberships->delete_related_data('000')","#6 \/wordpress\/core\/6.4.3\/wp-includes\/class-wp-hook.php(348): WP_Hook->apply_filters(NULL, Array)","#7 \/wordpress\/core\/6.4.3\/wp-includes\/plugin.php(517): WP_Hook->do_action(Array)","#8 \/wordpress\/core\/6.4.3\/wp-includes\/post.php(3496): do_action('delete_post', '000', Object(WP_Post))","#9 \/wordpress\/core\/6.4.3\/wp-includes\/post.php(7695): wp_delete_post('000', true)","#10 \/wordpress\/core\/6.4.3\/wp-includes\/class-wp-hook.php(324): wp_delete_auto_drafts()","#11 \/wordpress\/core\/6.4.3\/wp-includes\/class-wp-hook.php(348): WP_Hook->apply_filters(NULL, Array)","#12 \/wordpress\/core\/6.4.3\/wp-includes\/plugin.php(565): WP_Hook->do_action(Array)","#13 \/wordpress\/core\/6.4.3\/wp-cron.php(191): do_action_ref_array('wp_scheduled_au...', Array)","#14 {main}","thrown"]}≈
```

Theoretically you could temporarily mock the function in the WooCommerce Memberships plugin to return `false` to force the condition for the fatal, and confirm that this patch bails gracefully without triggering a fatal when you perform an action as a reader which would result in a Membership status change (e.g. buy a subscription or cancel/pause an existing membership-related subscription). You might need to view status logs in **WooCommerce > Status > Logs** in order to see the fatal when on `release`, since they happen outside of the normal site thread and thus won't hit the normal debug.log.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1206754741092185