### PR TITLE
feat: flag to delete all local lists

### DIFF
--- a/includes/class-subscription-lists.php
+++ b/includes/class-subscription-lists.php
@@ -582,16 +582,17 @@ class Subscription_Lists {
 	 *
 	 * @param array  $existing_ids The list of IDs that exist in the ESP. All other remote lists will be deleted.
 	 * @param string $provider_slug The provider slug to clean up lists for. Default is the current configured provider.
+	 * @param bool   $delete_local If true, delete all local lists as well.
 	 * @return void
 	 */
-	public static function garbage_collector( $existing_ids, $provider_slug = null ) {
+	public static function garbage_collector( $existing_ids, $provider_slug = null, $delete_local = false ) {
 		if ( is_null( $provider_slug ) ) {
 			$provider      = Newspack_Newsletters::get_service_provider();
 			$provider_slug = $provider->service;
 		}
 		$all_lists = self::get_all();
 		foreach ( $all_lists as $list ) {
-			if ( ! $list->is_local() && $provider_slug === $list->get_provider() && ! in_array( $list->get_id(), $existing_ids ) ) {
+			if ( ( $delete_local || ! $list->is_local() ) && $provider_slug === $list->get_provider() && ! in_array( $list->get_id(), $existing_ids ) ) {
 				self::delete_list( $list );
 			}
 		}
@@ -616,7 +617,7 @@ class Subscription_Lists {
 			printf( '<h2>%s</h2>', esc_html__( 'Description', 'newspack-newsletters' ) );
 		}
 	}
-	
+
 	/**
 	 * Outputs a link back to the Settings page above the title in the post editor.
 	 */
@@ -652,7 +653,7 @@ class Subscription_Lists {
 			}
 
 			foreach ( $lists as $list_id => $list ) {
-				
+
 				if ( Subscription_List::is_local_form_id( $list_id ) ) {
 					continue;
 				}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Small cleanup feature to delete all local lists for a connected ESP. Default behavior only deletes data for lists that are tied to a list in the connected ESP. Passing a truthy value for the new arg will delete all `newspack_nl_list` CPTs.

### How to test the changes in this Pull Request:

1. Check out this branch.
2. Connect an ESP in Newspack > Engagement > Newsletters. Enable some subscription lists from the ESP, update the titles and descriptions, and add some new (local) ones.
3. Run in CLI: `wp eval "\Newspack\Newsletters\Subscription_Lists::garbage_collector( [], $esp, true );"` where `$esp` is the slug for your connected ESP (e.g. `mailchimp` or `active_campaign`)
4. Confirm that all of the lists you edited and created in step 2 have been deleted. The remote ones will be recreated automatically but their names should be reset to match the source in the connected ESP.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
