### PR TITLE
fix: optimistic newsletter form submissions

### DIFF
--- a/src/blocks/subscribe/index.php
+++ b/src/blocks/subscribe/index.php
@@ -502,14 +502,8 @@ function process_form() {
 			'email'    => $email,
 			'metadata' => $metadata,
 		],
-		$lists,
-		true // Async.
+		$lists
 	);
-
-	// The async subscription strategy returns true.
-	if ( true === $result ) {
-		$result = [];
-	}
 
 	if ( \is_wp_error( $result ) ) {
 		return send_form_response( $result );


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes [0/1206709674365921/1206756862605997](https://app.asana.com/0/1206709674365921/1206756862605997/f).

When Reader Activation is set, the newsletter subscription form takes a long time to process. This is because the form is doing alot:

1. Sending a recaptcha request
2. Creating a WP user via reader activation
3. Creating a new contact via the ESP

Altogether, this takes anywhere from 3-7 seconds to complete before the form renders an error or success. This PR attempts to make this feel more immediate for readers by optimistically succeeding, and reverting to error message whenever one is returned from the backend:

https://github.com/Automattic/newspack-newsletters/assets/17905991/1359ecdc-153e-442e-83da-e857edeba2d0

Note that it's fine to default to success here since even if the reader navigates away from the page before the form finishes processing, the user account and contact should still be created on the backend provided there is not an error from ESP.

### How to test the changes in this Pull Request:

1. Verify reader activation is all set up on your test site
5. Add a newsletter subscription block to any page
6. Go to the relevant page as a logged out user
7. Input an invalid email address (such as `test@invalid.com`) and submit
8. On `trunk` the form will take anywhere from 3-7 seconds to process, before returning an error message. On this branch, the form will succeed immediately, then render an error after a few seconds.
9. Log out and clear local storage/cookies then repeat the above steps, this time with a valid email address. 
10. Verify you only see a success message.

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
