### PR TITLE
hotfix: adding contact to multiple groups within a list

### DIFF
--- a/includes/class-newspack-newsletters-subscription.php
+++ b/includes/class-newspack-newsletters-subscription.php
@@ -629,7 +629,7 @@ class Newspack_Newsletters_Subscription {
 			$errors->add( $result->get_error_code(), $result->get_error_message() );
 		}
 
-		// Perform side-effects of lists adding.
+		// Handle local lists feature.
 		foreach ( $lists as $list_id ) {
 			try {
 				$provider->add_contact_handling_local_list( $contact, $list_id );

--- a/includes/service-providers/class-newspack-newsletters-service-provider.php
+++ b/includes/service-providers/class-newspack-newsletters-service-provider.php
@@ -453,6 +453,9 @@ abstract class Newspack_Newsletters_Service_Provider implements Newspack_Newslet
 	 * @return true|WP_Error True or error.
 	 */
 	public function add_contact_handling_local_list( $contact, $list_id ) {
+		if ( ! static::$support_local_lists ) {
+			return true;
+		}
 		if ( Subscription_List::is_local_form_id( $list_id ) ) {
 			try {
 				$list = Subscription_List::from_form_id( $list_id );
@@ -460,10 +463,7 @@ abstract class Newspack_Newsletters_Service_Provider implements Newspack_Newslet
 					return new WP_Error( 'List not properly configured for the provider' );
 				}
 				$list_settings = $list->get_provider_settings( $this->service );
-				if ( static::$support_local_lists ) {
-					return $this->add_esp_local_list_to_contact( $contact['email'], $list_settings['tag_id'], $list_settings['list'] );
-				}
-				return true;
+				return $this->add_esp_local_list_to_contact( $contact['email'], $list_settings['tag_id'], $list_settings['list'] );
 			} catch ( \InvalidArgumentException $e ) {
 				return new WP_Error( 'List not found' );
 			}

--- a/includes/service-providers/class-newspack-newsletters-service-provider.php
+++ b/includes/service-providers/class-newspack-newsletters-service-provider.php
@@ -438,11 +438,8 @@ abstract class Newspack_Newsletters_Service_Provider implements Newspack_Newslet
 	}
 
 	/**
-	 * Add or update contact to a list, but handling local Subscription Lists
-	 *
-	 * The difference between this method and add_contact is that this method will identify and handle local lists
-	 *
-	 * If the $list_id informed is a local list, it will read its settings and call add_contact with the list associated and also add the tag to the contact
+	 * Handle adding to local lists.
+	 * If the $list_id is a local list, a tag will be added to the contact.
 	 *
 	 * @param array  $contact      {
 	 *    Contact data.
@@ -453,35 +450,24 @@ abstract class Newspack_Newsletters_Service_Provider implements Newspack_Newslet
 	 * }
 	 * @param string $list_id      List to add the contact to.
 	 *
-	 * @return array|WP_Error Contact data if it was added, or error otherwise.
+	 * @return true|WP_Error True or error.
 	 */
 	public function add_contact_handling_local_list( $contact, $list_id ) {
 		if ( Subscription_List::is_local_form_id( $list_id ) ) {
 			try {
 				$list = Subscription_List::from_form_id( $list_id );
-
 				if ( ! $list->is_configured_for_provider( $this->service ) ) {
 					return new WP_Error( 'List not properly configured for the provider' );
 				}
 				$list_settings = $list->get_provider_settings( $this->service );
-
-				$added_contact = $this->add_contact( $contact, $list_settings['list'] );
-
-				if ( is_wp_error( $added_contact ) ) {
-					return $added_contact;
-				}
-
 				if ( static::$support_local_lists ) {
-					$this->add_esp_local_list_to_contact( $contact['email'], $list_settings['tag_id'], $list_settings['list'] );
+					return $this->add_esp_local_list_to_contact( $contact['email'], $list_settings['tag_id'], $list_settings['list'] );
 				}
-
-				return $added_contact;
-
+				return true;
 			} catch ( \InvalidArgumentException $e ) {
 				return new WP_Error( 'List not found' );
 			}
 		}
-		return $this->add_contact( $contact, $list_id );
 	}
 
 	/**

--- a/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp.php
+++ b/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp.php
@@ -1048,6 +1048,36 @@ final class Newspack_Newsletters_Mailchimp extends \Newspack_Newsletters_Service
 	}
 
 	/**
+	 * Add contact to a list with multiple groups.
+	 *
+	 * @param array $contact The contact, as for the add_contact method.
+	 * @param array $lists List IDs to add the contact to.
+	 */
+	public function add_contact_with_groups( $contact, $lists ) {
+		$results = [];
+		$by_list = [];
+		foreach ( $lists as $list_id ) {
+			$list = $this->maybe_extract_group_list( $list_id );
+			if ( $list ) {
+				$list_id  = $list['list_id'];
+				$group_id = $list['group_id'];
+			}
+			if ( ! isset( $contact['interests'] ) ) {
+				$contact['interests'] = [];
+			}
+			if ( isset( $by_list[ $list_id ] ) ) {
+				$by_list[ $list_id ][] = $group_id;
+			} else {
+				$by_list[ $list_id ] = [ $group_id ];
+			}
+		}
+		foreach ( $by_list as $list_id => $group_ids ) {
+			$results[] = $this->add_contact( $contact, $list_id, $group_ids );
+		}
+		return $results;
+	}
+
+	/**
 	 * Add contact to a list.
 	 *
 	 * @param array  $contact      {
@@ -1058,10 +1088,11 @@ final class Newspack_Newsletters_Mailchimp extends \Newspack_Newsletters_Service
 	 *    @type string[] $metadata Contact additional metadata. Optional.
 	 * }
 	 * @param string $list_id      List to add the contact to.
+	 * @param string $group_ids    Group IDs within the list to add the contact to.
 	 *
 	 * @return array|WP_Error Contact data if it was added, or error otherwise.
 	 */
-	public function add_contact( $contact, $list_id = false ) {
+	public function add_contact( $contact, $list_id = false, $group_ids = [] ) {
 		if ( false === $list_id ) {
 			return new WP_Error( 'newspack_newsletters_mailchimp_list_id', __( 'Missing list id.' ) );
 		}
@@ -1158,6 +1189,12 @@ final class Newspack_Newsletters_Mailchimp extends \Newspack_Newsletters_Service
 				$update_payload['interests'] = [
 					$group_id => true,
 				];
+			}
+			if ( ! empty( $group_ids ) ) {
+				$update_payload['interests'] = [];
+				foreach ( $group_ids as $group_id ) {
+					$update_payload['interests'][ $group_id ] = true;
+				}
 			}
 
 			// If we're subscribing the contact to a newsletter, they should have some status


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes an issue with adding a contact to multiple interest groups in one go.

This is a bit rough – ideally the `add_contact` would handle the groups without the need for the `add_contact_with_groups` wrapper. 

### How to test the changes in this Pull Request:

1. Configure Mailchimp as the ESP and select at least two interest groups (Audience Dashboard -> Manage Audience -> Settings -> Groups). Select these in the Engagement wizard, so they are available for the Newsletter Signup Block
2. Visit a page with the Newsletter Signup Block
3. On `trunk`, check all "lists" and subscribe
4. Observe that an error* is being logged in the server logs, and the contact is added** only to one of the interest groups (or not at all)
5. Switch to this branch, again subscribe to all lists, observe the contact is added to all interest groups in MC

\* "Use PUT to insert or update list members"
\** In my testing MC instance, double-opt-in is required for all contacts, so a real email address will be needed if that's the case on your test instance

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
