### PR TITLE
feat(mailchimp): support tags as subscription lists

### DIFF
--- a/includes/class-subscription-list.php
+++ b/includes/class-subscription-list.php
@@ -53,6 +53,16 @@ class Subscription_List {
 	const REMOTE_ID_META = '_remote_id';
 
 	/**
+	 * The name of the meta key used to store the list's remote name, only present for remote lists
+	 */
+	const REMOTE_NAME_META = '_remote_name';
+
+	/**
+	 * The post meta key used to store the list's subscriber count, only present for Group-based lists.
+	 */
+	const SUBSCRIBER_COUNT_META = '_subscriber_count';
+
+	/**
 	 * Checks if a string $id is in the format of a local Subscription List Form ID
 	 *
 	 * @see self::get_form_id
@@ -288,6 +298,44 @@ class Subscription_List {
 	}
 
 	/**
+	 * Gets the subscriber count, only present for Group-based lists
+	 *
+	 * @return string
+	 */
+	public function get_subscriber_count() {
+		$count = get_post_meta( $this->get_id(), self::SUBSCRIBER_COUNT_META, true );
+		return empty( $count ) ? 0 : (int) $count;
+	}
+
+	/**
+	 * Sets the subscriber count, only present for Group-based lists
+	 *
+	 * @param int $count The subscriber count.
+	 * @return boolean
+	 */
+	public function set_subscriber_count( $count ) {
+		return update_post_meta( $this->get_id(), self::SUBSCRIBER_COUNT_META, (int) $count );
+	}
+
+	/**
+	 * Gets the list's remote name. Only present for remote lists.
+	 */
+	public function get_remote_name() {
+		$remote_name = get_post_meta( $this->get_id(), self::REMOTE_NAME_META, true );
+		return ( empty( $remote_name ) ) ? $this->get_title() : $remote_name;
+	}
+
+	/**
+	 * Sets the list's remote name. Only present for remote lists.
+	 *
+	 * @param string $remote_name The remote name.
+	 * @return boolean
+	 */
+	public function set_remote_name( $remote_name ) {
+		return update_post_meta( $this->get_id(), self::REMOTE_NAME_META, $remote_name );
+	}
+
+	/**
 	 * Generate the tag name that will be added to the ESP based on the post title
 	 *
 	 * @param string $prefix The prefix to be added to the tag name.
@@ -443,7 +491,7 @@ class Subscription_List {
 				'tag_name' => $tag_name,
 			];
 		}
-		
+
 		return update_post_meta( $this->get_id(), self::META_KEY, $settings );
 	}
 

--- a/includes/plugins/class-woocommerce-memberships.php
+++ b/includes/plugins/class-woocommerce-memberships.php
@@ -245,6 +245,9 @@ class Woocommerce_Memberships {
 	 * @return void
 	 */
 	public static function add_user_to_lists( $plan, $args ) {
+		if ( defined( 'NEWSPACK_ENABLE_POST_CHECKOUT_NEWSLETTER_SIGNUP' ) && NEWSPACK_ENABLE_POST_CHECKOUT_NEWSLETTER_SIGNUP ) {
+			return;
+		}
 
 		// When creating the membership via admin panel, this hook is called once before the membership is actually created.
 		if ( ! $plan instanceof \WC_Memberships_Membership_Plan ) {

--- a/includes/plugins/class-woocommerce-memberships.php
+++ b/includes/plugins/class-woocommerce-memberships.php
@@ -56,9 +56,6 @@ class Woocommerce_Memberships {
 	 * Initialize the hooks after all plugins are loaded
 	 */
 	public static function init_hooks() {
-		if ( ! class_exists( 'WC_Memberships_Loader' ) || ! function_exists( 'wc_memberships_is_post_content_restricted' ) ) {
-			return;
-		}
 		add_filter( 'newspack_newsletters_contact_lists', [ __CLASS__, 'filter_lists' ] );
 		add_filter( 'newspack_newsletters_subscription_block_available_lists', [ __CLASS__, 'filter_lists' ] );
 		add_filter( 'newspack_newsletters_manage_newsletters_available_lists', [ __CLASS__, 'filter_lists_objects' ] );
@@ -69,6 +66,19 @@ class Woocommerce_Memberships {
 	}
 
 	/**
+	 * Is WC Memberships enabled?
+	 *
+	 * @return bool
+	 */
+	public static function is_enabled() {
+		if ( class_exists( 'WC_Memberships_Loader' ) && function_exists( 'wc_memberships_is_post_content_restricted' ) ) {
+			return true;
+		}
+
+		return false;
+	}
+
+	/**
 	 * Keep users from being added to lists that require a membership plan they dont have
 	 * Also filters lists that require a membership plan to be displayed in the subscription block and in the Manage Newsletters page in My Account
 	 *
@@ -76,7 +86,7 @@ class Woocommerce_Memberships {
 	 * @return array
 	 */
 	public static function filter_lists( $lists ) {
-		if ( ! is_array( $lists ) || empty( $lists ) ) {
+		if ( ! self::is_enabled() || ! is_array( $lists ) || empty( $lists ) ) {
 			return $lists;
 		}
 		$lists = array_filter(
@@ -108,7 +118,7 @@ class Woocommerce_Memberships {
 	 * @return array
 	 */
 	public static function filter_lists_objects( $lists ) {
-		if ( ! is_array( $lists ) || empty( $lists ) ) {
+		if ( ! self::is_enabled() || ! is_array( $lists ) || empty( $lists ) ) {
 			return $lists;
 		}
 

--- a/includes/plugins/class-woocommerce-memberships.php
+++ b/includes/plugins/class-woocommerce-memberships.php
@@ -160,9 +160,9 @@ class Woocommerce_Memberships {
 		// Store the previous status so we can check it in the `add_user_to_lists` method, that runs on a later hook.
 		self::$previous_statuses[ $user_membership->get_id() ] = $old_status;
 
-		$status_considered_active = wc_memberships()->get_user_memberships_instance()->get_active_access_membership_statuses();
+		$active_statuses = wc_memberships()->get_user_memberships_instance()->get_active_access_membership_statuses();
 
-		if ( ! in_array( $new_status, $status_considered_active ) ) {
+		if ( ! in_array( $new_status, $active_statuses ) ) {
 			self::remove_user_from_lists( $user_membership );
 		}
 	}
@@ -245,28 +245,38 @@ class Woocommerce_Memberships {
 	 * @return void
 	 */
 	public static function add_user_to_lists( $plan, $args ) {
-		if ( defined( 'NEWSPACK_ENABLE_POST_CHECKOUT_NEWSLETTER_SIGNUP' ) && NEWSPACK_ENABLE_POST_CHECKOUT_NEWSLETTER_SIGNUP ) {
-			return;
-		}
-
 		// When creating the membership via admin panel, this hook is called once before the membership is actually created.
 		if ( ! $plan instanceof \WC_Memberships_Membership_Plan ) {
 			return;
 		}
 
-		$status_considered_active = wc_memberships()->get_user_memberships_instance()->get_active_access_membership_statuses();
-
+		$active_statuses = wc_memberships()->get_user_memberships_instance()->get_active_access_membership_statuses();
 		$user_membership = new \WC_Memberships_User_Membership( $args['user_membership_id'] );
+		$previous_status = ! empty( self::$previous_statuses[ $user_membership->get_id() ] ) ? self::$previous_statuses[ $user_membership->get_id() ] : false;
+		$current_status  = $user_membership->get_status();
+		$previous_lists  = get_user_meta( $user_membership->get_user_id(), self::SUBSCRIBED_ON_DEACTIVATION_META_KEY, true );
 
-		if ( ! in_array( $user_membership->get_status(), $status_considered_active, true ) ) {
+		// If the membership is no longer active, no need to proceed.
+		if ( ! in_array( $current_status, $active_statuses, true ) ) {
 			return;
 		}
 
 		// Check if we have the previous status stored. If we do and it's an active status
 		// it means the membership is being updated from one active status to another active status.
 		// In this case, we don't want to add the user to the lists again.
-		if ( ! empty( self::$previous_statuses[ $user_membership->get_id() ] ) && in_array( self::$previous_statuses[ $user_membership->get_id() ], $status_considered_active, true ) ) {
+		if ( $previous_status && in_array( $previous_status, $active_statuses, true ) ) {
 			Newspack_Newsletters_Logger::log( 'Membership ' . $user_membership->get_id() . ' was already active. No need to subscribe user to lists' );
+			return;
+		}
+
+		// If post-checkout newsletter signup is enabled, we only want to add the reader to premium lists if:
+		// - The membership is going from `paused` to `active` status (when a prior subscription is renewed).
+		// - The reader was already subscribed to the list(s).
+		$post_checkout_newsletter_signup_enabled = defined( 'NEWSPACK_ENABLE_POST_CHECKOUT_NEWSLETTER_SIGNUP' ) && NEWSPACK_ENABLE_POST_CHECKOUT_NEWSLETTER_SIGNUP;
+		if (
+			$post_checkout_newsletter_signup_enabled &&
+			( 'paused' !== $previous_status || ! $args['is_update'] || empty( $previous_lists[ $args['user_membership_id'] ] ) )
+		) {
 			return;
 		}
 
@@ -295,7 +305,9 @@ class Woocommerce_Memberships {
 			foreach ( $object_ids as $object_id ) {
 				try {
 					$subscription_list = new Subscription_List( $object_id );
-					$lists_to_add[]    = $subscription_list->get_form_id();
+					$list_id           = $subscription_list->get_form_id();
+
+					$lists_to_add[] = $list_id;
 				} catch ( \InvalidArgumentException $e ) {
 					continue;
 				}
@@ -307,7 +319,7 @@ class Woocommerce_Memberships {
 
 		// No need to re-add the user to the lists they are already subscribed to.
 		$current_user_lists = \Newspack_Newsletters_Subscription::get_contact_lists( $user_email );
-		$lists_to_add      = array_diff( $lists_to_add, $current_user_lists );
+		$lists_to_add = array_diff( $lists_to_add, $current_user_lists );
 		if ( empty( $lists_to_add ) ) {
 			return;
 		}

--- a/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp-cached-data.php
+++ b/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp-cached-data.php
@@ -586,7 +586,7 @@ final class Newspack_Newsletters_Mailchimp_Cached_Data {
 	 * @throws Exception In case of errors while fetching data from the server.
 	 * @return array The list interest_categories
 	 */
-	public static function fetch_merge_fields( $list_id ) {
+	private static function fetch_merge_fields( $list_id ) {
 		$mc       = new Mailchimp( ( self::get_mc_instance() )->api_key() );
 		$response = ( self::get_mc_instance() )->validate(
 			$mc->get(

--- a/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp-cached-data.php
+++ b/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp-cached-data.php
@@ -108,11 +108,11 @@ final class Newspack_Newsletters_Mailchimp_Cached_Data {
 	}
 
 	/**
-	 * Get segments of a given list
+	 * Get segments of a given audience (list)
 	 *
-	 * @param string $list_id The List ID.
+	 * @param string $list_id The audience (list) ID.
 	 * @throws Exception In case of errors while fetching data from the server.
-	 * @return array The list segments
+	 * @return array The audience segments
 	 */
 	public static function get_segments( $list_id ) {
 		$data = self::get_data( $list_id );
@@ -120,15 +120,27 @@ final class Newspack_Newsletters_Mailchimp_Cached_Data {
 	}
 
 	/**
-	 * Get Interest Categories (aka Groups) of a given list
+	 * Get Interest Categories (aka Groups) of a given audience
 	 *
-	 * @param string $list_id The List ID.
+	 * @param string $list_id The audience (list) ID.
 	 * @throws Exception In case of errors while fetching data from the server.
-	 * @return array The list interest categories
+	 * @return array The audience interest categories
 	 */
 	public static function get_interest_categories( $list_id ) {
 		$data = self::get_data( $list_id );
 		return $data['interest_categories'] ?? null;
+	}
+
+	/**
+	 * Get tags for a given audience
+	 *
+	 * @param string $list_id The audience (list) ID.
+	 * @throws Exception In case of errors while fetching data from the server.
+	 * @return array The audience tags
+	 */
+	public static function get_tags( $list_id ) {
+		$data = self::get_data( $list_id );
+		return $data['tags'] ?? null;
 	}
 
 	/**
@@ -147,7 +159,7 @@ final class Newspack_Newsletters_Mailchimp_Cached_Data {
 	/**
 	 * Get merge_fields of a given list
 	 *
-	 * @param string $list_id The List ID.
+	 * @param string $list_id The audience (list) ID.
 	 * @throws Exception In case of errors while fetching data from the server.
 	 * @return array The list merge_fields
 	 */
@@ -421,11 +433,13 @@ final class Newspack_Newsletters_Mailchimp_Cached_Data {
 		try {
 			$segments            = self::fetch_segments( $list_id );
 			$interest_categories = self::fetch_interest_categories( $list_id );
+			$tags                = self::fetch_tags( $list_id );
 			$folders             = self::fetch_folders();
 			$merge_fields        = self::fetch_merge_fields( $list_id );
 			$list_data           = [
 				'segments'            => $segments,
 				'interest_categories' => $interest_categories,
+				'tags'                => $tags,
 				'folders'             => $folders,
 				'merge_fields'        => $merge_fields,
 			];
@@ -471,11 +485,11 @@ final class Newspack_Newsletters_Mailchimp_Cached_Data {
 	/**
 	 * Fetches the segments for a given List from the Mailchimp server
 	 *
-	 * @param string $list_id The List ID.
+	 * @param string $list_id The audience (list) ID.
 	 * @throws Exception In case of errors while fetching data from the server.
-	 * @return array The list segments
+	 * @return array The audience segments
 	 */
-	private static function fetch_segments( $list_id ) {
+	public static function fetch_segments( $list_id ) {
 		$mc       = new Mailchimp( ( self::get_mc_instance() )->api_key() );
 		$segments = [];
 
@@ -483,25 +497,14 @@ final class Newspack_Newsletters_Mailchimp_Cached_Data {
 			$mc->get(
 				"lists/$list_id/segments",
 				[
-					'type'  => 'saved',
+					'type'  => 'saved', // 'saved' or 'static' segments. 'static' segments are actually the same thing as tags, so we can exclude them from this request as we fetch tags separately.
 					'count' => 1000,
 				],
 				60
 			),
 			__( 'Error retrieving Mailchimp segments.', 'newspack_newsletters' )
 		);
-		$static_segments_response = ( self::get_mc_instance() )->validate(
-			$mc->get(
-				"lists/$list_id/segments",
-				[
-					'type'  => 'static',
-					'count' => 1000,
-				],
-				60
-			),
-			__( 'Error retrieving Mailchimp segments.', 'newspack_newsletters' )
-		);
-		$segments                 = array_merge( $saved_segments_response['segments'], $static_segments_response['segments'] );
+		$segments = $saved_segments_response['segments'];
 
 		return $segments;
 	}
@@ -509,9 +512,9 @@ final class Newspack_Newsletters_Mailchimp_Cached_Data {
 	/**
 	 * Fetches the interest_categories (aka Groups) for a given List from the Mailchimp server
 	 *
-	 * @param string $list_id The List ID.
+	 * @param string $list_id The audience (list) ID.
 	 * @throws Exception In case of errors while fetching data from the server.
-	 * @return array The list interest_categories
+	 * @return array The audience interest_categories
 	 */
 	private static function fetch_interest_categories( $list_id ) {
 		$mc                  = new Mailchimp( ( self::get_mc_instance() )->api_key() );
@@ -531,6 +534,34 @@ final class Newspack_Newsletters_Mailchimp_Cached_Data {
 		}
 
 		return $interest_categories;
+	}
+
+	/**
+	 * Fetches the tags for a given audience (list) from the Mailchimp server
+	 *
+	 * @param string $list_id The audience (list) ID.
+	 * @throws Exception In case of errors while fetching data from the server.
+	 * @return array The audience tags
+	 */
+	public static function fetch_tags( $list_id ) {
+		$mc   = new Mailchimp( ( self::get_mc_instance() )->api_key() );
+		$tags = $list_id ? ( self::get_mc_instance() )->validate(
+			$mc->get(
+				"lists/$list_id/segments",
+				[
+					'type'  => 'static', // 'saved' or 'static' segments. Tags are called 'static' segments in Mailchimp's API.
+					'count' => 1000,
+				],
+				60
+			),
+			__( 'Error retrieving Mailchimp tags.', 'newspack_newsletters' )
+		) : null;
+
+		if ( $tags && count( $tags['segments'] ) ) {
+			return $tags['segments'];
+		}
+
+		return [];
 	}
 
 	/**
@@ -555,7 +586,7 @@ final class Newspack_Newsletters_Mailchimp_Cached_Data {
 	 * @throws Exception In case of errors while fetching data from the server.
 	 * @return array The list interest_categories
 	 */
-	private static function fetch_merge_fields( $list_id ) {
+	public static function fetch_merge_fields( $list_id ) {
 		$mc       = new Mailchimp( ( self::get_mc_instance() )->api_key() );
 		$response = ( self::get_mc_instance() )->validate(
 			$mc->get(

--- a/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp-groups.php
+++ b/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp-groups.php
@@ -8,6 +8,7 @@
 defined( 'ABSPATH' ) || exit;
 
 use DrewM\MailChimp\MailChimp;
+use Newspack\Newsletters\Subscription_List;
 
 /**
  * This trait adds the Mailchimp Groups implementation to the Mailchimp Service Provider.
@@ -100,7 +101,7 @@ trait Newspack_Newsletters_Mailchimp_Groups {
 	 * @return true|WP_Error
 	 */
 	public function remove_esp_local_list_from_contact( $email, $esp_local_list, $list_id = null ) {
-		return $this->remove_group_from_contact( $email, $esp_local_list, $list_id );
+		return $this->remove_group_or_tag_from_contact( $email, $esp_local_list, $list_id );
 	}
 
 	/**
@@ -328,23 +329,41 @@ trait Newspack_Newsletters_Mailchimp_Groups {
 	 * Remove a group from a contact
 	 *
 	 * @param string $email The contact email.
-	 * @param string $group_id The group ID.
+	 * @param string $sublist_id The group or tag ID.
 	 * @param string $list_id The List ID.
+	 * @param string $list_type The type of sublist: 'group' or 'tag'.
+	 *
 	 * @return true|WP_Error
 	 */
-	public function remove_group_from_contact( $email, $group_id, $list_id = null ) {
+	public function remove_group_or_tag_from_contact( $email, $sublist_id, $list_id = null, $list_type = 'group' ) {
 		$existing_contact = $this->get_contact_data( $email );
 		if ( is_wp_error( $existing_contact ) ) {
 			return $existing_contact;
 		}
 
-		$mc    = new Mailchimp( $this->api_key() );
-		$added = $mc->put(
-			sprintf( 'lists/%s/members/%s', $list_id, $existing_contact['id'] ),
-			[
-				'interests' => [ $group_id => false ],
-			]
-		);
+		$mc = new Mailchimp( $this->api_key() );
+		if ( 'group' === $list_type ) {
+			$added = $mc->put(
+				sprintf( 'lists/%s/members/%s', $list_id, $existing_contact['id'] ),
+				[
+					'interests' => [ $sublist_id => false ],
+				]
+			);
+		} elseif ( 'tag' === $list_type ) {
+			$subscription_list = Subscription_List::from_remote_id( "$list_type-$sublist_id-$list_id" );
+			$remote_tag_name   = $subscription_list->get_remote_name();
+			$added = $mc->post(
+				sprintf( 'lists/%s/members/%s/tags', $list_id, $existing_contact['id'] ),
+				[
+					'tags' => [
+						[
+							'name'   => $remote_tag_name,
+							'status' => 'inactive',
+						],
+					],
+				]
+			);
+		}
 
 		if ( is_array( $added ) && ! empty( $added['status'] ) ) {
 			return true;

--- a/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp.php
+++ b/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp.php
@@ -9,6 +9,7 @@ defined( 'ABSPATH' ) || exit;
 
 use DrewM\MailChimp\MailChimp;
 use Newspack\Newsletters\Subscription_Lists;
+use Newspack\Newsletters\Subscription_List;
 
 /**
  * Main Newspack Newsletters Class.
@@ -418,21 +419,20 @@ final class Newspack_Newsletters_Mailchimp extends \Newspack_Newsletters_Service
 				$mc->get( "campaigns/$mc_campaign_id" ),
 				__( 'Error retrieving Mailchimp campaign.', 'newspack_newsletters' )
 			);
-			$folders             = Newspack_Newsletters_Mailchimp_Cached_Data::get_folders();
-			$list_id             = $campaign && isset( $campaign['recipients']['list_id'] ) ? $campaign['recipients']['list_id'] : null;
-			$merge_fields        = $list_id ? Newspack_Newsletters_Mailchimp_Cached_Data::get_merge_fields( $list_id ) : [];
-			$interest_categories = $list_id ? Newspack_Newsletters_Mailchimp_Cached_Data::get_interest_categories( $list_id ) : null;
-			$segments            = $list_id ? Newspack_Newsletters_Mailchimp_Cached_Data::get_segments( $list_id ) : [];
+			$list_id = $campaign && isset( $campaign['recipients']['list_id'] ) ? $campaign['recipients']['list_id'] : null;
 
-			return [
-				'lists'               => $this->get_lists(),
-				'folders'             => $folders,
-				'merge_fields'        => $merge_fields,
+			$newsletter_data = [
 				'campaign'            => $campaign,
 				'campaign_id'         => $mc_campaign_id,
-				'interest_categories' => $interest_categories,
-				'segments'            => $segments,
+				'folders'             => Newspack_Newsletters_Mailchimp_Cached_Data::get_folders(),
+				'interest_categories' => $this->get_interest_categories( $list_id ),
+				'lists'               => $this->get_lists( true ),
+				'merge_fields'        => $list_id ? Newspack_Newsletters_Mailchimp_Cached_Data::get_merge_fields( $list_id ) : [],
+				'segments'            => $list_id ? Newspack_Newsletters_Mailchimp_Cached_Data::get_segments( $list_id ) : [],
+				'tags'                => $this->get_tags( $list_id ),
 			];
+
+			return $newsletter_data;
 		} catch ( Exception $e ) {
 			return new WP_Error(
 				'newspack_newsletters_mailchimp_error',
@@ -442,9 +442,14 @@ final class Newspack_Newsletters_Mailchimp extends \Newspack_Newsletters_Service
 	}
 
 	/**
-	 * Get lists.
+	 * Get audiences, groups, and tags that can be configured as subscription lists.
+	 * Reconcile edited names for locally-configured lists.
+	 *
+	 * @param boolean $audiences_only Whether to include groups and tags. If true, only return audiences.
+	 *
+	 * @return array|WP_Error List of subscription lists or error.
 	 */
-	public function get_lists() {
+	public function get_lists( $audiences_only = false ) {
 		try {
 			$mc             = new Mailchimp( $this->api_key() );
 			$lists_response = $this->validate(
@@ -471,15 +476,21 @@ final class Newspack_Newsletters_Mailchimp extends \Newspack_Newsletters_Service
 					$error_message
 				);
 			}
+
+			if ( $audiences_only ) {
+				return $lists_response['lists'];
+			}
+
 			$lists = [];
 
-			// In addition to Audiences, we also automatically fetch all groups and offer them as Subscription Lists.
+			// In addition to Audiences, we also automatically fetch all groups and tags and offer them as Subscription Lists.
 			// Build the final list inside the loop so groups are added after the list they belong to and we can then represent the hierarchy in the UI.
 			foreach ( $lists_response['lists'] as $list ) {
 
 				$lists[]        = $list;
 				$all_categories = Newspack_Newsletters_Mailchimp_Cached_Data::get_interest_categories( $list['id'] );
 				$all_categories = $all_categories['categories'] ?? [];
+				$all_tags       = Newspack_Newsletters_Mailchimp_Cached_Data::get_tags( $list['id'] ) ?? [];
 
 				foreach ( $all_categories as $found_category ) {
 
@@ -492,7 +503,7 @@ final class Newspack_Newsletters_Mailchimp extends \Newspack_Newsletters_Service
 
 					$groups = array_map(
 						function ( $group ) use ( $list ) {
-							$group['id']   = $this->create_group_list_id( $group['id'], $list['id'] );
+							$group['id']   = $this->create_group_or_tag_list_id( $group['id'], $list['id'] );
 							$group['type'] = 'mailchimp-group';
 							return $group;
 						},
@@ -500,7 +511,24 @@ final class Newspack_Newsletters_Mailchimp extends \Newspack_Newsletters_Service
 					);
 					$lists  = array_merge( $lists, $groups );
 				}
+
+				foreach ( $all_tags as $tag ) {
+					$tag['id']   = $this->create_group_or_tag_list_id( $tag['id'], $list['id'], 'tag' );
+					$tag['type'] = 'mailchimp-tag';
+					$lists[]     = $tag;
+				}
 			}
+
+			// Reconcile edited names for locally-configured lists.
+			$configured_lists = Newspack_Newsletters_Subscription::get_lists_config();
+			if ( ! empty( $configured_lists ) ) {
+				foreach ( $lists as &$list ) {
+					if ( ! empty( $configured_lists[ $list['id'] ]['name'] ) ) {
+						$list['local_name'] = $configured_lists[ $list['id'] ]['name'];
+					}
+				}
+			}
+
 			return $lists;
 		} catch ( Exception $e ) {
 			return new WP_Error(
@@ -508,6 +536,71 @@ final class Newspack_Newsletters_Mailchimp extends \Newspack_Newsletters_Service
 				$e->getMessage()
 			);
 		}
+	}
+
+	/**
+	 * Get interest categories and their groups.
+	 * Reconcile edited names for locally-configured lists.
+	 *
+	 * @param string $list_id List ID.
+	 *
+	 * @return array
+	 */
+	public function get_interest_categories( $list_id = null ) {
+		if ( ! $list_id ) {
+			return [];
+		}
+		$categories = Newspack_Newsletters_Mailchimp_Cached_Data::get_interest_categories( $list_id );
+		if ( empty( $categories['categories'] ) ) {
+			return [];
+		}
+
+		// Reconcile edited names for locally-configured lists.
+		$configured_lists = Newspack_Newsletters_Subscription::get_lists_config();
+		if ( ! empty( $configured_lists ) ) {
+			foreach ( $categories['categories'] as &$category ) {
+				if ( ! empty( $category['interests']['interests'] ) ) {
+					foreach ( $category['interests']['interests'] as &$interest ) {
+						$local_id = $this->create_group_or_tag_list_id( $interest['id'], $list_id );
+						if ( isset( $configured_lists[ $local_id ]['name'] ) ) {
+							$interest['local_name'] = $configured_lists[ $local_id ]['name'];
+						}
+					}
+				}
+			}
+		}
+
+		return $categories;
+	}
+
+	/**
+	 * Get tags. Reconcile edited names for locally-configured lists.
+	 *
+	 * @param string $list_id List ID.
+	 *
+	 * @return array
+	 */
+	public function get_tags( $list_id = null ) {
+		if ( ! $list_id ) {
+			return [];
+		}
+		$tags = Newspack_Newsletters_Mailchimp_Cached_Data::get_tags( $list_id );
+		if ( empty( $tags ) ) {
+			return [];
+		}
+
+		// Reconcile edited names for locally-configured lists.
+		$configured_lists = Newspack_Newsletters_Subscription::get_lists_config();
+		if ( ! empty( $configured_lists ) ) {
+			foreach ( $tags as &$tag ) {
+				$local_id = $this->create_group_or_tag_list_id( $tag['id'], $list_id, 'tag' );
+				if ( isset( $configured_lists[ $local_id ]['name'] ) ) {
+					$tag['local_name'] = $configured_lists[ $local_id ]['name'];
+				}
+			}
+		}
+
+		return $tags;
 	}
 
 	/**
@@ -1073,10 +1166,11 @@ final class Newspack_Newsletters_Mailchimp extends \Newspack_Newsletters_Service
 			return self::$contacts_added[ $list_id . $email_address ];
 		}
 
-		$list = $this->maybe_extract_group_list( $list_id );
+		$list = $this->maybe_extract_group_or_tag_list( $list_id );
 		if ( $list ) {
-			$list_id  = $list['list_id'];
-			$group_id = $list['group_id'];
+			$list_id    = $list['list_id'];
+			$list_type  = $list['type'];
+			$sublist_id = $list['id'];
 		}
 		$new_contact_status = 'subscribed';
 		if ( isset( $contact['metadata'] ) && ! empty( $contact['metadata']['status'] ) ) {
@@ -1154,15 +1248,21 @@ final class Newspack_Newsletters_Mailchimp extends \Newspack_Newsletters_Service
 				}
 			}
 
-			if ( ! empty( $group_id ) ) {
-				$update_payload['interests'] = [
-					$group_id => true,
-				];
+			if ( ! empty( $list_type ) ) {
+				if ( 'group' === $list_type ) {
+					$update_payload['interests'] = [
+						$sublist_id => true,
+					];
+				} elseif ( 'tag' === $list_type ) {
+					$subscription_list = Subscription_List::from_remote_id( "$list_type-$sublist_id-$list_id" );
+					$remote_tag_name   = $subscription_list->get_remote_name();
+					$update_payload['tags'] = [ $remote_tag_name ];
+				}
 			}
 
 			// If we're subscribing the contact to a newsletter, they should have some status
 			// because 'non-subscriber' status can't receive newsletters.
-			if ( ! empty( $group_id ) || ! empty( $list_id ) ) {
+			if ( ! empty( $sublist_id ) || ! empty( $list_id ) ) {
 				$update_payload['status_if_new'] = $new_contact_status ?? 'subscribed';
 				$update_payload['status']        = $new_contact_status ?? 'subscribed';
 			}
@@ -1253,11 +1353,17 @@ final class Newspack_Newsletters_Mailchimp extends \Newspack_Newsletters_Service
 		foreach ( $contact['interests'] as $list_id => $interests ) {
 			foreach ( $interests as $group_id => $active ) {
 				if ( $active ) {
-					$groups_lists[] = $this->create_group_list_id( $group_id, $list_id );
+					$groups_lists[] = $this->create_group_or_tag_list_id( $group_id, $list_id );
 				}
 			}
 		}
-		return array_merge( $audience_lists, $groups_lists );
+		$tags_lists = [];
+		foreach ( $contact['tags'] as $list_id => $tags ) {
+			foreach ( $tags as $tag ) {
+				$tags_lists[] = $this->create_group_or_tag_list_id( $tag['id'], $list_id, 'tag' );
+			}
+		}
+		return array_merge( $audience_lists, $groups_lists, $tags_lists );
 	}
 
 	/**
@@ -1282,15 +1388,20 @@ final class Newspack_Newsletters_Mailchimp extends \Newspack_Newsletters_Service
 		$mc = new Mailchimp( $this->api_key() );
 		try {
 			foreach ( $lists_to_add as $list_id ) {
-				$list = $this->maybe_extract_group_list( $list_id );
-				// If this is a group list, check if the contact is already subscribed to the group, so we don't make an unnecessary call.
+				$list = $this->maybe_extract_group_or_tag_list( $list_id );
+				// If this is a group or tag list, check if the contact is already subscribed to the group/tag, so we don't make an unnecessary call.
 				if ( $list ) {
-					if ( ! empty( $contact['interests'][ $list['list_id'] ] ) ) {
-						if ( isset( $contact['interests'][ $list['list_id'] ][ $list['group_id'] ] ) && $contact['interests'][ $list['list_id'] ][ $list['group_id'] ] ) {
+					if ( ! empty( $contact['interests'][ $list['list_id'] ] ) && 'group' === $list['type'] ) {
+						if ( ! empty( $contact['interests'][ $list['list_id'] ][ $list['id'] ] ) ) {
 							continue;
 						}
 					}
-					// If the group doesn't exits, the regular add_contact call below will take care of adding it.
+					if ( ! empty( $contact['tags'][ $list['list_id'] ] ) && 'tag' === $list['type'] ) {
+						if ( ! empty( $contact['tags'][ $list['list_id'] ][ $list['id'] ] ) ) {
+							continue;
+						}
+					}
+					// If the group or tag doesn't exist, the regular add_contact call below will take care of adding it.
 				}
 				if ( ! isset( $contact['lists'][ $list_id ] ) ) {
 					$this->add_contact( [ 'email' => $email ], $list_id );
@@ -1299,9 +1410,9 @@ final class Newspack_Newsletters_Mailchimp extends \Newspack_Newsletters_Service
 				}
 			}
 			foreach ( $lists_to_remove as $list_id ) {
-				$list = $this->maybe_extract_group_list( $list_id );
+				$list = $this->maybe_extract_group_or_tag_list( $list_id );
 				if ( $list ) {
-					$this->remove_group_from_contact( $email, $list['group_id'], $list['list_id'] );
+					$this->remove_group_or_tag_from_contact( $email, $list['id'], $list['list_id'], $list['type'] );
 					continue;
 				}
 				if ( ! isset( $contact['lists'][ $list_id ] ) ) {
@@ -1445,6 +1556,9 @@ final class Newspack_Newsletters_Mailchimp extends \Newspack_Newsletters_Service
 		if ( ! empty( $context ) && strpos( $context, 'group-' ) === 0 ) {
 			$labels['list_explanation'] = __( 'Mailchimp Group', 'newspack-newsletters' );
 		}
+		if ( ! empty( $context ) && strpos( $context, 'tag-' ) === 0 ) {
+			$labels['list_explanation'] = __( 'Mailchimp Tag', 'newspack-newsletters' );
+		}
 		return $labels;
 	}
 
@@ -1480,33 +1594,37 @@ final class Newspack_Newsletters_Mailchimp extends \Newspack_Newsletters_Service
 	}
 
 	/**
-	 * Creates a group list ID based on the group ID and the list ID
+	 * Creates a list ID based on the type, the ID and the list ID
 	 *
-	 * In Mailchimp, we offer both Audiences and Groups as Subscription Lists. We modify the groups IDs so we can differentiate them from the Audiences IDs.
+	 * In Mailchimp, we offer both Audiences, Groups, and Tags as Subscription Lists. We modify the group and tag IDs so we can differentiate them from the Audiences IDs.
 	 *
-	 * Also, when working with groups, we need to know the list ID, so we add it to the group ID.
+	 * Also, when working with groups or tags, we need to know the list ID, so we add it to the ID.
 	 *
-	 * @param string $group_id The Group ID.
+	 * @param string $item_id The item ID.
 	 * @param string $list_id The List/Audience ID.
+	 * @param string $type 'group' or 'tag'.
 	 * @return string
 	 */
-	public function create_group_list_id( $group_id, $list_id ) {
-		return 'group-' . $group_id . '-' . $list_id;
+	public function create_group_or_tag_list_id( $item_id, $list_id, $type = 'group' ) {
+		return $type . '-' . $item_id . '-' . $list_id;
 	}
 
 	/**
-	 * Extract the group and list ID from an ID created with create_group_list_id
+	 * Extract the group or tag + audience (list) ID from an ID created with create_group_or_tag_list_id
 	 *
 	 * @param string $list_id The list ID.
-	 * @return array|false Array with the group ID and the list ID or false if the ID is not a group list ID.
+	 * @return array|false Array with the group/tag ID and the list ID or false if the ID is not a group or tag list ID.
 	 */
-	public function maybe_extract_group_list( $list_id ) {
-		$pattern = '/^group-([^-]+)-([^-]+)$/';
+	public function maybe_extract_group_or_tag_list( $list_id ) {
+		$pattern = '/^(group|tag)-([^-]+)-([^-]+)$/';
 		if ( preg_match( $pattern, $list_id, $matches ) ) {
-			return [
-				'group_id' => $matches[1],
-				'list_id'  => $matches[2],
+			$extracted_ids = [
+				'id'      => $matches[2],
+				'list_id' => $matches[3],
+				'type'    => $matches[1],
 			];
+
+			return $extracted_ids;
 		}
 		return false;
 	}

--- a/src/components/select-control-with-optgroup/index.js
+++ b/src/components/select-control-with-optgroup/index.js
@@ -6,6 +6,7 @@ import { isEmpty } from 'lodash';
 /**
  * WordPress dependencies
  */
+import { __ } from '@wordpress/i18n';
 import { useInstanceId } from '@wordpress/compose';
 import { BaseControl } from '@wordpress/components';
 
@@ -20,6 +21,8 @@ export default function SelectControlWithOptGroup( {
 	optgroups = [],
 	className,
 	hideLabelFromVision,
+	deselectedOptionLabel = '',
+	deselectedOptionValue = '',
 	...props
 } ) {
 	const instanceId = useInstanceId( SelectControlWithOptGroup );
@@ -57,6 +60,11 @@ export default function SelectControlWithOptGroup( {
 				multiple={ multiple }
 				{ ...props }
 			>
+				{ ( deselectedOptionLabel || deselectedOptionValue ) && (
+					<option value={ deselectedOptionValue }>
+						{ deselectedOptionLabel || __( '-- Select --', 'newspack-newsletters' ) }
+					</option>
+				) }
 				{ optgroups.map( ( { label: optgroupLabel, options }, optgroupIndex ) => (
 					<optgroup label={ optgroupLabel } key={ optgroupIndex }>
 						{ options.map( ( option, optionIndex ) => (

--- a/src/service-providers/mailchimp/ProviderSidebar.js
+++ b/src/service-providers/mailchimp/ProviderSidebar.js
@@ -8,19 +8,20 @@ import { ExternalLink, SelectControl, Spinner, Notice } from '@wordpress/compone
 /**
  * Internal dependencies
  */
-import { getListInterestsSettings } from './utils';
+import { getGroupOptions, getSegmentOptions } from './utils';
+import SelectControlWithOptGroup from '../../components/select-control-with-optgroup/';
 
 const SegmentsSelection = ( {
 	onUpdate,
 	inFlight,
-	targetField,
 	chosenTarget,
-	availableInterests,
-	availableSegments,
+	groups = [],
+	tags = [],
+	segments = [],
 } ) => {
 	const [ targetId, setTargetId ] = useState( chosenTarget.toString() || '' );
-
 	const [ isInitial, setIsInitial ] = useState( true );
+
 	useEffect( () => {
 		if ( ! isInitial ) {
 			onUpdate( targetId );
@@ -28,60 +29,39 @@ const SegmentsSelection = ( {
 		setIsInitial( false );
 	}, [ targetId ] );
 
-	let options = [];
+	let optGroups = [];
 
-	if ( availableInterests.length > 0 ) {
-		options = options.concat( [
-			{
-				label: __( 'Group', 'newspack-newsletters' ),
-				value: 'groups',
-				disabled: true,
-			},
-			...availableInterests,
-		] );
+	if ( groups?.categories?.length > 0 ) {
+		optGroups = optGroups.concat( getGroupOptions( groups ) );
 	}
 
-	if ( availableSegments.length > 0 ) {
-		options = options.concat( [
-			{
-				label: __( 'Segment or tag', 'newspack-newsletters' ),
-				value: 'segments',
-				disabled: true,
-			},
-			...availableSegments.map( segment => ( {
-				label: ` - ${ segment.name }`,
-				value: segment.id.toString(),
-			} ) ),
-		] );
+	if ( tags.length > 0 ) {
+		optGroups.push( {
+			label: __( 'Tags', 'newspack-newsletters' ),
+			options: getSegmentOptions( tags ),
+		} );
 	}
 
-	useEffect( () => {
-		if ( targetId !== '' && ! options.find( option => option.value === targetId ) ) {
-			const foundOption = options.find(
-				option => option.value && option.value === `${ targetField || '' }:${ targetId }`
-			);
-			if ( foundOption ) setTargetId( foundOption.value );
-		}
-	}, [ targetId ] );
+	if ( segments.length > 0 ) {
+		optGroups.push( {
+			label: __( 'Segments', 'newspack-newsletters' ),
+			options: getSegmentOptions( segments ),
+		} );
+	}
+
+	if ( ! optGroups.length ) {
+		return null;
+	}
 
 	return (
-		<Fragment>
-			{ options.length ? (
-				<SelectControl
-					label={ __( 'Group, segment, or tag', 'newspack-newsletters' ) }
-					value={ targetId }
-					options={ [
-						{
-							label: __( 'All subscribers in audience', 'newspack-newsletters' ),
-							value: '',
-						},
-						...options,
-					] }
-					onChange={ id => setTargetId( id.toString() ) }
-					disabled={ inFlight }
-				/>
-			) : null }
-		</Fragment>
+		<SelectControlWithOptGroup
+			label={ __( 'Group, Segment, or Tag', 'newspack-newsletters' ) }
+			deselectedOptionLabel={ __( 'All subscribers in audience', 'newspack-newsletters' ) }
+			optgroups={ optGroups }
+			value={ targetId }
+			onChange={ setTargetId }
+			disabled={ inFlight }
+		/>
 	);
 };
 
@@ -97,12 +77,17 @@ const ProviderSidebar = ( {
 	updateMeta,
 } ) => {
 	const campaign = newsletterData.campaign;
-	const lists =
-		newsletterData.lists && newsletterData.lists.length
-			? newsletterData.lists.filter( list => list.type !== 'mailchimp-group' )
-			: [];
-	const folders = newsletterData.folders || [];
-	const segments = newsletterData.segments || newsletterData.tags || []; // Keep .tags for backwards compatibility.
+
+	// Separate out audiences from other data item types.
+	const audiences = newsletterData?.lists
+		? newsletterData.lists.filter(
+				list => 'mailchimp-group' !== list.type && 'mailchimp-tag' !== list.type
+		  )
+		: [];
+	const groups = newsletterData?.interest_categories || [];
+	const folders = newsletterData?.folders || [];
+	const segments = newsletterData?.segments || [];
+	const tags = newsletterData?.tags || [];
 
 	const setList = listId =>
 		apiFetch( {
@@ -190,8 +175,8 @@ const ProviderSidebar = ( {
 		);
 	}
 
-	const { list_id } = campaign.recipients || {};
-	const list = list_id && lists.find( ( { id } ) => list_id === id );
+	const { list_id: audienceId } = campaign.recipients || {};
+	const list = audienceId && audiences.find( ( { id } ) => audienceId === id );
 	const { web_id: listWebId } = list || {};
 
 	const recipients = newsletterData.campaign?.recipients;
@@ -200,12 +185,6 @@ const ProviderSidebar = ( {
 		recipients?.segment_opts?.saved_segment_id ||
 		recipients?.segment_opts?.conditions[ 0 ]?.value ||
 		'';
-
-	const targetField = recipients?.segment_opts?.conditions?.length
-		? recipients?.segment_opts?.conditions[ 0 ]?.field
-		: '';
-
-	const interestSettings = getListInterestsSettings( newsletterData );
 
 	return (
 		<Fragment>
@@ -233,13 +212,13 @@ const ProviderSidebar = ( {
 			<SelectControl
 				label={ __( 'Audience', 'newspack-newsletters' ) }
 				className="newspack-newsletters__to-selectcontrol"
-				value={ list_id }
+				value={ audienceId }
 				options={ [
 					{
 						value: null,
 						label: __( '-- Select an audience --', 'newspack-newsletters' ),
 					},
-					...lists.map( ( { id, name } ) => ( {
+					...audiences.map( ( { id, name } ) => ( {
 						value: id,
 						label: name,
 					} ) ),
@@ -256,9 +235,9 @@ const ProviderSidebar = ( {
 			) }
 			<SegmentsSelection
 				chosenTarget={ Array.isArray( chosenTarget ) ? chosenTarget[ 0 ] : chosenTarget }
-				targetField={ targetField }
-				availableInterests={ interestSettings.options }
-				availableSegments={ segments.filter( segment => segment.member_count > 0 ) }
+				groups={ groups }
+				tags={ tags }
+				segments={ segments }
 				apiFetch={ apiFetch }
 				inFlight={ inFlight }
 				onUpdate={ updateSegments }

--- a/tests/test-subscription-lists.php
+++ b/tests/test-subscription-lists.php
@@ -136,7 +136,7 @@ class Subscription_Lists_Test extends WP_UnitTestCase {
 		$count_after_existing = count( Subscription_Lists::get_all() );
 		$this->assertSame( $count, $count_after_existing );
 
-		
+
 		// new.
 		Newspack_Newsletters::set_service_provider( 'active_campaign' );
 		$new  = [
@@ -260,6 +260,11 @@ class Subscription_Lists_Test extends WP_UnitTestCase {
 				'title'       => 'MC3',
 				'description' => 'mc 3',
 			],
+			'tag-14370955-950aaf1a98'     => [
+				'active'      => false,
+				'title'       => 'MC4',
+				'description' => 'mc 4',
+			],
 		];
 
 		update_option( '_newspack_newsletters_mailchimp_lists', $mailchimp );
@@ -298,6 +303,12 @@ class Subscription_Lists_Test extends WP_UnitTestCase {
 		$this->assertSame( 'mc 3', $list->get_description() );
 		$this->assertTrue( $list->is_active() );
 		$this->assertSame( 'mailchimp', $list->get_provider() );
+
+		$list = Subscription_List::from_form_id( 'tag-14370955-950aaf1a98' );
+		$this->assertSame( 'MC4', $list->get_title() );
+		$this->assertSame( 'mc 4', $list->get_description() );
+		$this->assertFalse( $list->is_active() );
+		$this->assertSame( 'mailchimp', $list->get_provider() );
 	}
 
 	/**
@@ -310,7 +321,7 @@ class Subscription_Lists_Test extends WP_UnitTestCase {
 			function ( $list ) {
 				return $list->get_id();
 			},
-			$all_lists 
+			$all_lists
 		);
 		$this->assertContains( self::$posts['remote_mailchimp'], $ids );
 		$this->assertNotContains( self::$posts['remote_mailchimp_inactive'], $ids );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Mailchimp has several different data structures that can be used to divide an audience into what I'll collectively call **sublists**: Groups, Segments, and Tags. Currently, we support only entire audiences or Groups as configurable subscription lists in the Newspack admin.

This PR enables the use of [Mailchimp Tags](https://mailchimp.com/help/getting-started-tags/) as subscription lists. These can be enabled and configured just like Groups and Audiences in the **Newspack > Engagement > Newsletters** page, and Newsletter posts can be sent to them just like with Groups, Audiences, and Segments. The advantage of using Tags over Groups is that unlike Groups, Tags are not visible to anyone outside of the MC admin dashboard, so they're better-suited for creating premium sublists within an audience for which publishers want to control access and visibility.

Also makes some slight improvements to the Newsletter editor experience when using Mailchimp:

-  In current `trunk`, the `newsletterData` meta value which contains Mailchimp audience/group/segment/tag data is generated once when a new newsletter post is created, and then never again for that post. So this means that if any of those items change in the MC account, they're not updated in any preexisting newsletter post drafts. This PR updates the `newsletterData` meta value from the server whenever the post is first loaded in the editor so at least we fetch updated list data on editor load. This shouldn't have any major performance effects because the list data from Mailchimp is already [heavily cached](https://github.com/Automattic/newspack-newsletters/pull/1063) at the server level.
- Allows newsletter posts to be sent directly to segments. On current `trunk` these are fetched with the audience and group data but not shown in the "Send to" dropdown options. The code suggests they should be, even though they're not available to manage as subscription lists. In a future PR, they could be supported as subscription lists just like Tags (as in this PR). It would be a light lift because Tags are a sub-class of Segments, so the data structure is almost the same.
- Tweaks the dropdown list for selecting a Group/Tag/Segment to make use of an existing `SelectControlWithOptGroup` component for better readability. Because HTML only supports one level of nesting with `optgroup` elements, Groups are treated slightly differently from Segments and Tags, but I think it makes sense because only Groups can be sorted into separate categories, and each Group can have exactly one category. So the list is organized like this:
  - **Group Category 1** (also called "Interest Category" in MC)
    - **Group** (also called "Interest" in MC)
  - **Group Category 2**
    - **Group**
  - **Segments**
    - **Segment**
  - **Tags**
    - **Tag**

<img width="462" alt="Screenshot 2024-04-05 at 10 32 18 AM" src="https://github.com/Automattic/newspack-newsletters/assets/2230142/c98cb7ef-4e08-4637-83cc-a8913e5af2c5">

- If a Group or Tag has been edited locally with a different name than in MC, the dropdown will now display the local name in [brackets] so it's easier to see which sublist you're sending to.
- Segments and Tags now show subscriber counts, similar to how Groups already do.

Also makes a small but significant change to how Premium Newsletters features handle auto-subscriptions to premium lists. On `trunk`, when a user gains membership with a plan that's associated with any subscription lists, they're automatically subscribed to all lists. Now, when the post-checkout newsletter signup UI is enabled via the `NEWSPACK_ENABLE_POST_CHECKOUT_NEWSLETTER_SIGNUP` constant, the reader will now not be auto-subscribed to any lists as they can choose the one(s) they want in this post-checkout UI or in My Account. The exception is for when subscriptions get renewed—in this case, their membership is paused while payment is processing, and then reactivated when payment completes, so we want to seamlessly resubscribe the reader to any lists they were already subscribed to at the time the membership was paused.

### How to test the changes in this Pull Request:

1. On a site already connected to Mailchimp on `trunk`, make sure the Mailchimp account has some groups, tags, and segments created and that at least one group is enabled in **Newspack > Engagement > Newsletters**. Edit the name and description to be different from the group's name in Mailchimp.
2. Create a new newsletter and configure it to send to one of the enabled groups. Do not send it, just save it as a draft. (This is so we can confirm that existing drafts won't be affected negatively by the changes in this PR.)
3. Check out this PR and https://github.com/Automattic/newspack-plugin/pull/3035. Either wait for your Mailchimp cache to refresh after 10 minutes, or run `wp cron event run newspack_nl_mailchimp_refresh_cache` at the command line to force a refresh.
4. Visit **Newspack > Engagement > Newsletters** and confirm that you now see your MC account's tags as sublists of your connected audience:

<img width="1048" alt="Screenshot 2024-04-05 at 10 41 11 AM" src="https://github.com/Automattic/newspack-newsletters/assets/2230142/9181dc6c-41ec-4997-850d-ef3b5428b696">

5. Enable the tags, give them new/different names and descriptions and save.
6. Add a Registration and a Newsletter Subscription Form block to a post or page and confirm that the tags you just edited are available for the block. Enable them and publish.

<img width="276" alt="Screenshot 2024-04-05 at 10 42 48 AM" src="https://github.com/Automattic/newspack-newsletters/assets/2230142/87526c0c-55eb-4cab-b608-8c21648744f2">

7. On the front-end, visit the post with the Registration and Subscription blocks. Use both to sign up for different lists, including the tags. Confirm that the signups are reflected accurately in:
  - My Account for the reader, after verifying:

<img width="1235" alt="Screenshot 2024-04-05 at 10 44 26 AM" src="https://github.com/Automattic/newspack-newsletters/assets/2230142/048e9b2e-37ef-44f2-b9dd-05754628c7ea">

  - In the Mailchimp contacts list (the contact should have the corresponding groups and/or tags applied):
<img width="390" alt="Screenshot 2024-04-05 at 10 45 33 AM" src="https://github.com/Automattic/newspack-newsletters/assets/2230142/43731175-c313-4040-8074-f2b7d397d164">

8. Back in WP admin, edit the draft newsletter you created all the way back in step 2. Confirm that the dropdown to select a sublist has been updated to include the tags as well as the new organization as described above. Also confirm that the group you had selected before applying the changes in this PR is still selected.
9. Send this newsletter and confirm it gets sent to the proper contacts within that group.
10. Create a second newsletter and send it to a tag. Confirm that it gets sent to the proper contacts with that tag. (Note that if the tag is newly created and didn't have any subscribers until you subscribed in step 7, you may have to force a Mailchimp cache refresh again with `wp cron event run newspack_nl_mailchimp_refresh_cache` before it's selectable to send to)
11. Create a third newsletter and send it to a segment. Confirm that it gets sent to the proper contacts in that segment.

#### Optional: testing premium newsletter and other experimental features

Tags should also work for premium newsletter and post-checkout signup features, just like Groups.

1. Enable post-checkout signup by adding `define( 'NEWSPACK_ENABLE_POST_CHECKOUT_NEWSLETTER_SIGNUP', true );` to wp-config.php.
2. Enable premium newsletters by activation the Woo Memberships plugin and creating a Membership Plan. Set the plan to grant access upon **product(s) purchase** and choose a subscription product on your site, then add a rule under Restrict Content and select "Subscription Lists" and one of your tags here.

<img width="1243" alt="Screenshot 2024-04-05 at 10 53 13 AM" src="https://github.com/Automattic/newspack-newsletters/assets/2230142/6ddec412-46d0-4ded-afdd-f4b9fc1c357b">
<img width="1247" alt="Screenshot 2024-04-05 at 10 53 25 AM" src="https://github.com/Automattic/newspack-newsletters/assets/2230142/c87135b8-8a4e-4156-975c-d4c7c9379c27">

3. As a new reader, visit the site and confirm that the Registration and Newsletter Subscription Form blocks no longer show the restricted tag as an option to sign up.
4. Sign up for other non-restricted lists and visit My Account/verify. Confirm that the restricted tag isn't shown here, either.
5. Use the Checkout Button block + modal checkout flow to purchase the product you selected in the Membership Plan in step 2. Confirm that the post-checkout modal screen shows all your newsletters as an option to sign up, including the restricted tag.

<img width="574" alt="Screenshot 2024-04-05 at 10 59 52 AM" src="https://github.com/Automattic/newspack-newsletters/assets/2230142/131bd8ce-0b93-4b3d-bdfb-71a7bddeca8f">

6. Keep all selected (or at least the restricted tag) and visit My Account. Confirm that the restricted tag is now shown for this user, now that they meet the membership requirements.
7. As an admin, create a new newsletter and send it to the restricted tag. Confirm that it's sent to the reader who signed up for it with the subscription purchase, as well as any other contacts who have that tag in MC.
8. In WP admin, manually trigger a renewal of the reader's subscription. Confirm that the tag temporarily gets removed from the contact in MC while payment is processing and the subscription is in "On hold" status, but then gets automatically re-added when payment completes and the subscription is reactivated.
9. In WP admin, manually change the reader's subscription to "Cancelled" or "Expired" status. Confirm that the restricted tag is immediately removed from the contact in MC, and that the restricted tag is no longer available to the reader in My Account or in Registration/Newsletter Signup blocks unless their subscription is reactivated to "Active" status.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1206759769105465