### PR TITLE
Improve URL click tracking validation

### DIFF
--- a/includes/tracking/class-click.php
+++ b/includes/tracking/class-click.php
@@ -145,6 +145,14 @@ final class Click {
 		$url = html_entity_decode( esc_url_raw( \wp_unslash( $_GET['url'] ?? '' ) ) );
 		// phpcs:enable
 
+		// Double-check and make sure the URL is actually a URL within the email.
+		$url_without_query_args = untrailingslashit( strtok( $url, '?' ) );
+		$newsletter_content     = get_post_field( 'post_content', $newsletter_id, 'raw' );
+		if ( '' === $newsletter_content || false === stripos( $newsletter_content, $url_without_query_args ) ) {
+			\wp_die( 'Invalid URL' );
+			exit;
+		}
+
 		/**
 		 * The ESP tracking functionality may add UTM parameters to our proxied URL,
 		 * let's pass them along to the destination URL.


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

This PR makes an improvement to the click tracking validation to make sure the tracked URL is actually a URL within the newsletter. This will prevent to possibility of random URLs from counting in the click tracking.

### How to test the changes in this Pull Request:

1. Create a newsletter post. Within this post add: one or more custom links (e.g. `example.com`) and some posts with the posts inserter block.
2. Create a newsletter ad which will be inserted into the post.
3. Send yourself a test email. For the most realistic scenario, confirm that the URLs within the test email are wrapped in MailChimp or ActiveCampaign's click tracking (e.g. `https://us20.mailchimp.com/mctx/clicks?url=http%3A%2F%2Fnewspackdev.local%3Fnp_newsletters_click%3D1%26id%3D124%26url%3Dhttps%253A%252F%252Fexample.com%253Futm_medium%253Demail%26em%3D%2A%7CEMAIL%7C%2A&xid=e08d2d2e0c&uid=117743650&iid=4231610d1e&pool=cts&v=2&c=1712341131&h=1e9600990bd59207e808be990d1bf3ce78c8b03fd28739d7e62d4960cdf6a365`).
4. Click on the custom link, post links, and ad unit from within the newsletter. Observe that they redirect nicely and click tracking continues to work.
5. Grab that newsletter ID, craft a URL like this using that newsletter ID but with a URL that is not in the email content: `http://newspackdev.local/?np_newsletters_click=1&id=124&url=https://definitely-not-example.com`. Observe that you get an invalid URL error.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
