### PR TITLE
Hotfix: handle no list found; fix contact adding

### DIFF
--- a/includes/class-newspack-newsletters-subscription.php
+++ b/includes/class-newspack-newsletters-subscription.php
@@ -620,7 +620,15 @@ class Newspack_Newsletters_Subscription {
 		$result   = [];
 
 		try {
-			$result = $provider->add_contact_with_groups( $contact, $lists );
+			if ( method_exists( $provider, 'add_contact_with_groups' ) ) {
+				$result = $provider->add_contact_with_groups( $contact, $lists );
+			} elseif ( empty( $lists ) ) {
+				$result = $provider->add_contact( $contact );
+			} else {
+				foreach ( $lists as $list_id ) {
+					$result = $provider->add_contact( $contact, $list_id );
+				}
+			}
 		} catch ( \Exception $e ) {
 			$errors->add( 'newspack_newsletters_subscription_add_contact', $e->getMessage() );
 		}

--- a/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp.php
+++ b/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp.php
@@ -1062,8 +1062,11 @@ final class Newspack_Newsletters_Mailchimp extends \Newspack_Newsletters_Service
 			if ( ! $list ) {
 				// It might be a local list – the list id has to be extracted from the DB.
 				$list = Subscription_List::from_form_id( $list_id );
+				if ( ! $list ) {
+					return new WP_Error( 'List not found.' );
+				}
 				if ( ! $list->is_configured_for_provider( $this->service ) ) {
-					return new WP_Error( 'List not properly configured for the provider' );
+					return new WP_Error( 'List not properly configured for the provider.' );
 				}
 				$list_settings = $list->get_provider_settings( $this->service );
 				if ( $list_settings !== null ) {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

- Fixes a fatal occurring when a list cannot be found
- Fixes a regression introduced in #1460, in which contact adding was broken for ESP other than Mailchimp

Closes #1483 
Closes #1482

### How to test the changes in this Pull Request:

1. Using a Newsletters Subscribe block, add a contact to Mailchimp and then ActiveCampagin

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->