### PR TITLE
feat: color palette adjustments

### DIFF
--- a/includes/class-newspack-newsletters-editor.php
+++ b/includes/class-newspack-newsletters-editor.php
@@ -110,7 +110,7 @@ final class Newspack_Newsletters_Editor {
 	public static function get_color_palette_css( $container_selector = '' ) {
 		$rules = [];
 		// Add `.has-{color-name}-color` rules for each palette color.
-		$color_palette = json_decode( get_option( Newspack_Newsletters::NEWSPACK_NEWSLETTERS_PALETTE, false ), true );
+		$color_palette = json_decode( get_option( Newspack_Newsletters::NEWSPACK_NEWSLETTERS_PALETTE_META, false ), true );
 		if ( ! empty( $color_palette ) ) {
 			foreach ( $color_palette as $color_name => $color_value ) {
 				$rules[] = '.has-' . esc_html( $color_name ) . '-color { color: ' . esc_html( $color_value ) . '; }';

--- a/includes/class-newspack-newsletters-editor.php
+++ b/includes/class-newspack-newsletters-editor.php
@@ -110,7 +110,7 @@ final class Newspack_Newsletters_Editor {
 	public static function get_color_palette_css( $container_selector = '' ) {
 		$rules = [];
 		// Add `.has-{color-name}-color` rules for each palette color.
-		$color_palette = get_option( Newspack_Newsletters::NEWSPACK_NEWSLETTERS_PALETTE, false );
+		$color_palette = json_decode( get_option( Newspack_Newsletters::NEWSPACK_NEWSLETTERS_PALETTE, false ), true );
 		if ( ! empty( $color_palette ) ) {
 			foreach ( $color_palette as $color_name => $color_value ) {
 				$rules[] = '.has-' . esc_html( $color_name ) . '-color { color: ' . esc_html( $color_value ) . '; }';

--- a/includes/class-newspack-newsletters-editor.php
+++ b/includes/class-newspack-newsletters-editor.php
@@ -110,7 +110,7 @@ final class Newspack_Newsletters_Editor {
 	public static function get_color_palette_css( $container_selector = '' ) {
 		$rules = [];
 		// Add `.has-{color-name}-color` rules for each palette color.
-		$color_palette = json_decode( get_option( Newspack_Newsletters::NEWSPACK_NEWSLETTERS_PALETTE, false ), true );
+		$color_palette = get_option( Newspack_Newsletters::NEWSPACK_NEWSLETTERS_PALETTE, false );
 		if ( ! empty( $color_palette ) ) {
 			foreach ( $color_palette as $color_name => $color_value ) {
 				$rules[] = '.has-' . esc_html( $color_name ) . '-color { color: ' . esc_html( $color_value ) . '; }';

--- a/includes/class-newspack-newsletters-editor.php
+++ b/includes/class-newspack-newsletters-editor.php
@@ -110,7 +110,7 @@ final class Newspack_Newsletters_Editor {
 	public static function get_color_palette_css( $container_selector = '' ) {
 		$rules = [];
 		// Add `.has-{color-name}-color` rules for each palette color.
-		$color_palette = json_decode( get_option( 'newspack_newsletters_color_palette', false ), true );
+		$color_palette = json_decode( get_option( Newspack_Newsletters::NEWSPACK_NEWSLETTERS_PALETTE, false ), true );
 		if ( ! empty( $color_palette ) ) {
 			foreach ( $color_palette as $color_name => $color_value ) {
 				$rules[] = '.has-' . esc_html( $color_name ) . '-color { color: ' . esc_html( $color_value ) . '; }';

--- a/includes/class-newspack-newsletters-renderer.php
+++ b/includes/class-newspack-newsletters-renderer.php
@@ -180,7 +180,7 @@ final class Newspack_Newsletters_Renderer {
 			if ( 'is-style-filled-black' === $block_attrs['className'] || 'is-style-circle-white' === $block_attrs['className'] ) {
 				$icon = 'black';
 			} elseif ( 'is-style-filled-primary-text' === $block_attrs['className'] ) {
-				$palette = json_decode( get_option( Newspack_Newsletters::NEWSPACK_NEWSLETTERS_PALETTE, [] ), true );
+				$palette = json_decode( get_option( Newspack_Newsletters::NEWSPACK_NEWSLETTERS_PALETTE, '{}' ), true );
 
 				if ( isset( $palette['primary-text'] ) && ( $palette['primary-text'] === 'black' || $palette['primary-text'] === '#000000' ) ) {
 					$icon = 'black';

--- a/includes/class-newspack-newsletters-renderer.php
+++ b/includes/class-newspack-newsletters-renderer.php
@@ -1170,7 +1170,7 @@ final class Newspack_Newsletters_Renderer {
 	 */
 	public static function render_post_to_mjml( $post ) {
 		self::$newsletter_id = $post->ID;
-		self::$color_palette = json_decode( get_option( Newspack_Newsletters::NEWSPACK_NEWSLETTERS_PALETTE, false ), true );
+		self::$color_palette = get_option( Newspack_Newsletters::NEWSPACK_NEWSLETTERS_PALETTE, false );
 		self::$font_header   = get_post_meta( $post->ID, 'font_header', true );
 		self::$font_body     = get_post_meta( $post->ID, 'font_body', true );
 		$is_public           = get_post_meta( $post->ID, 'is_public', true );

--- a/includes/class-newspack-newsletters-renderer.php
+++ b/includes/class-newspack-newsletters-renderer.php
@@ -1164,7 +1164,7 @@ final class Newspack_Newsletters_Renderer {
 	 */
 	public static function render_post_to_mjml( $post ) {
 		self::$newsletter_id = $post->ID;
-		self::$color_palette = json_decode( get_option( 'newspack_newsletters_color_palette', false ), true );
+		self::$color_palette = json_decode( get_option( Newspack_Newsletters::NEWSPACK_NEWSLETTERS_PALETTE, false ), true );
 		self::$font_header   = get_post_meta( $post->ID, 'font_header', true );
 		self::$font_body     = get_post_meta( $post->ID, 'font_body', true );
 		$is_public           = get_post_meta( $post->ID, 'is_public', true );

--- a/includes/class-newspack-newsletters-renderer.php
+++ b/includes/class-newspack-newsletters-renderer.php
@@ -180,7 +180,7 @@ final class Newspack_Newsletters_Renderer {
 			if ( 'is-style-filled-black' === $block_attrs['className'] || 'is-style-circle-white' === $block_attrs['className'] ) {
 				$icon = 'black';
 			} elseif ( 'is-style-filled-primary-text' === $block_attrs['className'] ) {
-				$palette = get_option( Newspack_Newsletters::NEWSPACK_NEWSLETTERS_PALETTE, [] );
+				$palette = json_decode( get_option( Newspack_Newsletters::NEWSPACK_NEWSLETTERS_PALETTE, [] ), true );
 
 				if ( isset( $palette['primary-text'] ) && ( $palette['primary-text'] === 'black' || $palette['primary-text'] === '#000000' ) ) {
 					$icon = 'black';
@@ -1170,7 +1170,7 @@ final class Newspack_Newsletters_Renderer {
 	 */
 	public static function render_post_to_mjml( $post ) {
 		self::$newsletter_id = $post->ID;
-		self::$color_palette = get_option( Newspack_Newsletters::NEWSPACK_NEWSLETTERS_PALETTE, false );
+		self::$color_palette = json_decode( get_option( Newspack_Newsletters::NEWSPACK_NEWSLETTERS_PALETTE, false ), true );
 		self::$font_header   = get_post_meta( $post->ID, 'font_header', true );
 		self::$font_body     = get_post_meta( $post->ID, 'font_body', true );
 		$is_public           = get_post_meta( $post->ID, 'is_public', true );

--- a/includes/class-newspack-newsletters-renderer.php
+++ b/includes/class-newspack-newsletters-renderer.php
@@ -180,7 +180,7 @@ final class Newspack_Newsletters_Renderer {
 			if ( 'is-style-filled-black' === $block_attrs['className'] || 'is-style-circle-white' === $block_attrs['className'] ) {
 				$icon = 'black';
 			} elseif ( 'is-style-filled-primary-text' === $block_attrs['className'] ) {
-				$palette = json_decode( get_option( Newspack_Newsletters::NEWSPACK_NEWSLETTERS_PALETTE, '{}' ), true );
+				$palette = json_decode( get_option( Newspack_Newsletters::NEWSPACK_NEWSLETTERS_PALETTE_META, '{}' ), true );
 
 				if ( isset( $palette['primary-text'] ) && ( $palette['primary-text'] === 'black' || $palette['primary-text'] === '#000000' ) ) {
 					$icon = 'black';
@@ -1170,7 +1170,7 @@ final class Newspack_Newsletters_Renderer {
 	 */
 	public static function render_post_to_mjml( $post ) {
 		self::$newsletter_id = $post->ID;
-		self::$color_palette = json_decode( get_option( Newspack_Newsletters::NEWSPACK_NEWSLETTERS_PALETTE, false ), true );
+		self::$color_palette = json_decode( get_option( Newspack_Newsletters::NEWSPACK_NEWSLETTERS_PALETTE_META, false ), true );
 		self::$font_header   = get_post_meta( $post->ID, 'font_header', true );
 		self::$font_body     = get_post_meta( $post->ID, 'font_body', true );
 		$is_public           = get_post_meta( $post->ID, 'is_public', true );

--- a/includes/class-newspack-newsletters-renderer.php
+++ b/includes/class-newspack-newsletters-renderer.php
@@ -179,8 +179,14 @@ final class Newspack_Newsletters_Renderer {
 		if ( isset( $block_attrs['className'] ) ) {
 			if ( 'is-style-filled-black' === $block_attrs['className'] || 'is-style-circle-white' === $block_attrs['className'] ) {
 				$icon = 'black';
+			} elseif ( 'is-style-filled-primary-text' === $block_attrs['className'] ) {
+				$palette = get_option( Newspack_Newsletters::NEWSPACK_NEWSLETTERS_PALETTE, [] );
+
+				if ( isset( $palette['primary-text'] ) && ( $palette['primary-text'] === 'black' || $palette['primary-text'] === '#000000' ) ) {
+					$icon = 'black';
+				}
 			}
-			if ( 'is-style-filled-black' === $block_attrs['className'] || 'is-style-filled-white' === $block_attrs['className'] ) {
+			if ( 'is-style-filled-black' === $block_attrs['className'] || 'is-style-filled-white' === $block_attrs['className'] || 'is-style-filled-primary-text' === $block_attrs['className'] ) {
 				$color = 'transparent';
 			} elseif ( 'is-style-circle-black' === $block_attrs['className'] ) {
 				$color = '#000';

--- a/includes/class-newspack-newsletters.php
+++ b/includes/class-newspack-newsletters.php
@@ -1226,9 +1226,11 @@ final class Newspack_Newsletters {
 	public static function update_color_palette( $palette ) {
 		return update_option(
 			self::NEWSPACK_NEWSLETTERS_PALETTE,
-			array_merge(
-				get_option( self::NEWSPACK_NEWSLETTERS_PALETTE, [] ),
-				$palette
+			wp_json_encode(
+				array_merge(
+					json_decode( get_option( self::NEWSPACK_NEWSLETTERS_PALETTE, [] ), true ),
+					$palette
+				)
 			)
 		);
 	}

--- a/includes/class-newspack-newsletters.php
+++ b/includes/class-newspack-newsletters.php
@@ -1221,13 +1221,13 @@ final class Newspack_Newsletters {
 	 *
 	 * @param array $palette The updated color palette.
 	 *
-	 * @return void
+	 * @return bool True if the option was updated, false otherwise.
 	 */
 	public static function update_color_palette( $palette ) {
-		update_option(
+		return update_option(
 			self::NEWSPACK_NEWSLETTERS_PALETTE,
 			array_merge(
-				get_option( NEWSPACK_NEWSLETTERS_PALETTE, [] ),
+				get_option( self::NEWSPACK_NEWSLETTERS_PALETTE, [] ),
 				$palette
 			)
 		);

--- a/includes/class-newspack-newsletters.php
+++ b/includes/class-newspack-newsletters.php
@@ -14,9 +14,10 @@ use DrewM\MailChimp\MailChimp;
  */
 final class Newspack_Newsletters {
 
-	const NEWSPACK_NEWSLETTERS_CPT = 'newspack_nl_cpt';
-	const EMAIL_HTML_META          = 'newspack_email_html';
-	const PUBLIC_POST_ID_META      = 'newspack_nl_public_post_id';
+	const NEWSPACK_NEWSLETTERS_CPT     = 'newspack_nl_cpt';
+	const EMAIL_HTML_META              = 'newspack_email_html';
+	const NEWSPACK_NEWSLETTERS_PALETTE = 'newspack_newsletters_color_palette';
+	const PUBLIC_POST_ID_META          = 'newspack_nl_public_post_id';
 
 	/**
 	 * Supported fonts.
@@ -680,15 +681,8 @@ final class Newspack_Newsletters {
 	 * @param WP_REST_Request $request API request object.
 	 */
 	public static function api_set_color_palette( $request ) {
-		update_option(
-			'newspack_newsletters_color_palette',
-			wp_json_encode(
-				array_merge(
-					json_decode( (string) get_option( 'newspack_newsletters_color_palette', '{}' ), true ) ?? [],
-					json_decode( $request->get_body(), true )
-				)
-			)
-		);
+		self::update_color_palette( json_decode( $request->get_body(), true ) );
+
 		return \rest_ensure_response( [] );
 	}
 
@@ -1220,6 +1214,23 @@ final class Newspack_Newsletters {
 				exit;
 			}
 		}
+	}
+
+	/**
+	 * Updates the default newsletters color palette option.
+	 *
+	 * @param array $palette The updated color palette.
+	 *
+	 * @return void
+	 */
+	public static function update_color_palette( $palette ) {
+		update_option(
+			self::NEWSPACK_NEWSLETTERS_PALETTE,
+			array_merge(
+				get_option( NEWSPACK_NEWSLETTERS_PALETTE, [] ),
+				$palette
+			)
+		);
 	}
 }
 Newspack_Newsletters::instance();

--- a/includes/class-newspack-newsletters.php
+++ b/includes/class-newspack-newsletters.php
@@ -14,10 +14,10 @@ use DrewM\MailChimp\MailChimp;
  */
 final class Newspack_Newsletters {
 
-	const NEWSPACK_NEWSLETTERS_CPT     = 'newspack_nl_cpt';
-	const EMAIL_HTML_META              = 'newspack_email_html';
-	const NEWSPACK_NEWSLETTERS_PALETTE = 'newspack_newsletters_color_palette';
-	const PUBLIC_POST_ID_META          = 'newspack_nl_public_post_id';
+	const NEWSPACK_NEWSLETTERS_CPT          = 'newspack_nl_cpt';
+	const EMAIL_HTML_META                   = 'newspack_email_html';
+	const NEWSPACK_NEWSLETTERS_PALETTE_META = 'newspack_newsletters_color_palette';
+	const PUBLIC_POST_ID_META               = 'newspack_nl_public_post_id';
 
 	/**
 	 * Supported fonts.
@@ -1225,10 +1225,10 @@ final class Newspack_Newsletters {
 	 */
 	public static function update_color_palette( $palette ) {
 		return update_option(
-			self::NEWSPACK_NEWSLETTERS_PALETTE,
+			self::NEWSPACK_NEWSLETTERS_PALETTE_META,
 			wp_json_encode(
 				array_merge(
-					json_decode( (string) get_option( self::NEWSPACK_NEWSLETTERS_PALETTE, '{}' ), true ) ?? [],
+					json_decode( (string) get_option( self::NEWSPACK_NEWSLETTERS_PALETTE_META, '{}' ), true ) ?? [],
 					$palette
 				)
 			)

--- a/includes/class-newspack-newsletters.php
+++ b/includes/class-newspack-newsletters.php
@@ -1228,7 +1228,7 @@ final class Newspack_Newsletters {
 			self::NEWSPACK_NEWSLETTERS_PALETTE,
 			wp_json_encode(
 				array_merge(
-					json_decode( get_option( self::NEWSPACK_NEWSLETTERS_PALETTE, [] ), true ),
+					json_decode( (string) get_option( self::NEWSPACK_NEWSLETTERS_PALETTE, '{}' ), true ) ?? [],
 					$palette
 				)
 			)

--- a/tests/test-renderer.php
+++ b/tests/test-renderer.php
@@ -130,7 +130,7 @@ class Newsletters_Renderer_Test extends WP_UnitTestCase {
 					'innerHTML'    => $inner_html,
 				]
 			),
-			'<mj-section url="https://www.amazon.com/Learning-PHP-MySQL-JavaScript-Javascript/dp/1491978910" padding="0"><mj-column padding="12px" width="100%"><mj-text padding="0" line-height="1.5" font-size="16px" ><a href="https://www.amazon.com/Learning-PHP-MySQL-JavaScript-Javascript/dp/1491978910">Learning PHP, MYSQL &amp; JavaScript: With jQuery, CSS &amp; HTML5</a></mj-text></mj-column></mj-section>',
+			'<mj-section url="https://www.amazon.com/Learning-PHP-MySQL-JavaScript-Javascript/dp/1491978910" padding="0"><mj-column padding="12px" width="100%"><mj-text padding="0" line-height="1.5" font-size="16px" ><a href="https://www.amazon.com/Learning-PHP-MySQL-JavaScript-Javascript/dp/1491978910">Learning PHP, MySQL &amp; JavaScript: With jQuery, CSS &amp; HTML5</a></mj-text></mj-column></mj-section>',
 			'Renders invalid rich HTML as link'
 		);
 	}


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

This PR is paired with the following Plugin PR: https://github.com/Automattic/newspack-plugin/pull/3083

This makes the newsletter color palette a bit more flexible to work with by:

- Adding a new helper method for updating the newsletters palette option
- Adding a new social icons class/color palette variable to allow for more flexible social icon coloring in emails.

### How to test the changes in this Pull Request:

These changes should not change any of the existing behavior of newsletters.

- Smoke test the newsletter editor, confirming there are no errors when creating a new newsletter, and saving
- Smoke test sending a newsletter with social icons. There should be no changes to any of the default social icon selections

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
