### PR TITLE
fix: assorted hotfixes

### DIFF
--- a/includes/class-newspack-newsletters.php
+++ b/includes/class-newspack-newsletters.php
@@ -16,6 +16,7 @@ final class Newspack_Newsletters {
 
 	const NEWSPACK_NEWSLETTERS_CPT = 'newspack_nl_cpt';
 	const EMAIL_HTML_META          = 'newspack_email_html';
+	const PUBLIC_POST_ID_META      = 'newspack_nl_public_post_id';
 
 	/**
 	 * Supported fonts.
@@ -366,8 +367,7 @@ final class Newspack_Newsletters {
 	}
 
 	/**
-	 * Set default layout.
-	 * This can be removed once WP 5.5 adoption is sufficient.
+	 * Set post meta on post creation/save.
 	 *
 	 * @param string  $post_id Numeric ID of the campaign.
 	 * @param WP_Post $post The complete post object.
@@ -375,7 +375,8 @@ final class Newspack_Newsletters {
 	 */
 	public static function save( $post_id, $post, $update ) {
 		if ( ! $update ) {
-			update_post_meta( $post_id, 'template_id', -1 );
+			update_post_meta( $post_id, 'template_id', -1 ); // Set default layout. This can be removed once WP 5.5 adoption is sufficient.
+			update_post_meta( $post_id, self::PUBLIC_POST_ID_META, wp_generate_password( 20, false, false ) ); // Generate a token that can be used to identify this post publicly.
 		}
 	}
 

--- a/includes/service-providers/active_campaign/class-newspack-newsletters-active-campaign-controller.php
+++ b/includes/service-providers/active_campaign/class-newspack-newsletters-active-campaign-controller.php
@@ -115,15 +115,6 @@ class Newspack_Newsletters_Active_Campaign_Controller extends Newspack_Newslette
 		);
 		\register_rest_route(
 			$this->service_provider::BASE_NAMESPACE . $this->service_provider->service,
-			'(?P<id>[\a-z]+)/content',
-			[
-				'methods'             => \WP_REST_Server::READABLE,
-				'callback'            => [ $this, 'api_content' ],
-				'permission_callback' => '__return_true',
-			]
-		);
-		\register_rest_route(
-			$this->service_provider::BASE_NAMESPACE . $this->service_provider->service,
 			'(?P<id>[\a-z]+)/test',
 			[
 				'methods'             => \WP_REST_Server::EDITABLE,
@@ -170,21 +161,5 @@ class Newspack_Newsletters_Active_Campaign_Controller extends Newspack_Newslette
 			$emails
 		);
 		return self::get_api_response( $response );
-	}
-
-	/**
-	 * Get raw HTML for a campaign. Required for the ActiveCampaign API.
-	 *
-	 * @param WP_REST_Request $request API request object.
-	 * @return void
-	 */
-	public function api_content( $request ) {
-		$response = $this->service_provider->content(
-			$request['id']
-		);
-		header( 'Content-Type: text/html; charset=UTF-8' );
-
-		echo $response; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-		exit();
 	}
 }

--- a/includes/service-providers/campaign_monitor/class-newspack-newsletters-campaign-monitor-controller.php
+++ b/includes/service-providers/campaign_monitor/class-newspack-newsletters-campaign-monitor-controller.php
@@ -145,7 +145,7 @@ class Newspack_Newsletters_Campaign_Monitor_Controller extends Newspack_Newslett
 		);
 		\register_rest_route(
 			$this->service_provider::BASE_NAMESPACE . $this->service_provider->service,
-			'(?P<id>[\a-z]+)/content',
+			'(?P<public_id>[\a-z]+)/content',
 			[
 				'methods'             => \WP_REST_Server::READABLE,
 				'callback'            => [ $this, 'api_content' ],
@@ -206,12 +206,17 @@ class Newspack_Newsletters_Campaign_Monitor_Controller extends Newspack_Newslett
 	 * Get raw HTML for a campaign. Required for the Campaign Monitor API.
 	 *
 	 * @param WP_REST_Request $request API request object.
-	 * @return void
+	 * @return void|WP_Error
 	 */
 	public function api_content( $request ) {
 		$response = $this->service_provider->content(
-			$request['id']
+			$request['public_id']
 		);
+
+		if ( is_wp_error( $response ) ) {
+			return self::get_api_response( $response );
+		}
+
 		header( 'Content-Type: text/html; charset=UTF-8' );
 
 		echo $response; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

* When updating tracking settings, only flush rewrite rules after a verified option value update
* Fixes a bug where after turning OFF Newsletter Tracking settings, if you turn them ON again they can never again be turned OFF
* Implements a public ID token for fetching a newsletter post's HTML content via public API

### How to test the changes in this Pull Request:

#### Only flush rewrite rules after verified option update

1. Check out branch
2. Visit `<site URL>/wp-admin/edit.php?post_type=newspack_nl_cpt&page=newspack-newsletters-tracking&settings-updated=1`
3. Confirm that rewrite rules are NOT flushed
4. Change a setting here and save
5. Confirm that rewrite rules ARE flushed
6. Don't change any settings, and save again
7. Confirm that rewrite rules are NOT flushed

#### Option updating after prior update

1. Restore options to their default states: `wp option delete newspack_newsletters_use_tracking_pixel && wp option delete newspack_newsletters_use_click_trac
king`
2. Visit `<site URL>/wp-admin/edit.php?post_type=newspack_nl_cpt&page=newspack-newsletters-tracking`
3. Uncheck both boxes and save
4. Recheck both boxes and save
5. Uncheck both boxes and save—observe that they remain checked no matter what you do
6. Check out this branch and repeat steps 1-5—confirm that you can continue updating the values indefinitely and that your changes persist

#### Public ID token

1. Set ESP to Campaign Monitor
2. Send yourself a test campaign and send a live campaign to a test list, and confirm that it goes through with the correct email content

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1207141110640854