### PR TITLE
fix(mc): handle multiple groups and multiple tags per API request

### DIFF
--- a/includes/class-newspack-newsletters-subscription.php
+++ b/includes/class-newspack-newsletters-subscription.php
@@ -620,8 +620,8 @@ class Newspack_Newsletters_Subscription {
 		$result   = [];
 
 		try {
-			if ( method_exists( $provider, 'add_contact_with_groups' ) ) {
-				$result = $provider->add_contact_with_groups( $contact, $lists );
+			if ( method_exists( $provider, 'add_contact_with_groups_and_tags' ) ) {
+				$result = $provider->add_contact_with_groups_and_tags( $contact, $lists );
 			} elseif ( empty( $lists ) ) {
 				$result = $provider->add_contact( $contact );
 			} else {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes a regression introduced by the confluence of #1460 and #1471.

### How to test the changes in this Pull Request:

1. Check out this branch.
2. In a test Mailchimp account, make sure you have at two Groups and two Tags created (Audience Dashboard -> All Contacts -> Manage Contacts -> Groups/Tags)
3. On a site connected to Mailchimp, select all groups + tags in the Engagement wizard, so they are available for the Newsletter Signup Block. Publish a post with a Newsletter Signup Block and all groups + tags enabled.
4. As a reader, view a post with the Newsletter Signup Block, check all list options, and subscribe. Confirm in MC that a contact is created and added to all selected groups and tags.
5. Visit My Account > Newsletters, verify if needed, and confirm that you're signed up for all lists here. 
6. Deselect all and save, and confirm that the groups and tags are removed from the contact in MC.
7. Back in My Account, reselect a couple of lists and save. Confirm that you're readded to the groups and/or tags in MC.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
