### PR TITLE
fix: respect buttons alignment

### DIFF
--- a/includes/class-newspack-newsletters-renderer.php
+++ b/includes/class-newspack-newsletters-renderer.php
@@ -673,9 +673,13 @@ final class Newspack_Newsletters_Renderer {
 					)
 				);
 
-				$alignment     = isset( $attrs['layout'], $attrs['layout']['justifyContent'] ) ? $attrs['layout']['justifyContent'] : 'left';
 				$is_multi_row  = false;
 				$default_width = ! $no_widths ? 25 : max( 25, floor( ( 100 - $total_defined_width ) / $no_widths ) );
+				$alignment     = isset( $attrs['layout'], $attrs['layout']['justifyContent'] ) ? $attrs['layout']['justifyContent'] : 'left';
+				$wrapper_attrs = [
+					'padding'    => '0',
+					'text-align' => $alignment,
+				];
 
 				// If the total width of the buttons is greater than 100%, reduce the default width.
 				if ( ( $default_width * $no_widths ) + $total_defined_width > 100 ) {
@@ -705,11 +709,6 @@ final class Newspack_Newsletters_Renderer {
 					if ( ! $anchor ) {
 						break;
 					}
-
-					$wrapper_attrs = [
-						'padding'    => '0',
-						'text-align' => $alignment,
-					];
 
 					$default_button_attrs = array(
 						'align'         => $alignment,

--- a/includes/class-newspack-newsletters-renderer.php
+++ b/includes/class-newspack-newsletters-renderer.php
@@ -678,17 +678,13 @@ final class Newspack_Newsletters_Renderer {
 				$default_width = ! $no_widths ? 25 : max( 25, floor( ( 100 - $total_defined_width ) / $no_widths ) );
 
 				// If the total width of the buttons is greater than 100%, reduce the default width.
-				if ( ( count( $inner_blocks ) * $no_widths ) + $total_defined_width > 100 ) {
+				if ( ( $default_width * $no_widths ) + $total_defined_width > 100 ) {
 					$default_width = 25;
 					$is_multi_row  = true;
 				}
 
 				$remaining_width  = 100;
 				$block_mjml_array = [];
-				$wrapper_attrs    = [
-					'padding'    => '0',
-					'text-align' => $alignment,
-				];
 
 				foreach ( $inner_blocks as $button_block ) {
 					if ( empty( $button_block['innerHTML'] ) ) {
@@ -709,6 +705,11 @@ final class Newspack_Newsletters_Renderer {
 					if ( ! $anchor ) {
 						break;
 					}
+
+					$wrapper_attrs = [
+						'padding'    => '0',
+						'text-align' => $alignment,
+					];
 
 					$default_button_attrs = array(
 						'align'         => $alignment,

--- a/includes/class-newspack-newsletters-renderer.php
+++ b/includes/class-newspack-newsletters-renderer.php
@@ -673,6 +673,8 @@ final class Newspack_Newsletters_Renderer {
 					)
 				);
 
+				$alignment = isset( $attrs['layout'], $attrs['layout']['justifyContent'] ) ? $attrs['layout']['justifyContent'] : 'center';
+
 				// Default width is total amount of undefined width divided by number of undefined width columns, or a minimum of 10%.
 				$default_width = ! $no_widths ? 10 : max( 10, ( ( 100 - $total_defined_width ) / $no_widths ) );
 				foreach ( $inner_blocks as $button_block ) {
@@ -696,6 +698,7 @@ final class Newspack_Newsletters_Renderer {
 					}
 
 					$default_button_attrs = array(
+						'align'         => $alignment,
 						'padding'       => '0',
 						'inner-padding' => '12px 24px',
 						'line-height'   => '1.5',

--- a/includes/class-newspack-newsletters-renderer.php
+++ b/includes/class-newspack-newsletters-renderer.php
@@ -673,10 +673,11 @@ final class Newspack_Newsletters_Renderer {
 					)
 				);
 
-				$alignment = isset( $attrs['layout'], $attrs['layout']['justifyContent'] ) ? $attrs['layout']['justifyContent'] : 'center';
+				$alignment       = isset( $attrs['layout'], $attrs['layout']['justifyContent'] ) ? $attrs['layout']['justifyContent'] : 'center';
+				$remaining_width = 100 - $total_defined_width;
+				$default_width   = ! $no_widths ? 25 : max( 25, $remaining_width / ( $no_widths + 1 ) );
+				$width_padding   = $remaining_width < $default_width * ( $no_widths + 1 ) ? 0 : $default_width;
 
-				// Default width is total amount of undefined width divided by number of undefined width columns, or a minimum of 10%.
-				$default_width = ! $no_widths ? 10 : max( 10, ( ( 100 - $total_defined_width ) / $no_widths ) );
 				foreach ( $inner_blocks as $button_block ) {
 					if ( empty( $button_block['innerHTML'] ) ) {
 						break;
@@ -742,6 +743,17 @@ final class Newspack_Newsletters_Renderer {
 					}
 
 					$block_mjml_markup .= '<mj-column ' . self::array_to_attributes( $column_attrs ) . '><mj-button ' . self::array_to_attributes( $button_attrs ) . ">$text</mj-button></mj-column>";
+				}
+
+				// Add padding columns if needed.
+				if ( $width_padding > 0 ) {
+					if ( 'center' === $alignment ) {
+						$block_mjml_markup = '<mj-column width="' . $width_padding / 2 . '%" padding="0"></mj-column>' . $block_mjml_markup . '<mj-column width="' . $width_padding / 2 . '%" padding="0"></mj-column>';
+					} elseif ( 'right' === $alignment ) {
+						$block_mjml_markup = '<mj-column width="' . $width_padding . '%" padding="0"></mj-column>' . $block_mjml_markup;
+					} elseif ( 'left' === $alignment ) {
+						$block_mjml_markup = $block_mjml_markup . '<mj-column width="' . $width_padding . '%" padding="0"></mj-column>';
+					}
 				}
 
 

--- a/includes/class-newspack-newsletters-renderer.php
+++ b/includes/class-newspack-newsletters-renderer.php
@@ -673,7 +673,7 @@ final class Newspack_Newsletters_Renderer {
 					)
 				);
 
-				$alignment     = isset( $attrs['layout'], $attrs['layout']['justifyContent'] ) ? $attrs['layout']['justifyContent'] : 'center';
+				$alignment     = isset( $attrs['layout'], $attrs['layout']['justifyContent'] ) ? $attrs['layout']['justifyContent'] : 'left';
 				$is_multi_row  = false;
 				$default_width = ! $no_widths ? 25 : max( 25, floor( ( 100 - $total_defined_width ) / $no_widths ) );
 

--- a/src/editor/index.js
+++ b/src/editor/index.js
@@ -59,12 +59,7 @@ removeFilter( 'editor.BlockListBlock', 'core/editor/duotone/with-styles' );
 
 addFilter( 'blocks.registerBlockType', 'newspack-newsletters/core-blocks', ( settings, name ) => {
 	/* Remove left/right alignment options wherever possible */
-	if (
-		'core/paragraph' === name ||
-		'core/buttons' === name ||
-		'core/columns' === name ||
-		'core/separator' === name
-	) {
+	if ( 'core/paragraph' === name || 'core/columns' === name || 'core/separator' === name ) {
 		settings.supports = { ...settings.supports, align: [] };
 	}
 	if ( 'core/group' === name ) {

--- a/src/editor/style.scss
+++ b/src/editor/style.scss
@@ -141,6 +141,26 @@
 				font-size: 1em;
 				padding: 0.75em 1.5em;
 			}
+
+			// Default to left alignment styles.
+			.wp-block-button {
+				margin-left: 0 !important;
+				margin-right: auto !important;
+			}
+
+			&.is-content-justification-right {
+				.wp-block-button {
+					margin-left: auto !important;
+					margin-right: 0 !important;
+				}
+			}
+
+			&.is-content-justification-center {
+				.wp-block-button {
+					margin-left: auto !important;
+					margin-right: auto !important;
+				}
+			}
 		}
 
 		.wp-block-button {

--- a/src/editor/style.scss
+++ b/src/editor/style.scss
@@ -144,8 +144,6 @@
 		}
 
 		.wp-block-button {
-			margin-left: auto !important;
-			margin-right: auto !important;
 			padding: 0;
 		}
 

--- a/tests/test-renderer.php
+++ b/tests/test-renderer.php
@@ -154,6 +154,136 @@ class Newsletters_Renderer_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test buttons blocks rendering.
+	 */
+	public function test_render_buttons_blocks() {
+		// Left aligned button.
+		$inner_html = '<button><a>Test Button</a></button>';
+		$this->assertEquals(
+			Newspack_Newsletters_Renderer::render_mjml_component(
+				[
+					'blockName'    => 'core/buttons',
+					'attrs'        => [],
+					'innerBlocks'  => [
+						[
+							'blockName'    => 'core/button',
+							'attrs'        => [],
+							'innerBlocks'  => [],
+							'innerContent' => [ $inner_html ],
+							'innerHTML'    => $inner_html,
+						],
+					],
+					'innerContent' => [
+						'<div>',
+						null,
+						'</div>',
+					],
+					'innerHTML'    => '<div></div>',
+				]
+			),
+			'<mj-section padding="0"><mj-wrapper padding="0" text-align="left"><mj-section padding="0" text-align="left"><mj-column padding="12px" css-class="mj-column-has-width" width="100%"><mj-button align="left" padding="0" inner-padding="12px 24px" line-height="1.5" href="" border-radius="999px" font-size="16px"  font-weight="bold" color="#fff !important" background-color="#32373c">Test Button</mj-button></mj-column></mj-section></mj-wrapper></mj-section>',
+			'Renders left aligned button'
+		);
+
+		// Center aligned button.
+		$this->assertEquals(
+			Newspack_Newsletters_Renderer::render_mjml_component(
+				[
+					'blockName'    => 'core/buttons',
+					'attrs'        => [
+						'layout' => [
+							'justifyContent' => 'center',
+						],
+					],
+					'innerBlocks'  => [
+						[
+							'blockName'    => 'core/button',
+							'attrs'        => [],
+							'innerBlocks'  => [],
+							'innerContent' => [ $inner_html ],
+							'innerHTML'    => $inner_html,
+						],
+					],
+					'innerContent' => [
+						'<div>',
+						null,
+						'</div>',
+					],
+					'innerHTML'    => '<div></div>',
+				]
+			),
+			'<mj-section  padding="0"><mj-wrapper padding="0" text-align="center"><mj-section padding="0" text-align="center"><mj-column padding="12px" css-class="mj-column-has-width" width="100%"><mj-button align="center" padding="0" inner-padding="12px 24px" line-height="1.5" href="" border-radius="999px" font-size="16px"  font-weight="bold" color="#fff !important" background-color="#32373c">Test Button</mj-button></mj-column></mj-section></mj-wrapper></mj-section>',
+			'Renders center aligned button'
+		);
+
+		// Right aligned button.
+		$this->assertEquals(
+			Newspack_Newsletters_Renderer::render_mjml_component(
+				[
+					'blockName'    => 'core/buttons',
+					'attrs'        => [
+						'layout' => [
+							'justifyContent' => 'right',
+						],
+					],
+					'innerBlocks'  => [
+						[
+							'blockName'    => 'core/button',
+							'attrs'        => [],
+							'innerBlocks'  => [],
+							'innerContent' => [ $inner_html ],
+							'innerHTML'    => $inner_html,
+						],
+					],
+					'innerContent' => [
+						'<div>',
+						null,
+						'</div>',
+					],
+					'innerHTML'    => '<div></div>',
+				]
+			),
+			'<mj-section  padding="0"><mj-wrapper padding="0" text-align="right"><mj-section padding="0" text-align="right"><mj-column padding="12px" css-class="mj-column-has-width" width="100%"><mj-button align="right" padding="0" inner-padding="12px 24px" line-height="1.5" href="" border-radius="999px" font-size="16px"  font-weight="bold" color="#fff !important" background-color="#32373c">Test Button</mj-button></mj-column></mj-section></mj-wrapper></mj-section>',
+			'Renders right aligned button'
+		);
+
+
+		// Multiple buttons.
+		$this->assertEquals(
+			Newspack_Newsletters_Renderer::render_mjml_component(
+				[
+					'blockName'    => 'core/buttons',
+					'attrs'        => [],
+					'innerBlocks'  => [
+						[
+							'blockName'    => 'core/button',
+							'attrs'        => [],
+							'innerBlocks'  => [],
+							'innerContent' => [ $inner_html ],
+							'innerHTML'    => $inner_html,
+						],
+						[
+							'blockName'    => 'core/button',
+							'attrs'        => [],
+							'innerBlocks'  => [],
+							'innerContent' => [ $inner_html ],
+							'innerHTML'    => $inner_html,
+						],
+					],
+					'innerContent' => [
+						'<div>',
+						null,
+						'</div>',
+					],
+					'innerHTML'    => '<div></div>',
+				]
+			),
+			'<mj-section padding="0"><mj-wrapper padding="0" text-align="left"><mj-section padding="0" text-align="left"><mj-column padding="12px" css-class="mj-column-has-width" width="50%"><mj-button align="left" padding="0" inner-padding="12px 24px" line-height="1.5" href="" border-radius="999px" font-size="16px"  font-weight="bold" color="#fff !important" background-color="#32373c">Test Button</mj-button></mj-column><mj-column padding="12px" css-class="mj-column-has-width" width="50%"><mj-button align="left" padding="0" inner-padding="12px 24px" line-height="1.5" href="" border-radius="999px" font-size="16px"  font-weight="bold" color="#fff !important" background-color="#32373c">Test Button</mj-button></mj-column></mj-section></mj-wrapper></mj-section>',
+			'Renders multiple buttons'
+		);
+	}
+
+	/**
 	 * Test other rendering-related function.
 	 */
 	public function test_aux_functions() {


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

This PR fixes two issues:

1. Respects button alignmnet. Previously this was forced to be center even when another alignment was selected in the editor (this is needed for [RAS-ACC transactional email design updates](https://app.asana.com/0/1205234045751551/1205668937699542/f)):

Before:
![Screenshot 2024-04-26 at 14 21 38](https://github.com/Automattic/newspack-newsletters/assets/17905991/070f574d-ddb9-454d-b4d2-d81f3dafcce0)

After:
![Screenshot 2024-04-26 at 14 22 59](https://github.com/Automattic/newspack-newsletters/assets/17905991/c65188dc-b0f3-41e5-a063-cb3d014e051f)

2: Fixes an issue where the editor would allow for very thin buttons, resulting in some strange UI:

Before:
![Screenshot 2024-04-26 at 14 03 53](https://github.com/Automattic/newspack-newsletters/assets/17905991/50c9b002-8437-46c0-a404-6321598b0be2)

After:
![Screenshot 2024-04-26 at 14 25 16](https://github.com/Automattic/newspack-newsletters/assets/17905991/39a83a26-5989-4ce6-bf78-873e597d59b7)

**Note**: There are some issues with button spacing when there are multiple buttons but this issue is present on `trunk` as well. Overall, there seem to be some strict limitations with the mjml library we are using for emails, so I'm not sure how thorough these changes are for all button configurations. That said, I still want to submit this for review as I think its an improvement over our existing buttons.


### How to test the changes in this Pull Request:

1. Create a new newsletter
2. Add a buttons block with one button
3. Set the alignment to something other than center
4. On `trunk` the buttons will not respect the buttons alignment settings. On this branch it will.
5. Preview the email, or send a test
6. On `trunk` the buttons in the email will not respect the buttons alignment settings. On this branch it will.
7. Repeat the above steps with multiple buttons and width configurations

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
