### PR TITLE
feat(ras-acc): add helper method to identify premium lists

### DIFF
--- a/includes/plugins/class-woocommerce-memberships.php
+++ b/includes/plugins/class-woocommerce-memberships.php
@@ -388,6 +388,41 @@ class Woocommerce_Memberships {
 		}
 		return $value[ $membership_id ];
 	}
+
+	/**
+	 * Determines whether a given list id is associated with a membership plan.
+	 *
+	 * @param string $list_id The list ID.
+	 *
+	 * @return bool
+	 */
+	public static function is_membership_list( $list_id ) {
+		if ( ! function_exists( 'wc_memberships_get_membership_plans' ) ) {
+			return false;
+		}
+
+		$plans = wc_memberships_get_membership_plans();
+
+		if ( empty( $plans ) ) {
+			return false;
+		}
+
+		foreach ( $plans as $plan ) {
+			$rules = $plan->get_content_restriction_rules();
+
+			foreach ( $rules as $rule ) {
+				if ( Subscription_Lists::CPT !== $rule->get_content_type_name() ) {
+					continue;
+				}
+				$object_ids = $rule->get_object_ids();
+				if ( in_array( $list_id, $object_ids, true ) ) {
+					return true;
+				}
+			}
+		}
+
+		return false;
+	}
 }
 
 Woocommerce_Memberships::init();

--- a/includes/plugins/class-woocommerce-memberships.php
+++ b/includes/plugins/class-woocommerce-memberships.php
@@ -414,6 +414,7 @@ class Woocommerce_Memberships {
 				if ( Subscription_Lists::CPT !== $rule->get_content_type_name() ) {
 					continue;
 				}
+
 				$object_ids = $rule->get_object_ids();
 				if ( in_array( $list_id, $object_ids, true ) ) {
 					return true;

--- a/includes/plugins/class-woocommerce-memberships.php
+++ b/includes/plugins/class-woocommerce-memberships.php
@@ -396,7 +396,7 @@ class Woocommerce_Memberships {
 	 *
 	 * @return bool
 	 */
-	public static function is_membership_list( $list_id ) {
+	public static function is_subscription_list_tied_to_plan( $list_id ) {
 		if ( ! function_exists( 'wc_memberships_get_membership_plans' ) ) {
 			return false;
 		}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -39,4 +39,7 @@ require_once 'trait-lists-setup.php';
 // MailChimp mock.
 require_once 'class-mailchimp-mock.php';
 
+// WC Memberships mock.
+require_once 'mocks/wc-memberships.php';
+
 ini_set( 'error_log', 'php://stdout' ); // phpcs:ignore WordPress.PHP.IniSet.Risky

--- a/tests/mocks/wc-memberships.php
+++ b/tests/mocks/wc-memberships.php
@@ -1,14 +1,8 @@
 <?php // phpcs:ignoreFile
-
-function wc_memberships_get_membership_plans() {
-	return [
-		new WC_Memberships_Membership_Plan( 1 ),
-	];
-}
-
 class WC_Memberships_Membership_Plan {
 	private $id;
 	private $name;
+	private $rules;
 
 	public function __construct( $id ) {
 		$this->id   = $id;
@@ -16,18 +10,18 @@ class WC_Memberships_Membership_Plan {
 	}
 
 	public function get_content_restriction_rules() {
-		return [
-			new WC_Memberships_Membership_Plan_Rule( [
-				'id'                => $this->id,
-				'content_type_name' => 'newspack_nl_list',
-			] ),
-		];
+		return $this->rules;
+	}
+
+	public function set_content_restriction_rules( $rules ) {
+		$this->rules = $rules;
 	}
 }
 
 class WC_Memberships_Membership_Plan_Rule {
 	private $id;
 	private $content_type_name;
+	private $object_id_rules;
 
 	public function __construct( $data ) {
 		foreach ( $data as $key => $value ) {
@@ -40,6 +34,6 @@ class WC_Memberships_Membership_Plan_Rule {
 	}
 
 	public function get_object_ids() {
-		return [ 1, 2, 3 ];
+		return $this->object_id_rules;
 	}
 }

--- a/tests/mocks/wc-memberships.php
+++ b/tests/mocks/wc-memberships.php
@@ -1,0 +1,45 @@
+<?php // phpcs:ignoreFile
+
+function wc_memberships_get_membership_plans() {
+	return [
+		new WC_Memberships_Membership_Plan( 1 ),
+	];
+}
+
+class WC_Memberships_Membership_Plan {
+	private $id;
+	private $name;
+
+	public function __construct( $id ) {
+		$this->id   = $id;
+		$this->name = 'Test Membership';
+	}
+
+	public function get_content_restriction_rules() {
+		return [
+			new WC_Memberships_Membership_Plan_Rule( [
+				'id'                => $this->id,
+				'content_type_name' => 'newspack_nl_list',
+			] ),
+		];
+	}
+}
+
+class WC_Memberships_Membership_Plan_Rule {
+	private $id;
+	private $content_type_name;
+
+	public function __construct( $data ) {
+		foreach ( $data as $key => $value ) {
+			$this->$key = $value;
+		}
+	}
+
+	public function get_content_type_name() {
+		return $this->content_type_name;
+	}
+
+	public function get_object_ids() {
+		return [ 1, 2, 3 ];
+	}
+}

--- a/tests/plugins/test-woocommerce-memberships.php
+++ b/tests/plugins/test-woocommerce-memberships.php
@@ -1,18 +1,47 @@
-<?php
+<?php // phpcs:ignoreFile
 /**
  * Class Newsletters Test Woocommerce Memberships.
  *
  * @package Newspack_Newsletters
  */
 
-namespace Newspack_Newsletters\Plugins;
+use Newspack_Newsletters\Plugins\Woocommerce_Memberships;
+use Newspack\Newsletters\Subscription_Lists;
 
 /**
- * Test Woocommerce Memeberships.
+ * Test Woocommerce Memberships.
  */
 class Woocommerce_Memberships_Test extends \WP_UnitTestCase {
-	public function test_is_membership_list() { // phpcs:ignore Squiz.Commenting.FunctionComment.Missing
-		$this->assertTrue( Woocommerce_Memberships::is_membership_list( 1 ) );
-		$this->assertFalse( Woocommerce_Memberships::is_membership_list( 0 ) );
+	public static $subscription_list_id = 1;
+
+	public static function setup_membership_plans() {
+		$membership_plan_rule = new WC_Memberships_Membership_Plan_Rule(
+			[
+				'content_type_name' => Subscription_Lists::CPT,
+				'object_id_rules'   => [ self::$subscription_list_id ],
+			]
+		);
+
+		$membership_plan = new WC_Memberships_Membership_Plan( 1234 );
+		$membership_plan->set_content_restriction_rules( [ $membership_plan_rule ] );
+
+		return [ $membership_plan ];
 	}
+
+	public function test_is_subscription_list_tied_to_plan() { // phpcs:ignore Squiz.Commenting.FunctionComment.Missing
+		$subscription_list_tied_to_plan = Woocommerce_Memberships::is_subscription_list_tied_to_plan( self::$subscription_list_id );
+		$this->assertTrue( $subscription_list_tied_to_plan );
+
+		$subscription_list_not_tied_to_plan = Woocommerce_Memberships::is_subscription_list_tied_to_plan( 0 );
+		$this->assertFalse( $subscription_list_not_tied_to_plan );
+	}
+}
+
+/**
+ * Mock wc_memberships_get_membership_plans.
+ *
+ * @return array
+ */
+function wc_memberships_get_membership_plans() {
+	return Woocommerce_Memberships_Test::setup_membership_plans();
 }

--- a/tests/plugins/test-woocommerce-memberships.php
+++ b/tests/plugins/test-woocommerce-memberships.php
@@ -1,0 +1,18 @@
+<?php
+/**
+ * Class Newsletters Test Woocommerce Memberships.
+ *
+ * @package Newspack_Newsletters
+ */
+
+namespace Newspack_Newsletters\Plugins;
+
+/**
+ * Test Woocommerce Memeberships.
+ */
+class Woocommerce_Memberships_Test extends \WP_UnitTestCase {
+	public function test_is_membership_list() { // phpcs:ignore Squiz.Commenting.FunctionComment.Missing
+		$this->assertTrue( Woocommerce_Memberships::is_membership_list( 1 ) );
+		$this->assertFalse( Woocommerce_Memberships::is_membership_list( 0 ) );
+	}
+}


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes https://app.asana.com/0/1206943664367857/1205992141743582/f

Related to https://github.com/Automattic/newspack-plugin/pull/3105 and https://github.com/Automattic/newspack-blocks/pull/1727

This PR adds a helper method to identify whether a given list is associated with a membership plan.

### How to test the changes in this Pull Request:

There should be no changes in functionality. 

- Smoke tests around newsletter lists tied to membership plans.

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
