### PR TITLE
feat: save a backup of subscription attempts in a custom DB table

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 .DS_Store
 release
 .phpunit.result.cache
+codecov

--- a/includes/class-newspack-newsletters-subscription-attempts.php
+++ b/includes/class-newspack-newsletters-subscription-attempts.php
@@ -1,0 +1,160 @@
+<?php
+/**
+ * Custom table for subscription attempts.
+ * This will be a backup copy of any attempts to subscribe to newsletter lists,
+ * so recovery is possible in case things go wrong.
+ *
+ * @package Newspack
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Main class.
+ */
+class Newspack_Newsletters_Subscription_Attempts {
+	const TABLE_NAME = 'newspack_newsletters_subscription_attempts';
+	const TABLE_VERSION = '1.0';
+	const TABLE_VERSION_OPTION = '_newspack_newsletters_subscription_attempts_version';
+	const CRON_HOOK = 'np_newsletters_subscription_attempts_cleanup';
+
+	/**
+	 * Initialize hooks.
+	 *
+	 * @codeCoverageIgnore
+	 */
+	public static function init() {
+		register_activation_hook( NEWSPACK_NEWSLETTERS_PLUGIN_FILE, [ __CLASS__, 'create_custom_table' ] );
+		add_action( 'init', [ __CLASS__, 'check_update_version' ] );
+		add_action( 'init', [ __CLASS__, 'cron_init' ] );
+		add_action( self::CRON_HOOK, [ __CLASS__, 'cleanup' ] );
+
+		add_action( 'newspack_newsletters_pre_add_contact', [ __CLASS__, 'save_attempt' ], 10, 2 );
+	}
+
+	/**
+	 * Periodically delete old subscription attempts.
+	 *
+	 * @codeCoverageIgnore
+	 */
+	public static function cron_init() {
+		\register_deactivation_hook( NEWSPACK_NEWSLETTERS_PLUGIN_FILE, [ __CLASS__, 'cron_deactivate' ] );
+		if ( ! wp_next_scheduled( self::CRON_HOOK ) ) {
+			\wp_schedule_event( time(), 'weekly', self::CRON_HOOK );
+		}
+	}
+
+	/**
+	 * Deactivate the cron job.
+	 *
+	 * @codeCoverageIgnore
+	 */
+	public static function cron_deactivate() {
+		\wp_clear_scheduled_hook( self::CRON_HOOK );
+	}
+
+	/**
+	 * Get custom table name.
+	 */
+	public static function get_table_name() {
+		global $wpdb;
+		return $wpdb->prefix . self::TABLE_NAME;
+	}
+
+	/**
+	 * Checks if the custom table has been created and is up-to-date.
+	 * If not, run the create_custom_table method.
+	 * See: https://codex.wordpress.org/Creating_Tables_with_Plugins
+	 *
+	 * @codeCoverageIgnore
+	 */
+	public static function check_update_version() {
+		$current_version = \get_option( self::TABLE_VERSION_OPTION, false );
+		if ( self::TABLE_VERSION !== $current_version ) {
+			self::create_custom_table();
+			\update_option( self::TABLE_VERSION_OPTION, self::TABLE_VERSION );
+		}
+	}
+
+	/**
+	 * Create a custom DB table to store subscription attempts.
+	 *
+	 * @codeCoverageIgnore
+	 */
+	public static function create_custom_table() {
+		global $wpdb;
+		$table_name = self::get_table_name();
+
+		if ( $wpdb->get_var( $wpdb->prepare( 'SHOW TABLES LIKE %s', $table_name ) ) != $table_name ) { // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+			$charset_collate = $wpdb->get_charset_collate();
+			$sql             = "CREATE TABLE $table_name (
+				-- Email address.
+				email varchar(150) NOT NULL,
+				-- List IDs.
+				list_ids varchar(300) NOT NULL,
+				-- Timestamp when data was created.
+				created_at datetime NOT NULL,
+				KEY (email)
+			) $charset_collate;";
+
+			require_once ABSPATH . 'wp-admin/includes/upgrade.php';
+			dbDelta( $sql );
+		}
+	}
+
+	/**
+	 * Set a value in the database.
+	 *
+	 * @param string $email The reader's unique ID.
+	 * @param string $list_ids The list_ids of the data to set.
+	 *
+	 * @return mixed The value if it was set, false otherwise.
+	 */
+	public static function set( $email, $list_ids ) {
+		global $wpdb;
+		return $wpdb->insert( // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+			self::get_table_name(),
+			[
+				'email'      => $email,
+				'list_ids'   => $list_ids,
+				'created_at' => \current_time( 'mysql', true ), // GMT time.
+			],
+			[
+				'%s',
+				'%s',
+				'%s',
+			]
+		);
+	}
+
+	/**
+	 * Cleanup old subscription attempts. Limit to max 1000 at a time, just in case.
+	 */
+	public static function cleanup() {
+		global $wpdb;
+		$table_name = self::get_table_name();
+		$wpdb->query( "DELETE FROM $table_name WHERE created_at < now() - interval 6 MONTH LIMIT 1000" ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+	}
+
+	/**
+	 * Save a subscription attempt.
+	 *
+	 * @param string[]|false $lists    Array of list IDs the contact will be subscribed to, or false.
+	 * @param array          $contact  {
+	 *          Contact information.
+	 *
+	 *    @type string   $email    Contact email address.
+	 *    @type string   $name     Contact name. Optional.
+	 *    @type string[] $metadata Contact additional metadata. Optional.
+	 * }
+	 */
+	public static function save_attempt( $lists, $contact ) {
+		$list_ids = '';
+		if ( false !== $lists && is_array( $lists ) ) {
+			$list_ids = implode( ',', $lists );
+		}
+		self::set( $contact['email'], $list_ids );
+	}
+}
+
+Newspack_Newsletters_Subscription_Attempts::init();

--- a/includes/class-newspack-newsletters-subscription.php
+++ b/includes/class-newspack-newsletters-subscription.php
@@ -361,6 +361,20 @@ class Newspack_Newsletters_Subscription {
 			$lists = [ $lists ];
 		}
 
+		/**
+		 * Trigger an action before contact adding.
+		 *
+		 * @param string[]|false $lists    Array of list IDs the contact will be subscribed to, or false.
+		 * @param array          $contact  {
+		 *          Contact information.
+		 *
+		 *    @type string   $email    Contact email address.
+		 *    @type string   $name     Contact name. Optional.
+		 *    @type string[] $metadata Contact additional metadata. Optional.
+		 * }
+		 */
+		do_action( 'newspack_newsletters_pre_add_contact', $lists, $contact );
+
 		$provider = Newspack_Newsletters::get_service_provider();
 		if ( empty( $provider ) ) {
 			return new WP_Error( 'newspack_newsletters_invalid_provider', __( 'Provider is not set.' ) );

--- a/newspack-newsletters.php
+++ b/newspack-newsletters.php
@@ -63,6 +63,7 @@ require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/class-newspack-newsle
 require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/class-newspack-newsletters-bulk-actions.php';
 require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/class-newspack-newsletters-quick-edit.php';
 require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/class-newspack-newsletters-embed.php';
+require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/class-newspack-newsletters-subscription-attempts.php';
 require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/tracking/class-utils.php';
 require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/tracking/class-pixel.php';
 require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/tracking/class-click.php';

--- a/tests/test-subscription-attempts.php
+++ b/tests/test-subscription-attempts.php
@@ -22,19 +22,30 @@ class Subscription_Attempts_Test extends WP_UnitTestCase {
 	/**
 	 * Test if the attempt is added to the custom table when the WP hook is called.
 	 */
-	public function test_subscription_attempts_add() {
+	public function test_subscription_attempts_add_and_update() {
 		$lists = [ 'list1', 'list2' ];
 		$contact = [
 			'email' => 'tester@example.com',
 		];
 		do_action( 'newspack_newsletters_pre_add_contact', $lists, $contact );
 
-		global $wpdb;
-		$table_name = Newspack_Newsletters_Subscription_Attempts::get_table_name();
-		$query = "SELECT * FROM $table_name WHERE email = '" . $contact['email'] . "'";
-		$result = $wpdb->get_results( $query, ARRAY_A ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.PreparedSQL.NotPrepared
-		self::assertEquals( $contact['email'], $result[0]['email'] );
-		self::assertEquals( implode( ',', $lists ), $result[0]['list_ids'] );
+		$result = Newspack_Newsletters_Subscription_Attempts::get_by_email( $contact['email'] );
+		self::assertEquals( $contact['email'], $result->email );
+		self::assertEquals( implode( ',', $lists ), $result->list_ids );
+
+		$lists_added = [ 'list3', 'list4' ];
+		do_action( 'newspack_newsletters_update_contact_lists', 'some_esp', $contact['email'], $lists_added, [], true );
+
+		$result = Newspack_Newsletters_Subscription_Attempts::get_by_email( $contact['email'] );
+		$lists_expected = array_merge( $lists, $lists_added );
+		self::assertEquals( implode( ',', $lists_expected ), $result->list_ids );
+
+		$lists_removed = [ 'list1', 'list3' ];
+		do_action( 'newspack_newsletters_update_contact_lists', 'some_esp', $contact['email'], [], $lists_removed, true );
+
+		$result = Newspack_Newsletters_Subscription_Attempts::get_by_email( $contact['email'] );
+		$lists_expected = [ 'list2', 'list4' ];
+		self::assertEquals( implode( ',', $lists_expected ), $result->list_ids );
 	}
 
 	/**

--- a/tests/test-subscription-attempts.php
+++ b/tests/test-subscription-attempts.php
@@ -1,0 +1,68 @@
+<?php
+/**
+ * Class Newsletters Test Subscription_Attempts
+ *
+ * @package Newspack_Newsletters
+ */
+
+use Newspack\Newsletters\Subscription_Attempts;
+
+/**
+ * Tests the Subscription_Attempts class
+ */
+class Subscription_Attempts_Test extends WP_UnitTestCase {
+	/**
+	 * Test DB version.
+	 */
+	public static function test_subscription_attempts_db_version() {
+		$version = get_option( Newspack_Newsletters_Subscription_Attempts::TABLE_VERSION_OPTION );
+		self::assertEquals( Newspack_Newsletters_Subscription_Attempts::TABLE_VERSION, $version );
+	}
+
+	/**
+	 * Test if the attempt is added to the custom table when the WP hook is called.
+	 */
+	public function test_subscription_attempts_add() {
+		$lists = [ 'list1', 'list2' ];
+		$contact = [
+			'email' => 'tester@example.com',
+		];
+		do_action( 'newspack_newsletters_pre_add_contact', $lists, $contact );
+
+		global $wpdb;
+		$table_name = Newspack_Newsletters_Subscription_Attempts::get_table_name();
+		$query = "SELECT * FROM $table_name WHERE email = '" . $contact['email'] . "'";
+		$result = $wpdb->get_results( $query, ARRAY_A ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.PreparedSQL.NotPrepared
+		self::assertEquals( $contact['email'], $result[0]['email'] );
+		self::assertEquals( implode( ',', $lists ), $result[0]['list_ids'] );
+	}
+
+	/**
+	 * Test data cleanup.
+	 */
+	public function test_subscription_attempts_cleanup() {
+		global $wpdb;
+		$table_name = Newspack_Newsletters_Subscription_Attempts::get_table_name();
+		$wpdb->insert( // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+			$table_name,
+			[
+				'email'      => 'some@email.com',
+				'list_ids'   => '1,2',
+				// Set created time to one year ago.
+				'created_at' => \strtotime( '-1 year' ),
+			],
+			[
+				'%s',
+				'%s',
+				'%s',
+			]
+		);
+
+		$all_entries = $wpdb->get_results( "SELECT * FROM $table_name", ARRAY_A ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		self::assertEquals( 1, count( $all_entries ) );
+
+		Newspack_Newsletters_Subscription_Attempts::cleanup();
+		$all_entries = $wpdb->get_results( "SELECT * FROM $table_name", ARRAY_A ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		self::assertEmpty( $all_entries );
+	}
+}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Saves subscription attempts in a custom DB table. If for any reason a subscription attempt does not reach ESP, and we find out only later, this table will serve as a backup to restore the subscriptions. 

The table will be cleaned weekly of any attempts older than half a year.  

### How to test the changes in this Pull Request:

1. Use the Newsletter Subscribe block to subscribe to a newsleter
2. Observe a new DB table called `newspack_newsletters_subscription_attempts` has been created, and that it recorded the subscription attempt

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1207267351460369