### PR TITLE
Hotfix/tracking logfile fatals and mc interests

### DIFF
--- a/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp.php
+++ b/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp.php
@@ -1524,9 +1524,13 @@ final class Newspack_Newsletters_Mailchimp extends \Newspack_Newsletters_Service
 					$data[ $key ] = $contact[ $key ];
 				}
 			}
-			$data['tags'][ $contact['list_id'] ]      = $contact['tags'];
-			$data['interests'][ $contact['list_id'] ] = $contact['interests'];
-			$data['lists'][ $contact['list_id'] ]     = [
+			if ( isset( $contact['tags'] ) ) {
+				$data['tags'][ $contact['list_id'] ] = $contact['tags'];
+			}
+			if ( isset( $contact['interests'] ) ) {
+				$data['interests'][ $contact['list_id'] ] = $contact['interests'];
+			}
+			$data['lists'][ $contact['list_id'] ] = [
 				'id'         => $contact['id'], // md5 hash of email.
 				'contact_id' => $contact['contact_id'],
 				'status'     => $contact['status'],

--- a/tests/class-mailchimp-mock.php
+++ b/tests/class-mailchimp-mock.php
@@ -7,13 +7,32 @@ namespace DrewM\MailChimp;
  */
 class MailChimp {
 	private static $database = [ // phpcs:ignore Squiz.Commenting.VariableComment.Missing
-		'tags' => [
+		'tags'    => [
 			[
 				'id'   => 42,
 				'name' => 'Supertag',
 			],
 		],
+		'members' => [
+			[
+				'id'            => '123',
+				'contact_id'    => '123',
+				'email_address' => 'test1@example.com',
+				'full_name'     => 'Test User',
+				'list_id'       => 'test-list',
+				'status'        => 'subscribed',
+			],
+		],
 	];
+
+	/**
+	 * Add a member to the mock DB.
+	 *
+	 * @param array $contact Contact data.
+	 */
+	public static function mock_add_member( $contact ) {
+		self::$database['members'][] = $contact;
+	}
 
 	public static function get( $endpoint, $args = [] ) { // phpcs:ignore Squiz.Commenting.FunctionComment.Missing
 		if ( preg_match( '/lists\/.*\/merge-fields/', $endpoint ) ) {
@@ -33,7 +52,13 @@ class MailChimp {
 		}
 		switch ( $endpoint ) {
 			case 'search-members':
-				return [ 'exact_matches' => [ 'members' => [] ] ];
+				$results = array_filter(
+					self::$database['members'],
+					function( $member ) use ( $args ) {
+						return $member['email_address'] === $args['query'];
+					}
+				);
+				return [ 'exact_matches' => [ 'members' => $results ] ];
 			default:
 				return [];
 		}

--- a/tests/test-subscriptions.php
+++ b/tests/test-subscriptions.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ * Class Newsletters Test Subscriptions
+ *
+ * @package Newspack_Newsletters
+ */
+
+/**
+ * Tests various Subscriptions methods
+ */
+class Subscriptions_Test extends WP_UnitTestCase {
+	/**
+	 * Test set up.
+	 */
+	public static function set_up_before_class() {
+		// Set an ESP.
+		\Newspack_Newsletters::set_service_provider( 'mailchimp' );
+		update_option( 'newspack_mailchimp_api_key', 'test-us1' );
+	}
+
+	/**
+	 * Add a contact to a single list.
+	 */
+	public function test_get_contact_data() {
+		$result = Newspack_Newsletters_Subscription::get_contact_data( 'not-there@example.com' );
+		$this->assertTrue( is_wp_error( $result ), 'Should return WP_Error if no contact is found.' );
+
+		$result = Newspack_Newsletters_Subscription::get_contact_data( 'test1@example.com' );
+		$this->assertEquals(
+			[
+				'lists'         => [
+					'test-list' => [
+						'id'         => 123,
+						'contact_id' => 123,
+						'status'     => 'subscribed',
+					],
+				],
+				'tags'          => [],
+				'interests'     => [],
+				'full_name'     => 'Test User',
+				'email_address' => 'test1@example.com',
+				'id'            => 123,
+			],
+			$result
+		);
+	}
+}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes a PHP Fatal and a MC issue:

1. PHP Fatal is occuring when the tracking log file has exactly as many entries as the `process_logs` method will process in one batch (100 by default)
2. MC API won't always return `interests` in the contact data. This PR makes the code more defensive in the assumptions about what's returned.

### How to test the changes in this Pull Request:

1. On `release`
1. Edit the tracking log file, so there are exactly four entries there
3. Trigger the processing by calling the function directly, with four as the argument: `wp eval "Newspack_Newsletters\Tracking\Pixel::process_logs(4);"`
4. Observe that a PHP Fatal is thrown and the log file is not deleted
5. Switch to this branch, repeat, observe the log file is processed as expected and then promptly deleted

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1207342905728532