### PR TITLE
feat(error-codes): non-500 error codes where applicable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 .DS_Store
 release
 .phpunit.result.cache
+codecov

--- a/includes/class-newspack-newsletters-settings.php
+++ b/includes/class-newspack-newsletters-settings.php
@@ -430,13 +430,13 @@ class Newspack_Newsletters_Settings {
 			return;
 		}
 		if ( ! \check_admin_referer( "$action-options" ) ) {
-			\wp_die( \esc_html__( 'Invalid request.', 'newspack-newsletters' ) );
+			\wp_die( \esc_html__( 'Invalid request.', 'newspack-newsletters' ), '', 400 );
 		}
 		if ( ! isset( $_POST['lists'] ) ) {
 			return;
 		}
 		if ( ! is_array( $_POST['lists'] ) ) {
-			\wp_die( \esc_html__( 'Invalid request.', 'newspack-newsletters' ) );
+			\wp_die( \esc_html__( 'Invalid request.', 'newspack-newsletters' ), '', 400 );
 		}
 		$lists = [];
 		foreach ( $_POST['lists'] as $list_id => $list_data ) { // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized

--- a/includes/class-newspack-newsletters-subscription.php
+++ b/includes/class-newspack-newsletters-subscription.php
@@ -590,18 +590,18 @@ class Newspack_Newsletters_Subscription {
 		session_write_close(); // phpcs:ignore
 
 		if ( ! isset( $_REQUEST['nonce'] ) || ! \wp_verify_nonce( \sanitize_text_field( $_REQUEST['nonce'] ), self::ASYNC_ACTION ) ) {
-			\wp_die();
+			\wp_die( 'Invalid nonce.', '', 400 );
 		}
 
 		$intent_id = $_POST['intent_id'] ?? ''; // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 		$intent_id = \absint( $intent_id );
 
 		if ( empty( $intent_id ) ) {
-			\wp_die();
+			\wp_die( 'Invalid intent ID.', '', 400 );
 		}
 
 		self::process_subscription_intents( $intent_id );
-		\wp_die();
+		\wp_die( 'OK', '', 200 );
 	}
 
 	/**
@@ -942,7 +942,7 @@ class Newspack_Newsletters_Subscription {
 		}
 
 		if ( ! is_user_logged_in() ) {
-			wp_die( esc_html( __( 'Invalid request.', 'newspack-newsletters' ) ) );
+			wp_die( esc_html( __( 'Invalid request.', 'newspack-newsletters' ) ), '', 400 );
 		}
 
 		$user               = wp_get_current_user();
@@ -1035,15 +1035,15 @@ class Newspack_Newsletters_Subscription {
 			return;
 		}
 		if ( ! is_user_logged_in() ) {
-			wp_die( esc_html( __( 'You\'re not logged in.', 'newspack-newsletters' ) ) );
+			wp_die( esc_html( __( 'You\'re not logged in.', 'newspack-newsletters' ) ), '', 401 );
 		}
 		$transient_key = self::get_email_verification_transient_key();
 		$token         = get_transient( $transient_key );
 		if ( ! $token ) {
-			wp_die( esc_html( __( 'Invalid request.', 'newspack-newsletters' ) ) );
+			wp_die( esc_html( __( 'Invalid request.', 'newspack-newsletters' ) ), '', 400 );
 		}
 		if ( ! isset( $_GET['token'] ) || sanitize_text_field( $_GET['token'] ) !== $token ) {
-			wp_die( esc_html( __( 'Invalid request.', 'newspack-newsletters' ) ) );
+			wp_die( esc_html( __( 'Invalid request.', 'newspack-newsletters' ) ), '', 400 );
 		}
 
 		self::set_email_verified( get_current_user_id() );

--- a/includes/service-providers/class-newspack-newsletters-service-provider.php
+++ b/includes/service-providers/class-newspack-newsletters-service-provider.php
@@ -141,7 +141,7 @@ abstract class Newspack_Newsletters_Service_Provider implements Newspack_Newslet
 		// Prevent status change from the controlled status if newsletter has been sent.
 		if ( ! in_array( $new_status, self::$controlled_statuses, true ) && $old_status !== $new_status && $sent ) {
 			$error = new WP_Error( 'newspack_newsletters_error', __( 'You cannot change a sent newsletter status.', 'newspack-newsletters' ), [ 'status' => 403 ] );
-			wp_die( esc_html( $error->get_error_message() ) );
+			wp_die( esc_html( $error->get_error_message() ), '', 400 );
 		}
 
 		// Send if changing from any status to controlled statuses - 'publish' or 'private'.
@@ -153,7 +153,7 @@ abstract class Newspack_Newsletters_Service_Provider implements Newspack_Newslet
 		) {
 			$result = $this->send_newsletter( $post );
 			if ( is_wp_error( $result ) ) {
-				wp_die( esc_html( $result->get_error_message() ) );
+				wp_die( esc_html( $result->get_error_message() ), '', esc_html( $result->get_error_code() ) );
 			}
 		}
 	}
@@ -194,7 +194,7 @@ abstract class Newspack_Newsletters_Service_Provider implements Newspack_Newslet
 						'post_status' => 'draft',
 					]
 				);
-				wp_die( esc_html( $result->get_error_message() ) );
+				wp_die( esc_html( $result->get_error_message() ), '', esc_html( $result->get_error_code() ) );
 			}
 			delete_post_meta( $post->ID, 'sending_scheduled' );
 		}

--- a/includes/service-providers/constant_contact/class-newspack-newsletters-constant-contact.php
+++ b/includes/service-providers/constant_contact/class-newspack-newsletters-constant-contact.php
@@ -177,7 +177,7 @@ final class Newspack_Newsletters_Constant_Contact extends \Newspack_Newsletters_
 			}
 		</script>
 		<?php
-		wp_die();
+		wp_die( 'OK', '', 200 );
 	}
 
 	/**

--- a/includes/tracking/class-click.php
+++ b/includes/tracking/class-click.php
@@ -15,6 +15,8 @@ final class Click {
 
 	/**
 	 * Initialize hooks.
+	 *
+	 * @codeCoverageIgnore
 	 */
 	public static function init() {
 		\add_action( 'init', [ __CLASS__, 'rewrite_rule' ] );
@@ -28,6 +30,8 @@ final class Click {
 	 * Add rewrite rule for tracking url.
 	 *
 	 * Backwards compatibility for old tracking URLs.
+	 *
+	 * @codeCoverageIgnore
 	 */
 	public static function rewrite_rule() {
 		\add_rewrite_rule( 'np-newsletters-click', 'index.php?' . self::QUERY_VAR . '=1', 'top' );
@@ -41,6 +45,8 @@ final class Click {
 
 	/**
 	 * Add query vars.
+	 *
+	 * @codeCoverageIgnore
 	 *
 	 * @param array $vars Query vars.
 	 *
@@ -132,8 +138,10 @@ final class Click {
 
 	/**
 	 * Handle proxied URL click and redirect to destination.
+	 *
+	 * @param bool $with_redirect Whether to redirect after tracking the link click. This is for testing convenience.
 	 */
-	public static function handle_click() {
+	public static function handle_click( $with_redirect = true ) {
 		if ( ! \get_query_var( self::QUERY_VAR ) && ! isset( $_GET[ self::QUERY_VAR ] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 			return;
 		}
@@ -149,7 +157,7 @@ final class Click {
 		$url_without_query_args = untrailingslashit( strtok( $url, '?' ) );
 		$newsletter_content     = get_post_field( 'post_content', $newsletter_id, 'raw' );
 		if ( '' === $newsletter_content || false === stripos( $newsletter_content, $url_without_query_args ) ) {
-			\wp_die( 'Invalid URL' );
+			\wp_die( 'Invalid URL', '', 400 );
 			exit;
 		}
 
@@ -165,14 +173,16 @@ final class Click {
 		}
 
 		if ( ! $url || ! \wp_http_validate_url( $url ) ) {
-			\wp_die( 'Invalid URL' );
+			\wp_die( 'Invalid URL', '', 400 );
 			exit;
 		}
 
 		self::track_click( $newsletter_id, $email_address, $url );
 
-		\wp_redirect( $url ); // phpcs:ignore WordPress.Security.SafeRedirect.wp_redirect_wp_redirect
-		exit;
+		if ( $with_redirect ) {
+			\wp_redirect( $url ); // phpcs:ignore WordPress.Security.SafeRedirect.wp_redirect_wp_redirect
+			exit;
+		}
 	}
 }
 Click::init();

--- a/package.json
+++ b/package.json
@@ -10,6 +10,8 @@
 		"build": "newspack-scripts build",
 		"test": "echo \"Error: no test specified\" && exit 0",
 		"clean": "rm -rf dist/",
+		"test:php": "phpunit",
+		"test:php:coverage": "php -d xdebug.mode=coverage ./vendor/bin/phpunit --coverage-html codecov",
 		"lint": "npm run lint:scss && npm run lint:js",
 		"lint:js": "eslint --ext .js,.jsx src",
 		"lint:js:staged": "eslint --ext .js,.jsx",


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

`500` response code is sent by default when `wp_die` is called. This is polluting the server monitoring, because legitimate `500` errors are mixed with cases handled by the code. This PR adds error codes where applicable, so that `500` response codes are reserved only for unhandled exceptions.   

Also, adds `test:php` and `test:php:coverage` npm scripts for testing convenience. 

### How to test the changes in this Pull Request:

1. Create a newsletter, with a link in the body
2. Get the modified link (with tracking) from the HTML payload (`wp post meta get <post-id> newspack_email_html`)
3. Visit the modified link by pasting it in a browser, observe the redirection to the link target happens as expected
4. Change the modified link's `url` param to something else and verify the redirection would not happen

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->