### PR TITLE
feat: add new modern style variation to block

### DIFF
--- a/src/blocks/subscribe/block.json
+++ b/src/blocks/subscribe/block.json
@@ -97,12 +97,7 @@
 	"styles": [
 		{
 			"name": "modern",
-			"label": "Modern",
-			"isDefault": true
-		},
-		{
-			"name": "default",
-			"label": "Classic"
+			"label": "Modern"
 		}
 	]
 }

--- a/src/blocks/subscribe/block.json
+++ b/src/blocks/subscribe/block.json
@@ -93,5 +93,16 @@
 	"supports": {
 		"html": false,
 		"align": true
-	}
+	},
+	"styles": [
+		{
+			"name": "modern",
+			"label": "Modern",
+			"isDefault": true
+		},
+		{
+			"name": "default",
+			"label": "Classic"
+		}
+	]
 }

--- a/src/blocks/subscribe/editor.scss
+++ b/src/blocks/subscribe/editor.scss
@@ -1,11 +1,11 @@
 @use '~@wordpress/base-styles/colors' as wp-colors;
 
-.editor-styles-wrapper .newspack-newsletters-subscribe {
+.editor-styles-wrapper .wp-block-newspack-newsletters-subscribe {
 	form {
 		input[type='text'],
 		input[type='email'] {
 			background: #fff;
-			border: solid 1px #ccc;
+			border: solid 1px #ddd;
 			box-sizing: border-box;
 			outline: none;
 			padding: 0.36rem 0.66rem;
@@ -13,6 +13,34 @@
 			outline-offset: 0;
 			border-radius: 0;
 			font-size: 1rem;
+		}
+		input[type='checkbox'] {
+			background: #fff;
+			border: 1px solid #ddd;
+			box-shadow: none;
+			appearance: none;
+			display: inline-grid;
+			height: 20px !important;
+			margin: 2px 0 0;
+			place-content: center;
+			width: 20px !important;
+
+			&::before {
+				background: transparent url( "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' width='24' height='24'%3E%3Cpath d='M16.7 7.1l-6.3 8.5-3.3-2.5-.9 1.2 4.5 3.4L17.9 8z' fill='white' %3E%3C/path%3E%3C/svg%3E" ) 0 0 no-repeat;
+				content: "";
+				height: 24px;
+				margin: 0;
+				width: 24px;
+			}
+
+			&:checked {
+				background: #1e1e1e;
+				border-color: #1e1e1e;
+			}
+
+			&:focus {
+				box-shadow: none;
+			}
 		}
 		[type='submit'],
 		.submit-button {
@@ -28,18 +56,17 @@
 			line-height: 1.2;
 			outline: none;
 			padding: 0.76rem 1rem;
+			place-items: center;
 			text-decoration: none;
-			display: block;
+			display: grid;
 			width: 100%;
 			text-align: center;
 			@media ( min-width: 782px ) {
-				display: inline-block;
 				width: auto;
-				vertical-align: bottom;
 			}
 		}
 	}
-	&__state-bar {
+	.newspack-newsletters-subscribe__state-bar {
 		align-items: center;
 		border: 1px solid wp-colors.$gray-900;
 		border-radius: 2px;
@@ -71,6 +98,16 @@
 		div {
 			display: flex;
 			gap: 4px;
+		}
+	}
+
+	&.is-style-modern {
+		.newspack-newsletters-subscribe__response {
+			padding: 24px;
+
+			@media ( min-width: 782px ) {
+				padding: 48px;
+			}
 		}
 	}
 }

--- a/src/blocks/subscribe/editor.scss
+++ b/src/blocks/subscribe/editor.scss
@@ -68,8 +68,10 @@
 	}
 	.newspack-newsletters-subscribe__state-bar {
 		align-items: center;
+		background: white;
 		border: 1px solid wp-colors.$gray-900;
 		border-radius: 2px;
+		color: wp-colors.$gray-900 !important;
 		display: flex;
 		font-family: -apple-system, blinkmacsystemfont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell,
 			'Fira Sans', 'Droid Sans', 'Helvetica Neue', sans-serif;

--- a/src/blocks/subscribe/index.php
+++ b/src/blocks/subscribe/index.php
@@ -178,7 +178,7 @@ function render_block( $attrs ) {
 	ob_start();
 	?>
 	<div
-		class="newspack-newsletters-subscribe <?php echo esc_attr( get_block_classes( $attrs ) ); ?>"
+		class="wp-block-newspack-newsletters-subscribe newspack-newsletters-subscribe <?php echo esc_attr( get_block_classes( $attrs ) ); ?>"
 		data-success-message="<?php echo \esc_attr( $attrs['successMessage'] ); ?>"
 		<?php echo $subscribed ? 'data-status="200"' : ''; ?>
 	>

--- a/src/blocks/subscribe/style-variations.scss
+++ b/src/blocks/subscribe/style-variations.scss
@@ -168,13 +168,7 @@
 			&__response {
 				background: var( --newspack-ui-color-success-0, #EDFAEF );
 				border-radius: var( --newspack-ui-border-radius-m, 6px );
-				display: grid;
 				gap: var( --newspack-ui-spacer-5, 24px );
-				justify-items: center;
-			}
-
-			&__icon {
-				margin: 0;
 			}
 
 			&__message {
@@ -183,7 +177,6 @@
 					font-size: inherit;
 					font-weight: 600;
 					line-height: inherit;
-					margin: 0;
 					text-align: center;
 				}
 			}

--- a/src/blocks/subscribe/style-variations.scss
+++ b/src/blocks/subscribe/style-variations.scss
@@ -10,6 +10,7 @@
 		}
 
 		.newspack-newsletters-lists {
+			background: none;
 			border: none;
 			border-radius: 0;
 			font-size: inherit;

--- a/src/blocks/subscribe/style-variations.scss
+++ b/src/blocks/subscribe/style-variations.scss
@@ -1,0 +1,211 @@
+.wp-block-newspack-newsletters-subscribe {
+	&.is-style-modern {
+		font-family: var( --newspack-ui-font-family, system-ui, sans-serif );
+		font-size: var( --newspack-ui-font-size-s, 16px );
+		font-weight: 400;
+		line-height: var( --newspack-ui-line-height-s, 1.5 );
+
+		form {
+			gap: var( --newspack-ui-spacer-2, 12px );
+		}
+
+		.newspack-newsletters-lists {
+			border: none;
+			border-radius: 0;
+			font-size: inherit;
+			line-height: inherit;
+			padding: 0;
+
+			label {
+				cursor: pointer;
+				font-size: var( --newspack-ui-font-size-s, 16px );
+				font-weight: 400;
+				line-height: var( --newspack-ui-line-height-s, 1.5 );
+				margin: 0;
+			}
+
+			ul {
+				display: grid;
+				gap: var( --newspack-ui-spacer-2, 12px );
+
+				&:not( :has( .list-description ) ) {
+					background: var( --newspack-ui-color-neutral-0, #FFF );
+					border: 1px solid var( --newspack-ui-color-border, #DDD );
+					border-radius: var( --newspack-ui-border-radius-m, 6px );
+					gap: var( --newspack-ui-spacer-3, 16px );
+					padding: var( --newspack-ui-spacer-3, 16px );
+
+					.list-title {
+						font-weight: 400;
+					}
+				}
+				
+				li {
+					margin: 0;
+					min-width: 100%;
+
+					&:has( .list-description ) {
+						background: var( --newspack-ui-color-neutral-0, #FFF );
+						border: 1px solid var( --newspack-ui-color-border, #DDD );
+						border-radius: var( --newspack-ui-border-radius-m, 6px );
+						padding: var( --newspack-ui-spacer-3, 16px );
+						transition: background 125ms ease-in-out, border 125ms ease-in-out;
+
+						&:has( input[type='checkbox']:checked ) {
+							background: var( --newspack-ui-color-neutral-5, #F7F7F7 );
+							border-color: var( --newspack-ui-color-neutral-90, #1E1E1E );
+						}
+					}
+				}
+			}
+
+			.list-checkbox {
+				height: var( --newspack-ui-spacer-5, 24px );
+				margin-right: var( --newspack-ui-spacer-3, 16px );
+
+				input[type='checkbox'] {
+					&:focus {
+						outline: none;
+					}
+
+					&:focus-visible {
+						outline: 2px solid var( --newspack-ui-color-neutral-90, #1E1E1E );
+						outline-offset: 1px;
+					}
+
+					&:checked {
+						background: var( --newspack-ui-color-neutral-90, #1E1E1E );
+						color: var( --newspack-ui-color-neutral-0, #FFF );
+					}
+				}
+			}
+
+			.list-title {
+				color: var( --newspack-ui-color-neutral-90, #1E1E1E );
+				font-size: inherit;
+				font-weight: 600;
+				line-height: inherit;
+			}
+
+			.list-description {
+				color: var( --newspack-ui-color-neutral-60, #6C6C6C );
+				font-size: var( --newspack-ui-font-size-xs, 14px );
+				line-height: var( --newspack-ui-line-height-xs, 1.4286 );
+			}
+		}
+		
+		.newspack-newsletters-email-input,
+		.newspack-newsletters-name-input {
+			gap: var( --newspack-ui-spacer-2, 12px );
+
+			label {
+				font-size: inherit;
+				font-weight: 600;
+				line-height: inherit;
+				margin: 0;
+
+				&:empty {
+					display: none;
+				}
+			}
+
+			.newspack-newsletters-name-input-item {
+				gap: var( --newspack-ui-spacer-base, 8px );
+			}
+		}
+
+		.newspack-newsletters-email-input {
+			row-gap: var( --newspack-ui-spacer-base, 8px );
+		}
+
+		input[type='email'],
+		input[type='text'] {
+			background: var( --newspack-ui-color-neutral-0, #FFF );
+			border: 1px solid var( --newspack-ui-color-border, #DDD );
+			border-radius: var( --newspack-ui-border-radius-m, 6px );
+			color: var( --newspack-ui-color-neutral-90, #1E1E1E );
+			font-family: inherit;
+			font-size: inherit;
+			font-weight: inherit;
+			line-height: inherit;
+			padding: calc( var( --newspack-ui-spacer-2, 12px ) - 1px );
+			transition: border 125ms ease-in-out, outline 125ms ease-in-out;
+
+			&::placeholder {
+				color: var( --newspack-ui-color-neutral-60, #6C6C6C );
+			}
+
+			&:focus {
+				border-color: var( --newspack-ui-color-input-border-focus, #1E1E1E );
+				outline: 1px solid var( --newspack-ui-color-input-border-focus, #1E1E1E );
+				outline-offset: 0;
+			}
+		}
+
+		input[type='submit'],
+		.submit-button {
+			border: 0;
+			border-radius: var( --newspack-ui-border-radius-m, 6px );
+			cursor: pointer;
+			font-family: inherit;
+			font-size: inherit;
+			font-weight: 600;
+			line-height: inherit;
+			margin-top: calc( var( --newspack-ui-spacer-2, 12px ) - var( --newspack-ui-spacer-base, 8px ) );
+			padding: var( --newspack-ui-spacer-2, 12px ) var( --newspack-ui-spacer-5, 24px );
+
+			@media ( min-width: 782px ) {
+				margin-top: 0;
+			}
+
+			&:focus {
+				outline: 2px solid var( --newspack-ui-color-neutral-90, #1E1E1E );
+				outline-offset: 1px;
+			}
+		}
+
+		.newspack-newsletters-subscribe {
+			&__response {
+				background: var( --newspack-ui-color-success-0, #EDFAEF );
+				border-radius: var( --newspack-ui-border-radius-m, 6px );
+				display: grid;
+				gap: var( --newspack-ui-spacer-5, 24px );
+				justify-items: center;
+			}
+
+			&__icon {
+				margin: 0;
+			}
+
+			&__message {
+				p {
+					color: var( --newspack-ui-color-neutral-90, #1E1E1E );
+					font-size: inherit;
+					font-weight: 600;
+					line-height: inherit;
+					margin: 0;
+					text-align: center;
+				}
+			}
+		}
+
+		&[data-status='200'] {
+			.newspack-newsletters-subscribe {
+				&__response {
+					padding: var( --newspack-ui-spacer-5, 24px );
+	
+					@media ( min-width: 782px ) {
+						padding: var( --newspack-ui-spacer-9, 48px );
+					}
+				}
+	
+				&__message {
+					p {
+						font-size: inherit;
+						margin: 0;
+					}
+				}
+			}
+		}
+	}
+}

--- a/src/blocks/subscribe/style.scss
+++ b/src/blocks/subscribe/style.scss
@@ -69,6 +69,7 @@
 		opacity: 0.5;
 	}
 	.newspack-newsletters-lists {
+		background: white;
 		border: 1px solid wp-colors.$gray-200;
 		border-radius: 2px;
 		box-sizing: border-box;
@@ -114,11 +115,15 @@
 	}
 
 	&__response {
+		display: grid;
+		gap: 1.2rem;
+		justify-items: center;
+
 		.newspack-newsletters-subscribe[data-status='200'] & {
 			p {
 				text-align: center;
 				font-size: 0.8em;
-				margin: 0.5rem 0 0;
+				margin: 0;
 			}
 		}
 	}
@@ -130,7 +135,7 @@
 		display: flex;
 		height: 40px;
 		justify-content: center;
-		margin: 0 auto 0.8rem;
+		margin: 0;
 		width: 40px;
 
 		.newspack-newsletters-subscribe:not( [data-status='200'] ) & {
@@ -149,7 +154,7 @@
 	&__message {
 		p {
 			font-size: 0.8em;
-			margin-top: 8px;
+			margin: 0;
 
 			&.status-400,
 			&.status-500 {

--- a/src/blocks/subscribe/style.scss
+++ b/src/blocks/subscribe/style.scss
@@ -1,5 +1,6 @@
 @use '~@wordpress/base-styles/colors' as wp-colors;
-@import url('./style-variations.scss'); /* stylelint-disable-line */
+// stylelint-disable-next-line no-invalid-position-at-import-rule,import-notation
+@import 'style-variations';
 
 .newspack-newsletters-subscribe {
 	form {

--- a/src/blocks/subscribe/style.scss
+++ b/src/blocks/subscribe/style.scss
@@ -1,5 +1,5 @@
-@import url('./style-variations.scss');
 @use '~@wordpress/base-styles/colors' as wp-colors;
+@import url('./style-variations.scss'); /* stylelint-disable-line */
 
 .newspack-newsletters-subscribe {
 	form {

--- a/src/blocks/subscribe/style.scss
+++ b/src/blocks/subscribe/style.scss
@@ -1,3 +1,4 @@
+@import url('./style-variations.scss');
 @use '~@wordpress/base-styles/colors' as wp-colors;
 
 .newspack-newsletters-subscribe {
@@ -123,8 +124,7 @@
 
 	&__icon {
 		align-items: center;
-		animation: fadein 125ms ease-in;
-		background: wp-colors.$alert-green;
+		background: var( --newspack-ui-color-success-50 , #008A20 );
 		border-radius: 50%;
 		display: flex;
 		height: 40px;
@@ -137,14 +137,10 @@
 		}
 
 		&::before {
-			animation: bounce 125ms ease-in;
-			animation-delay: 500ms;
-			animation-fill-mode: forwards;
 			background-image: url( "data:image/svg+xml,%3Csvg viewBox='0 0 24 24' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M16.7 7.1l-6.3 8.5-3.3-2.5-.9 1.2 4.5 3.4L17.9 8z' fill='white'/%3E%3C/svg%3E" );
 			content: '';
 			display: block;
 			height: 24px;
-			transform: scale( 0 );
 			width: 24px;
 		}
 	}
@@ -156,7 +152,7 @@
 
 			&.status-400,
 			&.status-500 {
-				color: wp-colors.$alert-red;
+				color: var( --newspack-ui-color-error-50 , #D63638 );
 			}
 		}
 	}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR introduces a new style variation (SV) to the Newsletter Subscription Form block.

This SV is based on our Newspack Components and is designed to match the rest of our reader-facing UI.

![subscription-block-eg](https://github.com/Automattic/newspack-newsletters/assets/177929/46801b05-c276-4e0a-b5bd-ec8ca57db494)

### How to test the changes in this Pull Request:

1. Switch to this branch
2. Add the block to a page and change the SV to "Modern"
3. Play with the settings (and preview front-end)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
