### PR TITLE
fix(test-email): remove multi-recipient help text if ESP is AC

### DIFF
--- a/src/newsletter-editor/testing/index.js
+++ b/src/newsletter-editor/testing/index.js
@@ -15,6 +15,9 @@ import { hasValidEmail } from '../utils';
 import withApiHandler from '../../components/with-api-handler';
 import './style.scss';
 
+const serviceProvider =
+	window && window.newspack_newsletters_data && window.newspack_newsletters_data.service_provider;
+
 export default compose( [
 	withApiHandler(),
 	withSelect( select => {
@@ -42,10 +45,6 @@ export default compose( [
 		const [ localInFlight, setLocalInFlight ] = useState( false );
 		const [ localMessage, setLocalMessage ] = useState( '' );
 		const sendTestEmail = async () => {
-			const serviceProvider =
-				window &&
-				window.newspack_newsletters_data &&
-				window.newspack_newsletters_data.service_provider;
 			if ( inlineNotifications ) {
 				setLocalInFlight( true );
 			} else {
@@ -78,6 +77,8 @@ export default compose( [
 				apiFetchWithErrorHandling( params );
 			}
 		};
+
+		const supportsMultipleTestEmailRecipients = serviceProvider !== 'active_campaign';
 		return (
 			<Fragment>
 				<TextControl
@@ -86,7 +87,11 @@ export default compose( [
 					type="email"
 					onChange={ onChangeEmail }
 					disabled={ localInFlight || inFlight }
-					help={ __( 'Use commas to separate multiple emails.', 'newspack-newsletters' ) }
+					help={
+						supportsMultipleTestEmailRecipients
+							? __( 'Use commas to separate multiple emails.', 'newspack-newsletters' )
+							: ''
+					}
 				/>
 				<div className="newspack-newsletters__testing-controls">
 					<Button


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

ActiveCampaign [does not support](https://www.activecampaign.com/api/example.php?call=campaign_send) sending a campaign to a literal list of emails. This PR disambiguates it for the email editor.

### How to test the changes in this Pull Request:

1. Set ESP to ActiveCampaign
2. Create or edit a newsletter, observe there's no "Use commas to separate multiple emails." help text in the "Send a test to" input in the "Testing" panel
3. Switch ESP to Mailchimp, observe the help text is there

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1207302515738515