### PR TITLE
fix(email-rendering): add side margin to list blocks

### DIFF
--- a/includes/email-template-mjml.css
+++ b/includes/email-template-mjml.css
@@ -71,7 +71,7 @@ blockquote,
 .wp-block-quote {
 	background: transparent;
 	border-left: 0.25em solid;
-	margin: 0;
+	margin: 0 0 0 12px;
 	padding-left: 24px;
 }
 blockquote cite,

--- a/includes/email-template-mjml.css
+++ b/includes/email-template-mjml.css
@@ -61,7 +61,7 @@ h6 {
 
 /* List */
 ul, ol {
-	margin: 12px 0;
+	margin: 12px 15px;
 	padding: 0;
 	list-style-position: inside;
 }

--- a/src/editor/style.scss
+++ b/src/editor/style.scss
@@ -210,8 +210,13 @@
 		.wp-block-quote {
 			margin: 0 auto;
 
+			&::before {
+				left: 0 !important;
+			}
+
 			p {
-				margin: 0 0 12px;
+				margin: 0;
+				padding: 8px 0;
 			}
 
 			&__citation {
@@ -226,7 +231,7 @@
 				border: 0;
 				margin: 12px auto;
 				padding: 0;
-				padding-left: calc( 36px + 0.25em );
+				padding-left: calc( 24px + 0.25em );
 				position: relative;
 
 				&::before {
@@ -283,17 +288,18 @@
 		}
 
 		.wp-block {
-			&[data-type='core/list'] {
-				padding: 12px;
-				padding-left: calc( 12px + 1.3em );
+			padding: 6px 12px;
 
-				ol,
-				ul {
-					margin-left: 0;
-					margin-right: 0;
+			// More specific styles for the list block.
+			&[data-type='core/list'] {
+				padding: 6px 15px;
+				li:first-child {
+					padding: 12px 7px 0;
+				}
+				li {
+					padding: 0 7px;
 				}
 			}
-
 			&[data-type='core/social-link'] {
 				align-items: center;
 				display: flex;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Adds a bit of side margin to list blocks, to prevent misaligned content:

<img width="1051" alt="image" src="https://github.com/Automattic/newspack-newsletters/assets/7383192/bc52fe9f-08da-40ca-b63e-8e9982689e20">

### How to test the changes in this Pull Request:

1. Insert a list block in a newsletter, with paragraphs above and below for reference
2. Preview email or send a test email
3. Observe the list is aligned with the paragraps

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1206910890455747