### PR TITLE
fix(newsletter-editor): tag/segment selection

### DIFF
--- a/src/service-providers/mailchimp/ProviderSidebar.js
+++ b/src/service-providers/mailchimp/ProviderSidebar.js
@@ -71,7 +71,9 @@ const getSubAudienceValue = newsletterData => {
 	if ( ! targetField || ! targetId ) {
 		return false;
 	}
-	return `${ targetField || '' }:${ targetId }`;
+	return 'Interests' === recipients?.segment_opts?.conditions[ 0 ]?.condition_type
+		? `${ targetField || '' }:${ targetId }`
+		: targetId;
 };
 
 const ProviderSidebar = ( {

--- a/src/service-providers/mailchimp/utils.js
+++ b/src/service-providers/mailchimp/utils.js
@@ -35,7 +35,6 @@ export const getGroupOptions = interestCategories => {
 						interest.local_name ? ' [' + interest.local_name + ']' : ''
 					} (${ subscriberCountInfo })`,
 					value: `interests-${ id }:${ interest.id }`,
-					disabled: subscriberCount === 0,
 				} );
 			} );
 			accumulator.push( optGroup );
@@ -67,6 +66,5 @@ export const getSegmentOptions = segments => {
 			segment?.member_count || 0
 		) })`,
 		value: segment.id.toString(),
-		disabled: 0 === parseInt( segment?.member_count || 0 ),
 	} ) );
 };


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes a regression introduced in #1461. Also removes a requirement for a Group/Tag/Segment to contain any subscribers before being selectable in the editor, because the subscriber count data is cached and isn't guaranteed to be accurate.

### How to test the changes in this Pull Request:

1. Set up your site to connect to Mailchimp, and make sure there's at least one Group, Tag, and Segment created in the connected audience.
2. On `alpha`, create a new newsletter and select a Tag or Segment in the "Group, Segment, or Tag" field. Observe that after a moment, the field value reverts to "All subscribers in audience" instead of retaining your selection.

<img width="268" alt="Screenshot 2024-05-28 at 12 18 21 PM" src="https://github.com/Automattic/newspack-newsletters/assets/2230142/89c4ca3b-a0ac-43e4-8f45-91802d97da01">

3. Check out this branch and confirm that your selection is persisted when selecting a Group, Segment, and Tag. Also confirm in the connected Mailchimp account that the synced campaign shows the correct recipients in the Campaigns dashboard based on your selection.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
