### PR TITLE
Hot(feature): enable disabling the newsletter send failure email notification

### DIFF
--- a/includes/service-providers/class-newspack-newsletters-service-provider.php
+++ b/includes/service-providers/class-newspack-newsletters-service-provider.php
@@ -85,7 +85,10 @@ abstract class Newspack_Newsletters_Service_Provider implements Newspack_Newslet
 	 * Manage singleton instances of all descendant service provider classes.
 	 */
 	public static function instance() {
-		if ( empty( self::$instances[ static::class ] ) ) {
+		// Escape hatch from the OOP logic for tests. When running in PHPUnit, some tests only pass if
+		// the class is always instantiated and not returned from self::$instances.
+		$is_test = defined( 'IS_TEST_ENV' ) && IS_TEST_ENV;
+		if ( $is_test || empty( self::$instances[ static::class ] ) ) {
 			self::$instances[ static::class ] = new static();
 		}
 		return self::$instances[ static::class ];
@@ -373,29 +376,32 @@ abstract class Newspack_Newsletters_Service_Provider implements Newspack_Newslet
 			$errors   = array_slice( $errors, -10, 10, true );
 			update_post_meta( $post_id, 'newsletter_send_errors', $errors );
 
-			$message = sprintf(
-				/* translators: %1$s is the campaign title, %2$s is the edit link, %3$s is the error message. */
-				__(
-					'Hi,
+			$email_sending_disabled = defined( 'NEWSPACK_NEWSLETTERS_DISABLE_SEND_FAILURE_EMAIL' ) && NEWSPACK_NEWSLETTERS_DISABLE_SEND_FAILURE_EMAIL;
+			if ( ! $email_sending_disabled ) {
+				$message = sprintf(
+					/* translators: %1$s is the campaign title, %2$s is the edit link, %3$s is the error message. */
+					__(
+						'Hi,
 
 A newsletter campaign called "%1$s" failed to send on your site.
 
 You can edit the campaign here: %2$s.
 
 Details of the error message: "%3$s"
-',
-					'newspack-newsletters'
-				),
-				$post->post_title,
-				get_edit_post_link( $post_id ),
-				$error_message
-			);
+	',
+						'newspack-newsletters'
+					),
+					$post->post_title,
+					get_edit_post_link( $post_id ),
+					$error_message
+				);
 
-			\wp_mail( // phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.wp_mail_wp_mail
-				get_option( 'admin_email' ),
-				__( 'Sending a newsletter failed', 'newspack-newsletters' ),
-				$message
-			);
+				\wp_mail( // phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.wp_mail_wp_mail
+					get_option( 'admin_email' ),
+					__( 'Sending a newsletter failed', 'newspack-newsletters' ),
+					$message
+				);
+			}
 		}
 
 		return $result;

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -43,3 +43,16 @@ require_once 'class-mailchimp-mock.php';
 require_once 'mocks/wc-memberships.php';
 
 ini_set( 'error_log', 'php://stdout' ); // phpcs:ignore WordPress.PHP.IniSet.Risky
+
+
+/**
+ * Exception to be thrown when wp_die is called.
+ *
+ * @param string $message The error message.
+ * @throws WPDieException The exception.
+ */
+function handle_wpdie_in_tests( $message ) {
+	throw new WPDieException( $message ); // phpcs:ignore
+}
+
+define( 'IS_TEST_ENV', 1 );

--- a/tests/test-newsletter-ads.php
+++ b/tests/test-newsletter-ads.php
@@ -6,7 +6,7 @@
  */
 
 /**
- * Newsletters Tracking Test.
+ * Newsletters Ads Test.
  */
 class Newsletters_Newsletter_Ads_Test extends WP_UnitTestCase {
 	/**

--- a/tests/test-service-provider.php
+++ b/tests/test-service-provider.php
@@ -1,0 +1,50 @@
+<?php
+/**
+ * Test Newsletter Service Provider class.
+ *
+ * @package Newspack_Newsletters
+ */
+
+/**
+ * Newsletters Service Provider class Test.
+ */
+class Newsletters_Newsletter_Service_Provider_Test extends WP_UnitTestCase {
+	/**
+	 * Test set up.
+	 */
+	public function set_up() {
+		// Set an ESP.
+		\Newspack_Newsletters::set_service_provider( 'mailchimp' );
+		// Ensure the API key is not set (might be set by a different test).
+		delete_option( 'newspack_mailchimp_api_key' );
+
+		add_filter(
+			'wp_die_handler',
+			function() {
+				return 'handle_wpdie_in_tests';}
+		);
+	}
+
+	/**
+	 * Test sending a newsletter.
+	 */
+	public function test_service_provider_send_newsletter_unconfigured() {
+		// Create a draft and then publish, to trigger a sending.
+		$post_id = self::factory()->post->create(
+			[
+				'post_type'   => \Newspack_Newsletters::NEWSPACK_NEWSLETTERS_CPT,
+				'post_status' => 'draft',
+			]
+		);
+
+		$this->expectException( WPDieException::class );
+		$this->expectExceptionMessage( 'No Mailchimp API key available.' );
+
+		wp_update_post(
+			[
+				'ID'          => $post_id,
+				'post_status' => 'publish',
+			]
+		);
+	}
+}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

There are cases where the newsletter failure email notification (https://github.com/Automattic/newspack-newsletters/pull/1434) is sent despite the newsletter being sent successfully. While that's investigated, this PR will adds means of disabling this notification per-site. 

I had to add a special is-test-env case in `Newspack_Newsletters_Service_Provider::instance` method, but this is a code smell (special case for test env) and should be rewritten later. 

### How to test the changes in this Pull Request:

1. Test https://github.com/Automattic/newspack-newsletters/pull/1434 with `NEWSPACK_NEWSLETTERS_DISABLE_SEND_FAILURE_EMAIL` environment variable set to `true` and observe the email is not sent

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->