### PR TITLE
feat: add spinner to subscribe block submit button

### DIFF
--- a/src/blocks/subscribe/index.php
+++ b/src/blocks/subscribe/index.php
@@ -274,7 +274,9 @@ function render_block( $attrs ) {
 						<input type="hidden" name="double_optin" value="1" />
 					<?php endif; ?>
 
-					<input class="<?php echo \esc_attr( get_block_button_classes( $attrs ) ); ?>"type="submit" value="<?php echo \esc_attr( $attrs['label'] ); ?>" style="<?php echo \esc_attr( get_block_button_styles( $attrs ) ); ?>" />
+					<button class="<?php echo \esc_attr( get_block_button_classes( $attrs ) ); ?>"type="submit" style="<?php echo \esc_attr( get_block_button_styles( $attrs ) ); ?>">
+						<?php echo \esc_html( $attrs['label'] ); ?>
+					</button>
 				</div>
 			</form>
 		<?php endif; ?>

--- a/src/blocks/subscribe/index.php
+++ b/src/blocks/subscribe/index.php
@@ -275,7 +275,7 @@ function render_block( $attrs ) {
 					<?php endif; ?>
 
 					<button class="<?php echo \esc_attr( get_block_button_classes( $attrs ) ); ?>"type="submit" style="<?php echo \esc_attr( get_block_button_styles( $attrs ) ); ?>">
-						<?php echo \esc_html( $attrs['label'] ); ?>
+						<span class="submit"><?php echo \esc_html( $attrs['label'] ); ?></span>
 					</button>
 				</div>
 			</form>

--- a/src/blocks/subscribe/style.scss
+++ b/src/blocks/subscribe/style.scss
@@ -14,6 +14,34 @@
 		@media ( min-width: 782px ) {
 			gap: 0.4rem;
 		}
+
+		&.in-progress {
+			button[type='submit'] {
+				color: #d33;
+				position: relative;
+
+				span {
+					--animation-duration: 900ms;
+					--animation-timing-function: linear;
+					--color-spinner-primary: white;
+					--color-spinner-background: #d33;
+					--size: 18px;
+					--stroke-width: 1.5px;
+
+					animation: var(--animation-timing-function) var(--animation-duration) infinite spin;
+					border-color: var(--color-spinner-primary) var(--color-spinner-primary) var(--color-spinner-background) var(--color-spinner-background);
+					border-radius: 50%;
+					border-style: solid;
+					border-width: var(--stroke-width);
+					height: var(--size);
+					transform: rotate(0deg);
+					width: var(--size);
+					position: absolute;
+					left: calc( 50% - ( var(--size) / 2 ) );
+				}
+			}
+
+		}
 	}
 	.newspack-newsletters-name-input,
 	.newspack-newsletters-email-input {
@@ -56,7 +84,7 @@
 			width: 0;
 		}
 	}
-	input[type='submit'] {
+	button[type='submit'] {
 		background-color: #d33;
 		color: white;
 		flex: 1 1 100%;
@@ -175,4 +203,13 @@
 		width: 1px;
 		word-wrap: normal !important;
 	}
+}
+
+@keyframes spin {
+  from {
+    transform: rotate( 0deg );
+  }
+  to {
+    transform: rotate( 360deg );
+  }
 }

--- a/src/blocks/subscribe/style.scss
+++ b/src/blocks/subscribe/style.scss
@@ -17,14 +17,17 @@
 
 		&.in-progress {
 			button[type='submit'] {
-				color: #d33;
 				position: relative;
 
-				span {
+				span.submit {
+					visibility: hidden;
+				}
+
+				span.spinner {
 					--animation-duration: 900ms;
 					--animation-timing-function: linear;
-					--color-spinner-primary: white;
-					--color-spinner-background: #d33;
+					--color-spinner-primary: transparent;
+					--color-spinner-background: currentcolor;
 					--size: 18px;
 					--stroke-width: 1.5px;
 

--- a/src/blocks/subscribe/view.js
+++ b/src/blocks/subscribe/view.js
@@ -70,12 +70,16 @@ domReady( function () {
 		);
 		const messageContainer = container.querySelector( '.newspack-newsletters-subscribe__message' );
 		const emailInput = container.querySelector( 'input[type="email"]' );
-		const submit = container.querySelector( 'input[type="submit"]' );
+		const submit = container.querySelector( 'button[type="submit"]' );
+		const spinner = document.createElement( 'span' );
+
 		form.endFlow = ( message, status = 500, wasSubscribed = false ) => {
 			container.setAttribute( 'data-status', status );
 			const messageNode = document.createElement( 'p' );
 			emailInput.removeAttribute( 'disabled' );
+			submit.remove( spinner );
 			submit.removeAttribute( 'disabled' );
+			form.classList.remove( 'in-progress' );
 			messageNode.innerHTML = wasSubscribed
 				? container.getAttribute( 'data-success-message' )
 				: message;
@@ -88,7 +92,9 @@ domReady( function () {
 		form.addEventListener( 'submit', ev => {
 			ev.preventDefault();
 			messageContainer.innerHTML = '';
+			form.classList.add( 'in-progress' );
 			submit.disabled = true;
+			submit.appendChild( spinner );
 
 			if ( ! form.npe?.value ) {
 				return form.endFlow( newspack_newsletters_subscribe_block.invalid_email, 400 );

--- a/src/blocks/subscribe/view.js
+++ b/src/blocks/subscribe/view.js
@@ -72,6 +72,7 @@ domReady( function () {
 		const emailInput = container.querySelector( 'input[type="email"]' );
 		const submit = container.querySelector( 'button[type="submit"]' );
 		const spinner = document.createElement( 'span' );
+		spinner.classList.add( 'spinner' );
 
 		form.endFlow = ( message, status = 500, wasSubscribed = false ) => {
 			container.setAttribute( 'data-status', status );


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes https://app.asana.com/0/1207385073694408/1206756862605997/f

The subscribe block can take a few seconds to complete and the current loading state is not entirely clear for all publishers. This PR adds a loading spinner to the subscribe form submit button when clicked to make it more clear the form is loading:

https://github.com/Automattic/newspack-newsletters/assets/17905991/c18eda2d-89c5-4355-9c83-b8951dd48e9e

### How to test the changes in this Pull Request:

1. Verify reader activation is all set up on your test site
2. Add a newsletter subscription block to any page
3. Go to the relevant page as a reader
4. Input an email address and submit. Confirm a loading spinner appears within the submit button as shown above.

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
