### PR TITLE
fix(mailchimp-usage-reports): fix total contacts counting

### DIFF
--- a/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp-usage-reports.php
+++ b/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp-usage-reports.php
@@ -51,14 +51,14 @@ class Newspack_Newsletters_Mailchimp_Usage_Reports {
 		for ( $day_index = 1; $day_index <= $days_in_past_count; $day_index++ ) {
 			$report = new Newspack_Newsletters_Service_Provider_Usage_Report();
 			$report->set_date( gmdate( 'Y-m-d', strtotime( "-$day_index day" ) ) );
-			$report->total_contacts += $list['stats']['member_count'];
 
-			foreach ( $lists['lists'] as $list ) {
-				$list_activity_for_day = $list['activity'][ $day_index ];
-				$report->emails_sent  += $list_activity_for_day['emails_sent'];
-				$report->opens        += $list_activity_for_day['unique_opens'];
-				$report->clicks       += $list_activity_for_day['recipient_clicks'];
-				$report->subscribes   += $list_activity_for_day['subs'];
+			foreach ( $lists['lists'] as $list_data ) {
+				$report->total_contacts += $list_data['stats']['member_count'];
+				$list_activity_for_day = $list_data['activity'][ $day_index ];
+				$report->emails_sent += $list_activity_for_day['emails_sent'];
+				$report->opens += $list_activity_for_day['unique_opens'];
+				$report->clicks += $list_activity_for_day['recipient_clicks'];
+				$report->subscribes += $list_activity_for_day['subs'];
 				$report->unsubscribes += $list_activity_for_day['unsubs'];
 			}
 			$reports[] = $report;

--- a/tests/mocks/class-mailchimp-mock.php
+++ b/tests/mocks/class-mailchimp-mock.php
@@ -19,6 +19,11 @@ class MailChimp {
 					'name'  => 'Test List',
 					'stats' => [ 'member_count' => 42 ],
 				],
+				[
+					'id'    => 'test-list-2',
+					'name'  => 'Test List 2',
+					'stats' => [ 'member_count' => 21 ],
+				],
 			],
 			'reports' => [
 				[

--- a/tests/test-mailchimp-usage-report.php
+++ b/tests/test-mailchimp-usage-report.php
@@ -24,9 +24,9 @@ class MailchimpUsageReportsTest extends WP_UnitTestCase {
 				'emails_sent'    => 12,
 				'opens'          => 13,
 				'clicks'         => 14,
-				'subscribes'     => 1,
-				'unsubscribes'   => 1,
-				'total_contacts' => 42,
+				'subscribes'     => 2,
+				'unsubscribes'   => 2,
+				'total_contacts' => 63,
 			]
 		);
 
@@ -54,9 +54,9 @@ class MailchimpUsageReportsTest extends WP_UnitTestCase {
 				'emails_sent'    => 12,
 				'opens'          => 13 + 23 - 10,
 				'clicks'         => 14 + 24 - 10,
-				'subscribes'     => 1,
-				'unsubscribes'   => 1,
-				'total_contacts' => 42,
+				'subscribes'     => 2,
+				'unsubscribes'   => 2,
+				'total_contacts' => 63,
 			]
 		);
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

#1521 fixed the sent/opens/clicks counts, but introduced a regressions in total contacts, subscribes, unsubscribes counting: only the total contacts from one of the lists would be counted. Because the tests were written with just one list in the mock API response, this was not caught. This PR fixes that. 

### How to test the changes in this Pull Request:

1. Ensure Mailchimp is configured as the ESP 
2. Run `wp eval "echo print_r( Newspack_Newsletters_Mailchimp_Usage_Reports::get_usage_report()->to_array(), true );"` and observe a usage report is printed

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->