### PR TITLE
fix: specifically set the subscription list colour

### DIFF
--- a/src/blocks/subscribe/style.scss
+++ b/src/blocks/subscribe/style.scss
@@ -73,6 +73,7 @@
 		border: 1px solid wp-colors.$gray-200;
 		border-radius: 2px;
 		box-sizing: border-box;
+		color: var( --newspack-ui-color-neutral-90, #1e1e1e );
 		flex: 1 1 100%;
 		font-size: 0.8rem;
 		padding: 0.5em;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR fixes a really specific edge case: if you have the Newsletter Subscription Form inside of another block with a colour set (like a Group or Cover block), the newsletter lists will pick up that block's text colours. A white background colour was added to the lists [here](https://github.com/Automattic/newspack-newsletters/pull/1513/files#diff-bb09ed8cb7e0f6604c1d72c36e6bfb866010cc2e5d8dc319c3c1c8238af7e6f3R72), so if that containing block's text is set to white, it's no longer visible. 

### How to test the changes in this Pull Request:

1. Set up a page with a Group Block with a background colour and a white text colour. Add the Newsletter Subscription Form block inside of that Group block, and enable more than one list so you get a list.
2. View on the front-end and in the editor; note the list names are white on white:

![image](https://github.com/Automattic/newspack-newsletters/assets/177561/82711126-c88e-4c7d-adb6-b4cb1712aab1)

3. Apply this PR and run `npm run build`.
4. Review the lists again and confirm they are visible:

![image](https://github.com/Automattic/newspack-newsletters/assets/177561/03c498e8-b1e4-4714-a9de-5a3818e864b1)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
