### PR TITLE
feat: ensure regenerator-runtime is available (for WP 6.6)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,8 @@
 				"csslint": "^1.0.5",
 				"mjml-browser": "^4.15.3",
 				"newspack-components": "^2.2.1",
-				"qs": "^6.12.1"
+				"qs": "^6.12.1",
+				"regenerator-runtime": "^0.14.1"
 			},
 			"devDependencies": {
 				"@rushstack/eslint-patch": "^1.10.3",
@@ -1970,6 +1971,17 @@
 			"engines": {
 				"node": ">=6.9.0"
 			}
+		},
+		"node_modules/@babel/runtime-corejs3/node_modules/regenerator-runtime": {
+			"version": "0.13.11",
+			"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
+			"integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==",
+			"dev": true
+		},
+		"node_modules/@babel/runtime/node_modules/regenerator-runtime": {
+			"version": "0.13.11",
+			"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
+			"integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg=="
 		},
 		"node_modules/@babel/template": {
 			"version": "7.22.15",
@@ -32321,9 +32333,9 @@
 			}
 		},
 		"node_modules/regenerator-runtime": {
-			"version": "0.13.5",
-			"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.5.tgz",
-			"integrity": "sha512-ZS5w8CpKFinUzOwW3c83oPeVXoNsrLsaCoLtJvAClH135j/R77RuymhiSErhm2lKcwSCIpmvIWSbDkIfAqKQlA=="
+			"version": "0.14.1",
+			"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
+			"integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw=="
 		},
 		"node_modules/regenerator-transform": {
 			"version": "0.14.5",
@@ -38505,6 +38517,13 @@
 			"integrity": "sha512-lkqXDcvlFT5rvEjiu6+QYO+1GXrEHRo2LOtS7E4GtX5ESIZOgepqsZBVIj6Pv+a6zqsya9VCgiK1KAK4BvJDAw==",
 			"requires": {
 				"regenerator-runtime": "^0.13.4"
+			},
+			"dependencies": {
+				"regenerator-runtime": {
+					"version": "0.13.11",
+					"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
+					"integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg=="
+				}
 			}
 		},
 		"@babel/runtime-corejs3": {
@@ -38515,6 +38534,14 @@
 			"requires": {
 				"core-js-pure": "^3.20.2",
 				"regenerator-runtime": "^0.13.4"
+			},
+			"dependencies": {
+				"regenerator-runtime": {
+					"version": "0.13.11",
+					"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
+					"integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==",
+					"dev": true
+				}
 			}
 		},
 		"@babel/template": {
@@ -61650,9 +61677,9 @@
 			}
 		},
 		"regenerator-runtime": {
-			"version": "0.13.5",
-			"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.5.tgz",
-			"integrity": "sha512-ZS5w8CpKFinUzOwW3c83oPeVXoNsrLsaCoLtJvAClH135j/R77RuymhiSErhm2lKcwSCIpmvIWSbDkIfAqKQlA=="
+			"version": "0.14.1",
+			"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
+			"integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw=="
 		},
 		"regenerator-transform": {
 			"version": "0.14.5",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,8 @@
 		"csslint": "^1.0.5",
 		"mjml-browser": "^4.15.3",
 		"newspack-components": "^2.2.1",
-		"qs": "^6.12.1"
+		"qs": "^6.12.1",
+		"regenerator-runtime": "^0.14.1"
 	},
 	"devDependencies": {
 		"@rushstack/eslint-patch": "^1.10.3",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -13,34 +13,29 @@ const path = require( 'path' );
 /**
  * Internal variables
  */
-const editor = path.join( __dirname, 'src', 'editor' );
-const admin = path.join( __dirname, 'src', 'admin' );
-const adsEditor = path.join( __dirname, 'src', 'ads', 'editor' );
-const newsletterAdsEditor = path.join( __dirname, 'src', 'ads', 'newsletter-editor' );
-const branding = path.join( __dirname, 'src', 'branding' );
-const quickEdit = path.join( __dirname, 'src', 'quick-edit' );
-const editorBlocks = path.join( __dirname, 'src', 'editor', 'blocks' );
-const newsletterEditor = path.join( __dirname, 'src', 'newsletter-editor' );
-const blocks = path.join( __dirname, 'src', 'blocks' );
-const subscribeBlock = path.join( __dirname, 'src', 'blocks', 'subscribe', 'view.js' );
-const subscriptions = path.join( __dirname, 'src', 'subscriptions' );
+
+const entry = {
+	editor: path.join( __dirname, 'src', 'editor' ),
+	admin: path.join( __dirname, 'src', 'admin' ),
+	adsEditor: path.join( __dirname, 'src', 'ads', 'editor' ),
+	newsletterAdsEditor: path.join( __dirname, 'src', 'ads', 'newsletter-editor' ),
+	branding: path.join( __dirname, 'src', 'branding' ),
+	quickEdit: path.join( __dirname, 'src', 'quick-edit' ),
+	editorBlocks: path.join( __dirname, 'src', 'editor', 'blocks' ),
+	newsletterEditor: path.join( __dirname, 'src', 'newsletter-editor' ),
+	blocks: path.join( __dirname, 'src', 'blocks' ),
+	subscribeBlock: path.join( __dirname, 'src', 'blocks', 'subscribe', 'view.js' ),
+	subscriptions: path.join( __dirname, 'src', 'subscriptions' ),
+};
+
+Object.keys( entry ).forEach( key => {
+	entry[ key ] = [ 'regenerator-runtime/runtime', entry[ key ] ];
+} );
 
 const webpackConfig = getBaseWebpackConfig(
 	{ WP: true },
 	{
-		entry: {
-			editor,
-			admin,
-			adsEditor,
-			newsletterAdsEditor,
-			branding,
-			quickEdit,
-			editorBlocks,
-			newsletterEditor,
-			blocks,
-			subscribeBlock,
-			subscriptions,
-		},
+		entry,
 		'output-path': path.join( __dirname, 'dist' ),
 	}
 );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

WP 6.6 changes some things and `regenerator-runtime` is not available anymore. This PR adds it to every entry file processed by webpack. 

### How to test the changes in this Pull Request:

1. On `trunk`, open a newsletter editor with WordPress 6.6* installed 
1. Observe the editor crashes after choosing a layout 
2. Switch to this branch, rebuild, observe the editor loading as expected
3. Switch WP to 6.5, again observe the editor loading as expected

\* `6.6-beta2` to be exact

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->