### PR TITLE
fix: ensure form_processed hook is always and correctly fired

### DIFF
--- a/src/blocks/subscribe/index.php
+++ b/src/blocks/subscribe/index.php
@@ -508,6 +508,15 @@ function process_form() {
 		true // Async.
 	);
 
+	/**
+	 * Fires after subscribing a user to a list.
+	 *
+	 * @param string              $email  Email address of the reader.
+	 * @param bool|array|WP_Error $result Contact data if it was added, True if it async subscription strategy was used or error otherwise.
+	 * @param array               $metadata Some metadata about the subscription. Always contains `current_page_url`, `newspack_popup_id` and `newsletters_subscription_method` keys.
+	 */
+	\do_action( 'newspack_newsletters_subscribe_form_processed', $email, $result, $metadata );
+
 	// The async subscription strategy returns true.
 	if ( true === $result ) {
 		$result = [];
@@ -516,15 +525,6 @@ function process_form() {
 	if ( \is_wp_error( $result ) ) {
 		return send_form_response( $result );
 	}
-
-	/**
-	 * Fires after subscribing a user to a list.
-	 *
-	 * @param string         $email  Email address of the reader.
-	 * @param array|WP_Error $result Contact data if it was added, or error otherwise.
-	 * @param array          $metadata Some metadata about the subscription. Always contains `current_page_url`, `newspack_popup_id` and `newsletters_subscription_method` keys.
-	 */
-	\do_action( 'newspack_newsletters_subscribe_form_processed', $email, $result, $metadata );
 
 	// Generate a new nonce for subsequent form submissions.
 	$result[ FORM_ACTION ] = \wp_create_nonce( FORM_ACTION );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

After https://github.com/Automattic/newspack-newsletters/pull/1344, all form submissions were triggering a `form_submission_failure` for the `prompt_interaction` event (handled in https://github.com/Automattic/newspack-plugin/blob/f600358261f438d6b00b1b52ed38fe47ee701078/includes/data-events/class-popups.php#L181)

This PR makes sure form submissions handled via the async strategy are considered successful

### How to test the changes in this Pull Request:

Setup:

1. Configure your site with a valid ESP
2. Create a prompt with a Newsletter Subscription block
3. Make sure you go to Newspack > Analytics > Newspack Custom events and add your GA4 credentials (alternatively, you can add a debug on [this line](https://github.com/Automattic/newspack-plugin/blob/f600358261f438d6b00b1b52ed38fe47ee701078/includes/data-events/class-popups.php#L200) to inspect what is the event data. We want to check the value of `action`)

Testing on `trunk`

1. Visit the site as an anonymous reader
2. See the prompt with the newsletters subscription block
4. subscribe
5. inspect the error log and search for the `Dispatching action "prompt_interaction"` message
6. below that, if GA4 is configured, you will see `Event sent to...` message and then `Event payload` where you can check the value of `action`
7. Confirm that the value is `form_submission_failure` even though it was successful
8. Switch to this branch and repeat steps 1 to 6
9. Confirm that now the action is `form_submission_success` 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
