### PR TITLE
fix: don't refresh HTML on autosave, and refresh when other meta is saved

### DIFF
--- a/includes/class-newspack-newsletters-renderer.php
+++ b/includes/class-newspack-newsletters-renderer.php
@@ -1252,7 +1252,8 @@ final class Newspack_Newsletters_Renderer {
 			self::$font_body = 'Georgia';
 		}
 
-		$title = $post->post_title; // phpcs:ignore WordPressVIPMinimum.Variables.VariableAnalysis.UnusedVariable
+		$updated = time();
+		$title   = $post->post_title; // phpcs:ignore WordPressVIPMinimum.Variables.VariableAnalysis.UnusedVariable
 
 		/**
 		 * Generate a string of MJML as the body of the email. We include ads at this stage.

--- a/includes/email-template.mjml.php
+++ b/includes/email-template.mjml.php
@@ -25,7 +25,7 @@
 			<mj-preview><?php echo $preview_text; ?></mj-preview>
 		<?php endif; ?>
 	</mj-head>
-	<mj-body background-color="<?php echo $background_color; ?>">
+	<mj-body background-color="<?php echo $background_color; ?>" css-class="updated-<?php echo $updated; ?>">
 		<?php echo $body; ?>
 		<?php do_action( 'newspack_newsletters_editor_mjml_body', $post ); ?>
 	</mj-body>

--- a/src/newsletter-editor/editor/index.js
+++ b/src/newsletter-editor/editor/index.js
@@ -111,14 +111,13 @@ const Editor = compose( [
 		createNotice,
 		didPostSaveRequestSucceed,
 		html,
-		isAutosavingPost,
 		isCustomFieldsMetaBoxActive,
 		isPublic,
 		isReady,
 		isSaving,
 		isPublished,
 		isPublishing,
-		isAutoSaving,
+		isAutosaving,
 		lockPostAutosaving,
 		lockPostSaving,
 		newsletterSendErrors,
@@ -134,6 +133,7 @@ const Editor = compose( [
 		successNote,
 		updateMetaValue,
 	} ) => {
+		const [ isRefreshingHTML, setIsRefreshingHTML ] = useState( false );
 		const [ publishEl ] = useState( document.createElement( 'div' ) );
 
 		// Create alternate publish button
@@ -249,17 +249,19 @@ const Editor = compose( [
 
 		// After the post is successfully saved, refresh the email HTML.
 		const wasSaving = usePrevProp( isSaving );
-		const wasAutoSaving = usePrevProp( isAutosavingPost );
+		const wasAutoSaving = usePrevProp( isAutosaving );
 		useEffect( () => {
 			if (
 				wasSaving &&
 				! isPublished &&
 				! wasAutoSaving &&
 				! isSaving &&
-				! isAutoSaving &&
+				! isAutosaving &&
 				! isPublishing &&
+				! isRefreshingHTML &&
 				didPostSaveRequestSucceed()
 			) {
+				setIsRefreshingHTML( true );
 				lockPostAutosaving();
 				lockPostSaving( 'newspack-newsletters-refresh-html' );
 				refreshEmailHtml( postId, postTitle, postContent )
@@ -274,9 +276,10 @@ const Editor = compose( [
 					.finally( () => {
 						unlockPostSaving( 'newspack-newsletters-refresh-html' );
 						unlockPostAutosaving();
+						setIsRefreshingHTML( false );
 					} );
 			}
-		}, [ isSaving, isAutoSaving ] );
+		}, [ isSaving, isAutosaving ] );
 
 		return createPortal( <SendButton />, publishEl );
 	}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes some issues that slipped into #1526. Some variable naming conflicts were causing autosaves to still trigger HTML refreshes, and the use of the `updated_post_meta` hook meant that campaigns weren't synced to the ESP if nothing in the actual post body changed. Both issues should be fixed now.

### How to test the changes in this Pull Request:

#### REALLY don't refresh HTML on autosave

1. On `alpha`, create a new newsletter and add some content. Save as a draft and leave the editor open without touching (Tab A).
2. Open the same newsletter in a new tab (Tab B). Make some further edits and save again.
3. Wait a few minutes and check the synced campaign in the connected ESP. Observe that the content matches Tab A, despite Tab B being saved more recently.
4. Check out this branch and repeat all steps. This time confirm that after the wait period in step 3, the synced campaign in the ESP still matches Tab B (the more recently saved tab).

##### Refresh HTML and resync when non-post-content is saved

This PR adds a timestamp to the rendered HTML so that a resync is triggered after any save, even if the post content hasn't changed.

1. On `alpha`, create a new newsletter and add some content. Save as a draft and confirm that it's synced to the connected ESP.
2. Edit the "Campaign Name" field only and save again. Observe that the synced campaign is not updated.
3. Check out this branch, repeat, and confirm that the synced campaign is updated.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
