### PR TITLE
feat(subscribe-block): update error style; display state-bar only when selected

### DIFF
--- a/src/blocks/subscribe/editor.scss
+++ b/src/blocks/subscribe/editor.scss
@@ -26,8 +26,10 @@
 			width: 20px !important;
 
 			&::before {
-				background: transparent url( "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' width='24' height='24'%3E%3Cpath d='M16.7 7.1l-6.3 8.5-3.3-2.5-.9 1.2 4.5 3.4L17.9 8z' fill='white' %3E%3C/path%3E%3C/svg%3E" ) 0 0 no-repeat;
-				content: "";
+				background: transparent
+					url( "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' width='24' height='24'%3E%3Cpath d='M16.7 7.1l-6.3 8.5-3.3-2.5-.9 1.2 4.5 3.4L17.9 8z' fill='white' %3E%3C/path%3E%3C/svg%3E" )
+					0 0 no-repeat;
+				content: '';
 				height: 24px;
 				margin: 0;
 				width: 24px;

--- a/src/blocks/subscribe/editor.scss
+++ b/src/blocks/subscribe/editor.scss
@@ -72,9 +72,8 @@
 		border: 1px solid wp-colors.$gray-900;
 		border-radius: 2px;
 		color: wp-colors.$gray-900 !important;
-		display: flex;
-		font-family: -apple-system, blinkmacsystemfont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell,
-			'Fira Sans', 'Droid Sans', 'Helvetica Neue', sans-serif;
+		display: none;
+		font-family: system-ui, sans-serif;
 		flex-wrap: wrap;
 		font-size: 13px;
 		gap: 8px;
@@ -110,6 +109,12 @@
 			@media ( min-width: 782px ) {
 				padding: 48px;
 			}
+		}
+	}
+
+	&.is-selected {
+		.newspack-newsletters-subscribe__state-bar {
+			display: flex;
 		}
 	}
 }

--- a/src/blocks/subscribe/style-variations.scss
+++ b/src/blocks/subscribe/style-variations.scss
@@ -30,8 +30,8 @@
 				gap: var( --newspack-ui-spacer-2, 12px );
 
 				&:not( :has( .list-description ) ) {
-					background: var( --newspack-ui-color-neutral-0, #FFF );
-					border: 1px solid var( --newspack-ui-color-border, #DDD );
+					background: var( --newspack-ui-color-neutral-0, #fff );
+					border: 1px solid var( --newspack-ui-color-border, #ddd );
 					border-radius: var( --newspack-ui-border-radius-m, 6px );
 					gap: var( --newspack-ui-spacer-3, 16px );
 					padding: var( --newspack-ui-spacer-3, 16px );
@@ -46,15 +46,15 @@
 					min-width: 100%;
 
 					&:has( .list-description ) {
-						background: var( --newspack-ui-color-neutral-0, #FFF );
-						border: 1px solid var( --newspack-ui-color-border, #DDD );
+						background: var( --newspack-ui-color-neutral-0, #fff );
+						border: 1px solid var( --newspack-ui-color-border, #ddd );
 						border-radius: var( --newspack-ui-border-radius-m, 6px );
 						padding: var( --newspack-ui-spacer-3, 16px );
 						transition: background 125ms ease-in-out, border 125ms ease-in-out;
 
 						&:has( input[type='checkbox']:checked ) {
-							background: var( --newspack-ui-color-neutral-5, #F7F7F7 );
-							border-color: var( --newspack-ui-color-neutral-90, #1E1E1E );
+							background: var( --newspack-ui-color-neutral-5, #f7f7f7 );
+							border-color: var( --newspack-ui-color-neutral-90, #1e1e1e );
 						}
 					}
 				}
@@ -70,26 +70,26 @@
 					}
 
 					&:focus-visible {
-						outline: 2px solid var( --newspack-ui-color-neutral-90, #1E1E1E );
+						outline: 2px solid var( --newspack-ui-color-neutral-90, #1e1e1e );
 						outline-offset: 1px;
 					}
 
 					&:checked {
-						background: var( --newspack-ui-color-neutral-90, #1E1E1E );
-						color: var( --newspack-ui-color-neutral-0, #FFF );
+						background: var( --newspack-ui-color-neutral-90, #1e1e1e );
+						color: var( --newspack-ui-color-neutral-0, #fff );
 					}
 				}
 			}
 
 			.list-title {
-				color: var( --newspack-ui-color-neutral-90, #1E1E1E );
+				color: var( --newspack-ui-color-neutral-90, #1e1e1e );
 				font-size: inherit;
 				font-weight: 600;
 				line-height: inherit;
 			}
 
 			.list-description {
-				color: var( --newspack-ui-color-neutral-60, #6C6C6C );
+				color: var( --newspack-ui-color-neutral-60, #6c6c6c );
 				font-size: var( --newspack-ui-font-size-xs, 14px );
 				line-height: var( --newspack-ui-line-height-xs, 1.4286 );
 			}
@@ -121,10 +121,10 @@
 
 		input[type='email'],
 		input[type='text'] {
-			background: var( --newspack-ui-color-neutral-0, #FFF );
-			border: 1px solid var( --newspack-ui-color-border, #DDD );
+			background: var( --newspack-ui-color-neutral-0, #fff );
+			border: 1px solid var( --newspack-ui-color-border, #ddd );
 			border-radius: var( --newspack-ui-border-radius-m, 6px );
-			color: var( --newspack-ui-color-neutral-90, #1E1E1E );
+			color: var( --newspack-ui-color-neutral-90, #1e1e1e );
 			font-family: inherit;
 			font-size: inherit;
 			font-weight: inherit;
@@ -133,12 +133,12 @@
 			transition: border 125ms ease-in-out, outline 125ms ease-in-out;
 
 			&::placeholder {
-				color: var( --newspack-ui-color-neutral-60, #6C6C6C );
+				color: var( --newspack-ui-color-neutral-60, #6c6c6c );
 			}
 
 			&:focus {
-				border-color: var( --newspack-ui-color-input-border-focus, #1E1E1E );
-				outline: 1px solid var( --newspack-ui-color-input-border-focus, #1E1E1E );
+				border-color: var( --newspack-ui-color-input-border-focus, #1e1e1e );
+				outline: 1px solid var( --newspack-ui-color-input-border-focus, #1e1e1e );
 				outline-offset: 0;
 			}
 		}
@@ -152,7 +152,9 @@
 			font-size: inherit;
 			font-weight: 600;
 			line-height: inherit;
-			margin-top: calc( var( --newspack-ui-spacer-2, 12px ) - var( --newspack-ui-spacer-base, 8px ) );
+			margin-top: calc(
+				var( --newspack-ui-spacer-2, 12px ) - var( --newspack-ui-spacer-base, 8px )
+			);
 			padding: var( --newspack-ui-spacer-2, 12px ) var( --newspack-ui-spacer-5, 24px );
 
 			@media ( min-width: 782px ) {
@@ -160,21 +162,21 @@
 			}
 
 			&:focus {
-				outline: 2px solid var( --newspack-ui-color-neutral-90, #1E1E1E );
+				outline: 2px solid var( --newspack-ui-color-neutral-90, #1e1e1e );
 				outline-offset: 1px;
 			}
 		}
 
 		.newspack-newsletters-subscribe {
 			&__response {
-				background: var( --newspack-ui-color-success-0, #EDFAEF );
+				background: var( --newspack-ui-color-success-0, #edfaef );
 				border-radius: var( --newspack-ui-border-radius-m, 6px );
 				gap: var( --newspack-ui-spacer-5, 24px );
 			}
 
 			&__message {
 				p {
-					color: var( --newspack-ui-color-neutral-90, #1E1E1E );
+					color: var( --newspack-ui-color-neutral-90, #1e1e1e );
 					font-size: inherit;
 					font-weight: 600;
 					line-height: inherit;
@@ -202,7 +204,7 @@
 			}
 		}
 
-		form:has( input[value*="invalid_email"] ),
+		form:has( input[value*='invalid_email'] ),
 		&[data-status='400'] {
 			+ .newspack-newsletters-subscribe__response,
 			.newspack-newsletters-subscribe__response {
@@ -212,7 +214,7 @@
 				margin-top: var( --newspack-ui-spacer-base, 8px );
 
 				p {
-					color: var( --newspack-ui-color-error-50, #D63638 );
+					color: var( --newspack-ui-color-error-50, #d63638 );
 					font-size: var( --newspack-ui-font-size-xs, 14px );
 					font-weight: 400;
 					line-height: var( --newspack-ui-line-height-xs, 1.4286 );
@@ -222,15 +224,15 @@
 
 			.newspack-newsletters-email-input {
 				label {
-					color: var( --newspack-ui-color-error-50, #D63638 );
+					color: var( --newspack-ui-color-error-50, #d63638 );
 				}
 
 				input[type='email'] {
-					border-color: var( --newspack-ui-color-error-50, #D63638 );
+					border-color: var( --newspack-ui-color-error-50, #d63638 );
 
 					&:focus {
-						border-color: var( --newspack-ui-color-error-50, #D63638 );
-						outline-color: var( --newspack-ui-color-error-50, #D63638 );
+						border-color: var( --newspack-ui-color-error-50, #d63638 );
+						outline-color: var( --newspack-ui-color-error-50, #d63638 );
 					}
 				}
 			}

--- a/src/blocks/subscribe/style-variations.scss
+++ b/src/blocks/subscribe/style-variations.scss
@@ -40,7 +40,7 @@
 						font-weight: 400;
 					}
 				}
-				
+
 				li {
 					margin: 0;
 					min-width: 100%;
@@ -94,7 +94,7 @@
 				line-height: var( --newspack-ui-line-height-xs, 1.4286 );
 			}
 		}
-		
+
 		.newspack-newsletters-email-input,
 		.newspack-newsletters-name-input {
 			gap: var( --newspack-ui-spacer-2, 12px );
@@ -187,16 +187,50 @@
 			.newspack-newsletters-subscribe {
 				&__response {
 					padding: var( --newspack-ui-spacer-5, 24px );
-	
+
 					@media ( min-width: 782px ) {
 						padding: var( --newspack-ui-spacer-9, 48px );
 					}
 				}
-	
+
 				&__message {
 					p {
 						font-size: inherit;
 						margin: 0;
+					}
+				}
+			}
+		}
+
+		form:has( input[value*="invalid_email"] ),
+		&[data-status='400'] {
+			+ .newspack-newsletters-subscribe__response,
+			.newspack-newsletters-subscribe__response {
+				background: none;
+				border-radius: 0;
+				display: block;
+				margin-top: var( --newspack-ui-spacer-base, 8px );
+
+				p {
+					color: var( --newspack-ui-color-error-50, #D63638 );
+					font-size: var( --newspack-ui-font-size-xs, 14px );
+					font-weight: 400;
+					line-height: var( --newspack-ui-line-height-xs, 1.4286 );
+					text-align: initial;
+				}
+			}
+
+			.newspack-newsletters-email-input {
+				label {
+					color: var( --newspack-ui-color-error-50, #D63638 );
+				}
+
+				input[type='email'] {
+					border-color: var( --newspack-ui-color-error-50, #D63638 );
+
+					&:focus {
+						border-color: var( --newspack-ui-color-error-50, #D63638 );
+						outline-color: var( --newspack-ui-color-error-50, #D63638 );
 					}
 				}
 			}

--- a/src/blocks/subscribe/style.scss
+++ b/src/blocks/subscribe/style.scss
@@ -37,10 +37,11 @@
 					border-style: solid;
 					border-width: var(--stroke-width);
 					height: var(--size);
+					left: calc( 50% - ( var(--size) / 2 ) );
+					position: absolute;
+					top: calc( 50% - ( var(--size) / 2 ) );
 					transform: rotate(0deg);
 					width: var(--size);
-					position: absolute;
-					left: calc( 50% - ( var(--size) / 2 ) );
 				}
 			}
 

--- a/src/blocks/subscribe/style.scss
+++ b/src/blocks/subscribe/style.scss
@@ -31,20 +31,20 @@
 					--size: 18px;
 					--stroke-width: 1.5px;
 
-					animation: var(--animation-timing-function) var(--animation-duration) infinite spin;
-					border-color: var(--color-spinner-primary) var(--color-spinner-primary) var(--color-spinner-background) var(--color-spinner-background);
+					animation: var( --animation-timing-function ) var( --animation-duration ) infinite spin;
+					border-color: var( --color-spinner-primary ) var( --color-spinner-primary )
+						var( --color-spinner-background ) var( --color-spinner-background );
 					border-radius: 50%;
 					border-style: solid;
-					border-width: var(--stroke-width);
-					height: var(--size);
-					left: calc( 50% - ( var(--size) / 2 ) );
+					border-width: var( --stroke-width );
+					height: var( --size );
+					left: calc( 50% - ( var( --size ) / 2 ) );
 					position: absolute;
-					top: calc( 50% - ( var(--size) / 2 ) );
-					transform: rotate(0deg);
-					width: var(--size);
+					top: calc( 50% - ( var( --size ) / 2 ) );
+					transform: rotate( 0deg );
+					width: var( --size );
 				}
 			}
-
 		}
 	}
 	.newspack-newsletters-name-input,
@@ -162,7 +162,7 @@
 
 	&__icon {
 		align-items: center;
-		background: var( --newspack-ui-color-success-50 , #008A20 );
+		background: var( --newspack-ui-color-success-50, #008a20 );
 		border-radius: 50%;
 		display: flex;
 		height: 40px;
@@ -190,7 +190,7 @@
 
 			&.status-400,
 			&.status-500 {
-				color: var( --newspack-ui-color-error-50 , #D63638 );
+				color: var( --newspack-ui-color-error-50, #d63638 );
 			}
 		}
 	}
@@ -210,10 +210,10 @@
 }
 
 @keyframes spin {
-  from {
-    transform: rotate( 0deg );
-  }
-  to {
-    transform: rotate( 360deg );
-  }
+	from {
+		transform: rotate( 0deg );
+	}
+	to {
+		transform: rotate( 360deg );
+	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

If you submit the form with an invalid email address (e.g. no email address...) the error message sort of inherits the style of the success message. This PR makes sure the error message displayed correctly and the input has visual feedback.

I've also modified the way the "state-bar" is displayed in the editor. By default it's now hidden and it's only displayed when the block is selected.

Note: sometimes (I'm not able to replicate this all the time) the "Sign Up" button disappear after I submit the form. Not sure what's going on here but it's also happening on `trunk`. Issue: https://github.com/Automattic/newspack-newsletters/issues/1546

![1 before](https://github.com/Automattic/newspack-newsletters/assets/177929/258ab650-940a-4eb8-9da9-55959270b8cf)
![2 after](https://github.com/Automattic/newspack-newsletters/assets/177929/f84cc61d-ab3b-4718-acff-b33afa5ec819)

### How to test the changes in this Pull Request:

1. Add a Subscription block to a page, choose "Modern" style.
2. On the front-end, submit the form without an email address
3. Notice the error message
4. Switch to this branch
5. Refresh and retry submitting the form with an empty email address field
6. Error message should be displayed properly now.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
