### PR TITLE
fix: disable autosaves for newsletters

### DIFF
--- a/includes/class-newspack-newsletters-editor.php
+++ b/includes/class-newspack-newsletters-editor.php
@@ -45,6 +45,7 @@ final class Newspack_Newsletters_Editor {
 	 */
 	public function __construct() {
 		add_action( 'init', [ __CLASS__, 'register_meta' ] );
+		add_action( 'block_editor_settings_all', [ __CLASS__, 'disable_autosave' ], 10, 2 );
 		add_action( 'the_post', [ __CLASS__, 'strip_editor_modifications' ] );
 		add_action( 'after_setup_theme', [ __CLASS__, 'newspack_font_sizes' ], 11 );
 		add_action( 'enqueue_block_editor_assets', [ __CLASS__, 'enqueue_block_editor_assets' ] );
@@ -126,6 +127,23 @@ final class Newspack_Newsletters_Editor {
 			);
 		}
 		return implode( "\n", $rules );
+	}
+
+	/**
+	 * Disable autosaving in the editor for newsletter posts.
+	 * For currently unknown reasons, autosaves for this CPT result in true saves
+	 * instead of creating an autosave revision, which could persist unintended changes.
+	 *
+	 * @param array                   $editor_settings      Default editor settings.
+	 * @param WP_Block_Editor_Context $block_editor_context The current block editor context.
+	 *
+	 * @return array
+	 */
+	public static function disable_autosave( $editor_settings, $block_editor_context ) {
+		if ( isset( $block_editor_context->post->post_type ) && Newspack_Newsletters::NEWSPACK_NEWSLETTERS_CPT === $block_editor_context->post->post_type ) {
+			$editor_settings['autosaveInterval'] = 999999;
+		}
+		return $editor_settings;
 	}
 
 	/**

--- a/includes/class-newspack-newsletters-editor.php
+++ b/includes/class-newspack-newsletters-editor.php
@@ -45,7 +45,7 @@ final class Newspack_Newsletters_Editor {
 	 */
 	public function __construct() {
 		add_action( 'init', [ __CLASS__, 'register_meta' ] );
-		add_action( 'block_editor_settings_all', [ __CLASS__, 'disable_autosave' ], 10, 2 );
+		add_filter( 'block_editor_settings_all', [ __CLASS__, 'disable_autosave' ], 10, 2 );
 		add_action( 'the_post', [ __CLASS__, 'strip_editor_modifications' ] );
 		add_action( 'after_setup_theme', [ __CLASS__, 'newspack_font_sizes' ], 11 );
 		add_action( 'enqueue_block_editor_assets', [ __CLASS__, 'enqueue_block_editor_assets' ] );

--- a/src/components/init-modal/screens/api-keys/index.js
+++ b/src/components/init-modal/screens/api-keys/index.js
@@ -14,7 +14,7 @@ import { dispatch } from '@wordpress/data';
 import classnames from 'classnames';
 import { values } from 'lodash';
 
-const { lockPostAutosaving, unlockPostAutosaving, savePost } = dispatch( 'core/editor' );
+const { savePost } = dispatch( 'core/editor' );
 
 export default ( { onSetupStatus } ) => {
 	const [ settings, setSettings ] = useState( {} );
@@ -31,7 +31,6 @@ export default ( { onSetupStatus } ) => {
 		} )
 			.then( results => {
 				window.newspack_newsletters_data.service_provider = results.service_provider;
-				unlockPostAutosaving( 'newsletters-modal-is-open-lock' );
 				savePost().then( () => {
 					setInFlight( false );
 					setSettings( results );
@@ -61,7 +60,6 @@ export default ( { onSetupStatus } ) => {
 	};
 
 	useEffect( () => {
-		lockPostAutosaving( 'newsletters-modal-is-open-lock' );
 		setInFlight( true );
 		apiFetch( { path: `/newspack-newsletters/v1/settings` } )
 			.then( results => {

--- a/src/components/send-button/index.js
+++ b/src/components/send-button/index.js
@@ -22,7 +22,7 @@ import { refreshEmailHtml, validateNewsletter } from '../../newsletter-editor/ut
 import './style.scss';
 
 function PreviewHTML() {
-	const { isSaving, isAutoSaving, postId, postContent, postTitle } = useSelect( select => {
+	const { isSaving, isAutosaving, postId, postContent, postTitle } = useSelect( select => {
 		const {
 			getCurrentPostId,
 			getCurrentPostType,
@@ -33,7 +33,7 @@ function PreviewHTML() {
 		} = select( 'core/editor' );
 		return {
 			isSaving: isSavingPost(),
-			isAutoSaving: isAutosavingPost(),
+			isAutosaving: isAutosavingPost(),
 			postContent: getEditedPostContent(),
 			postId: getCurrentPostId(),
 			postTitle: getEditedPostAttribute( 'title' ),
@@ -41,7 +41,7 @@ function PreviewHTML() {
 		};
 	} );
 	const [ previewHtml, setPreviewHtml ] = useState( '' );
-	const showSpinner = ( isSaving && ! isAutoSaving ) || ! previewHtml;
+	const showSpinner = ( isSaving && ! isAutosaving ) || ! previewHtml;
 
 	useEffect( () => {
 		if ( ! previewHtml ) {
@@ -183,8 +183,9 @@ export default compose( [
 			0 === newsletterValidationErrors.length;
 		let label;
 		if ( isPublished ) {
-			if ( isSaving ) label = __( 'Sending', 'newspack-newsletters' );
-			else {
+			if ( isSaving ) {
+				label = __( 'Sending', 'newspack-newsletters' );
+			} else {
 				label = is_public
 					? __( 'Sent and Published', 'newspack-newsletters' )
 					: __( 'Sent', 'newspack-newsletters' );
@@ -251,7 +252,9 @@ export default compose( [
 						onClick={ async () => {
 							try {
 								await savePost();
-								if ( saveDidSucceed && renderPostUpdateInfo ) setModalVisible( true );
+								if ( saveDidSucceed && renderPostUpdateInfo ) {
+									setModalVisible( true );
+								}
 							} catch ( e ) {
 								setModalVisible( false );
 							}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

After testing #1526 we found that for `newspack_nl_cpt` posts, for currently unknown reasons, autosaving behaves differently compared to other post types.

- In other post types: Autosave requests create a revision which can be reviewed and manually restored to the current edited post state. Autosave revisions will never automatically replace data in the post object.
- In `newspack_nl_cpt` posts: Autosave requests do not create any revision. Instead, they behave exactly like a regular save request, so that any unsaved changes in the post editor are persisted to the post object, just as if you clicked "Save draft".

This PR disables autosaving entirely for `newspack_nl_cpt` posts because this behavior is undesirable and may cause unintentional updates. Since there's no core-sanctioned hook or function for disabling autosaves in a specific post type, this PR does so somewhat redundantly in two different ways:

- By hooking into the `block_editor_settings_all` filter on `newspack_nl_cpt` posts and setting the `autosaveInterval` option to a very high interval (`999999` seconds or ~11 days—this means that a newsletter editor continually open for longer than this might still autosave, but we found that setting this any higher resulted in _far more_ autosave requests rather than fewer).
- By dispatching `lockPostAutosaving()` when the newsletter editor first loads, and whenever `isAutosaveLocked` changes to `false`, so that autosave requests regardless of origin are effectively blocked by the editor.

### How to test the changes in this Pull Request:

1. On `alpha`, open a newsletter and make some edits, but do not save.
2. Wait few minutes and refresh the editor, and observe that the unsaved edits were in fact saved.
3. Check out this branch and repeat, and this time confirm that any unsaved edits are lost unless you manually save, send a test, or send the live campaign.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
