### PR TITLE
fix: avoid fatal errors on usage reports

### DIFF
--- a/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp-usage-reports.php
+++ b/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp-usage-reports.php
@@ -25,13 +25,33 @@ class Newspack_Newsletters_Mailchimp_Usage_Reports {
 	}
 
 	/**
+	 * Retrieves an instance of the Mailchimp api
+	 *
+	 * @return DrewM\MailChimp\MailChimp|WP_Error
+	 */
+	private static function get_mc_api() {
+		try {
+			return new Mailchimp( self::get_mc_instance()->api_key() );
+		} catch ( Exception $e ) {
+			return new WP_Error(
+				'newspack_newsletters_mailchimp_error',
+				$e->getMessage()
+			);
+		}
+	}
+
+	/**
 	 * Get list activity reports for a specific timeframe between n days in past and yesterday.
 	 *
 	 * @param string $days_in_past_count How many days in the past to look for.
-	 * @return Newspack_Newsletters_Service_Provider_Usage_Report[] Usage reports.
+	 * @return Newspack_Newsletters_Service_Provider_Usage_Report[]|WP_Error Usage reports.
 	 */
 	public static function get_list_activity_reports( $days_in_past_count = 1 ) {
-		$mc_api = new Mailchimp( self::get_mc_instance()->api_key() );
+		$mc_api = self::get_mc_api();
+
+		if ( is_wp_error( $mc_api ) ) {
+			return $mc_api;
+		}
 
 		$reports = [];
 		$lists  = $mc_api->get( 'lists', [ 'count' => 1000 ] );
@@ -72,17 +92,22 @@ class Newspack_Newsletters_Mailchimp_Usage_Reports {
 	/**
 	 * Creates a usage report.
 	 *
-	 * @return Newspack_Newsletters_Service_Provider_Usage_Report Usage report.
+	 * @return Newspack_Newsletters_Service_Provider_Usage_Report|WP_Error Usage report.
 	 */
 	public static function get_usage_report() {
+
+		// Check and bail early if MC is misconfigured.
+		$mc_api = self::get_mc_api();
+		if ( is_wp_error( $mc_api ) ) {
+			return $mc_api;
+		}
+
 		// Start with lists activity reports. These are good for historical data and also will provide
 		// subscribes and unsubscribes data. However, in order to get recent
 		// sent/opens/clicks data, the campaign reports have to be used.
 		// It appears that the sent/opens/clicks data in the lists activity are only added after a
 		// delay of 2-3 days.
 		$reports = self::get_list_activity_reports( 1 );
-
-		$mc_api = new Mailchimp( self::get_mc_instance()->api_key() );
 
 		$campaign_reports = [];
 		$campaign_reports_response = $mc_api->get(


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Avoids Fatal Errors on Usage report generation if Mailchimp is misconfigred (or not configured)

### How to test the changes in this Pull Request:

1.Set Marilchimp as ESP
2. Leave the API key field blank or with a key in an invalid format (ex: 'asd')
3. Start on `trunk`
4. Open WP Shell and run: `Newspack_Manager\Data_Report::export_available_data();`
5. Confirm you see a Fatal error
6. Switch to this branch and run the command again
7. Confirm you see the following message in the logs:

```
[data_report_esp_data][Newspack_Manager\Data_Report::get_esp_data][ERROR]: Invalid MailChimp API key supplied.
```

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1207670445966109