### PR TITLE
fix: remove grid block from newsletters

### DIFF
--- a/src/editor/index.js
+++ b/src/editor/index.js
@@ -49,6 +49,8 @@ domReady( () => {
 	unregisterBlockStyle( 'core/social-links', 'pill-shape' );
 	/* Unregister "row" group block variation */
 	unregisterBlockVariation( 'core/group', 'group-row' );
+	/* Unregister "grid" group block variation */
+	unregisterBlockVariation( 'core/group', 'group-grid' );
 } );
 
 /* Remove Duotone filters */


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR replaces https://github.com/Automattic/newspack-newsletters/pull/1553, but in hotfix form.

WordPress 6.6 is introducing a 'Grid' variation of the Group block, which, like the Row variation, uses CSS that doesn't work with email clients. 

This PR removes the Grid style, similar to [the Row block fix](https://github.com/Automattic/newspack-newsletters/pull/772).

See 1207594452716169-as-1207718126040684

### How to test the changes in this Pull Request:

1. Start on a test site running the latest WP 6.6 RC.
2. Create a new newsletter and try to add a 'Grid' block; note it's available (as a block in the list, and as a style when you add the Group block).
3. Apply this PR and run `npm run build`.
4. Confirm that the Grid layout is no longer available.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
