### PR TITLE
fix: update CSS selector used to fix linked header style editor previews

### DIFF
--- a/src/editor/blocks/posts-inserter/style.scss
+++ b/src/editor/blocks/posts-inserter/style.scss
@@ -82,13 +82,7 @@
 	}
 }
 
-h1,
-h2,
-h3,
-h4,
-h5,
-h6 {
-	&.block-editor-rich-text__editable a {
-		color: inherit;
-	}
+
+.wp-block-heading a {
+	color: inherit;
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

In WordPress 6.6, there are a couple visual discrepancies in the Post Inserter in the Newsletter editor compared to WP 6.5; this PR fixes one, but also captures the other one since it's noticeable when reviewing this PR:

**Change one:**
In WP 6.5, text blocks in the Newsletter editor like headings and paragraphs have the following CSS classes:
* block-editor-rich-text__editable 
* block-editor-block-list__block
* wp-block 
* wp-elements-[#]
* wp-block-[name] 
* rich-text

But in 6.6, two are removed, leaving:
* block-editor-block-list__block
* wp-block 
* wp-elements-[#]
* wp-block-[name] 

I don't get why this changed, since the classes are still used in Gutenberg, but this causes links in headings -- like the linked headings in the Post Inserter block -- not to use the correct link colour by default (black), and not to pick up custom Heading colours in the editor preview. For both, this is because we're using the `block-editor-rich-text__editable` class to [make sure links in headers inherit the colour from the header](https://github.com/Automattic/newspack-newsletters/pull/286).
    
**Change two:**
The CSS reset classes in the editor [got a little more specific in WP 6.6](https://github.com/WordPress/gutenberg/pull/62350). It's specifically noticeable in what the Post Inserter is picking up style-wise on the `body` tag, and both seem to be improvements: it gets rid of the grey background that the Post Inserter was picking up from WP admin, and it makes the font size a little more true to the sent newsletter. This is not something that needs to be "fixed", but it explains some extra discrepancies between the 6.5 and 6.6 screenshots below.

See: 1207594452716169-as-1207759233535677

### How to test the changes in this Pull Request:

1. Start on a test site running WP 6.6 RC, and create a new Newsletter. 
2. Add two Post Inserter blocks. On one, change the Heading and Paragraph colours in the sidebar settings.
3. Note that in the editor the headers are blue by default, and changing their colour won't change them. This differs from the newsletter preview, and how it looks when sent.

![image](https://github.com/Automattic/newspack-newsletters/assets/177561/ef80632d-ba22-4da9-a735-8343cccf7dc1)

4. Apply this PR and run `npm run build`. 
5. Confirm that the newsletter preview looks better:

![image](https://github.com/Automattic/newspack-newsletters/assets/177561/8824d593-0f29-4ed4-a998-3081a73c4acf)

6. Test the PR on a site running WP 6.5 and confirm it doesn't change how the link colour looks compared to `trunk`.

On `trunk`:

![image](https://github.com/Automattic/newspack-newsletters/assets/177561/bd380b8e-49d5-4e4d-bdd0-93aa9ed0a6ce)

With this PR:

![image](https://github.com/Automattic/newspack-newsletters/assets/177561/208cf8b4-af67-49de-a1a4-f0c125f4f254)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
