### PR TITLE
fix(subscribe-block): remove errant nonexistent JS method

### DIFF
--- a/src/blocks/subscribe/view.js
+++ b/src/blocks/subscribe/view.js
@@ -101,7 +101,6 @@ domReady( function () {
 					if ( nonce ) {
 						body.set( 'newspack_newsletters_subscribe', nonce );
 					}
-					form.setLoading();
 
 					fetch( form.getAttribute( 'action' ) || window.location.pathname, {
 						method: 'POST',


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

#1514 included a reference to a nonexistent JS method which breaks the block. This removes it.

### How to test the changes in this Pull Request:

1. Check out this branch, connect reCAPTCHA v2 and confirm that the Subscribe block works on the front-end.
2. Reconnect reCAPTCHA v3 and retest

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
