### PR TITLE
fix: recaptcha

### DIFF
--- a/src/blocks/subscribe/edit.js
+++ b/src/blocks/subscribe/edit.js
@@ -244,7 +244,7 @@ export default function SubscribeEdit( {
 						<p>
 							{ sprintf(
 								// translators: %s is either 'enabled' or 'disabled'.
-								__( 'reCAPTCHA v3 is currently %s.', 'newspack-newsletters' ),
+								__( 'reCAPTCHA is currently %s.', 'newspack-newsletters' ),
 								newspack_newsletters_blocks.has_recaptcha
 									? __( 'enabled', 'newspack-newsletters' )
 									: __( 'disabled', 'newspack-newsletters' )
@@ -253,7 +253,7 @@ export default function SubscribeEdit( {
 						{ ! newspack_newsletters_blocks.has_recaptcha && (
 							<p>
 								{ __(
-									"It's highly recommended that you enable reCAPTCHA v3 protection to prevent spambots from using this form!",
+									"It's highly recommended that you enable reCAPTCHA protection to prevent spambots from using this form!",
 									'newspack-newsletters'
 								) }
 							</p>

--- a/src/blocks/subscribe/index.php
+++ b/src/blocks/subscribe/index.php
@@ -257,6 +257,7 @@ function render_block( $attrs ) {
 						<?php endif; ?>
 					</div>
 				<?php endif; ?>
+				<?php do_action( 'newspack_newsletters_subscribe_block_before_email_field', $attrs ); ?>
 				<div class="newspack-newsletters-email-input">
 					<?php if ( $email_label ) : ?>
 						<label for="<?php echo \esc_attr( $input_id . '-email' ); ?>"><?php echo \esc_html( $email_label ); ?></label>
@@ -451,8 +452,7 @@ function process_form() {
 
 	// reCAPTCHA test.
 	if ( method_exists( '\Newspack\Recaptcha', 'can_use_captcha' ) && \Newspack\Recaptcha::can_use_captcha() ) {
-		$captcha_token  = isset( $_REQUEST['captcha_token'] ) ? \sanitize_text_field( $_REQUEST['captcha_token'] ) : '';
-		$captcha_result = \Newspack\Recaptcha::verify_captcha( $captcha_token );
+		$captcha_result = \Newspack\Recaptcha::verify_captcha();
 		if ( \is_wp_error( $captcha_result ) ) {
 			return send_form_response( $captcha_result );
 		}

--- a/src/blocks/subscribe/view.js
+++ b/src/blocks/subscribe/view.js
@@ -101,7 +101,8 @@ domReady( function () {
 					if ( nonce ) {
 						body.set( 'newspack_newsletters_subscribe', nonce );
 					}
-					form.setLoading();
+					emailInput.setAttribute( 'disabled', 'true' );
+					submit.setAttribute( 'disabled', 'true' );
 
 					fetch( form.getAttribute( 'action' ) || window.location.pathname, {
 						method: 'POST',


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

#1514 is required for https://github.com/Automattic/newspack-plugin/pull/3126, but never made it to `release`. This fixes it and also fixes an errant reference to a nonexistent JS method.

### How to test the changes in this Pull Request:

1. Test this PR with current `release` branches for Newspack Plugin and Blocks.
2. Connect reCAPTCHA v2 with the highest security setting and confirm that the Subscribe block works.
3. Connect reCAPTCHA v3 with a threshold value of 1 and confirm that the Subscribe rejects the signup with a `Could not complete this request. Please try again later` error, and then again with a value of 0.1 and confirm that the signup succeeds.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
