### PR TITLE
fix: nonexistent method; don't remove the submit button (just the spinner)

### DIFF
--- a/src/blocks/subscribe/view.js
+++ b/src/blocks/subscribe/view.js
@@ -47,7 +47,7 @@ domReady( function () {
 			container.setAttribute( 'data-status', status );
 			const messageNode = document.createElement( 'p' );
 			emailInput.removeAttribute( 'disabled' );
-			submit.remove( spinner );
+			submit.removeChild( spinner );
 			submit.removeAttribute( 'disabled' );
 			form.classList.remove( 'in-progress' );
 			messageNode.innerHTML = wasSubscribed
@@ -101,7 +101,8 @@ domReady( function () {
 					if ( nonce ) {
 						body.set( 'newspack_newsletters_subscribe', nonce );
 					}
-					form.setLoading();
+					emailInput.setAttribute( 'disabled', 'true' );
+					submit.setAttribute( 'disabled', 'true' );
 
 					fetch( form.getAttribute( 'action' ) || window.location.pathname, {
 						method: 'POST',


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes submit action for the Subscription Form block. #1514 introduced a new `setLoading()` method which we ended up not moving, but still references the nonexistent method.

Also fixes a post-submit action which unintentionally removes the submit button from the DOM with `submit.remove( spinner )`. It's supposed to remove just the spinner child element with `submit.removeChild( spinner )`.

### How to test the changes in this Pull Request:

1. On `trunk`, attempt to sign up for newsletters via the Subscription Form block. Observe an `setLoading is undefined` JS console error which prevents the form submission. Also observe that the submit button disappears from the form after clicking it.
2. Check out this branch and repeat. The submission should work now, and the submit button should remain after form submission.
3. Test with: 
  - reCAPTCHA v3
  - reCAPTCHA v2
  - reCAPTCHA disabled

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
