### PR TITLE
feat(constant-contact): enable subscription management in my account

### DIFF
--- a/includes/class-newspack-newsletters-subscription.php
+++ b/includes/class-newspack-newsletters-subscription.php
@@ -1152,7 +1152,6 @@ class Newspack_Newsletters_Subscription {
 				 * @param array|WP_Error $lists_config Associative array with list configuration keyed by list ID or WP_Error.
 				 */
 				$list_config  = apply_filters( 'newspack_newsletters_manage_newsletters_available_lists', self::get_lists_config() );
-				$list_map     = [];
 				$user_lists   = array_flip( self::get_contact_lists( $email ) );
 				$intent_error = self::get_user_subscription_intent_error( $user_id );
 				if ( $intent_error ) :

--- a/includes/service-providers/constant_contact/class-newspack-newsletters-constant-contact-sdk.php
+++ b/includes/service-providers/constant_contact/class-newspack-newsletters-constant-contact-sdk.php
@@ -640,7 +640,7 @@ final class Newspack_Newsletters_Constant_Contact_SDK {
 	 *   @type string[] $custom_fields Custom field values keyed by their label.
 	 * }
 	 *
-	 * @return array Created contact data.
+	 * @return WP_Error|object|false Created contact data or false.
 	 */
 	public function upsert_contact( $email_address, $data = [] ) {
 		$contact = $this->get_contact( $email_address );

--- a/includes/service-providers/constant_contact/class-newspack-newsletters-constant-contact-sdk.php
+++ b/includes/service-providers/constant_contact/class-newspack-newsletters-constant-contact-sdk.php
@@ -597,6 +597,33 @@ final class Newspack_Newsletters_Constant_Contact_SDK {
 	}
 
 	/**
+	 * Remove one or more contacts from one or more lists.
+	 *
+	 * @param string[] $contact_ids Contact IDs.
+	 * @param string[] $list_ids List IDs.
+	 *
+	 * @return array|WP_Error
+	 */
+	public function remove_contacts_from_lists( $contact_ids, $list_ids ) {
+		$body = [
+			'source'   => [
+				'contact_ids' => $contact_ids,
+			],
+			'list_ids' => $list_ids,
+		];
+		try {
+			$res = $this->request(
+				'POST',
+				'/activities/remove_list_memberships',
+				[ 'body' => wp_json_encode( $body ) ]
+			);
+			return $res;
+		} catch ( Exception $e ) {
+			return new WP_Error( 'newspack_newsletter_error_removing_contact_from_lists', $e->getMessage() );
+		}
+	}
+
+	/**
 	 * Create or update a contact
 	 *
 	 * @param string $email_address Email address.
@@ -668,11 +695,17 @@ final class Newspack_Newsletters_Constant_Contact_SDK {
 				$body['taggings'] = $data['taggings'];
 			}
 		}
-		$res = $this->request(
-			$contact ? 'PUT' : 'POST',
-			$contact ? 'contacts/' . $contact->contact_id : 'contacts',
-			[ 'body' => wp_json_encode( $body ) ]
-		);
+
+		try {
+			$res = $this->request(
+				$contact ? 'PUT' : 'POST',
+				$contact ? 'contacts/' . $contact->contact_id : 'contacts',
+				[ 'body' => wp_json_encode( $body ) ]
+			);
+		} catch ( Exception $e ) {
+			return new WP_Error( 'newspack_newsletter_error_upserting_contact', $e->getMessage() );
+		}
+
 		return $this->get_contact( $email_address );
 	}
 

--- a/includes/service-providers/constant_contact/class-newspack-newsletters-constant-contact-sdk.php
+++ b/includes/service-providers/constant_contact/class-newspack-newsletters-constant-contact-sdk.php
@@ -490,17 +490,21 @@ final class Newspack_Newsletters_Constant_Contact_SDK {
 	 * @return object|false Contact or false if not found.
 	 */
 	public function get_contact( $email_address ) {
-		$res = $this->request(
-			'GET',
-			'contacts',
-			[
-				'query' => [
-					'email'   => $email_address,
-					'status'  => 'all',
-					'include' => 'custom_fields,list_memberships,taggings',
-				],
-			]
-		);
+		try {
+			$res = $this->request(
+				'GET',
+				'contacts',
+				[
+					'query' => [
+						'email'   => $email_address,
+						'status'  => 'all',
+						'include' => 'custom_fields,list_memberships,taggings',
+					],
+				]
+			);
+		} catch ( Exception $e ) {
+			return new WP_Error( 'newspack_newsletter_error_get_contact', $e->getMessage() );
+		}
 		if ( empty( $res->contacts ) ) {
 			return false;
 		}

--- a/includes/service-providers/constant_contact/class-newspack-newsletters-constant-contact.php
+++ b/includes/service-providers/constant_contact/class-newspack-newsletters-constant-contact.php
@@ -7,8 +7,6 @@
 
 defined( 'ABSPATH' ) || exit;
 
-use Newspack\Newsletters\Subscription_List;
-
 /**
  * Main Newspack Newsletters Class for Constant Contact ESP.
  */

--- a/includes/service-providers/constant_contact/class-newspack-newsletters-constant-contact.php
+++ b/includes/service-providers/constant_contact/class-newspack-newsletters-constant-contact.php
@@ -864,7 +864,19 @@ final class Newspack_Newsletters_Constant_Contact extends \Newspack_Newsletters_
 				$data['custom_fields'][ strval( $key ) ] = strval( $value );
 			}
 		}
-		return get_object_vars( $cc->upsert_contact( $contact['email'], $data ) );
+
+		$result = $cc->upsert_contact( $contact['email'], $data );
+		if ( is_wp_error( $result ) ) {
+			return $result;
+		}
+		if ( ! $result ) {
+			return new WP_Error(
+				'newspack_newsletters_error',
+				__( 'Failed to add contact.', 'newspack-newsletters' )
+			);
+		}
+
+		return get_object_vars( $result );
 	}
 
 	/**

--- a/includes/service-providers/constant_contact/class-newspack-newsletters-constant-contact.php
+++ b/includes/service-providers/constant_contact/class-newspack-newsletters-constant-contact.php
@@ -850,14 +850,6 @@ final class Newspack_Newsletters_Constant_Contact extends \Newspack_Newsletters_
 	public function add_contact( $contact, $list_id = false ) {
 		$cc   = new Newspack_Newsletters_Constant_Contact_SDK( $this->api_key(), $this->api_secret(), $this->access_token() );
 		$data = [];
-		// If the $list_id belongs to a tag, we need to add the contact to the tag's parent list.
-		if ( Subscription_List::is_local_form_id( $list_id ) ) {
-			$list              = Newspack\Newsletters\Subscription_List::from_form_id( $list_id );
-			$provider_settings = $list->get_provider_settings( $this->service );
-			if ( ! empty( $provider_settings['list'] ) ) {
-				$list_id = $provider_settings['list'];
-			}
-		}
 		if ( $list_id ) {
 			$data['list_ids'] = [ $list_id ];
 		}
@@ -1068,6 +1060,9 @@ final class Newspack_Newsletters_Constant_Contact extends \Newspack_Newsletters_
 	 */
 	public function add_tag_to_contact( $email, $tag, $list_id = null ) {
 		$tags = $this->get_contact_tags_ids( $email );
+		if ( is_wp_error( $tags ) ) {
+			$tags = [];
+		}
 		if ( in_array( $tag, $tags, true ) ) {
 			return true;
 		}

--- a/includes/service-providers/constant_contact/class-newspack-newsletters-constant-contact.php
+++ b/includes/service-providers/constant_contact/class-newspack-newsletters-constant-contact.php
@@ -933,9 +933,12 @@ final class Newspack_Newsletters_Constant_Contact extends \Newspack_Newsletters_
 		}
 
 		// Existing contact lists/tags.
-		$new_contact_data = [];
 		$contact_lists    = $contact_data['list_memberships'] ?? [];
 		$contact_tags     = $contact_data['taggings'] ?? [];
+		$new_contact_data = [
+			'list_ids' => $contact_lists,
+			'taggings' => $contact_tags,
+		];
 
 		// Remove lists or tags from contact.
 		foreach ( $lists_to_remove as $list_id ) {
@@ -943,7 +946,7 @@ final class Newspack_Newsletters_Constant_Contact extends \Newspack_Newsletters_
 			if ( $is_tag ) {
 				$new_contact_data['taggings'] = array_values(
 					array_filter(
-						$contact_tags,
+						$new_contact_data['taggings'],
 						function ( $tag_id ) use ( $list_id ) {
 							return $tag_id !== $list_id;
 						}
@@ -965,7 +968,7 @@ final class Newspack_Newsletters_Constant_Contact extends \Newspack_Newsletters_
 			$new_contact_data[ $item_type ] = array_values(
 				array_unique(
 					array_merge(
-						$is_tag ? $contact_tags : $contact_lists,
+						$new_contact_data[ $item_type ],
 						[ $list_id ]
 					)
 				)


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Adds missing methods to the Constant Contact service provider class to enable list/tag subscription self-management via the My Account > Newsletters dashboard. This should allow Constant Contact to be used with Premium Newsletter features.

### How to test the changes in this Pull Request:

1. Check out this branch.
2. Connect Constant Contact as your ESP and authorize as needed.
3. In **Newspack > Engagement > Newsletters**, enable at least two lists as  subscription lists and also create and publish at least one local subscription list (which will create a tag in the ESP).
4. As a reader, sign up for the list and the tag via any means.
5. Visit My Account, verify as needed, and confirm you see the "Newsletters" menu item in the sidebar.
6. Visit Newsletters and confirm that you see all enabled subscription lists and that the ones you signed up for as a reader are checked.
7. Unsubscribe from all and confirm that they remain unchecked after the page refreshes. Also confirm that the contact in the ESP has been removed from all tags and lists they were subscribed to.
8. Resubscribe to all and confirm that they remain checked after the page refreshes. Also confirm that the contact in the ESP has been readded to all tags and lists you selected in My Account.
9. Resubscribe only to the local (tag) list and confirm it works
10. Unsubscribe from that and subscribe only to one normal list
11. Test all possible combinations you can

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
