### PR TITLE
fix: error handling for Mailchimp `add_contact` method

### DIFF
--- a/includes/class-newspack-newsletters-subscription.php
+++ b/includes/class-newspack-newsletters-subscription.php
@@ -660,8 +660,6 @@ class Newspack_Newsletters_Subscription {
 			}
 		}
 
-		$result = $errors->has_errors() ? $errors : $result;
-
 		/**
 		 * Fires after a contact is added.
 		 *
@@ -685,6 +683,8 @@ class Newspack_Newsletters_Subscription {
 			if ( $user ) {
 				delete_user_meta( $user->ID, 'newspack_newsletters_subscription_error' );
 			}
+		} else {
+			return $errors;
 		}
 
 		return $result;

--- a/includes/class-newspack-newsletters-subscription.php
+++ b/includes/class-newspack-newsletters-subscription.php
@@ -680,7 +680,7 @@ class Newspack_Newsletters_Subscription {
 		do_action( 'newspack_newsletters_add_contact', $provider->service, $contact, $lists, $result, $is_updating );
 
 		// Remove any existing subscription error message.
-		if ( ! is_wp_error( $result ) ) {
+		if ( ! $errors->has_errors() ) {
 			$user = get_user_by( 'email', $contact['email'] );
 			if ( $user ) {
 				delete_user_meta( $user->ID, 'newspack_newsletters_subscription_error' );

--- a/includes/service-providers/class-newspack-newsletters-service-provider.php
+++ b/includes/service-providers/class-newspack-newsletters-service-provider.php
@@ -516,13 +516,10 @@ Details of the error message: "%3$s"
 		$contact = $this->get_contact_data( $email );
 		if ( is_wp_error( $contact ) ) {
 			// Create contact.
-			// Use  Newspack_Newsletters_Subscription::add_contact to trigger hooks and call add_contact_handling_local_list if needed.
+			// Use Newspack_Newsletters_Subscription::add_contact to trigger hooks and call add_contact_handling_local_list if needed.
 			$result = Newspack_Newsletters_Subscription::add_contact( [ 'email' => $email ], $lists_to_add );
 			if ( is_wp_error( $result ) ) {
 				return $result;
-			}
-			if ( is_array( $result ) && is_wp_error( $result[0] ) ) {
-				return $result[0];
 			}
 			return true;
 		}

--- a/includes/service-providers/class-newspack-newsletters-service-provider.php
+++ b/includes/service-providers/class-newspack-newsletters-service-provider.php
@@ -521,6 +521,9 @@ Details of the error message: "%3$s"
 			if ( is_wp_error( $result ) ) {
 				return $result;
 			}
+			if ( is_array( $result ) && is_wp_error( $result[0] ) ) {
+				return $result[0];
+			}
 			return true;
 		}
 		if ( static::$support_local_lists ) {

--- a/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp.php
+++ b/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp.php
@@ -1202,7 +1202,12 @@ final class Newspack_Newsletters_Mailchimp extends \Newspack_Newsletters_Service
 		}
 
 		foreach ( $by_list as $list_id => $sublists ) {
-			$results[] = $this->add_contact( $contact, $list_id, $sublists );
+			$result = $this->add_contact( $contact, $list_id, $sublists );
+			if ( is_wp_error( $result ) ) {
+				return $result;
+			}
+
+			$results[] = $result;
 		}
 		return $results;
 	}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

While testing #1562 I noticed Mailchimp was failing to add contacts, but I wasn't seeing any error messages on the front-end or in the logs. I traced it to the fact that errors returned by the submit request in My Account can be an array of `WP_Error` objects, but our error handling isn't accounting for this fact, so it ends up returning a success state even if the Mailchimp API returns an error.

### How to test the changes in this Pull Request:

1. On `trunk`, connect Mailchimp as your ESP.
2. Register a reader account using an email address that will be flagged as "obviously fake" by Mailchimp, such as `email@test.com`, then visit My Account > Newsletters (and verify if needed).
3. Sign up for one or more lists from here and observe that you see the "subscriptions updated" success message, but that you were not actually subscribed to the lists you checked, and that no contact was added in Mailchimp.
4. Check out this branch, repeat the signup in My Account, and confirm that after the page refreshes you now see the error message that the Mailchimp API returned, something like `Failed to add contact to list. email@test.com looks fake or invalid, please enter a real email address.`

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
