### PR TITLE
fix(recaptcha): handle inactive recaptcha

### DIFF
--- a/src/blocks/subscribe/view.js
+++ b/src/blocks/subscribe/view.js
@@ -1,4 +1,4 @@
-/* globals newspack_newsletters_subscribe_block, newspack_grecaptcha */
+/* globals newspack_newsletters_subscribe_block */
 /**
  * Internal dependencies
  */
@@ -70,6 +70,7 @@ domReady( function () {
 				return form.endFlow( newspack_newsletters_subscribe_block.invalid_email, 400 );
 			}
 
+			const newspack_grecaptcha = window.newspack_grecaptcha || null;
 			const getCaptchaV3Token = newspack_grecaptcha
 				? newspack_grecaptcha?.getCaptchaV3Token
 				: () => new Promise( res => res( '' ) ); // Empty promise.


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes handling of inactive reCAPTCHA.

### How to test the changes in this Pull Request:

1. On `trunk`, visit Connections wizard of the Newspack plugin and turn off reCAPTCHA
2. Visit a page with the Newsletter subscription block, try to subscribe, observe a JS error in the console: `newspack_grecaptcha is not defined`
3. Switch to this branch, repeat, observe no error and that subscribing is possible

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->