### PR TITLE
fix: refresh MJML on save for all newsletter editor CPTs

### DIFF
--- a/includes/class-newspack-newsletters-editor.php
+++ b/includes/class-newspack-newsletters-editor.php
@@ -96,7 +96,7 @@ final class Newspack_Newsletters_Editor {
 	 *
 	 * @param int $post_id Optional post ID to check.
 	 */
-	private static function is_editing_email( $post_id = null ) {
+	public static function is_editing_email( $post_id = null ) {
 		$post_id = empty( $post_id ) ? get_the_ID() : $post_id;
 		return in_array( get_post_type( $post_id ), self::get_email_editor_cpts() );
 	}

--- a/includes/service-providers/active_campaign/class-newspack-newsletters-active-campaign.php
+++ b/includes/service-providers/active_campaign/class-newspack-newsletters-active-campaign.php
@@ -867,7 +867,7 @@ final class Newspack_Newsletters_Active_Campaign extends \Newspack_Newsletters_S
 			return;
 		}
 		$post = get_post( $post_id );
-		if ( Newspack_Newsletters::NEWSPACK_NEWSLETTERS_CPT !== $post->post_type ) {
+		if ( ! Newspack_Newsletters_Editor::is_editing_email( $post_id ) ) {
 			return;
 		}
 		if ( 'trash' === $post->post_status ) {

--- a/includes/service-providers/constant_contact/class-newspack-newsletters-constant-contact.php
+++ b/includes/service-providers/constant_contact/class-newspack-newsletters-constant-contact.php
@@ -699,10 +699,10 @@ final class Newspack_Newsletters_Constant_Contact extends \Newspack_Newsletters_
 		if ( Newspack_Newsletters::EMAIL_HTML_META !== $meta_key ) {
 			return;
 		}
-		$post = get_post( $post_id );
-		if ( Newspack_Newsletters::NEWSPACK_NEWSLETTERS_CPT !== $post->post_type ) {
+		if ( ! Newspack_Newsletters_Editor::is_editing_email( $post_id ) ) {
 			return;
 		}
+		$post = get_post( $post_id );
 		if ( 'trash' === $post->post_status ) {
 			return;
 		}

--- a/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp.php
+++ b/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp.php
@@ -868,7 +868,7 @@ final class Newspack_Newsletters_Mailchimp extends \Newspack_Newsletters_Service
 			return;
 		}
 		$post = get_post( $post_id );
-		if ( Newspack_Newsletters::NEWSPACK_NEWSLETTERS_CPT !== $post->post_type ) {
+		if ( ! Newspack_Newsletters_Editor::is_editing_email( $post_id ) ) {
 			return;
 		}
 		if ( 'trash' === $post->post_status ) {

--- a/src/editor/index.js
+++ b/src/editor/index.js
@@ -25,6 +25,7 @@ import registerVisibilityFilters from './blocks/visibility-attribute';
 import registerConditionalContent from './blocks/conditional-content';
 import { addBlocksValidationFilter } from './blocks-validation/blocks-filters';
 import { NestedColumnsDetection } from './blocks-validation/nesting-detection';
+import MJML from './mjml';
 
 addBlocksValidationFilter();
 registerAdBlock();
@@ -106,5 +107,10 @@ registerBlockStyle( 'core/social-links', {
 
 registerPlugin( 'newspack-newsletters-plugin', {
 	render: NestedColumnsDetection,
+	icon: null,
+} );
+
+registerPlugin( 'newspack-newsletters-mjml', {
+	render: MJML,
 	icon: null,
 } );

--- a/src/editor/mjml/index.js
+++ b/src/editor/mjml/index.js
@@ -1,0 +1,111 @@
+/* global newspack_email_editor_data */
+
+/**
+ * WordPress dependencies
+ */
+import apiFetch from '@wordpress/api-fetch';
+import { useSelect, useDispatch } from '@wordpress/data';
+import { useEffect, useRef, useState } from '@wordpress/element';
+import { refreshEmailHtml } from '../../newsletter-editor/utils';
+
+/**
+ * Custom hook for fetching the prior value of a prop.
+ *
+ * @param {*} value The prop to track.
+ * @return {*} The prior value of the prop.
+ */
+const usePrevProp = value => {
+	const ref = useRef();
+	useEffect( () => {
+		ref.current = value;
+	}, [ value ] );
+	return ref.current;
+};
+
+function MJML() {
+	const [ isRefreshingHTML, setIsRefreshingHTML ] = useState( false );
+	const {
+		saveSucceeded,
+		isPublishing,
+		isAutosaving,
+		isAutosaveLocked,
+		isSaving,
+		isSent,
+		postContent,
+		postId,
+		postTitle,
+		postType,
+	} = useSelect( select => {
+		const {
+			didPostSaveRequestSucceed,
+			getCurrentPostAttribute,
+			getCurrentPostId,
+			getCurrentPostType,
+			getEditedPostAttribute,
+			getEditedPostContent,
+			isSavingPost,
+			isPostAutosavingLocked,
+			isAutosavingPost,
+			isCurrentPostPublished,
+		} = select( 'core/editor' );
+
+		return {
+			postContent: getEditedPostContent(),
+			postId: getCurrentPostId(),
+			postTitle: getEditedPostAttribute( 'title' ),
+			postType: getCurrentPostType(),
+			isPublished: isCurrentPostPublished(),
+			saveSucceeded: didPostSaveRequestSucceed(),
+			isSaving: isSavingPost(),
+			isSent: getCurrentPostAttribute( 'meta' ).newsletter_sent,
+			isAutosaving: isAutosavingPost(),
+			isAutosaveLocked: isPostAutosavingLocked(),
+		};
+	} );
+
+	const { lockPostAutosaving, lockPostSaving, unlockPostSaving, editPost } =
+		useDispatch( 'core/editor' );
+	const updateMetaValue = ( key, value ) => editPost( { meta: { [ key ]: value } } );
+
+	// Disable autosave requests in the editor.
+	useEffect( () => {
+		if ( ! isAutosaveLocked ) {
+			lockPostAutosaving();
+		}
+	}, [ isAutosaveLocked ] );
+
+	// After the post is successfully saved, refresh the email HTML.
+	const wasSaving = usePrevProp( isSaving );
+	useEffect( () => {
+		if (
+			wasSaving &&
+			! isSaving &&
+			! isAutosaving &&
+			! isPublishing &&
+			! isRefreshingHTML &&
+			! isSent &&
+			saveSucceeded
+		) {
+			setIsRefreshingHTML( true );
+			lockPostSaving( 'newspack-newsletters-refresh-html' );
+			refreshEmailHtml( postId, postTitle, postContent )
+				.then( refreshedHtml => {
+					updateMetaValue( newspack_email_editor_data.email_html_meta, refreshedHtml );
+					apiFetch( {
+						data: { meta: { [ newspack_email_editor_data.email_html_meta ]: refreshedHtml } },
+						method: 'POST',
+						path: `/wp/v2/${ postType }/${ postId }`,
+					} );
+				} )
+				.catch( e => {
+					console.warn( e ); // eslint-disable-line no-console
+				} )
+				.finally( () => {
+					unlockPostSaving( 'newspack-newsletters-refresh-html' );
+					setIsRefreshingHTML( false );
+				} );
+		}
+	}, [ isSaving, isAutosaving ] );
+}
+
+export default MJML;

--- a/src/newsletter-editor/utils.js
+++ b/src/newsletter-editor/utils.js
@@ -2,7 +2,6 @@
  * WordPress dependencies
  */
 import apiFetch from '@wordpress/api-fetch';
-import { useEffect, useRef } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -37,20 +36,6 @@ export const validateNewsletter = newsletterData => {
  * @return {boolean} True if it contains a valid email string.
  */
 export const hasValidEmail = string => /\S+@\S+/.test( string );
-
-/**
- * Custom hook for fetching the prior value of a prop.
- *
- * @param {*} value The prop to track.
- * @return {*} The prior value of the prop.
- */
-export const usePrevProp = value => {
-	const ref = useRef();
-	useEffect( () => {
-		ref.current = value;
-	}, [ value ] );
-	return ref.current;
-};
 
 /**
  * Refresh the email-compliant HTML for a post.


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

#1526 implemented improvements in how we handle refreshing MJML and email-compliant HTML for newsletter posts, but it left out other CPTs that also use the Newsletters plugin's editor (notably, the custom receipts and reader-facing emails we have for Reader Activation). This corrects the issue by moving the MJML handling from the `newsletter-editor.js` file (which is enqueued only for the `newspack_nl_cpt` post type) to the `editor.js` file (which is enqueued for all CPTs which use the newsletter editor).

### How to test the changes in this Pull Request:

1. On `release`, create or edit a custom receipt email in Newspack > Reader Revenue > Emails.
2. Edit the post content and update.
3. As a reader, make a purchase. Observe that the custom receipt email you receive doesn't reflect the changes you made in step 2.
4. Check out this branch, edit the receipt email again and save, and make another purchase. Confirm that the receipt email you receive this time does have the changes you made.
5. Create a new newsletter post, edit the post content, save, preview, send a test/live campaign, etc. and make sure the email content always reflects your latest changes.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
