### PR TITLE
feat: update method calls

### DIFF
--- a/includes/class-newspack-newsletters-subscription.php
+++ b/includes/class-newspack-newsletters-subscription.php
@@ -34,7 +34,6 @@ class Newspack_Newsletters_Subscription {
 	public static function init() {
 		add_action( 'rest_api_init', [ __CLASS__, 'register_api_endpoints' ] );
 		add_action( 'newspack_registered_reader', [ __CLASS__, 'newspack_registered_reader' ], 10, 5 );
-		add_action( 'delete_user', [ __CLASS__, 'delete_user' ], 10, 3 );
 
 		/** User email verification for subscription management. */
 		add_action( 'resetpass_form', [ __CLASS__, 'set_current_user_email_verified' ] );
@@ -589,31 +588,6 @@ class Newspack_Newsletters_Subscription {
 			// Avoid breaking the registration process.
 			Newspack_Newsletters_Logger::log( 'Error adding contact: ' . $e->getMessage() );
 		}
-	}
-
-	/**
-	 * Delete a contact from ESP when a reader is deleted.
-	 *
-	 * @param int      $user_id  ID of the user to delete.
-	 * @param int|null $reassign ID of the user to reassign posts and links to.
-	 *                           Default null, for no reassignment.
-	 * @param WP_User  $user     WP_User object of the user to delete.
-	 *
-	 * @return bool|WP_Error Whether the contact was deleted or error.
-	 */
-	public static function delete_user( $user_id, $reassign, $user ) {
-		if ( ! class_exists( '\Newspack\Reader_Activation' ) || ! \Newspack\Reader_Activation::is_user_reader( $user ) ) {
-			return;
-		}
-		$sync = \Newspack\Reader_Activation::get_setting( 'sync_esp' );
-		if ( ! $sync ) {
-			return;
-		}
-		$sync_delete = \Newspack\Reader_Activation::get_setting( 'sync_esp_delete' );
-		if ( ! $sync_delete ) {
-			return;
-		}
-		return Newspack_Newsletters_Contacts::delete( $user_id );
 	}
 
 	/**

--- a/includes/class-newspack-newsletters-subscription.php
+++ b/includes/class-newspack-newsletters-subscription.php
@@ -33,6 +33,7 @@ class Newspack_Newsletters_Subscription {
 	 */
 	public static function init() {
 		add_action( 'rest_api_init', [ __CLASS__, 'register_api_endpoints' ] );
+		add_action( 'newspack_registered_reader', [ __CLASS__, 'newspack_registered_reader' ], 10, 5 );
 
 		/** User email verification for subscription management. */
 		add_action( 'resetpass_form', [ __CLASS__, 'set_current_user_email_verified' ] );
@@ -547,6 +548,46 @@ class Newspack_Newsletters_Subscription {
 	public static function delete_user_subscription( $user_id ) {
 		_deprecated_function( __METHOD__, '2.21', 'Newspack_Newsletters_Contacts::delete' );
 		return Newspack_Newsletters_Contacts::delete( $user_id );
+	}
+
+	/**
+	 * Add a contact to ESP when a reader is registered.
+	 *
+	 * @param string         $email         Email address.
+	 * @param bool           $authenticate  Whether to authenticate after registering.
+	 * @param false|int      $user_id       The created user id.
+	 * @param false|\WP_User $existing_user The existing user object.
+	 * @param array          $metadata      Metadata.
+	 */
+	public static function newspack_registered_reader( $email, $authenticate, $user_id, $existing_user, $metadata ) {
+		// Prevent double-syncing to audience if the registration method was through a Newsletter Subscription Form block.
+		if ( isset( $metadata['registration_method'] ) && 'newsletters-subscription' === $metadata['registration_method'] ) {
+			return;
+		}
+
+		if ( empty( $metadata['lists'] ) ) {
+			return;
+		}
+
+		$lists = $metadata['lists'];
+		unset( $metadata['lists'] );
+
+		$metadata['newsletters_subscription_method'] = 'reader-registration';
+
+		// Adding is actually upserting, so no need to check if the hook is called for an existing user.
+		try {
+			self::add_contact(
+				[
+					'email'    => $email,
+					'metadata' => $metadata,
+				],
+				$lists,
+				true // Async.
+			);
+		} catch ( \Exception $e ) {
+			// Avoid breaking the registration process.
+			Newspack_Newsletters_Logger::log( 'Error adding contact: ' . $e->getMessage() );
+		}
 	}
 
 	/**

--- a/includes/service-providers/active_campaign/class-newspack-newsletters-active-campaign.php
+++ b/includes/service-providers/active_campaign/class-newspack-newsletters-active-campaign.php
@@ -1150,9 +1150,9 @@ final class Newspack_Newsletters_Active_Campaign extends \Newspack_Newsletters_S
 		$existing_contact = $this->get_contact_data( $email );
 		if ( is_wp_error( $existing_contact ) ) {
 			/** Create contact */
-			// Call Newspack_Newsletters_Subscription's method (not the provider's directly),
+			// Call Newspack_Newsletters_Contacts's method (not the provider's directly),
 			// so the appropriate hooks are called.
-			$contact_data = Newspack_Newsletters_Subscription::add_contact( [ 'email' => $email ] );
+			$contact_data = Newspack_Newsletters_Contacts::upsert( [ 'email' => $email ] );
 			if ( is_wp_error( $contact_data ) ) {
 				return $contact_data;
 			}

--- a/includes/service-providers/constant_contact/class-newspack-newsletters-constant-contact.php
+++ b/includes/service-providers/constant_contact/class-newspack-newsletters-constant-contact.php
@@ -936,9 +936,9 @@ final class Newspack_Newsletters_Constant_Contact extends \Newspack_Newsletters_
 		$contact_data = $this->get_contact_data( $email );
 		if ( is_wp_error( $contact_data ) ) {
 			/** Create contact */
-			// Call Newspack_Newsletters_Subscription's method (not the provider's directly),
+			// Call Newspack_Newsletters_Contacts's method (not the provider's directly),
 			// so the appropriate hooks are called.
-			$contact_data = Newspack_Newsletters_Subscription::add_contact( [ 'email' => $email ] );
+			$contact_data = Newspack_Newsletters_Contacts::upsert( [ 'email' => $email ] );
 			if ( is_wp_error( $contact_data ) ) {
 				return $contact_data;
 			}

--- a/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp.php
+++ b/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp.php
@@ -1535,7 +1535,7 @@ final class Newspack_Newsletters_Mailchimp extends \Newspack_Newsletters_Service
 		$contact = $this->get_contact_data( $email );
 		if ( is_wp_error( $contact ) ) {
 			/** Create contact */
-			$result = Newspack_Newsletters_Subscription::add_contact( [ 'email' => $email ], $lists_to_add );
+			$result = Newspack_Newsletters_Contacts::upsert( [ 'email' => $email ], $lists_to_add );
 			if ( is_wp_error( $result ) ) {
 				return $result;
 			}

--- a/src/blocks/subscribe/index.php
+++ b/src/blocks/subscribe/index.php
@@ -498,7 +498,7 @@ function process_form() {
 		\Newspack\Reader_Activation::register_reader( $email, $name, true, $metadata );
 	}
 
-	$result = \Newspack_Newsletters_Subscription::add_contact(
+	$result = \Newspack_Newsletters_Contacts::upsert(
 		[
 			'name'     => $name ?? null,
 			'email'    => $email,


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

This brings a few changes

https://github.com/Automattic/newspack-newsletters/pull/1575/commits/75eb9ffb2cb83e130820a5b6e2c032a4fb9fecf0 just replaces calls to the deprecated methods to the new ones. No actual testing needed.

https://github.com/Automattic/newspack-newsletters/pull/1575/commits/a1fea57388a608f38016ab5c34b1b8d7bd2674d0 moves the `delete_user` hook to the main plugin as a Data Events API event,  since it is a RAS related feature. Testing instructions below.

### How to test the changes in this Pull Request:

Testing use delete

1. checktou https://github.com/Automattic/newspack-plugin/pull/3259
2. Make sure you have RAS enabled and SYnc to ESP enabled
3. Register a reader (or use an existing registered reader)
4. Delete the user from the wp-admin dashboard
5.Confirm you see `Executing action handlers for "reader_deleted".` on your logs
6. Confirm the contact is deleted from the ESP

Note: we are just moving code around, if the contact is not deleted from the ESP chances are that this was broken before. The important test is to see if the code that should be invoked is being invoked.

Also, there is supposed to be a `sync_esp_delete` options for RAS but I couldn't find a UI for it.

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
