### PR TITLE
feat: make "Send To" UI autocomplete instead of dropdowns

### DIFF
--- a/includes/class-subscription-list.php
+++ b/includes/class-subscription-list.php
@@ -537,15 +537,16 @@ class Subscription_List {
 	 */
 	public function to_array() {
 		return [
-			'id'          => $this->get_form_id(),
-			'db_id'       => $this->get_id(),
-			'title'       => $this->get_title(),
-			'name'        => $this->get_title(),
-			'description' => $this->get_description(),
-			'type'        => $this->get_type(),
-			'type_label'  => $this->get_type_label(),
-			'edit_link'   => $this->get_edit_link(),
-			'active'      => $this->is_active(),
+			'id'           => $this->get_form_id(),
+			'db_id'        => $this->get_id(),
+			'title'        => $this->get_title(),
+			'name'         => $this->get_title(),
+			'description'  => $this->get_description(),
+			'type'         => $this->get_type(),
+			'type_label'   => $this->get_type_label(),
+			'edit_link'    => $this->get_edit_link(),
+			'active'       => $this->is_active(),
+			'esp_settings' => $this->get_current_provider_settings(),
 		];
 	}
 }

--- a/includes/service-providers/constant_contact/class-newspack-newsletters-constant-contact.php
+++ b/includes/service-providers/constant_contact/class-newspack-newsletters-constant-contact.php
@@ -387,7 +387,7 @@ final class Newspack_Newsletters_Constant_Contact extends \Newspack_Newsletters_
 			$activity = $campaign->activity;
 
 			if ( ! in_array( $segment_id, $activity->segment_ids, true ) ) {
-				$activity->segment_ids[]    = $segment_id;
+				$activity->segment_ids      = [ $segment_id ];
 				$activity->contact_list_ids = [];
 			}
 
@@ -461,13 +461,16 @@ final class Newspack_Newsletters_Constant_Contact extends \Newspack_Newsletters_
 			$lists    = $cc->get_contact_lists();
 			$segments = $cc->get_segments();
 
-			return [
+			$data = [
 				'lists'       => $lists,
 				'campaign'    => $campaign,
 				'campaign_id' => $cc_campaign_id,
 				'segments'    => $segments,
 			];
 
+			update_post_meta( $post_id, 'newsletterData', $data );
+
+			return $data;
 		} catch ( Exception $e ) {
 			return new WP_Error(
 				'newspack_newsletters_constant_contact_error',
@@ -671,11 +674,6 @@ final class Newspack_Newsletters_Constant_Contact extends \Newspack_Newsletters_
 				$campaign_result = $cc->create_campaign( $campaign );
 			}
 			update_post_meta( $post->ID, 'cc_campaign_id', $campaign_result->campaign_id );
-			// Retrieve and store campaign data.
-			$data = $this->retrieve( $post->ID );
-			if ( ! is_wp_error( $data ) ) {
-				update_post_meta( $post->ID, 'newsletterData', $data );
-			}
 			return $campaign_result;
 
 		} catch ( Exception $e ) {

--- a/includes/service-providers/constant_contact/class-newspack-newsletters-constant-contact.php
+++ b/includes/service-providers/constant_contact/class-newspack-newsletters-constant-contact.php
@@ -468,6 +468,7 @@ final class Newspack_Newsletters_Constant_Contact extends \Newspack_Newsletters_
 				'segments'    => $segments,
 			];
 
+			// Store retrieved campaign data.
 			update_post_meta( $post_id, 'newsletterData', $data );
 
 			return $data;
@@ -674,6 +675,10 @@ final class Newspack_Newsletters_Constant_Contact extends \Newspack_Newsletters_
 				$campaign_result = $cc->create_campaign( $campaign );
 			}
 			update_post_meta( $post->ID, 'cc_campaign_id', $campaign_result->campaign_id );
+
+			// Retrieve and store campaign data.
+			$this->retrieve( $post->ID );
+
 			return $campaign_result;
 
 		} catch ( Exception $e ) {

--- a/src/newsletter-editor/public/index.js
+++ b/src/newsletter-editor/public/index.js
@@ -13,6 +13,7 @@ const PublicSettingsComponent = props => {
 
 	return (
 		<Fragment>
+			<hr />
 			<ToggleControl
 				className="newspack-newsletters__public-toggle-control"
 				label={ __( 'Public newsletter', 'newspack-newsletters' ) }

--- a/src/newsletter-editor/sidebar/index.js
+++ b/src/newsletter-editor/sidebar/index.js
@@ -22,6 +22,7 @@ import withApiHandler from '../../components/with-api-handler';
 import './style.scss';
 
 const Sidebar = ( {
+	createErrorNotice,
 	isConnected,
 	oauthUrl,
 	onAuthorize,
@@ -151,6 +152,7 @@ const Sidebar = ( {
 				renderSubject={ renderSubject }
 				renderFrom={ renderFrom }
 				renderPreviewText={ renderPreviewText }
+				createErrorNotice={ createErrorNotice }
 				updateMeta={ meta => editPost( { meta } ) }
 			/>
 		</Fragment>
@@ -175,6 +177,7 @@ export default compose( [
 	} ),
 	withDispatch( dispatch => {
 		const { editPost } = dispatch( 'core/editor' );
-		return { editPost };
+		const { createErrorNotice } = dispatch( 'core/notices' );
+		return { editPost, createErrorNotice };
 	} ),
 ] )( Sidebar );

--- a/src/newsletter-editor/sidebar/index.js
+++ b/src/newsletter-editor/sidebar/index.js
@@ -16,7 +16,7 @@ import { once } from 'lodash';
 /**
  * Internal dependencies
  */
-import { getEditPostPayload, hasValidEmail } from '../utils';
+import { hasValidEmail } from '../utils';
 import { getServiceProvider } from '../../service-providers';
 import withApiHandler from '../../components/with-api-handler';
 import './style.scss';
@@ -35,17 +35,8 @@ const Sidebar = ( {
 	previewText,
 	newsletterData,
 	stringifiedLayoutDefaults,
-	apiFetchWithErrorHandling,
 	postId,
 } ) => {
-	const apiFetch = config =>
-		apiFetchWithErrorHandling( config ).then( result => {
-			if ( typeof result === 'object' && result.campaign ) {
-				editPost( getEditPostPayload( result ) );
-			}
-			return result;
-		} );
-
 	const getCampaignName = () => {
 		if ( typeof campaignName === 'string' ) {
 			return campaignName;
@@ -155,7 +146,7 @@ const Sidebar = ( {
 				newsletterData={ newsletterData }
 				stringifiedLayoutDefaults={ stringifiedLayoutDefaults }
 				inFlight={ inFlight }
-				apiFetch={ apiFetch }
+				editPost={ editPost }
 				renderCampaignName={ renderCampaignName }
 				renderSubject={ renderSubject }
 				renderFrom={ renderFrom }

--- a/src/newsletter-editor/sidebar/send-to.js
+++ b/src/newsletter-editor/sidebar/send-to.js
@@ -4,6 +4,7 @@
 import { __ } from '@wordpress/i18n';
 import { FormTokenField, Button, ButtonGroup, Notice } from '@wordpress/components';
 import { useState } from '@wordpress/element';
+import { Icon, external } from '@wordpress/icons';
 
 const SendTo = ( {
 	availableLists,
@@ -31,7 +32,6 @@ const SendTo = ( {
 				<div>
 					<p>
 						<strong>{ getLabel( selectedList ) }</strong>{ ' ' }
-						{ getLink ? getLink( selectedList ) : null }
 					</p>
 				</div>
 			) : (
@@ -67,6 +67,7 @@ const SendTo = ( {
 							<Button
 								disabled={ isUpdating }
 								onClick={ () => setIsEditing( true ) }
+								size="small"
 								variant="secondary"
 							>
 								{ __( 'Edit', 'newspack-newsletters' ) }
@@ -88,15 +89,29 @@ const SendTo = ( {
 												setIsEditing( false );
 											} );
 									} }
+									size="small"
 									variant="secondary"
 								>
 									{ __( 'Reset', 'newspack-newsletters' ) }
 								</Button>
 							) }
+							{ getLink && (
+								<Button
+									disabled={ isUpdating }
+									href={ getLink( selectedList ) }
+									size="small"
+									target="_blank"
+									variant="secondary"
+									rel="noopener noreferrer"
+								>
+									{ __( 'Manage', 'newspack-newsletters' ) }
+									<Icon icon={ external } size={ 14 } />
+								</Button>
+							) }
 						</>
 					) }
 					{ isEditing && (
-						<Button onClick={ () => setIsEditing( false ) } variant="secondary">
+						<Button onClick={ () => setIsEditing( false ) } variant="secondary" size="small">
 							{ __( 'Cancel', 'newspack-newsletters' ) }
 						</Button>
 					) }

--- a/src/newsletter-editor/sidebar/send-to.js
+++ b/src/newsletter-editor/sidebar/send-to.js
@@ -1,21 +1,12 @@
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import { FormTokenField, Button, ButtonGroup, Notice } from '@wordpress/components';
 import { useState } from '@wordpress/element';
 import { Icon, external } from '@wordpress/icons';
 
-const SendTo = ( {
-	availableLists,
-	formLabel,
-	getLabel,
-	getLink = null,
-	onChange,
-	placeholder,
-	reset,
-	selectedList,
-} ) => {
+const SendTo = ( { availableItems, formLabel, onChange, placeholder, reset, selectedItem } ) => {
 	const [ isEditing, setIsEditing ] = useState( false );
 	const [ isUpdating, setIsUpdating ] = useState( false );
 	const [ error, setError ] = useState( false );
@@ -28,12 +19,26 @@ const SendTo = ( {
 				</Notice>
 			) }
 
-			{ selectedList && ! isEditing ? (
-				<div>
-					<p>
-						<strong>{ getLabel( selectedList ) }</strong>{ ' ' }
+			{ selectedItem && ! isEditing ? (
+				<>
+					<p className="newspack-newsletters__send-to-details">
+						{ selectedItem.name }
+						<span>
+							{ sprintf(
+								// Translators: %1$s is the item type, %2$s is details about the item.
+								__( '%1$s %2$s', 'newspack-newsletters' ),
+								isUpdating
+									? sprintf(
+											// Translators: The item type.
+											__( 'Resetting %s…', 'newspack-newsletters' ),
+											selectedItem.typeLabel.toLowerCase()
+									  )
+									: selectedItem.typeLabel,
+								! isUpdating && selectedItem.details ? ' • ' + selectedItem.details : ''
+							).trim() }
+						</span>
 					</p>
-				</div>
+				</>
 			) : (
 				<>
 					<FormTokenField
@@ -52,7 +57,7 @@ const SendTo = ( {
 									setIsEditing( false );
 								} );
 						} }
-						suggestions={ availableLists.map( suggestion => suggestion.label ) }
+						suggestions={ availableItems.map( item => item.label ) }
 						placeholder={ isUpdating ? __( 'Updating campaign…', 'newspack' ) : placeholder }
 						value={ [] }
 						__experimentalExpandOnFocus={ true }
@@ -60,7 +65,7 @@ const SendTo = ( {
 					/>
 				</>
 			) }
-			{ selectedList && (
+			{ selectedItem && (
 				<ButtonGroup>
 					{ ! isEditing && (
 						<>
@@ -95,10 +100,10 @@ const SendTo = ( {
 									{ __( 'Reset', 'newspack-newsletters' ) }
 								</Button>
 							) }
-							{ getLink && (
+							{ selectedItem.editLink && (
 								<Button
 									disabled={ isUpdating }
-									href={ getLink( selectedList ) }
+									href={ selectedItem.editLink }
 									size="small"
 									target="_blank"
 									variant="secondary"

--- a/src/newsletter-editor/sidebar/send-to.js
+++ b/src/newsletter-editor/sidebar/send-to.js
@@ -39,6 +39,7 @@ const SendTo = ( {
 					<FormTokenField
 						disabled={ isUpdating }
 						label={ formLabel || __( 'Select a list', 'newspack' ) }
+						maxSuggestions={ 10 }
 						onChange={ items => {
 							setError( false );
 							setIsUpdating( true );
@@ -54,6 +55,7 @@ const SendTo = ( {
 						suggestions={ availableLists.map( suggestion => suggestion.label ) }
 						placeholder={ isUpdating ? __( 'Updating campaign…', 'newspack' ) : placeholder }
 						value={ [] }
+						__experimentalExpandOnFocus={ true }
 						__experimentalShowHowTo={ false }
 					/>
 				</>

--- a/src/newsletter-editor/sidebar/send-to.js
+++ b/src/newsletter-editor/sidebar/send-to.js
@@ -24,30 +24,21 @@ const SendTo = ( { availableItems, formLabel, onChange, placeholder, reset, sele
 					<p className="newspack-newsletters__send-to-details">
 						{ selectedItem.name }
 						<span>
-							{ sprintf(
-								// Translators: %1$s is the item type, %2$s is details about the item.
-								__( '%1$s %2$s', 'newspack-newsletters' ),
-								isUpdating
-									? sprintf(
-											// Translators: The item type.
-											__( 'Resetting %s…', 'newspack-newsletters' ),
-											selectedItem.typeLabel.toLowerCase()
-									  )
-									: selectedItem.typeLabel,
-								! isUpdating && selectedItem.hasOwnProperty( 'count' )
-									? ' • ' +
-											sprintf(
-												// Translators: %d is the number of contacts in the list.
-												_n(
-													'%d contact',
-													'%d contacts',
-													selectedItem.count,
-													'newspack-newsletters'
-												),
-												selectedItem.count.toLocaleString()
-											)
-									: ''
-							).trim() }
+							{ isUpdating
+								? sprintf(
+										// Translators: Shown while resetting the selected send-to item. %s is the item type.
+										__( 'Resetting %s…', 'newspack-newsletters' ),
+										selectedItem.typeLabel.toLowerCase()
+								  )
+								: selectedItem.typeLabel }
+							{ ! isUpdating && selectedItem.hasOwnProperty( 'count' )
+								? ' • ' +
+								  sprintf(
+										// Translators: If available, show a contact count alongside the selected item's type. %d is the number of contacts in the item.
+										_n( '%d contact', '%d contacts', selectedItem.count, 'newspack-newsletters' ),
+										selectedItem.count.toLocaleString()
+								  )
+								: '' }
 						</span>
 					</p>
 				</>

--- a/src/newsletter-editor/sidebar/send-to.js
+++ b/src/newsletter-editor/sidebar/send-to.js
@@ -1,0 +1,105 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { FormTokenField, Button, ButtonGroup, Notice } from '@wordpress/components';
+import { useState } from '@wordpress/element';
+
+const SendTo = ( {
+	availableLists,
+	formLabel,
+	getLabel,
+	getLink = null,
+	onChange,
+	placeholder,
+	reset,
+	selectedList,
+} ) => {
+	const [ isEditing, setIsEditing ] = useState( false );
+	const [ isUpdating, setIsUpdating ] = useState( false );
+	const [ error, setError ] = useState( false );
+
+	return (
+		<>
+			{ error && ! isEditing && (
+				<Notice status="error" isDismissible={ false }>
+					{ error }
+				</Notice>
+			) }
+
+			{ selectedList && ! isEditing ? (
+				<div>
+					<p>
+						<strong>{ getLabel( selectedList ) }</strong>{ ' ' }
+						{ getLink ? getLink( selectedList ) : null }
+					</p>
+				</div>
+			) : (
+				<>
+					<FormTokenField
+						disabled={ isUpdating }
+						label={ formLabel || __( 'Select a list', 'newspack' ) }
+						onChange={ items => {
+							setError( false );
+							setIsUpdating( true );
+							onChange( items )
+								.catch( e => {
+									setError( e.message || __( 'Error updating campaign.', 'newspack-newsletters' ) );
+								} )
+								.finally( () => {
+									setIsUpdating( false );
+									setIsEditing( false );
+								} );
+						} }
+						suggestions={ availableLists.map( suggestion => suggestion.label ) }
+						placeholder={ isUpdating ? __( 'Updating campaign…', 'newspack' ) : placeholder }
+						value={ [] }
+						__experimentalShowHowTo={ false }
+					/>
+				</>
+			) }
+			{ selectedList && (
+				<ButtonGroup>
+					{ ! isEditing && (
+						<>
+							<Button
+								disabled={ isUpdating }
+								onClick={ () => setIsEditing( true ) }
+								variant="secondary"
+							>
+								{ __( 'Edit', 'newspack-newsletters' ) }
+							</Button>
+							<Button
+								disabled={ isUpdating }
+								onClick={ () => {
+									setError( false );
+									setIsUpdating( true );
+									reset()
+										.catch( e => {
+											setError(
+												e.message || __( 'Error updating campaign.', 'newspack-newsletters' )
+											);
+										} )
+										.finally( () => {
+											setIsUpdating( false );
+											setIsEditing( false );
+										} );
+								} }
+								variant="secondary"
+							>
+								{ __( 'Reset', 'newspack-newsletters' ) }
+							</Button>
+						</>
+					) }
+					{ isEditing && (
+						<Button onClick={ () => setIsEditing( false ) } variant="secondary">
+							{ __( 'Cancel', 'newspack-newsletters' ) }
+						</Button>
+					) }
+				</ButtonGroup>
+			) }
+		</>
+	);
+};
+
+export default SendTo;

--- a/src/newsletter-editor/sidebar/send-to.js
+++ b/src/newsletter-editor/sidebar/send-to.js
@@ -34,7 +34,7 @@ const SendTo = ( { availableItems, formLabel, onChange, placeholder, reset, sele
 											selectedItem.typeLabel.toLowerCase()
 									  )
 									: selectedItem.typeLabel,
-								! isUpdating && selectedItem.count
+								! isUpdating && selectedItem.hasOwnProperty( 'count' )
 									? ' • ' +
 											sprintf(
 												// Translators: %d is the number of contacts in the list.

--- a/src/newsletter-editor/sidebar/send-to.js
+++ b/src/newsletter-editor/sidebar/send-to.js
@@ -116,7 +116,12 @@ const SendTo = ( { availableItems, formLabel, onChange, placeholder, reset, sele
 						</>
 					) }
 					{ isEditing && (
-						<Button onClick={ () => setIsEditing( false ) } variant="secondary" size="small">
+						<Button
+							disabled={ isUpdating }
+							onClick={ () => setIsEditing( false ) }
+							variant="secondary"
+							size="small"
+						>
 							{ __( 'Cancel', 'newspack-newsletters' ) }
 						</Button>
 					) }

--- a/src/newsletter-editor/sidebar/send-to.js
+++ b/src/newsletter-editor/sidebar/send-to.js
@@ -20,7 +20,7 @@ const SendTo = ( {
 	const [ error, setError ] = useState( false );
 
 	return (
-		<>
+		<div className="newspack-newsletters__send-to">
 			{ error && ! isEditing && (
 				<Notice status="error" isDismissible={ false }>
 					{ error }
@@ -69,26 +69,28 @@ const SendTo = ( {
 							>
 								{ __( 'Edit', 'newspack-newsletters' ) }
 							</Button>
-							<Button
-								disabled={ isUpdating }
-								onClick={ () => {
-									setError( false );
-									setIsUpdating( true );
-									reset()
-										.catch( e => {
-											setError(
-												e.message || __( 'Error updating campaign.', 'newspack-newsletters' )
-											);
-										} )
-										.finally( () => {
-											setIsUpdating( false );
-											setIsEditing( false );
-										} );
-								} }
-								variant="secondary"
-							>
-								{ __( 'Reset', 'newspack-newsletters' ) }
-							</Button>
+							{ reset && (
+								<Button
+									disabled={ isUpdating }
+									onClick={ () => {
+										setError( false );
+										setIsUpdating( true );
+										reset()
+											.catch( e => {
+												setError(
+													e.message || __( 'Error updating campaign.', 'newspack-newsletters' )
+												);
+											} )
+											.finally( () => {
+												setIsUpdating( false );
+												setIsEditing( false );
+											} );
+									} }
+									variant="secondary"
+								>
+									{ __( 'Reset', 'newspack-newsletters' ) }
+								</Button>
+							) }
 						</>
 					) }
 					{ isEditing && (
@@ -98,7 +100,7 @@ const SendTo = ( {
 					) }
 				</ButtonGroup>
 			) }
-		</>
+		</div>
 	);
 };
 

--- a/src/newsletter-editor/sidebar/send-to.js
+++ b/src/newsletter-editor/sidebar/send-to.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { __, sprintf } from '@wordpress/i18n';
+import { __, _n, sprintf } from '@wordpress/i18n';
 import { FormTokenField, Button, ButtonGroup, Notice } from '@wordpress/components';
 import { useState } from '@wordpress/element';
 import { Icon, external } from '@wordpress/icons';
@@ -34,7 +34,19 @@ const SendTo = ( { availableItems, formLabel, onChange, placeholder, reset, sele
 											selectedItem.typeLabel.toLowerCase()
 									  )
 									: selectedItem.typeLabel,
-								! isUpdating && selectedItem.details ? ' • ' + selectedItem.details : ''
+								! isUpdating && selectedItem.count
+									? ' • ' +
+											sprintf(
+												// Translators: %d is the number of contacts in the list.
+												_n(
+													'%d contact',
+													'%d contacts',
+													selectedItem.count,
+													'newspack-newsletters'
+												),
+												selectedItem.count.toLocaleString()
+											)
+									: ''
 							).trim() }
 						</span>
 					</p>

--- a/src/newsletter-editor/sidebar/style.scss
+++ b/src/newsletter-editor/sidebar/style.scss
@@ -27,6 +27,13 @@
 		}
 	}
 
+	&__send-to {
+		margin-top: 16px;
+		.components-notice + * {
+			margin-top: 16px;
+		}
+	}
+
 	&__send-test {
 		.components-button + .components-button {
 			margin-left: 12px;

--- a/src/newsletter-editor/sidebar/style.scss
+++ b/src/newsletter-editor/sidebar/style.scss
@@ -32,11 +32,14 @@
 		.components-notice + * {
 			margin-top: 16px;
 		}
-
+		.components-button-group {
+			margin-top: 8px;
+		}
 		.newspack-newsletters__send-to-details {
 			font-weight: 500;
+			margin-bottom: 0;
 			span {
-				color: var(--wp-components-color-accent, var(--wp-admin-theme-color, #3858e9));
+				color: wp-colors.$gray-600;
 				display: block;
 			}
 		}

--- a/src/newsletter-editor/sidebar/style.scss
+++ b/src/newsletter-editor/sidebar/style.scss
@@ -28,9 +28,17 @@
 	}
 
 	&__send-to {
-		margin-top: 16px;
+		margin: 16px 0;
 		.components-notice + * {
 			margin-top: 16px;
+		}
+
+		.newspack-newsletters__send-to-details {
+			font-weight: 500;
+			span {
+				color: var(--wp-components-color-accent, var(--wp-admin-theme-color, #3858e9));
+				display: block;
+			}
 		}
 	}
 

--- a/src/newsletter-editor/utils.js
+++ b/src/newsletter-editor/utils.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import apiFetch from '@wordpress/api-fetch';
-import { __, sprintf } from '@wordpress/i18n';
+import { __, _n, sprintf } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -74,11 +74,11 @@ export const getSuggestionLabel = item => {
 		__( '[%1$s] %2$s %3$s', 'newspack-newsletters' ),
 		item.typeLabel,
 		item.name,
-		item?.details && null !== item.details
+		item?.count && null !== item?.count
 			? sprintf(
-					// Translators: %s contains more details about the item.
-					__( '(%s)', 'newspack-newsletters' ),
-					item.details
+					// Translators: %d is the number of contacts in the list.
+					_n( '(%d contact)', '(%d contacts)', item.count, 'newspack-newsletters' ),
+					item.count
 			  )
 			: ''
 	).trim();

--- a/src/newsletter-editor/utils.js
+++ b/src/newsletter-editor/utils.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import apiFetch from '@wordpress/api-fetch';
-import { __, _n, sprintf } from '@wordpress/i18n';
+import { _n, sprintf } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -64,22 +64,19 @@ export const refreshEmailHtml = async ( postId, postTitle, postContent ) => {
 
 /**
  * Get a label for the Send To autocomplete field.
+ * Format: [ITEM TYPE] Item Name (contact count)
  *
  * @param {Object} item A list or sublist item.
  * @return {string} The autocomplete suggestion label for the item.
  */
 export const getSuggestionLabel = item => {
-	return sprintf(
-		// Translators: %1$s is the item type, %2$s is the item name, %3$s is more details about the item, if available.
-		__( '[%1$s] %2$s %3$s', 'newspack-newsletters' ),
-		item.typeLabel,
-		item.name,
+	const contactCount =
 		item?.count && null !== item?.count
 			? sprintf(
-					// Translators: %d is the number of contacts in the list.
+					// Translators: If available, show a contact count alongside the suggested item. %d is the number of contacts in the suggested item.
 					_n( '(%d contact)', '(%d contacts)', item.count, 'newspack-newsletters' ),
 					item.count
 			  )
-			: ''
-	).trim();
+			: '';
+	return `[${ item.typeLabel.toUpperCase() }] ${ item.name } ${ contactCount }`.trim();
 };

--- a/src/newsletter-editor/utils.js
+++ b/src/newsletter-editor/utils.js
@@ -2,6 +2,7 @@
  * WordPress dependencies
  */
 import apiFetch from '@wordpress/api-fetch';
+import { __, sprintf } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -59,4 +60,26 @@ export const refreshEmailHtml = async ( postId, postTitle, postContent ) => {
 	// Once received MJML markup, convert it to email-compliant HTML and save as post meta.
 	const { html } = mjml2html( mjml, { keepComments: false, minify: true } );
 	return html;
+};
+
+/**
+ * Get a label for the Send To autocomplete field.
+ *
+ * @param {Object} item A list or sublist item.
+ * @return {string} The autocomplete suggestion label for the item.
+ */
+export const getSuggestionLabel = item => {
+	return sprintf(
+		// Translators: %1$s is the item type, %2$s is the item name, %3$s is more details about the item, if available.
+		__( '[%1$s] %2$s %3$s', 'newspack-newsletters' ),
+		item.typeLabel,
+		item.name,
+		item?.details && null !== item.details
+			? sprintf(
+					// Translators: %s contains more details about the item.
+					__( '(%s)', 'newspack-newsletters' ),
+					item.details
+			  )
+			: ''
+	).trim();
 };

--- a/src/service-providers/active_campaign/ProviderSidebar.js
+++ b/src/service-providers/active_campaign/ProviderSidebar.js
@@ -215,7 +215,7 @@ const ProviderSidebarComponent = ( {
 					selectedSegment.typeLabel.toLowerCase()
 			  )
 			: sprintf(
-					// Translators: A summary of which list the campaign is set to send to, and the total number of contacts, if available.
+					// Translators: A summary of which list the campaign is set to send to, and the total number of contacts, if available. %1$s is the number of contacts. %2$s us the label of the list (ex: Main), %3$s is the label for the type of the list (ex: "list" on Active Campaign and "audience" on Mailchimp).
 					_n(
 						'This newsletter will be sent to <strong>%1$s contact</strong> in the <strong>%2$s</strong> %3$s.',
 						'This newsletter will be sent to <strong>%1$s contacts</strong> in the <strong>%2$s</strong> %3$s.',

--- a/src/service-providers/active_campaign/ProviderSidebar.js
+++ b/src/service-providers/active_campaign/ProviderSidebar.js
@@ -201,36 +201,38 @@ const ProviderSidebarComponent = ( {
 	}
 
 	const renderSelectedSummary = () => {
-		return selectedList ? (
+		if ( ! selectedList ) {
+			return null;
+		}
+
+		const summary = selectedSegment
+			? sprintf(
+					// Translators: A summary of which list and sublist the campaign is set to send to, and the total number of contacts, if available.
+					'This newsletter will be sent to <strong>all contacts</strong> in the <strong>%1$s</strong> %2$s who are part of the <strong>%3$s</strong> %4$s.',
+					selectedList.name,
+					selectedList.typeLabel.toLowerCase(),
+					selectedSegment.name,
+					selectedSegment.typeLabel.toLowerCase()
+			  )
+			: sprintf(
+					// Translators: A summary of which list the campaign is set to send to, and the total number of contacts, if available.
+					_n(
+						'This newsletter will be sent to <strong>%1$s contact</strong> in the <strong>%2$s</strong> %3$s.',
+						'This newsletter will be sent to <strong>%1$s contacts</strong> in the <strong>%2$s</strong> %3$s.',
+						selectedList.count,
+						'newspack-newsletters'
+					),
+					selectedList.count.toLocaleString(),
+					selectedList.name,
+					selectedList.typeLabel.toLowerCase()
+			  );
+		return (
 			<p
 				dangerouslySetInnerHTML={ {
-					__html: sprintf(
-						// Translators: %1$s is the number of members, %2$s is the item name, %3$s is the item type, %4$s is the subitem name and type (if any).
-						__(
-							'This newsletter will be sent to <strong>%1$s</strong> in the <strong>%2$s</strong> %3$s%4$s.',
-							'newspack-newsletters'
-						),
-						! selectedSegment && selectedList?.count // AC doesn't provide contact counts for segments, so we only want to show a count if a list is selected without a segment.
-							? sprintf(
-									// Translators: %d is the number of contacts in the list.
-									_n( '%d contact', '%d contacts', selectedList.count, 'newspack-newsletters' ),
-									selectedList.count.toLocaleString()
-							  )
-							: __( 'all contacts', 'newspack-newsletters' ),
-						selectedList.name,
-						selectedList.typeLabel.toLowerCase(),
-						selectedSegment
-							? sprintf(
-									// Translators: %1$s is the parent item name, %2$s is the parent item type.
-									__( ' who are part of the %1$s %2$s', 'newspack-newsletters' ),
-									`<strong>${ selectedSegment.name }</strong>`,
-									selectedSegment.typeLabel.toLowerCase()
-							  )
-							: ''
-					),
+					__html: summary,
 				} }
 			/>
-		) : null;
+		);
 	};
 
 	return (

--- a/src/service-providers/active_campaign/ProviderSidebar.js
+++ b/src/service-providers/active_campaign/ProviderSidebar.js
@@ -263,7 +263,7 @@ const ProviderSidebarComponent = ( {
 								'This newsletter will be sent to all %1$smembers of the %2$s %3$s%4$s.',
 								'newspack-newsletters'
 							),
-							selectedList.typeLabel && ! isNaN( selectedList.details )
+							selectedList.details && ! isNaN( selectedList.details )
 								? `<strong>${ selectedList.details.toLocaleString() }</strong>` + ' '
 								: '',
 							`<strong>${ selectedList.name }</strong>`,

--- a/src/service-providers/active_campaign/ProviderSidebar.js
+++ b/src/service-providers/active_campaign/ProviderSidebar.js
@@ -235,7 +235,7 @@ const ProviderSidebarComponent = ( {
 			<SendTo
 				availableItems={ lists }
 				onChange={ selected => onChangeSendTo( selected ) }
-				placeholder={ __( 'Type a list name to search.', 'newspack' ) }
+				placeholder={ __( 'Type a list name to search', 'newspack' ) }
 				reset={ async () => {
 					updateMeta( { ac_list_id: '' } );
 					updateMeta( { ac_segment_id: '' } );
@@ -247,8 +247,8 @@ const ProviderSidebarComponent = ( {
 					<SendTo
 						availableItems={ segments }
 						onChange={ selected => onChangeSendTo( selected, 'segment' ) }
-						formLabel={ __( 'Select a segment (optional)', 'newspack' ) }
-						placeholder={ __( 'Filter by segment', 'newspack' ) }
+						formLabel={ __( 'Filter by segment (optional)', 'newspack' ) }
+						placeholder={ __( 'Type a segment name to search', 'newspack' ) }
 						reset={ async () => updateMeta( { ac_segment_id: '' } ) }
 						selectedItem={ selectedSegment }
 					/>

--- a/src/service-providers/active_campaign/ProviderSidebar.js
+++ b/src/service-providers/active_campaign/ProviderSidebar.js
@@ -259,11 +259,11 @@ const ProviderSidebarComponent = ( {
 						__html: sprintf(
 							// Translators: %1$s is the number of members, %2$s is the item name, %3$s is the item type, %4$s is the parent item name and type (if any).
 							__(
-								'This newsletter will be sent to all %1$s of the %2$s %3$s%4$s.',
+								'This newsletter will be sent to all %1$s in the %2$s %3$s%4$s.',
 								'newspack-newsletters'
 							),
-							! selectedSegment && selectedList.details
-								? `<strong>${ selectedList.details }</strong> `
+							selectedSegment?.details || ( ! selectedSegment && selectedList?.details )
+								? `<strong>${ selectedSegment?.details || selectedList?.details }</strong> `
 								: __( 'contacts', 'newspack-newsletters' ),
 							`<strong>${ selectedList.name }</strong>`,
 							selectedList.typeLabel.toLowerCase(),

--- a/src/service-providers/active_campaign/ProviderSidebar.js
+++ b/src/service-providers/active_campaign/ProviderSidebar.js
@@ -114,7 +114,6 @@ const ProviderSidebarComponent = ( {
 				response.segments.map( item => {
 					const formattedItem = {
 						...item,
-						details: __( 'id: ', 'newspack-newsletters' ) + item.id,
 						name: item.name,
 						typeLabel: __( 'Segment', 'newspack-newsletters' ),
 						type: 'segment',

--- a/src/service-providers/active_campaign/ProviderSidebar.js
+++ b/src/service-providers/active_campaign/ProviderSidebar.js
@@ -32,7 +32,7 @@ const getSendToLabel = ( item, type = 'list' ) => {
 			isList
 				? sprintf(
 						// Translators: %d is the number of contacts in the list.
-						_n( '(%d contact)', '(%d contacts)', item.subscriber_count, 'newspack-newsletters' ),
+						_n( '%d contact', '%d contacts', item.subscriber_count, 'newspack-newsletters' ),
 						item.subscriber_count
 				  )
 				: __( 'id: ', 'newspack-newsletters' ) + item.id

--- a/src/service-providers/active_campaign/ProviderSidebar.js
+++ b/src/service-providers/active_campaign/ProviderSidebar.js
@@ -207,7 +207,7 @@ const ProviderSidebarComponent = ( {
 
 		const summary = selectedSegment
 			? sprintf(
-					// Translators: A summary of which list and sublist the campaign is set to send to, and the total number of contacts, if available.
+					// Translators: A summary of which list and sublist the campaign is set to send to, and the total number of contacts, if available. %1$s is the label of the list (ex: Main), %2$s is the label for the type of the list (ex: "list" on Active Campaign and "audience" on Mailchimp). %3$s is the label of the sublist (ex: "paid customers"), and %4$s is the label for the sublist type (ex: tag, group or segment)
 					'This newsletter will be sent to <strong>all contacts</strong> in the <strong>%1$s</strong> %2$s who are part of the <strong>%3$s</strong> %4$s.',
 					selectedList.name,
 					selectedList.typeLabel.toLowerCase(),

--- a/src/service-providers/active_campaign/ProviderSidebar.js
+++ b/src/service-providers/active_campaign/ProviderSidebar.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import apiFetch from '@wordpress/api-fetch';
-import { __, sprintf } from '@wordpress/i18n';
+import { __, _n, sprintf } from '@wordpress/i18n';
 import { compose } from '@wordpress/compose';
 import { withSelect } from '@wordpress/data';
 import { useEffect, useState } from '@wordpress/element';
@@ -30,7 +30,11 @@ const getSendToLabel = ( item, type = 'list' ) => {
 			// Translators: more details on the list or segment.
 			__( '(%s)', 'newspack-newsletters' ),
 			isList
-				? item.subscriber_count + __( ' contacts', 'newspack-newsletters' )
+				? sprintf(
+						// Translators: %d is the number of contacts in the list.
+						_n( '(%d contact)', '(%d contacts)', item.subscriber_count, 'newspack-newsletters' ),
+						item.subscriber_count
+				  )
 				: __( 'id: ', 'newspack-newsletters' ) + item.id
 		)
 	).trim();

--- a/src/service-providers/active_campaign/ProviderSidebar.js
+++ b/src/service-providers/active_campaign/ProviderSidebar.js
@@ -90,13 +90,14 @@ const ProviderSidebarComponent = ( {
 			} );
 			setLists(
 				response.lists.map( item => {
+					const contactCount = parseInt( item.subscriber_count );
 					const formattedItem = {
 						...item,
-						details: item.hasOwnProperty( 'subscriber_count' )
+						details: ! isNaN( contactCount )
 							? sprintf(
 									// Translators: %d is the number of contacts in the list.
-									_n( '%d contact', '%d contacts', item.subscriber_count, 'newspack-newsletters' ),
-									item.subscriber_count.toLocaleString()
+									_n( '%d contact', '%d contacts', contactCount, 'newspack-newsletters' ),
+									contactCount.toLocaleString()
 							  )
 							: null,
 						name: item.name,

--- a/src/service-providers/active_campaign/ProviderSidebar.js
+++ b/src/service-providers/active_campaign/ProviderSidebar.js
@@ -181,7 +181,7 @@ const ProviderSidebarComponent = ( {
 		return selectedItem;
 	};
 
-	if ( ! inFlight && 'publish' === status ) {
+	if ( ! inFlight && ( 'publish' === status || 'private' === status ) ) {
 		return (
 			<Notice status="success" isDismissible={ false }>
 				{ __( 'Campaign has been sent.', 'newspack-newsletters' ) }

--- a/src/service-providers/active_campaign/ProviderSidebar.js
+++ b/src/service-providers/active_campaign/ProviderSidebar.js
@@ -230,6 +230,7 @@ const ProviderSidebarComponent = ( {
 				disabled={ inFlight }
 				onChange={ value => updateMeta( { ac_from_email: value } ) }
 			/>
+			<hr />
 			<strong className="newspack-newsletters__label">
 				{ __( 'Send to', 'newspack-newsletters' ) }
 			</strong>
@@ -247,7 +248,6 @@ const ProviderSidebarComponent = ( {
 			/>
 			{ selectedList && (
 				<>
-					<hr />
 					<SendTo
 						availableLists={ segments }
 						onChange={ selected => onChangeSendTo( selected, 'segment' ) }

--- a/src/service-providers/active_campaign/ProviderSidebar.js
+++ b/src/service-providers/active_campaign/ProviderSidebar.js
@@ -260,12 +260,12 @@ const ProviderSidebarComponent = ( {
 						__html: sprintf(
 							// Translators: %1$s is the number of members, %2$s is the item name, %3$s is the item type, %4$s is the parent item name and type (if any).
 							__(
-								'This newsletter will be sent to all %1$smembers of the %2$s %3$s%4$s.',
+								'This newsletter will be sent to all %1$s of the %2$s %3$s%4$s.',
 								'newspack-newsletters'
 							),
-							selectedList.details && ! isNaN( selectedList.details )
-								? `<strong>${ selectedList.details.toLocaleString() }</strong>` + ' '
-								: '',
+							! selectedSegment && selectedList.details
+								? `<strong>${ selectedList.details }</strong> `
+								: __( 'contacts', 'newspack-newsletters' ),
 							`<strong>${ selectedList.name }</strong>`,
 							selectedList.typeLabel.toLowerCase(),
 							selectedSegment

--- a/src/service-providers/constant_contact/ProviderSidebar.js
+++ b/src/service-providers/constant_contact/ProviderSidebar.js
@@ -173,14 +173,14 @@ const ProviderSidebarComponent = ( {
 				<p
 					dangerouslySetInnerHTML={ {
 						__html: sprintf(
-							// Translators: %1$s is the number of members, %2$s is the item name, %3$s is the item type.
+							// Translators: %1$s is the number of contacts, %2$s is the item name, %3$s is the item type.
 							__(
-								'This newsletter will be sent to all %1$smembers of the %2$s %3$s.',
+								'This newsletter will be sent to all %1$s in the %2$s %3$s.',
 								'newspack-newsletters'
 							),
-							selected.details && ! isNaN( selected.details )
-								? `<strong>${ selected.details.toLocaleString() }</strong>` + ' '
-								: '',
+							selected.details
+								? `<strong>${ selected.details }</strong> `
+								: __( 'contacts', 'newspack-newsletters' ),
 							`<strong>${ selected.name }</strong>`,
 							selected.typeLabel.toLowerCase()
 						),

--- a/src/service-providers/constant_contact/ProviderSidebar.js
+++ b/src/service-providers/constant_contact/ProviderSidebar.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import apiFetch from '@wordpress/api-fetch';
-import { __, sprintf } from '@wordpress/i18n';
+import { __, _n, sprintf } from '@wordpress/i18n';
 import { ExternalLink, Spinner, Notice } from '@wordpress/components';
 import { useEffect } from '@wordpress/element';
 
@@ -19,8 +19,11 @@ const getSendToLabel = item => {
 		isList ? __( 'LIST', 'newspack-newsletters' ) : __( 'SEGMENT', 'newspack-newsletters' ),
 		item.name,
 		item.hasOwnProperty( 'membership_count' )
-			? // Translators: %d is the number of contacts in the list or segment.
-			  sprintf( __( '(%d contacts)', 'newspack-newsletters' ), item.membership_count )
+			? sprintf(
+					// Translators: %d is the number of contacts in the list or segment.
+					_n( '(%d contact)', '(%d contacts)', item.membership_count, 'newspack-newsletters' ),
+					item.membership_count
+			  )
 			: ''
 	).trim();
 };

--- a/src/service-providers/constant_contact/ProviderSidebar.js
+++ b/src/service-providers/constant_contact/ProviderSidebar.js
@@ -32,13 +32,14 @@ const ProviderSidebarComponent = ( {
 	// Standardize data schema. We'll eventually move this standardization to the provider API handlers instead.
 	const availableItems = [ ...lists, ...segments ].map( item => {
 		const isList = item.hasOwnProperty( 'list_id' );
+		const contactCount = parseInt( item.membership_count );
 		const formattedItem = {
 			...item,
-			details: item.hasOwnProperty( 'membership_count' )
+			details: ! isNaN( contactCount )
 				? sprintf(
 						// Translators: %d is the number of contacts in the list or segment.
-						_n( '%d contact', '%d contacts', item.membership_count, 'newspack-newsletters' ),
-						item.membership_count.toLocaleString()
+						_n( '%d contact', '%d contacts', contactCount, 'newspack-newsletters' ),
+						contactCount.toLocaleString()
 				  )
 				: null,
 			editLink: isList

--- a/src/service-providers/constant_contact/ProviderSidebar.js
+++ b/src/service-providers/constant_contact/ProviderSidebar.js
@@ -137,28 +137,36 @@ const ProviderSidebarComponent = ( {
 	}
 
 	const renderSelectedSummary = () => {
-		return selected ? (
+		if ( ! selected ) {
+			return null;
+		}
+
+		const summary = ! selected.hasOwnProperty( 'count' )
+			? sprintf(
+					// Translators: A summary of which list or segment the campaign is set to send to, and the total number of contacts, if available.
+					'This newsletter will be sent to <strong>all contacts</strong> in the <strong>%1$s</strong> %2$s.',
+					selected.name,
+					selected.typeLabel.toLowerCase()
+			  )
+			: sprintf(
+					// Translators: A summary of which list the campaign is set to send to, and the total number of contacts, if available.
+					_n(
+						'This newsletter will be sent to <strong>%1$s contact</strong> in the <strong>%2$s</strong> %3$s.',
+						'This newsletter will be sent to <strong>%1$s contacts</strong> in the <strong>%2$s</strong> %3$s.',
+						selected.count,
+						'newspack-newsletters'
+					),
+					selected.count.toLocaleString(),
+					selected.name,
+					selected.typeLabel.toLowerCase()
+			  );
+		return (
 			<p
 				dangerouslySetInnerHTML={ {
-					__html: sprintf(
-						// Translators: %1$s is the number of contacts, %2$s is the item name, %3$s is the item type.
-						__(
-							'This newsletter will be sent to <strong>%1$s</strong> in the <strong>%2$s</strong> %3$s.',
-							'newspack-newsletters'
-						),
-						selected?.count // CC doesn't provide contact counts for segments, so we only want to show a count if a list is selected without a segment.
-							? sprintf(
-									// Translators: %d is the number of contacts in the list.
-									_n( '%d contact', '%d contacts', selected.count, 'newspack-newsletters' ),
-									selected.count.toLocaleString()
-							  )
-							: __( 'all contacts', 'newspack-newsletters' ),
-						selected.name,
-						selected.typeLabel.toLowerCase()
-					),
+					__html: summary,
 				} }
 			/>
-		) : null;
+		);
 	};
 
 	if (

--- a/src/service-providers/constant_contact/ProviderSidebar.js
+++ b/src/service-providers/constant_contact/ProviderSidebar.js
@@ -57,7 +57,7 @@ const ProviderSidebar = ( {
 	renderPreviewText,
 	newsletterData,
 	postId,
-	updateMeta,
+	updateMetaValue,
 } ) => {
 	const { campaign, lists = [], segments = [] } = newsletterData;
 	const availableLists = [ ...lists, ...segments ].map( item => {
@@ -132,7 +132,7 @@ const ProviderSidebar = ( {
 
 	useEffect( () => {
 		if ( campaign ) {
-			updateMeta( {
+			updateMetaValue( {
 				senderName: campaign.activity.from_name,
 				senderEmail: campaign.activity.from_email,
 			} );

--- a/src/service-providers/constant_contact/ProviderSidebar.js
+++ b/src/service-providers/constant_contact/ProviderSidebar.js
@@ -143,7 +143,7 @@ const ProviderSidebarComponent = ( {
 
 		const summary = ! selected.hasOwnProperty( 'count' )
 			? sprintf(
-					// Translators: A summary of which list or segment the campaign is set to send to, and the total number of contacts, if available.
+					// Translators: A summary of which list or segment the campaign is set to send to, and the total number of contacts, if available.  %1$s us the label of the list (ex: Main), %2$s is the label for the type of the list (ex: "list" on Active Campaign and "audience" on Mailchimp).
 					'This newsletter will be sent to <strong>all contacts</strong> in the <strong>%1$s</strong> %2$s.',
 					selected.name,
 					selected.typeLabel.toLowerCase()

--- a/src/service-providers/constant_contact/ProviderSidebar.js
+++ b/src/service-providers/constant_contact/ProviderSidebar.js
@@ -149,7 +149,7 @@ const ProviderSidebarComponent = ( {
 					selected.typeLabel.toLowerCase()
 			  )
 			: sprintf(
-					// Translators: A summary of which list the campaign is set to send to, and the total number of contacts, if available.
+					// Translators: A summary of which list the campaign is set to send to, and the total number of contacts, if available.  %1$s is the number of contacts. %2$s us the label of the list (ex: Main), %3$s is the label for the type of the list (ex: "list" on Active Campaign and "audience" on Mailchimp).
 					_n(
 						'This newsletter will be sent to <strong>%1$s contact</strong> in the <strong>%2$s</strong> %3$s.',
 						'This newsletter will be sent to <strong>%1$s contacts</strong> in the <strong>%2$s</strong> %3$s.',

--- a/src/service-providers/constant_contact/ProviderSidebar.js
+++ b/src/service-providers/constant_contact/ProviderSidebar.js
@@ -175,10 +175,10 @@ const ProviderSidebarComponent = ( {
 						__html: sprintf(
 							// Translators: %1$s is the number of members, %2$s is the item name, %3$s is the item type.
 							__(
-								'This newsletter will be sent to all %1$smembers of the %2$s %3$s%4$s.',
+								'This newsletter will be sent to all %1$smembers of the %2$s %3$s.',
 								'newspack-newsletters'
 							),
-							selected.typeLabel && ! isNaN( selected.details )
+							selected.details && ! isNaN( selected.details )
 								? `<strong>${ selected.details.toLocaleString() }</strong>` + ' '
 								: '',
 							`<strong>${ selected.name }</strong>`,

--- a/src/service-providers/constant_contact/ProviderSidebar.js
+++ b/src/service-providers/constant_contact/ProviderSidebar.js
@@ -3,7 +3,7 @@
  */
 import apiFetch from '@wordpress/api-fetch';
 import { __, _n, sprintf } from '@wordpress/i18n';
-import { ExternalLink, Spinner, Notice } from '@wordpress/components';
+import { Spinner, Notice } from '@wordpress/components';
 import { compose } from '@wordpress/compose';
 import { withSelect } from '@wordpress/data';
 import { useEffect } from '@wordpress/element';
@@ -31,21 +31,9 @@ const getSendToLabel = item => {
 };
 
 const getSendToLink = item => {
-	const isList = item.hasOwnProperty( 'list_id' );
-
-	return (
-		<p>
-			<ExternalLink
-				href={
-					isList
-						? `https://app.constantcontact.com/pages/contacts/ui#contacts/${ item.list_id }`
-						: `https://app.constantcontact.com/pages/contacts/ui#segments/${ item.segment_id }/preview`
-				}
-			>
-				{ __( 'View in Constant Contact', 'newspack-newsletters' ) }
-			</ExternalLink>
-		</p>
-	);
+	return item.hasOwnProperty( 'list_id' )
+		? `https://app.constantcontact.com/pages/contacts/ui#contacts/${ item.list_id }`
+		: `https://app.constantcontact.com/pages/contacts/ui#segments/${ item.segment_id }/preview`;
 };
 
 /**

--- a/src/service-providers/constant_contact/ProviderSidebar.js
+++ b/src/service-providers/constant_contact/ProviderSidebar.js
@@ -63,7 +63,7 @@ const ProviderSidebarComponent = ( {
 	renderPreviewText,
 	newsletterData,
 	postId,
-	updateMetaValue,
+	updateMeta,
 	status,
 } ) => {
 	const { campaign, lists = [], segments = [] } = newsletterData;
@@ -139,7 +139,7 @@ const ProviderSidebarComponent = ( {
 
 	useEffect( () => {
 		if ( campaign ) {
-			updateMetaValue( {
+			updateMeta( {
 				senderName: campaign.activity.from_name,
 				senderEmail: campaign.activity.from_email,
 			} );

--- a/src/service-providers/constant_contact/ProviderSidebar.js
+++ b/src/service-providers/constant_contact/ProviderSidebar.js
@@ -136,6 +136,31 @@ const ProviderSidebarComponent = ( {
 		);
 	}
 
+	const renderSelectedSummary = () => {
+		return selected ? (
+			<p
+				dangerouslySetInnerHTML={ {
+					__html: sprintf(
+						// Translators: %1$s is the number of contacts, %2$s is the item name, %3$s is the item type.
+						__(
+							'This newsletter will be sent to <strong>%1$s</strong> in the <strong>%2$s</strong> %3$s.',
+							'newspack-newsletters'
+						),
+						selected?.count // CC doesn't provide contact counts for segments, so we only want to show a count if a list is selected without a segment.
+							? sprintf(
+									// Translators: %d is the number of contacts in the list.
+									_n( '%d contact', '%d contacts', selected.count, 'newspack-newsletters' ),
+									selected.count.toLocaleString()
+							  )
+							: __( 'all contacts', 'newspack-newsletters' ),
+						selected.name,
+						selected.typeLabel.toLowerCase()
+					),
+				} }
+			/>
+		) : null;
+	};
+
 	if (
 		! inFlight &&
 		( 'DRAFT' !== campaign?.current_status || 'publish' === status || 'private' === status )
@@ -166,28 +191,7 @@ const ProviderSidebarComponent = ( {
 				reset={ resetSendTo }
 				selectedItem={ selected }
 			/>
-			{ selected && (
-				<p
-					dangerouslySetInnerHTML={ {
-						__html: sprintf(
-							// Translators: %1$s is the number of contacts, %2$s is the item name, %3$s is the item type.
-							__(
-								'This newsletter will be sent to <strong>%1$s</strong> in the <strong>%2$s</strong> %3$s.',
-								'newspack-newsletters'
-							),
-							selected?.count // CC doesn't provide contact counts for segments, so we only want to show a count if a list is selected without a segment.
-								? sprintf(
-										// Translators: %d is the number of contacts in the list.
-										_n( '%d contact', '%d contacts', selected.count, 'newspack-newsletters' ),
-										selected.count.toLocaleString()
-								  )
-								: __( 'all contacts', 'newspack-newsletters' ),
-							selected.name,
-							selected.typeLabel.toLowerCase()
-						),
-					} }
-				/>
-			) }
+			{ renderSelectedSummary() }
 		</>
 	);
 };

--- a/src/service-providers/constant_contact/ProviderSidebar.js
+++ b/src/service-providers/constant_contact/ProviderSidebar.js
@@ -32,16 +32,9 @@ const ProviderSidebarComponent = ( {
 	// Standardize data schema. We'll eventually move this standardization to the provider API handlers instead.
 	const availableItems = [ ...lists, ...segments ].map( item => {
 		const isList = item.hasOwnProperty( 'list_id' );
-		const contactCount = parseInt( item.membership_count );
+		const count = item.membership_count || null;
 		const formattedItem = {
 			...item,
-			details: ! isNaN( contactCount )
-				? sprintf(
-						// Translators: %d is the number of contacts in the list or segment.
-						_n( '%d contact', '%d contacts', contactCount, 'newspack-newsletters' ),
-						contactCount.toLocaleString()
-				  )
-				: null,
 			editLink: isList
 				? `https://app.constantcontact.com/pages/contacts/ui#contacts/${ item.list_id }`
 				: `https://app.constantcontact.com/pages/contacts/ui#segments/${ item.segment_id }/preview`,
@@ -53,6 +46,9 @@ const ProviderSidebarComponent = ( {
 			value: item.list_id || item.segment_id,
 		};
 
+		if ( null !== count ) {
+			formattedItem.count = parseInt( count );
+		}
 		formattedItem.label = getSuggestionLabel( formattedItem );
 
 		return formattedItem;
@@ -176,13 +172,17 @@ const ProviderSidebarComponent = ( {
 						__html: sprintf(
 							// Translators: %1$s is the number of contacts, %2$s is the item name, %3$s is the item type.
 							__(
-								'This newsletter will be sent to all %1$s in the %2$s %3$s.',
+								'This newsletter will be sent to <strong>%1$s</strong> in the <strong>%2$s</strong> %3$s.',
 								'newspack-newsletters'
 							),
-							selected.details
-								? `<strong>${ selected.details }</strong> `
-								: __( 'contacts', 'newspack-newsletters' ),
-							`<strong>${ selected.name }</strong>`,
+							selected?.count // CC doesn't provide contact counts for segments, so we only want to show a count if a list is selected without a segment.
+								? sprintf(
+										// Translators: %d is the number of contacts in the list.
+										_n( '%d contact', '%d contacts', selected.count, 'newspack-newsletters' ),
+										selected.count.toLocaleString()
+								  )
+								: __( 'all contacts', 'newspack-newsletters' ),
+							selected.name,
 							selected.typeLabel.toLowerCase()
 						),
 					} }

--- a/src/service-providers/constant_contact/ProviderSidebar.js
+++ b/src/service-providers/constant_contact/ProviderSidebar.js
@@ -138,7 +138,7 @@ const ProviderSidebarComponent = ( {
 	};
 
 	useEffect( () => {
-		if ( campaign ) {
+		if ( campaign?.activity?.from_name && campaign?.activity?.from_email ) {
 			updateMeta( {
 				senderName: campaign.activity.from_name,
 				senderEmail: campaign.activity.from_email,

--- a/src/service-providers/constant_contact/ProviderSidebar.js
+++ b/src/service-providers/constant_contact/ProviderSidebar.js
@@ -1,60 +1,81 @@
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
-import { Fragment, useEffect, useState } from '@wordpress/element';
-import {
-	BaseControl,
-	Button,
-	ButtonGroup,
-	CheckboxControl,
-	SelectControl,
-	Spinner,
-	Notice,
-} from '@wordpress/components';
+import apiFetch from '@wordpress/api-fetch';
+import { __, sprintf } from '@wordpress/i18n';
+import { ExternalLink, Spinner, Notice } from '@wordpress/components';
+import { useEffect } from '@wordpress/element';
 
 /**
  * Internal dependencies
  */
+import SendTo from '../../newsletter-editor/sidebar/send-to';
+
+const getSendToLabel = item => {
+	const isList = item.hasOwnProperty( 'list_id' );
+	return sprintf(
+		// Translators: %1$s is the type of list or segment, %2$s is the name of the list or segment, %3$s is the number of contacts in the list.
+		__( '[%1$s] %2$s %3$s', 'newspack-newsletters' ),
+		isList ? __( 'LIST', 'newspack-newsletters' ) : __( 'SEGMENT', 'newspack-newsletters' ),
+		item.name,
+		item.hasOwnProperty( 'membership_count' )
+			? // Translators: %d is the number of contacts in the list or segment.
+			  sprintf( __( '(%d contacts)', 'newspack-newsletters' ), item.membership_count )
+			: ''
+	).trim();
+};
+
+const getSendToLink = item => {
+	const isList = item.hasOwnProperty( 'list_id' );
+
+	return (
+		<p>
+			<ExternalLink
+				href={
+					isList
+						? `https://app.constantcontact.com/pages/contacts/ui#contacts/${ item.list_id }`
+						: `https://app.constantcontact.com/pages/contacts/ui#segments/${ item.segment_id }/preview`
+				}
+			>
+				{ __( 'View in Constant Contact', 'newspack-newsletters' ) }
+			</ExternalLink>
+		</p>
+	);
+};
+
+/**
+ * Internal dependencies
+ */
+import { getEditPostPayload } from '../../newsletter-editor/utils';
 import './style.scss';
 
 const ProviderSidebar = ( {
+	editPost,
 	renderCampaignName,
 	renderSubject,
 	renderFrom,
 	renderPreviewText,
-	inFlight,
 	newsletterData,
-	apiFetch,
 	postId,
 	updateMeta,
 } ) => {
-	const campaign = newsletterData.campaign;
-	const lists = newsletterData.lists || [];
-	const segments = newsletterData.segments || [];
+	const { campaign, lists = [], segments = [] } = newsletterData;
+	const availableLists = [ ...lists, ...segments ].map( item => {
+		item.value = item.list_id || item.segment_id;
+		item.label = getSendToLabel( item );
+		return item;
+	} );
 
-	const [ sendMode, setSendMode ] = useState( 'list' );
-
-	let segment_id = '';
-	if ( campaign?.activity?.segment_ids?.length ) {
-		segment_id = campaign.activity.segment_ids[ 0 ];
-	}
-
-	const setList = ( listId, value ) => {
-		const method = value ? 'PUT' : 'DELETE';
-		apiFetch( {
-			path: `/newspack-newsletters/v1/constant_contact/${ postId }/list/${ listId }`,
-			method,
-		} );
-	};
-
-	const setSegment = segmentId => {
-		const method = segmentId ? 'PUT' : 'DELETE';
-		apiFetch( {
-			path: `/newspack-newsletters/v1/constant_contact/${ postId }/segment/${ segmentId }`,
-			method,
-		} );
-	};
+	const selectedList =
+		availableLists.find( list => {
+			if ( campaign?.activity?.contact_list_ids?.length ) {
+				return list.list_id === campaign.activity.contact_list_ids[ 0 ];
+			}
+			if ( campaign?.activity?.segment_ids?.length ) {
+				return list.segment_id === campaign.activity.segment_ids[ 0 ];
+			}
+			return false;
+		} ) || null;
 
 	const setSender = ( { senderName, senderEmail } ) =>
 		apiFetch( {
@@ -66,17 +87,55 @@ const ProviderSidebar = ( {
 			method: 'POST',
 		} );
 
+	const updateCampaign = config => {
+		return apiFetch( config ).then( result => {
+			if ( typeof result === 'object' && result.campaign ) {
+				editPost( getEditPostPayload( result ) );
+			}
+			return result;
+		} );
+	};
+
+	const setList = ( listId, value ) => {
+		return updateCampaign( {
+			path: `/newspack-newsletters/v1/constant_contact/${ postId }/list/${ listId }`,
+			method: value ? 'PUT' : 'DELETE',
+		} );
+	};
+
+	const setSegment = segmentId => {
+		return updateCampaign( {
+			path: `/newspack-newsletters/v1/constant_contact/${ postId }/segment/${ segmentId || '' }`,
+			method: segmentId ? 'PUT' : 'DELETE',
+		} );
+	};
+
+	const onChangeSendTo = labels => {
+		const selectedLabel = labels[ 0 ];
+		const selectedItem = availableLists.find( item => item.label === selectedLabel );
+
+		// If the selected item is already selected in the campaign, no need to update.
+		if ( selectedItem.value === selectedList?.value ) {
+			return;
+		}
+
+		return selectedItem.hasOwnProperty( 'list_id' )
+			? setList( selectedItem.value, true )
+			: setSegment( selectedItem.value );
+	};
+
+	const resetSendTo = () => {
+		return selectedList && selectedList.hasOwnProperty( 'list_id' )
+			? setList( selectedList.list_id, false )
+			: setSegment( false );
+	};
+
 	useEffect( () => {
 		if ( campaign ) {
 			updateMeta( {
 				senderName: campaign.activity.from_name,
 				senderEmail: campaign.activity.from_email,
 			} );
-			if ( campaign?.activity?.contact_list_ids?.length ) {
-				setSendMode( 'list' );
-			} else if ( campaign?.activity?.segment_ids?.length ) {
-				setSendMode( 'segment' );
-			}
 		}
 	}, [ campaign ] );
 
@@ -99,7 +158,7 @@ const ProviderSidebar = ( {
 	}
 
 	return (
-		<Fragment>
+		<>
 			{ renderCampaignName() }
 			{ renderSubject() }
 			{ renderPreviewText() }
@@ -109,58 +168,17 @@ const ProviderSidebar = ( {
 			<strong className="newspack-newsletters__label">
 				{ __( 'Send to', 'newspack-newsletters' ) }
 			</strong>
-			<ButtonGroup className="newspack-newsletters-cc__send-mode">
-				<Button
-					className="newspack-newsletters-cc__send-mode-button"
-					variant={ sendMode === 'list' ? 'primary' : 'secondary' }
-					onClick={ () => setSendMode( 'list' ) }
-				>
-					{ __( 'List', 'newspack-newsletters' ) }
-				</Button>
-				<Button
-					className="newspack-newsletters-cc__send-mode-button"
-					variant={ sendMode === 'segment' ? 'primary' : 'secondary' }
-					onClick={ () => setSendMode( 'segment' ) }
-					text={ __( 'Segment', 'newspack-newsletters' ) }
-				/>
-			</ButtonGroup>
-
-			{ 'list' === sendMode && (
-				<BaseControl
-					className="newspack-newsletters-constant_contact-lists"
-					id="newspack-newsletters-constant_contact-lists"
-				>
-					{ lists.map( ( { list_id: id, name } ) => (
-						<CheckboxControl
-							key={ id }
-							label={ name }
-							value={ id }
-							checked={ campaign?.activity?.contact_list_ids?.some( listId => listId === id ) }
-							onChange={ value => setList( id, value ) }
-							disabled={ inFlight }
-						/>
-					) ) }
-				</BaseControl>
-			) }
-			{ 'segment' === sendMode && (
-				<SelectControl
-					className="newspack-newsletters-constant_contact-segments"
-					value={ segment_id }
-					options={ [
-						{
-							value: null,
-							label: __( '-- Select a segment --', 'newspack-newsletters' ),
-						},
-						...segments.map( ( { segment_id: id, name } ) => ( {
-							value: id,
-							label: name,
-						} ) ),
-					] }
-					onChange={ setSegment }
-					disabled={ inFlight }
-				/>
-			) }
-		</Fragment>
+			<SendTo
+				availableLists={ availableLists }
+				onChange={ onChangeSendTo }
+				formLabel={ __( 'Select a list or segment', 'newspack' ) }
+				getLabel={ getSendToLabel }
+				getLink={ getSendToLink }
+				placeholder={ __( 'Type a list or segment name to search.', 'newspack' ) }
+				reset={ resetSendTo }
+				selectedList={ selectedList }
+			/>
+		</>
 	);
 };
 

--- a/src/service-providers/constant_contact/index.js
+++ b/src/service-providers/constant_contact/index.js
@@ -6,7 +6,7 @@ import { __, sprintf, _n } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import ProviderSidebar from './ProviderSidebar';
+import { ProviderSidebar } from './ProviderSidebar';
 
 const hasOauth = true;
 

--- a/src/service-providers/mailchimp/ProviderSidebar.js
+++ b/src/service-providers/mailchimp/ProviderSidebar.js
@@ -59,6 +59,7 @@ const ProviderSidebarComponent = ( {
 					...audience,
 					value: audience.id,
 					label: getSendToLabel( audience, 'audience' ),
+					list_type: 'audience',
 				} ) )
 		: [];
 	const folders = newsletterData?.folders || [];

--- a/src/service-providers/mailchimp/ProviderSidebar.js
+++ b/src/service-providers/mailchimp/ProviderSidebar.js
@@ -198,7 +198,7 @@ const ProviderSidebarComponent = ( {
 
 		const summary = selectedSubAudience?.count
 			? sprintf(
-					// Translators: A summary of which list and sublist the campaign is set to send to, and the total number of contacts, if available.
+					// Translators: A summary of which list and sublist the campaign is set to send to, and the total number of contacts, if available.  %1$s is the number of contacts. %2$s is the label of the list (ex: Main), %3$s is the label for the type of the list (ex: "list" on Active Campaign and "audience" on Mailchimp). %4$s is the label of the sublist (ex: "paid customers"), and %5$s is the label for the sublist type (ex: tag, group or segment)
 					_n(
 						'This newsletter will be sent to <strong>%1$s contact</strong> in the <strong>%2$s</strong> %3$s who is part of the <strong>%4$s</strong> %5$s.',
 						'This newsletter will be sent to <strong>%1$s contacts</strong> in the <strong>%2$s</strong> %3$s who are part of the <strong>%4$s</strong> %5$s.',

--- a/src/service-providers/mailchimp/ProviderSidebar.js
+++ b/src/service-providers/mailchimp/ProviderSidebar.js
@@ -47,6 +47,7 @@ const ProviderSidebarComponent = ( {
 	updateMeta,
 	createErrorNotice,
 	meta,
+	status,
 } ) => {
 	const campaign = newsletterData.campaign;
 
@@ -185,9 +186,13 @@ const ProviderSidebarComponent = ( {
 		);
 	}
 
-	const { status } = campaign || {};
-
-	if ( 'sent' === status || 'sending' === status ) {
+	if (
+		! inFlight &&
+		( 'publish' === status ||
+			'private' === status ||
+			'sent' === campaign?.status ||
+			'sending' === campaign?.status )
+	) {
 		return (
 			<Notice status="success" isDismissible={ false }>
 				{ __( 'Campaign has been sent.', 'newspack-newsletters' ) }
@@ -265,9 +270,10 @@ const ProviderSidebarComponent = ( {
 };
 
 const mapStateToProps = select => {
-	const { getEditedPostAttribute } = select( 'core/editor' );
+	const { getCurrentPostAttribute, getEditedPostAttribute } = select( 'core/editor' );
 	return {
 		meta: getEditedPostAttribute( 'meta' ),
+		status: getCurrentPostAttribute( 'status' ),
 	};
 };
 

--- a/src/service-providers/mailchimp/ProviderSidebar.js
+++ b/src/service-providers/mailchimp/ProviderSidebar.js
@@ -293,11 +293,11 @@ const ProviderSidebarComponent = ( {
 						__html: sprintf(
 							// Translators: %1$s is the number of members, %2$s is the item name, %3$s is the item type, %4$s is the parent item name and type (if any).
 							__(
-								'This newsletter will be sent to all %1$s of the %2$s %3$s%4$s.',
+								'This newsletter will be sent to all %1$s in the %2$s %3$s%4$s.',
 								'newspack-newsletters'
 							),
-							! selectedSubAudience && selectedAudience.details
-								? `<strong>${ selectedAudience.details }</strong> `
+							selectedSubAudience?.details || ( ! selectedSubAudience && selectedAudience?.details )
+								? `<strong>${ selectedSubAudience?.details || selectedAudience?.details }</strong> `
 								: '',
 							`<strong>${ selectedAudience.name }</strong>`,
 							selectedAudience.typeLabel.toLowerCase(),

--- a/src/service-providers/mailchimp/ProviderSidebar.js
+++ b/src/service-providers/mailchimp/ProviderSidebar.js
@@ -192,41 +192,44 @@ const ProviderSidebarComponent = ( {
 	}, [ stringifiedLayoutDefaults.length ] );
 
 	const renderSelectedSummary = () => {
-		return selectedAudience ? (
+		if ( ! selectedAudience ) {
+			return null;
+		}
+
+		const summary = selectedSubAudience?.count
+			? sprintf(
+					// Translators: A summary of which list and sublist the campaign is set to send to, and the total number of contacts, if available.
+					_n(
+						'This newsletter will be sent to <strong>%1$s contact</strong> in the <strong>%2$s</strong> %3$s who are part of the <strong>%4$s</strong> %5$s.',
+						'This newsletter will be sent to <strong>%1$s contacts</strong> in the <strong>%2$s</strong> %3$s who are part of the <strong>%4$s</strong> %5$s.',
+						selectedSubAudience.count,
+						'newspack-newsletters'
+					),
+					selectedSubAudience.count.toLocaleString(),
+					selectedAudience.name,
+					selectedAudience.typeLabel.toLowerCase(),
+					selectedSubAudience.name,
+					selectedSubAudience.typeLabel.toLowerCase()
+			  )
+			: sprintf(
+					// Translators: A summary of which list the campaign is set to send to, and the total number of contacts, if available.
+					_n(
+						'This newsletter will be sent to <strong>%1$s contact</strong> in the <strong>%2$s</strong> %3$s.',
+						'This newsletter will be sent to <strong>%1$s contacts</strong> in the <strong>%2$s</strong> %3$s.',
+						selectedAudience.count,
+						'newspack-newsletters'
+					),
+					selectedAudience.count.toLocaleString(),
+					selectedAudience.name,
+					selectedAudience.typeLabel.toLowerCase()
+			  );
+		return (
 			<p
 				dangerouslySetInnerHTML={ {
-					__html: sprintf(
-						// Translators: %1$s is the number of contacts, %2$s is the item name, %3$s is the item type, %4$s is the subitem name and type (if any).
-						__(
-							'This newsletter will be sent to <strong>%1$s</strong> in the <strong>%2$s</strong> %3$s%4$s.',
-							'newspack-newsletters'
-						),
-						selectedSubAudience?.count || selectedAudience?.count
-							? sprintf(
-									// Translators: %d is the number of contacts in the list.
-									_n(
-										'%d contact',
-										'%d contacts',
-										selectedSubAudience?.count || selectedAudience.count,
-										'newspack-newsletters'
-									),
-									( selectedSubAudience?.count || selectedAudience.count ).toLocaleString()
-							  )
-							: __( 'all contacts', 'newspack-newsletters' ),
-						selectedAudience.name,
-						selectedAudience.typeLabel.toLowerCase(),
-						selectedSubAudience
-							? sprintf(
-									// Translators: %1$s is the parent item name, %2$s is the parent item type.
-									__( ' who are part of the %1$s %2$s', 'newspack-newsletters' ),
-									`<strong>${ selectedSubAudience.name }</strong>`,
-									selectedSubAudience.typeLabel.toLowerCase()
-							  )
-							: ''
-					),
+					__html: summary,
 				} }
 			/>
-		) : null;
+		);
 	};
 
 	if ( ! campaign ) {

--- a/src/service-providers/mailchimp/ProviderSidebar.js
+++ b/src/service-providers/mailchimp/ProviderSidebar.js
@@ -13,7 +13,7 @@ import { SelectControl, Spinner, Notice } from '@wordpress/components';
  */
 import SendTo from '../../newsletter-editor/sidebar/send-to';
 import { getSuggestionLabel } from '../../newsletter-editor/utils';
-import { getSubAudienceOptions, getSendToLabel, getSendToLink } from './utils';
+import { getSubAudienceOptions } from './utils';
 
 const getSubAudienceValue = newsletterData => {
 	const recipients = newsletterData.campaign?.recipients;
@@ -271,8 +271,6 @@ const ProviderSidebarComponent = ( {
 				availableItems={ audiences }
 				onChange={ selected => onChangeSendTo( selected ) }
 				formLabel={ __( 'Select a list', 'newspack' ) }
-				getLabel={ getSendToLabel }
-				getLink={ getSendToLink }
 				placeholder={ __( 'Type a list name to search', 'newspack' ) }
 				reset={ null } // Mailchimp API doesn't support unsetting a campaign's list, once set.
 				selectedItem={ selectedAudience }
@@ -295,11 +293,11 @@ const ProviderSidebarComponent = ( {
 						__html: sprintf(
 							// Translators: %1$s is the number of members, %2$s is the item name, %3$s is the item type, %4$s is the parent item name and type (if any).
 							__(
-								'This newsletter will be sent to all %1$smembers of the %2$s %3$s%4$s.',
+								'This newsletter will be sent to all %1$s of the %2$s %3$s%4$s.',
 								'newspack-newsletters'
 							),
-							selectedAudience.details && ! isNaN( selectedAudience.details )
-								? `<strong>${ selectedAudience.details.toLocaleString() }</strong>` + ' '
+							! selectedSubAudience && selectedAudience.details
+								? `<strong>${ selectedAudience.details }</strong> `
 								: '',
 							`<strong>${ selectedAudience.name }</strong>`,
 							selectedAudience.typeLabel.toLowerCase(),

--- a/src/service-providers/mailchimp/ProviderSidebar.js
+++ b/src/service-providers/mailchimp/ProviderSidebar.js
@@ -57,11 +57,12 @@ const ProviderSidebarComponent = ( {
 		? newsletterData.lists
 				.filter( list => 'mailchimp-group' !== list.type && 'mailchimp-tag' !== list.type )
 				.map( item => {
-					const contactCount =
-						item?.member_count || item?.subscriber_count || item?.stats?.member_count;
+					const contactCount = parseInt(
+						item?.member_count || item?.subscriber_count || item?.stats?.member_count
+					);
 					const formattedItem = {
 						...item,
-						details: contactCount
+						details: ! isNaN( contactCount )
 							? sprintf(
 									// Translators: %d is the number of contacts in the list.
 									_n( '%d contact', '%d contacts', contactCount, 'newspack-newsletters' ),

--- a/src/service-providers/mailchimp/ProviderSidebar.js
+++ b/src/service-providers/mailchimp/ProviderSidebar.js
@@ -191,6 +191,44 @@ const ProviderSidebarComponent = ( {
 		}
 	}, [ stringifiedLayoutDefaults.length ] );
 
+	const renderSelectedSummary = () => {
+		return selectedAudience ? (
+			<p
+				dangerouslySetInnerHTML={ {
+					__html: sprintf(
+						// Translators: %1$s is the number of contacts, %2$s is the item name, %3$s is the item type, %4$s is the subitem name and type (if any).
+						__(
+							'This newsletter will be sent to <strong>%1$s</strong> in the <strong>%2$s</strong> %3$s%4$s.',
+							'newspack-newsletters'
+						),
+						selectedSubAudience?.count || selectedAudience?.count
+							? sprintf(
+									// Translators: %d is the number of contacts in the list.
+									_n(
+										'%d contact',
+										'%d contacts',
+										selectedSubAudience?.count || selectedAudience.count,
+										'newspack-newsletters'
+									),
+									( selectedSubAudience?.count || selectedAudience.count ).toLocaleString()
+							  )
+							: __( 'all contacts', 'newspack-newsletters' ),
+						selectedAudience.name,
+						selectedAudience.typeLabel.toLowerCase(),
+						selectedSubAudience
+							? sprintf(
+									// Translators: %1$s is the parent item name, %2$s is the parent item type.
+									__( ' who are part of the %1$s %2$s', 'newspack-newsletters' ),
+									`<strong>${ selectedSubAudience.name }</strong>`,
+									selectedSubAudience.typeLabel.toLowerCase()
+							  )
+							: ''
+					),
+				} }
+			/>
+		) : null;
+	};
+
 	if ( ! campaign ) {
 		return (
 			<div className="newspack-newsletters__loading-data">
@@ -283,41 +321,7 @@ const ProviderSidebarComponent = ( {
 					/>
 				</>
 			) }
-			{ selectedAudience && (
-				<p
-					dangerouslySetInnerHTML={ {
-						__html: sprintf(
-							// Translators: %1$s is the number of contacts, %2$s is the item name, %3$s is the item type, %4$s is the subitem name and type (if any).
-							__(
-								'This newsletter will be sent to <strong>%1$s</strong> in the <strong>%2$s</strong> %3$s%4$s.',
-								'newspack-newsletters'
-							),
-							selectedSubAudience?.count || selectedAudience?.count
-								? sprintf(
-										// Translators: %d is the number of contacts in the list.
-										_n(
-											'%d contact',
-											'%d contacts',
-											selectedSubAudience?.count || selectedAudience.count,
-											'newspack-newsletters'
-										),
-										( selectedSubAudience?.count || selectedAudience.count ).toLocaleString()
-								  )
-								: __( 'all contacts', 'newspack-newsletters' ),
-							selectedAudience.name,
-							selectedAudience.typeLabel.toLowerCase(),
-							selectedSubAudience
-								? sprintf(
-										// Translators: %1$s is the parent item name, %2$s is the parent item type.
-										__( ' who are part of the %1$s %2$s', 'newspack-newsletters' ),
-										`<strong>${ selectedSubAudience.name }</strong>`,
-										selectedSubAudience.typeLabel.toLowerCase()
-								  )
-								: ''
-						),
-					} }
-				/>
-			) }
+			{ renderSelectedSummary() }
 		</Fragment>
 	);
 };

--- a/src/service-providers/mailchimp/ProviderSidebar.js
+++ b/src/service-providers/mailchimp/ProviderSidebar.js
@@ -239,7 +239,7 @@ const ProviderSidebarComponent = ( {
 			return;
 		}
 
-		return selectedItem.list_type === 'audience'
+		return 'list' === selectedItem.type
 			? setList( selectedItem.value )
 			: updateSegments( selectedItem.value );
 	};
@@ -269,9 +269,9 @@ const ProviderSidebarComponent = ( {
 			</strong>
 			<SendTo
 				availableItems={ audiences }
-				onChange={ selected => onChangeSendTo( selected ) }
-				formLabel={ __( 'Select a list', 'newspack' ) }
-				placeholder={ __( 'Type a list name to search', 'newspack' ) }
+				onChange={ onChangeSendTo }
+				formLabel={ __( 'Select an audience', 'newspack' ) }
+				placeholder={ __( 'Type an audience name to search', 'newspack' ) }
 				reset={ null } // Mailchimp API doesn't support unsetting a campaign's list, once set.
 				selectedItem={ selectedAudience }
 			/>
@@ -280,8 +280,8 @@ const ProviderSidebarComponent = ( {
 					<SendTo
 						availableItems={ subAudiences }
 						onChange={ onChangeSendTo }
-						formLabel={ __( 'Group, Segment, or Tag (optional)', 'newspack' ) }
-						placeholder={ __( 'Filter by group, segment, or tag', 'newspack' ) }
+						formLabel={ __( 'Filter by Group, Segment, or Tag (optional)', 'newspack' ) }
+						placeholder={ __( 'Type a group, segment, or tag name to search', 'newspack' ) }
 						reset={ () => updateSegments( '' ) }
 						selectedItem={ selectedSubAudience }
 					/>

--- a/src/service-providers/mailchimp/ProviderSidebar.js
+++ b/src/service-providers/mailchimp/ProviderSidebar.js
@@ -212,7 +212,7 @@ const ProviderSidebarComponent = ( {
 					selectedSubAudience.typeLabel.toLowerCase()
 			  )
 			: sprintf(
-					// Translators: A summary of which list the campaign is set to send to, and the total number of contacts, if available.
+					// Translators: A summary of which list the campaign is set to send to, and the total number of contacts, if available. %1$s is the number of contacts. %2$s is the label of the list (ex: Main), %3$s is the label for the type of the list (ex: "list" on Active Campaign and "audience" on Mailchimp).
 					_n(
 						'This newsletter will be sent to <strong>%1$s contact</strong> in the <strong>%2$s</strong> %3$s.',
 						'This newsletter will be sent to <strong>%1$s contacts</strong> in the <strong>%2$s</strong> %3$s.',

--- a/src/service-providers/mailchimp/ProviderSidebar.js
+++ b/src/service-providers/mailchimp/ProviderSidebar.js
@@ -57,24 +57,19 @@ const ProviderSidebarComponent = ( {
 		? newsletterData.lists
 				.filter( list => 'mailchimp-group' !== list.type && 'mailchimp-tag' !== list.type )
 				.map( item => {
-					const contactCount = parseInt(
-						item?.member_count || item?.subscriber_count || item?.stats?.member_count
-					);
+					const count =
+						item?.member_count || item?.subscriber_count || item?.stats?.member_count || null;
 					const formattedItem = {
 						...item,
-						details: ! isNaN( contactCount )
-							? sprintf(
-									// Translators: %d is the number of contacts in the list.
-									_n( '%d contact', '%d contacts', contactCount, 'newspack-newsletters' ),
-									contactCount.toLocaleString()
-							  )
-							: null,
 						name: item.name || item.title,
 						typeLabel: __( 'Audience', 'newspack-newsletters' ),
 						type: 'list',
 						value: item.id,
 					};
 
+					if ( null !== count ) {
+						formattedItem.count = parseInt( count );
+					}
 					formattedItem.label = getSuggestionLabel( formattedItem );
 
 					return formattedItem;
@@ -292,15 +287,24 @@ const ProviderSidebarComponent = ( {
 				<p
 					dangerouslySetInnerHTML={ {
 						__html: sprintf(
-							// Translators: %1$s is the number of members, %2$s is the item name, %3$s is the item type, %4$s is the parent item name and type (if any).
+							// Translators: %1$s is the number of contacts, %2$s is the item name, %3$s is the item type, %4$s is the subitem name and type (if any).
 							__(
-								'This newsletter will be sent to all %1$s in the %2$s %3$s%4$s.',
+								'This newsletter will be sent to <strong>%1$s</strong> in the <strong>%2$s</strong> %3$s%4$s.',
 								'newspack-newsletters'
 							),
-							selectedSubAudience?.details || ( ! selectedSubAudience && selectedAudience?.details )
-								? `<strong>${ selectedSubAudience?.details || selectedAudience?.details }</strong> `
-								: '',
-							`<strong>${ selectedAudience.name }</strong>`,
+							selectedSubAudience?.count || selectedAudience?.count
+								? sprintf(
+										// Translators: %d is the number of contacts in the list.
+										_n(
+											'%d contact',
+											'%d contacts',
+											selectedSubAudience?.count || selectedAudience.count,
+											'newspack-newsletters'
+										),
+										( selectedSubAudience?.count || selectedAudience.count ).toLocaleString()
+								  )
+								: __( 'all contacts', 'newspack-newsletters' ),
+							selectedAudience.name,
 							selectedAudience.typeLabel.toLowerCase(),
 							selectedSubAudience
 								? sprintf(

--- a/src/service-providers/mailchimp/ProviderSidebar.js
+++ b/src/service-providers/mailchimp/ProviderSidebar.js
@@ -298,7 +298,7 @@ const ProviderSidebarComponent = ( {
 								'This newsletter will be sent to all %1$smembers of the %2$s %3$s%4$s.',
 								'newspack-newsletters'
 							),
-							selectedAudience.typeLabel && ! isNaN( selectedAudience.details )
+							selectedAudience.details && ! isNaN( selectedAudience.details )
 								? `<strong>${ selectedAudience.details.toLocaleString() }</strong>` + ' '
 								: '',
 							`<strong>${ selectedAudience.name }</strong>`,

--- a/src/service-providers/mailchimp/ProviderSidebar.js
+++ b/src/service-providers/mailchimp/ProviderSidebar.js
@@ -200,7 +200,7 @@ const ProviderSidebarComponent = ( {
 			? sprintf(
 					// Translators: A summary of which list and sublist the campaign is set to send to, and the total number of contacts, if available.
 					_n(
-						'This newsletter will be sent to <strong>%1$s contact</strong> in the <strong>%2$s</strong> %3$s who are part of the <strong>%4$s</strong> %5$s.',
+						'This newsletter will be sent to <strong>%1$s contact</strong> in the <strong>%2$s</strong> %3$s who is part of the <strong>%4$s</strong> %5$s.',
 						'This newsletter will be sent to <strong>%1$s contacts</strong> in the <strong>%2$s</strong> %3$s who are part of the <strong>%4$s</strong> %5$s.',
 						selectedSubAudience.count,
 						'newspack-newsletters'

--- a/src/service-providers/mailchimp/index.js
+++ b/src/service-providers/mailchimp/index.js
@@ -12,7 +12,7 @@ import { find } from 'lodash';
 /**
  * Internal dependencies
  */
-import ProviderSidebar from './ProviderSidebar';
+import { ProviderSidebar } from './ProviderSidebar';
 
 const validateNewsletter = ( { campaign } ) => {
 	const { recipients, settings, status } = campaign || {};

--- a/src/service-providers/mailchimp/utils.js
+++ b/src/service-providers/mailchimp/utils.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { __, _n, sprintf } from '@wordpress/i18n';
+import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -50,15 +50,9 @@ export const getSubAudienceOptions = newsletterData => {
 	} ) );
 
 	return formattedItems.map( item => {
-		const contactCount = parseInt(
-			item?.member_count || item?.subscriber_count || item?.stats?.member_count
-		);
-		if ( ! isNaN( contactCount ) ) {
-			item.details = sprintf(
-				// Translators: %d is the number of contacts in the list.
-				_n( '%d contact', '%d contacts', contactCount, 'newspack-newsletters' ),
-				contactCount.toLocaleString()
-			);
+		const count = item?.member_count || item?.subscriber_count || item?.stats?.member_count || null;
+		if ( null !== count ) {
+			item.count = parseInt( count );
 		}
 
 		item.name = item.name || item.title;

--- a/src/service-providers/mailchimp/utils.js
+++ b/src/service-providers/mailchimp/utils.js
@@ -50,8 +50,10 @@ export const getSubAudienceOptions = newsletterData => {
 	} ) );
 
 	return formattedItems.map( item => {
-		const contactCount = item?.member_count || item?.subscriber_count || item?.stats?.member_count;
-		if ( contactCount ) {
+		const contactCount = parseInt(
+			item?.member_count || item?.subscriber_count || item?.stats?.member_count
+		);
+		if ( ! isNaN( contactCount ) ) {
 			item.details = sprintf(
 				// Translators: %d is the number of contacts in the list.
 				_n( '%d contact', '%d contacts', contactCount, 'newspack-newsletters' ),

--- a/src/service-providers/mailchimp/utils.js
+++ b/src/service-providers/mailchimp/utils.js
@@ -9,44 +9,6 @@ import { __, _n, sprintf } from '@wordpress/i18n';
 import { getSuggestionLabel } from '../../newsletter-editor/utils';
 
 /**
- * Get a label describing the audience or subaudience for the autocomplete UI.
- *
- * @param {Object} item The audience or subaudience object.
- * @param {string} type The type of audience or subgroup.
- * @return {string} The formatted label.
- */
-export const getSendToLabel = ( item, type = 'audience' ) => {
-	const contactCount = item?.member_count || item?.subscriber_count || item?.stats?.member_count;
-	return sprintf(
-		// Translators: %1$s is the type of audience or subgroup, %2$s is the name of the audience or subgroup, %3$s is the number of contacts in the audience or subgroup.
-		__( '[%1$s] %2$s %3$s', 'newspack-newsletters' ),
-		type.toUpperCase(),
-		item.name || item.title,
-		contactCount
-			? sprintf(
-					// Translators: The number of contacts in the audience or subgroup.
-					_n( '(%d contact)', '(%d contacts)', contactCount, 'newspack-newsletters' ),
-					contactCount
-			  )
-			: ''
-	).trim();
-};
-
-/**
- * Get a link to manage the audience or subaudience in the ESP.
- *
- * @param {Object} item The audience or subaudience object.
- * @return {Object} JSX element.
- */
-export const getSendToLink = item => {
-	const { web_id: webId } = item;
-	if ( webId ) {
-		return `https://admin.mailchimp.com/lists/members/?id=${ webId }`;
-	}
-	return null;
-};
-
-/**
  * Get the subaudience options for the autocomplete UI.
  *
  * @param {Object} newsletterData Newsletter campaign data.

--- a/src/service-providers/mailchimp/utils.js
+++ b/src/service-providers/mailchimp/utils.js
@@ -2,7 +2,6 @@
  * WordPress dependencies
  */
 import { __, _n, sprintf } from '@wordpress/i18n';
-import { ExternalLink } from '@wordpress/components';
 
 /**
  * Get a label describing the audience or subaudience for the autocomplete UI.
@@ -37,13 +36,7 @@ export const getSendToLabel = ( item, type = 'audience' ) => {
 export const getSendToLink = item => {
 	const { web_id: webId } = item;
 	if ( webId ) {
-		return (
-			<p>
-				<ExternalLink href={ `https://admin.mailchimp.com/lists/members/?id=${ webId }` }>
-					{ __( 'Manage audience', 'newspack-newsletters' ) }
-				</ExternalLink>
-			</p>
-		);
+		return `https://admin.mailchimp.com/lists/members/?id=${ webId }`;
 	}
 	return null;
 };

--- a/src/service-providers/mailchimp/utils.js
+++ b/src/service-providers/mailchimp/utils.js
@@ -4,6 +4,11 @@
 import { __, _n, sprintf } from '@wordpress/i18n';
 
 /**
+ * Internal dependencies
+ */
+import { getSuggestionLabel } from '../../newsletter-editor/utils';
+
+/**
  * Get a label describing the audience or subaudience for the autocomplete UI.
  *
  * @param {Object} item The audience or subaudience object.
@@ -56,7 +61,8 @@ export const getSubAudienceOptions = newsletterData => {
 					accumulator.push( {
 						...interest,
 						value: `interests-${ id }:${ interest.id }`,
-						list_type: 'group',
+						type: 'group',
+						typeLabel: __( 'Group', 'newspack-newsletters' ),
 					} );
 				} );
 			}
@@ -67,16 +73,33 @@ export const getSubAudienceOptions = newsletterData => {
 	const segments = ( newsletterData?.segments || [] ).map( item => ( {
 		...item,
 		value: item.id,
-		list_type: 'segment',
+		type: 'segment',
+		typeLabel: __( 'Segment', 'newspack-newsletters' ),
 	} ) );
 	const tags = ( newsletterData?.tags || [] ).map( item => ( {
 		...item,
 		value: item.id,
-		list_type: 'tag',
+		type: 'tag',
+		typeLabel: __( 'Tag', 'newspack-newsletters' ),
 	} ) );
 
-	return [ ...groups, ...segments, ...tags ].map( item => ( {
+	const formattedItems = [ ...groups, ...segments, ...tags ].map( item => ( {
 		...item,
-		label: getSendToLabel( item, item.list_type ),
 	} ) );
+
+	return formattedItems.map( item => {
+		const contactCount = item?.member_count || item?.subscriber_count || item?.stats?.member_count;
+		if ( contactCount ) {
+			item.details = sprintf(
+				// Translators: %d is the number of contacts in the list.
+				_n( '%d contact', '%d contacts', contactCount, 'newspack-newsletters' ),
+				contactCount.toLocaleString()
+			);
+		}
+
+		item.name = item.name || item.title;
+		item.label = getSuggestionLabel( item );
+
+		return item;
+	} );
 };


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Changes the "Send To" sidebar UI in the Newsletter editor from a series of dropdowns to an autocomplete input field for Mailchimp, ActiveCampaign, and Constant Contact. This PR doesn't change the way the audience/list/tag/segment/etc. data is fetched and stored in the editor for different ESPs, it only standardizes the UIs for now. The ultimate goal to simplify the data handling across ESPs will happen in future PRs.

Doesn't touch the editor UI for Campaign Monitor as we're planning to deprecate support for this ESP in the near future. Since this implements new editor-facing UI, I'll tag @Automattic/newspack-design for feedback (but note that it only uses existing core WP components).

Also note that this PR breaks error handling for the "Update Sender" UI, but since we're planning to update this UI as well we'll fix it in a future PR.

#### Before

<table>
<tr>
<th>Mailchimp</th>
<th>ActiveCampaign</th>
<th>Constant Contact</th>
</tr>
<tr>
<td>
<img width="276" alt="before-mc" src="https://github.com/user-attachments/assets/845e1f65-7ccb-4369-a757-8a03303f05cf">
</td>
<td>
<img width="276" alt="before-ac" src="https://github.com/user-attachments/assets/949e5bc5-1e2a-4aa7-8527-ece1c522fd36">
</td>
<td>
<img width="276" alt="before-cc" src="https://github.com/user-attachments/assets/406e2804-30df-4177-b49e-a17aaf2c7692">
</td>
</tr>
</table>

#### After

<table>
<tr>
<th>Mailchimp</th>
<th>ActiveCampaign</th>
<th>Constant Contact</th>
</tr>
<tr>
<td>
<img width="275" alt="after-mc" src="https://github.com/user-attachments/assets/3241a867-79cf-4148-a3f5-f2f7840db9a4">
</td>
<td>
<img width="278" alt="after-ac" src="https://github.com/user-attachments/assets/7f93b536-11ff-460f-adf7-2ba415c4e82a">
</td>
<td>
<img width="275" alt="after-cc" src="https://github.com/user-attachments/assets/fb26f983-c712-4bda-a9ea-99475170f429">
</td>
</tr>
</table>

### How to test the changes in this Pull Request:

We'll want to test editing and sending newsletters for each ESP.

1. Connect your site to Mailchimp via the Newsletters settings page or Engagement > Newsletters dashboard.
2. Create a new newsletter.
3. Confirm that the new UI shows an autocomplete field for Audience.
4. Start typing the name of an audience in your connected Mailchimp account (typing `audience` should also work) and confirm that the autocomplete shows suggestions based on the available audiences.
5. Choose an audience and confirm that the autocomplete input changes to show the selected audience, and that a new "Group, Segment, or Tag" autocomplete field appears underneath it. Also confirm in the connected Mailchimp account that the synced campaign is updated whenever you select an audience in the editor. Note that Mailchimp doesn't support unsetting an audience for a campaign via API once it's been set, so you can't reset the audience to empty—you can only edit and choose a different audience.

<img width="275" alt="after-mc" src="https://github.com/user-attachments/assets/8c798e9c-77d8-4609-87d5-53cca48cde03">

6. Start typing a group, segment, or tag name (typing `group`, `segment`, or `tag` should also work) and confirm that the input shows appropriate suggestions from your Mailchimp account.
7. Choose one and confirm that the UI updates and that the synced campaign also updates to match your selection. Edit and repeat with each sub-audience type to confirm that all work as expected.
8. Click "Reset" and confirm that the autocomplete input appears again, and that the synced campaign is reset to "All subscribers in audience"
9. Send a newsletter to an entire audience, then another to each sub-audience type, and confirm that it gets sent correctly in each case
10. Change your site's connected ESP to ActiveCampaign and repeat all testing steps, then again with Constant Contact. Note the following subtle differences between ESPs:
  - ActiveCampaign won't sync new campaigns in the connected ESP account due to limitations in their API around updating existing campaigns. Instead, list selections are stored as post meta and only synced when sending the live campaign.
  - ActiveCampaign segments have a truly strange UI to create/edit. See [this doc](https://help.activecampaign.com/hc/en-us/articles/221483407-How-to-create-segments-in-ActiveCampaign#h_01HHFAA1Q15DMK9V53GX2YJNCQ) for details on how.
  - Constant Contact's API does support sending to more than one list at a time, a feature we support in the current UI. However, in order to standardize the UI across ESPs, this PR deprecates this ability and enforces selecting only one list per newsletter.
  - Constant Contact also supports sending to either multiple lists OR a single segment, but not both at the same time, so its UI shows only a single autocomplete that covers both data types.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1207717004877578