### PR TITLE
fix: avoid fatal when provider is manual

### DIFF
--- a/includes/class-newspack-newsletters-editor.php
+++ b/includes/class-newspack-newsletters-editor.php
@@ -302,9 +302,16 @@ final class Newspack_Newsletters_Editor {
 		$mjml_handling_post_types = array_values( array_diff( self::get_email_editor_cpts(), [ Newspack_Newsletters_Ads::CPT ] ) );
 		$provider                 = Newspack_Newsletters::get_service_provider();
 		$conditional_tag_support  = false;
+		$error_message            = false;
+
 		if ( $provider && ( self::is_editing_newsletter() || self::is_editing_newsletter_ad() ) ) {
 			$conditional_tag_support = $provider::get_conditional_tag_support();
+
+			// Fetch async error messages to display on editor load.
+			$transient_name = $provider->get_transient_name( get_the_ID() );
+			$error_message  = get_transient( $transient_name );
 		}
+
 		$email_editor_data = [
 			'email_html_meta'                => Newspack_Newsletters::EMAIL_HTML_META,
 			'mjml_handling_post_types'       => $mjml_handling_post_types,
@@ -319,9 +326,6 @@ final class Newspack_Newsletters_Editor {
 			'supported_social_icon_services' => Newspack_Newsletters_Renderer::get_supported_social_icons_services(),
 		];
 
-		// Fetch async error messages to display on editor load.
-		$transient_name = $provider->get_transient_name( get_the_ID() );
-		$error_message  = get_transient( $transient_name );
 		if ( $error_message ) {
 			$email_editor_data['error_message'] = $error_message;
 		}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Avoids Fatal error when provider is manual

### How to test the changes in this Pull Request:

1. Set provider to manual
2. Edit a Newsletter


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
