### PR TITLE
feat(campaign-monitor): deprecation warning and environment constant for CM

### DIFF
--- a/includes/class-newspack-newsletters-settings.php
+++ b/includes/class-newspack-newsletters-settings.php
@@ -42,7 +42,7 @@ class Newspack_Newsletters_Settings {
 	}
 
 	/**
-	 * Retreives list of settings.
+	 * Retrieves list of settings.
 	 *
 	 * @return array Settings list.
 	 */
@@ -183,13 +183,28 @@ class Newspack_Newsletters_Settings {
 			);
 		}
 
-		$settings_list = array_map(
-			function ( $item ) {
+		// Filter out options related to unsupported providers.
+		$supported_providers = Newspack_Newsletters::get_supported_providers();
+		$settings_list       = array_reduce(
+			$settings_list,
+			function ( $acc, $item ) use ( $supported_providers ) {
+				if ( ! empty( $item['provider'] ) && ! in_array( $item['provider'], $supported_providers, true ) ) {
+					return $acc;
+				}
+				if ( ! empty( $item['options'] ) ) {
+					$item['options'] = array_filter(
+						$item['options'],
+						function ( $option ) use ( $supported_providers ) {
+							return ! $option['value'] || in_array( $option['value'], $supported_providers, true );
+						}
+					);
+				}
 				$default       = ! empty( $item['default'] ) ? $item['default'] : false;
 				$item['value'] = get_option( $item['key'], $default );
-				return $item;
+				$acc[]         = $item;
+				return $acc;
 			},
-			$settings_list
+			[]
 		);
 
 		return $settings_list;
@@ -216,6 +231,12 @@ class Newspack_Newsletters_Settings {
 		?>
 		<div class="wrap">
 			<h1><?php esc_html_e( 'Newsletters Settings', 'newspack-newsletters' ); ?></h1>
+			<?php if ( Newspack_Newsletters::should_deprecate_campaign_monitor() ) : ?>
+			<div class="newspack-newsletters-oauth notice notice-warning">
+				<h2><?php esc_html_e( 'Campaign Monitor support will be deprecated', 'newspack-newsletters' ); ?></h2>
+				<p><?php esc_html_e( 'Please connect a different service provider to ensure continued support.', 'newspack-newsletters' ); ?></p>
+			</div>
+			<?php endif; ?>
 			<form method="post" action="options.php">
 				<?php
 				self::render_oauth_authorization();

--- a/includes/class-newspack-newsletters-settings.php
+++ b/includes/class-newspack-newsletters-settings.php
@@ -191,12 +191,14 @@ class Newspack_Newsletters_Settings {
 				if ( ! empty( $item['provider'] ) && ! in_array( $item['provider'], $supported_providers, true ) ) {
 					return $acc;
 				}
-				if ( ! empty( $item['options'] ) ) {
-					$item['options'] = array_filter(
-						$item['options'],
-						function ( $option ) use ( $supported_providers ) {
-							return ! $option['value'] || in_array( $option['value'], $supported_providers, true );
-						}
+				if ( 'select' === $item['type'] && ! empty( $item['options'] ) ) {
+					$item['options'] = array_values(
+						array_filter(
+							$item['options'],
+							function ( $option ) use ( $supported_providers ) {
+								return ! $option['value'] || in_array( $option['value'], $supported_providers, true );
+							}
+						)
 					);
 				}
 				$default       = ! empty( $item['default'] ) ? $item['default'] : false;

--- a/includes/class-newspack-newsletters.php
+++ b/includes/class-newspack-newsletters.php
@@ -109,6 +109,34 @@ final class Newspack_Newsletters {
 	}
 
 	/**
+	 * In preparation for deprecating support for Campaign Monitor, locks support behind an environment flag.
+	 *
+	 * @return array
+	 */
+	public static function get_supported_providers() {
+		$supported_providers = array_keys( self::REGISTERED_PROVIDERS );
+
+		// Add support for manual/other.
+		$supported_providers[] = 'manual';
+
+		// Remove support for Campaign Monitor if we don't have the required environment flag.
+		if ( 'campaign_monitor' !== self::service_provider() && ( ! defined( 'NEWSPACK_NEWSLETTERS_SUPPORT_DEPRECATED_CAMPAIGN_MONITOR' ) || ! NEWSPACK_NEWSLETTERS_SUPPORT_DEPRECATED_CAMPAIGN_MONITOR ) ) {
+			$supported_providers = array_diff( $supported_providers, [ 'campaign_monitor' ] );
+		}
+
+		return $supported_providers;
+	}
+
+	/**
+	 * Should we show a warning about the coming deprecation of Campaign Monitor?
+	 *
+	 * @return bool
+	 */
+	public static function should_deprecate_campaign_monitor() {
+		return 'campaign_monitor' === self::service_provider() && ( ! defined( 'NEWSPACK_NEWSLETTERS_SUPPORT_DEPRECATED_CAMPAIGN_MONITOR' ) || ! NEWSPACK_NEWSLETTERS_SUPPORT_DEPRECATED_CAMPAIGN_MONITOR );
+	}
+
+	/**
 	 * Set service provider.
 	 *
 	 * @param string $service_provider Service provider slug.

--- a/includes/class-newspack-newsletters.php
+++ b/includes/class-newspack-newsletters.php
@@ -133,7 +133,7 @@ final class Newspack_Newsletters {
 	 * @return bool
 	 */
 	public static function should_deprecate_campaign_monitor() {
-		return 'campaign_monitor' === self::service_provider() && ( ! defined( 'NEWSPACK_NEWSLETTERS_SUPPORT_DEPRECATED_CAMPAIGN_MONITOR' ) || ! NEWSPACK_NEWSLETTERS_SUPPORT_DEPRECATED_CAMPAIGN_MONITOR );
+		return 'campaign_monitor' === self::service_provider();
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Kicks off the deprecation process for Campaign Monitor as an ESP:

- If your site isn't using Campaign Monitor already, hides all Campaign Monitor settings behind an environment flag
- If your site is using Campaign Monitor already, allows the settings to remain but with a warning in the plugin settings page (and in the Engagement > Newsletters wizard with https://github.com/Automattic/newspack-plugin/pull/3264)

### How to test the changes in this Pull Request:

1. Connect your site to Campaign Monitor.
2. Check out this branch and https://github.com/Automattic/newspack-plugin/pull/3264. 
3. Visit **Newsletters > Settings** and confirm a new warning at the top of the page:

<img width="685" alt="Screenshot 2024-07-22 at 4 42 07 PM" src="https://github.com/user-attachments/assets/4bc2979e-9938-4dff-b7cf-83f96d8ae676">

4. Visit **Newspack > Engagement > Newsletters** and confirm there's a warning here too:

<img width="1058" alt="Screenshot 2024-07-22 at 4 42 19 PM" src="https://github.com/user-attachments/assets/0405f4ce-33d9-462d-bbdd-f62b0f28094e">

5. Smoke test creating, editing, test-sending, and sending a newsletter via Campaign Monitor to make sure it still works.
6. Change your ESP to some other provider and confirm that Campaign Monitor is no longer a selectable option for provider, and its API fields are hidden in both **Newsletters > Settings** and **Newspack > Engagement > Newsletters**
7. Add `define( 'NEWSPACK_NEWSLETTERS_SUPPORT_DEPRECATED_CAMPAIGN_MONITOR', true );` to wp-config.php and confirm that the options are restored, but that you'll see the warning if you switch to Campaign Monitor

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1207799991082612