### PR TITLE
fix(layouts): settings defaults from layout (mailchimp)

### DIFF
--- a/src/service-providers/mailchimp/ProviderSidebar.js
+++ b/src/service-providers/mailchimp/ProviderSidebar.js
@@ -100,8 +100,43 @@ const ProviderSidebar = ( {
 		: [];
 	const folders = newsletterData?.folders || [];
 
+	const setDefaultsFromLayout = () => {
+		try {
+			const layoutDefaults = JSON.parse( stringifiedLayoutDefaults );
+			if ( layoutDefaults.senderEmail && layoutDefaults.senderName ) {
+				const existingSenderData = meta.senderEmail && meta.senderName;
+				if ( ! existingSenderData ) {
+					setSender( {
+						senderName: layoutDefaults.senderName,
+						senderEmail: layoutDefaults.senderEmail,
+					} );
+				}
+			}
+			if ( layoutDefaults.newsletterData?.campaign?.recipients?.list_id ) {
+				const existingListId = newsletterData.campaign?.recipients?.list_id;
+				if ( ! existingListId ) {
+					setList( layoutDefaults.newsletterData?.campaign.recipients.list_id ).then( () => {
+						const subAudienceValue = getSubAudienceValue( layoutDefaults.newsletterData );
+						if ( subAudienceValue ) {
+							updateSegments( subAudienceValue );
+						}
+					} );
+				}
+			}
+		} catch ( e ) {
+			// Ignore it.
+		}
+	};
+
 	useEffect( () => {
-		fetchListsAndSegments();
+		const performSetup = async () => {
+			await fetchListsAndSegments();
+			// If there is a stringified newsletter data from the layout, use it to set the list and segments.
+			if ( stringifiedLayoutDefaults.length ) {
+				setDefaultsFromLayout();
+			}
+		};
+		performSetup();
 	}, [] );
 
 	const fetchListsAndSegments = async () => {
@@ -183,35 +218,6 @@ const ProviderSidebar = ( {
 			} );
 		}
 	}, [ campaign ] );
-
-	// If there is a stringified newsletter data from the layout, use it to set the list and segments.
-	useEffect( () => {
-		try {
-			const layoutDefaults = JSON.parse( stringifiedLayoutDefaults );
-			if ( layoutDefaults.senderEmail && layoutDefaults.senderName ) {
-				const existingSenderData = meta.senderEmail && meta.senderName;
-				if ( ! existingSenderData ) {
-					setSender( {
-						senderName: layoutDefaults.senderName,
-						senderEmail: layoutDefaults.senderEmail,
-					} );
-				}
-			}
-			if ( layoutDefaults.newsletterData?.campaign?.recipients?.list_id ) {
-				const existingListId = newsletterData.campaign?.recipients?.list_id;
-				if ( ! existingListId ) {
-					setList( layoutDefaults.newsletterData?.campaign.recipients.list_id ).then( () => {
-						const subAudienceValue = getSubAudienceValue( layoutDefaults.newsletterData );
-						if ( subAudienceValue ) {
-							updateSegments( subAudienceValue );
-						}
-					} );
-				}
-			}
-		} catch ( e ) {
-			// Ignore it.
-		}
-	}, [ stringifiedLayoutDefaults.length ] );
 
 	if ( ! campaign ) {
 		return (


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes an issue with setting the default sender & audience data when Mailchimp is set as the ESP. 

### How to test the changes in this Pull Request:

1. On `trunk` or `release`
1. Set Mailchimp as the ESP
2. Create a new newsletter, set sender data and choose an audience, save that as a new layout
3. Create a new newsletters, use the newly created layout
4. Observe two error notices in the editor and that the sender and audience are not filled
5. Switch to this branch, create a new newsletter from that same layout again, observe the sender and audience are filled, and no error notices are displayed

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1207937306459773