### PR TITLE
fix: human-readable timestamp of sent newsletters

### DIFF
--- a/includes/class-newspack-newsletters.php
+++ b/includes/class-newspack-newsletters.php
@@ -1175,7 +1175,8 @@ final class Newspack_Newsletters {
 
 		/** Detect meta that determines the sent state */
 		$sent         = get_post_meta( $post_id, 'newsletter_sent', true );
-		$is_published = 'publish' === get_post_status( $post_id ) || $sent;
+		$post_status  = get_post_status( $post_id );
+		$is_published = 'publish' === $post_status || 'private' === $post_status;
 		$publish_date = $is_published ? get_post_datetime( $post_id, 'date', 'gmt' )->getTimestamp() : 0;
 		if ( 0 < $sent && $sent === $publish_date ) {
 			return $sent;

--- a/includes/class-newspack-newsletters.php
+++ b/includes/class-newspack-newsletters.php
@@ -1181,7 +1181,6 @@ final class Newspack_Newsletters {
 			return $sent;
 		}
 
-		/** Legacy check for sent/publish newsletters without meta. */
 		if ( $publish_date ) {
 			self::set_newsletter_sent( $post_id, $publish_date );
 			return $publish_date;

--- a/includes/class-newspack-newsletters.php
+++ b/includes/class-newspack-newsletters.php
@@ -1175,7 +1175,7 @@ final class Newspack_Newsletters {
 
 		/** Detect meta that determines the sent state */
 		$sent         = get_post_meta( $post_id, 'newsletter_sent', true );
-		$is_published = 'publish' === get_post_status( $post_id );
+		$is_published = 'publish' === get_post_status( $post_id ) || $sent;
 		$publish_date = $is_published ? get_post_datetime( $post_id, 'date', 'gmt' )->getTimestamp() : 0;
 		if ( 0 < $sent && $sent === $publish_date ) {
 			return $sent;

--- a/includes/class-newspack-newsletters.php
+++ b/includes/class-newspack-newsletters.php
@@ -546,8 +546,6 @@ final class Newspack_Newsletters {
 
 		$post_status = get_post_status_object( $post->post_status );
 		$sent        = self::is_newsletter_sent( $post->ID );
-		$is_public   = get_post_meta( $post->ID, 'is_public', true );
-
 		if ( $sent ) {
 			$time_diff = time() - $sent;
 
@@ -1176,17 +1174,17 @@ final class Newspack_Newsletters {
 		}
 
 		/** Detect meta that determines the sent state */
-		$sent = get_post_meta( $post_id, 'newsletter_sent', true );
-		if ( 0 < $sent ) {
+		$sent         = get_post_meta( $post_id, 'newsletter_sent', true );
+		$is_published = 'publish' === get_post_status( $post_id );
+		$publish_date = $is_published ? get_post_datetime( $post_id, 'date', 'gmt' )->getTimestamp() : 0;
+		if ( 0 < $sent && $sent === $publish_date ) {
 			return $sent;
 		}
 
 		/** Legacy check for sent/publish newsletters without meta. */
-		if ( 'publish' === get_post_status( $post_id ) ) {
-			$post = get_post( $post_id );
-			$sent = strtotime( $post->post_date );
-			self::set_newsletter_sent( $post_id, $sent );
-			return $sent;
+		if ( $publish_date ) {
+			self::set_newsletter_sent( $post_id, $publish_date );
+			return $publish_date;
 		}
 
 		return false;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes a bug where the human-readable timestamp shown next to sent newsletters doesn't respect the site's local timezone.

### How to test the changes in this Pull Request:

1. Ensure your site has a time zone set in **Settings > General** that's different from GMT/Universal Time.
2. On `trunk`, send a newsletter.
3. Go back to the **Newsletters** post list and observe that the sent label says something inaccurate. For instance, my site is set to Denver/Mountain Time, and so seconds after sending the newsletter the human-readable timestamp reads like this:

<img width="200" alt="Screenshot 2024-08-01 at 4 20 30 PM" src="https://github.com/user-attachments/assets/12a8d51e-cfd6-497d-8664-bc8cc7e896c6">

4. Check out this branch and refresh. Confirm that the timestamp is now more accurate based on when the newsletter was actually sent:

<img width="188" alt="Screenshot 2024-08-01 at 4 23 55 PM" src="https://github.com/user-attachments/assets/91650f60-e4c3-47b9-a692-29e7386a2698">

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1207957618908225