### PR TITLE
Hotfix/mc data report missing days

### DIFF
--- a/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp-usage-reports.php
+++ b/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp-usage-reports.php
@@ -74,16 +74,22 @@ class Newspack_Newsletters_Mailchimp_Usage_Reports {
 			$report = new Newspack_Newsletters_Service_Provider_Usage_Report();
 			$report->set_date( gmdate( 'Y-m-d', strtotime( "-$day_index day" ) ) );
 
+			$report_updated = false;
 			foreach ( $lists['lists'] as $list_data ) {
 				$report->total_contacts += $list_data['stats']['member_count'];
-				$list_activity_for_day = $list_data['activity'][ $day_index ];
-				$report->emails_sent += $list_activity_for_day['emails_sent'];
-				$report->opens += $list_activity_for_day['unique_opens'];
-				$report->clicks += $list_activity_for_day['recipient_clicks'];
-				$report->subscribes += $list_activity_for_day['subs'];
-				$report->unsubscribes += $list_activity_for_day['unsubs'];
+				if ( isset( $list_data['activity'][ $day_index ] ) ) {
+					$list_activity_for_day = $list_data['activity'][ $day_index ];
+					$report->emails_sent += $list_activity_for_day['emails_sent'];
+					$report->opens += $list_activity_for_day['unique_opens'];
+					$report->clicks += $list_activity_for_day['recipient_clicks'];
+					$report->subscribes += $list_activity_for_day['subs'];
+					$report->unsubscribes += $list_activity_for_day['unsubs'];
+					$report_updated = true;
+				}
 			}
-			$reports[] = $report;
+			if ( $report_updated ) {
+				$reports[] = $report;
+			}
 		}
 
 		return $reports;

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
 		"": {
 			"name": "newspack-newsletters",
 			"version": "2.21.1",
+			"hasInstallScript": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@uiw/react-codemirror": "^3.2.10",
@@ -26204,6 +26205,22 @@
 				"node": ">= 0.8.0"
 			}
 		},
+		"node_modules/newspack-scripts/node_modules/prettier": {
+			"name": "wp-prettier",
+			"version": "2.8.5",
+			"resolved": "https://registry.npmjs.org/wp-prettier/-/wp-prettier-2.8.5.tgz",
+			"integrity": "sha512-gkphzYtVksWV6D7/V530bTehKkhrABUru/Gy4reOLOHJoKH4i9lcE1SxqU2VDxC3gCOx/Nk9alZmWk6xL/IBCw==",
+			"dev": true,
+			"bin": {
+				"prettier": "bin-prettier.js"
+			},
+			"engines": {
+				"node": ">=10.13.0"
+			},
+			"funding": {
+				"url": "https://github.com/prettier/prettier?sponsor=1"
+			}
+		},
 		"node_modules/newspack-scripts/node_modules/react": {
 			"version": "17.0.2",
 			"resolved": "https://registry.npmjs.org/react/-/react-17.0.2.tgz",
@@ -32159,9 +32176,9 @@
 		},
 		"node_modules/prettier": {
 			"name": "wp-prettier",
-			"version": "2.8.5",
-			"resolved": "https://registry.npmjs.org/wp-prettier/-/wp-prettier-2.8.5.tgz",
-			"integrity": "sha512-gkphzYtVksWV6D7/V530bTehKkhrABUru/Gy4reOLOHJoKH4i9lcE1SxqU2VDxC3gCOx/Nk9alZmWk6xL/IBCw==",
+			"version": "2.6.2-beta-1",
+			"resolved": "https://registry.npmjs.org/wp-prettier/-/wp-prettier-2.6.2-beta-1.tgz",
+			"integrity": "sha512-kd+i3MlSSpRMFA9wL+RTk7Y0sflV3VE3NvvAnBFDotwfmZmlbBtnUzX0+dahPMoMBgeifGribIzbNYhTayGN3w==",
 			"dev": true,
 			"bin": {
 				"prettier": "bin-prettier.js"

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
 		"format:scss": "prettier --write 'src/**/*.scss'",
 		"format:php": "./vendor/bin/phpcbf .",
 		"release:archive": "rm -rf release && mkdir -p release && rsync -r . ./release/newspack-newsletters --exclude-from='./.distignore' && cd release && zip -r newspack-newsletters.zip newspack-newsletters",
-		"release": "npm run build && npm run semantic-release"
+		"release": "npm run build && npm run semantic-release",
+		"postinstall": "rm -rf node_modules/newspack-scripts/node_modules/prettier"
 	},
 	"lint-staged": {
 		"*.js": "npm run lint:js:staged",

--- a/src/ads/editor/index.js
+++ b/src/ads/editor/index.js
@@ -21,19 +21,25 @@ import { format, isInTheFuture } from '@wordpress/date';
 import { SelectControl } from 'newspack-components';
 
 function AdEdit() {
-	const { price, startDate, expiryDate, insertionStrategy, positionInContent, positionBlockCount } =
-		useSelect( select => {
-			const { getEditedPostAttribute } = select( 'core/editor' );
-			const meta = getEditedPostAttribute( 'meta' );
-			return {
-				price: meta.price,
-				startDate: meta.start_date,
-				expiryDate: meta.expiry_date,
-				insertionStrategy: meta.insertion_strategy,
-				positionInContent: meta.position_in_content,
-				positionBlockCount: meta.position_block_count,
-			};
-		} );
+	const {
+		price,
+		startDate,
+		expiryDate,
+		insertionStrategy,
+		positionInContent,
+		positionBlockCount,
+	} = useSelect( select => {
+		const { getEditedPostAttribute } = select( 'core/editor' );
+		const meta = getEditedPostAttribute( 'meta' );
+		return {
+			price: meta.price,
+			startDate: meta.start_date,
+			expiryDate: meta.expiry_date,
+			insertionStrategy: meta.insertion_strategy,
+			positionInContent: meta.position_in_content,
+			positionBlockCount: meta.position_block_count,
+		};
+	} );
 	const { editPost } = useDispatch( 'core/editor' );
 	const { removeEditorPanel } = useDispatch( editPostStore );
 	const messages = [];

--- a/src/editor/blocks/posts-inserter/index.js
+++ b/src/editor/blocks/posts-inserter/index.js
@@ -51,10 +51,10 @@ const PostsInserterBlock = ( {
 	const stringifiedPostList = JSON.stringify( postList );
 
 	// Stringify added to minimize flicker.
-	const templateBlocks = useMemo(
-		() => getTemplateBlocks( postList, attributes ),
-		[ stringifiedPostList, attributes ]
-	);
+	const templateBlocks = useMemo( () => getTemplateBlocks( postList, attributes ), [
+		stringifiedPostList,
+		attributes,
+	] );
 
 	const stringifiedTemplateBlocks = JSON.stringify( templateBlocks );
 
@@ -392,8 +392,9 @@ const PostsInserterBlockWithSelect = compose( [
 	} ),
 	withDispatch( ( dispatch, props ) => {
 		const { replaceBlocks } = dispatch( 'core/block-editor' );
-		const { setHandledPostsIds, setInsertedPostsIds, removeBlock } =
-			dispatch( POSTS_INSERTER_STORE_NAME );
+		const { setHandledPostsIds, setInsertedPostsIds, removeBlock } = dispatch(
+			POSTS_INSERTER_STORE_NAME
+		);
 		return {
 			replaceBlocks: blocks => {
 				replaceBlocks( props.selectedBlock.clientId, blocks );

--- a/src/editor/mjml/index.js
+++ b/src/editor/mjml/index.js
@@ -63,8 +63,9 @@ function MJML() {
 		};
 	} );
 
-	const { lockPostAutosaving, lockPostSaving, unlockPostSaving, editPost } =
-		useDispatch( 'core/editor' );
+	const { lockPostAutosaving, lockPostSaving, unlockPostSaving, editPost } = useDispatch(
+		'core/editor'
+	);
 	const updateMetaValue = ( key, value ) => editPost( { meta: { [ key ]: value } } );
 
 	// Disable autosave requests in the editor.

--- a/src/newsletter-editor/editor/index.js
+++ b/src/newsletter-editor/editor/index.js
@@ -66,8 +66,13 @@ const Editor = compose( [
 		};
 	} ),
 	withDispatch( dispatch => {
-		const { lockPostAutosaving, lockPostSaving, unlockPostAutosaving, unlockPostSaving, editPost } =
-			dispatch( 'core/editor' );
+		const {
+			lockPostAutosaving,
+			lockPostSaving,
+			unlockPostAutosaving,
+			unlockPostSaving,
+			editPost,
+		} = dispatch( 'core/editor' );
 		const { createNotice, removeNotice } = dispatch( 'core/notices' );
 		const { openModal } = dispatch( 'core/interface' );
 		return {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes an edge case in MC data reports. There was an assumption that MC API will return as much data as requested – e.g. 20 last days – but if the MC account was set up later – e.g. 10 days ago – there will be less data. This PR adjusts the reports creation to first check if the data is there and return only as many daily-reports are there are days-of-data available. 

Including part of #1588 to make CI linting pass. 

### How to test the changes in this Pull Request:

1. On `release` branch,
1. You'd need a fresh MC account – created less than 180 days ago. But it can be simulated by adding the following line below line 78 in `includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp-usage-reports.php`:

```
$list_data['activity'] = array_slice( $list_data['activity'], 0, 3 );
```

3. This will simulate the API returning just three days worth of data. 
4. Enter `wp shell` and execute `Newspack_Newsletters_Mailchimp_Usage_Reports::get_usage_reports(4)` (requesting reports for four days) 
5. Observe four reports returned, and a bunch of PHP Warnings logged
6. Switch to this branch, again add the aforementioned line (below line 79), repeat step 4
7. Observe no warnings logged and two* reports returned

\* the first day is disregarded – it's the current day so data is yet incomplete

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->