### PR TITLE
feat: introduce "subscribe" method

### DIFF
--- a/includes/class-newspack-newsletters-contacts.php
+++ b/includes/class-newspack-newsletters-contacts.php
@@ -15,6 +15,67 @@ defined( 'ABSPATH' ) || exit;
 class Newspack_Newsletters_Contacts {
 
 	/**
+	 * Subscribe a contact to lists.
+	 *
+	 * This method uses an upsert strategy, which means the contact will be
+	 * created if it doesn't exist, or updated if it does.
+	 *
+	 * A contact can be added asynchronously, which means the request will return
+	 * immediately and the contact will be added in the background. In this case
+	 * the response will be `true` and the caller must handle it optimistically.
+	 * NEWSPACK_NEWSLETTERS_ASYNC_SUBSCRIPTION_ENABLED must be defined as true for
+	 * this feature to be available.
+	 *
+	 * @param array          $contact {
+	 *          Contact information.
+	 *
+	 *    @type string   $email    Contact email address.
+	 *    @type string   $name     Contact name. Optional.
+	 *    @type string[] $metadata Contact additional metadata. Optional.
+	 * }
+	 * @param string[]|false $lists   Array of list IDs to subscribe the contact to. If empty or false, contact will be created but not subscribed to any lists.
+	 * @param bool           $async   Whether to add the contact asynchronously. Default is false.
+	 *
+	 * @return array|WP_Error|true Contact data if it was added, or error otherwise. True if async.
+	 */
+	public static function subscribe_contact( $contact, $lists = false, $async = false ) {
+		$provider = Newspack_Newsletters::get_service_provider();
+
+		if ( defined( 'NEWSPACK_NEWSLETTERS_ASYNC_SUBSCRIPTION_ENABLED' ) && NEWSPACK_NEWSLETTERS_ASYNC_SUBSCRIPTION_ENABLED && true === $async ) {
+			Newspack_Newsletters_Subscription::add_subscription_intent( $contact, $lists );
+			return true;
+		}
+
+		$existing_contact = Newspack_Newsletters_Subscription::get_contact_data( $contact['email'], true );
+		$is_updating      = \is_wp_error( $existing_contact ) ? false : true;
+
+		$result = self::upsert( $contact, $lists, $existing_contact );
+
+		if ( is_wp_error( $result ) ) {
+			return $result;
+		}
+
+		/**
+		 * Fires after a contact subscribes.
+		 *
+		 * @param string              $provider The provider name.
+		 * @param array               $contact  {
+		 *    Contact information.
+		 *
+		 *    @type string   $email    Contact email address.
+		 *    @type string   $name     Contact name. Optional.
+		 *    @type string[] $metadata Contact additional metadata. Optional.
+		 * }
+		 * @param string[]|false      $lists    Array of list IDs to subscribe the contact to.
+		 * @param array|WP_Error      $result   Array with data if the contact was added or error if failed.
+		 * @param bool|null           $is_updating Whether the contact is being updated. If false, the contact is being created.
+		 */
+		do_action( 'newspack_newsletters_contact_subscribed', $provider->service, $contact, $lists, $result, $is_updating );
+
+		return $result;
+	}
+
+	/**
 	 * Upserts a contact to lists.
 	 *
 	 * @param array          $contact          {

--- a/includes/class-newspack-newsletters-contacts.php
+++ b/includes/class-newspack-newsletters-contacts.php
@@ -39,7 +39,7 @@ class Newspack_Newsletters_Contacts {
 	 *
 	 * @return array|WP_Error|true Contact data if it was added, or error otherwise. True if async.
 	 */
-	public static function subscribe_contact( $contact, $lists = false, $async = false, $context = 'Subscribe contact' ) {
+	public static function subscribe( $contact, $lists = false, $async = false, $context = 'Subscribe contact' ) {
 		$provider = Newspack_Newsletters::get_service_provider();
 
 		if ( defined( 'NEWSPACK_NEWSLETTERS_ASYNC_SUBSCRIPTION_ENABLED' ) && NEWSPACK_NEWSLETTERS_ASYNC_SUBSCRIPTION_ENABLED && true === $async ) {

--- a/includes/class-newspack-newsletters-subscription.php
+++ b/includes/class-newspack-newsletters-subscription.php
@@ -24,7 +24,7 @@ class Newspack_Newsletters_Subscription {
 	const WC_ENDPOINT         = 'newsletters';
 	const SUBSCRIPTION_UPDATE = 'newspack_newsletters_subscription';
 
-	const ASYNC_ACTION = 'newspack_newsletters_subscription_add_contact';
+	const ASYNC_ACTION = 'newspack_newsletters_subscription_subscribe_contact';
 
 	const SUBSCRIPTION_INTENT_CPT = 'np_nl_sub_intent';
 

--- a/includes/class-newspack-newsletters-subscription.php
+++ b/includes/class-newspack-newsletters-subscription.php
@@ -356,69 +356,8 @@ class Newspack_Newsletters_Subscription {
 	 * @return array|WP_Error|true Contact data if it was added, or error otherwise. True if async.
 	 */
 	public static function add_contact( $contact, $lists = false, $async = false ) {
-		_deprecated_function( __METHOD__, '2.21', 'Newspack_Newsletters_Subscription::subscribe_contact' );
-		return self::subscribe_contact( $contact, $lists, $async );
-	}
-
-	/**
-	 * Subscribe a contact to lists.
-	 *
-	 * This method uses an upsert strategy, which means the contact will be
-	 * created if it doesn't exist, or updated if it does.
-	 *
-	 * A contact can be added asynchronously, which means the request will return
-	 * immediately and the contact will be added in the background. In this case
-	 * the response will be `true` and the caller must handle it optimistically.
-	 * NEWSPACK_NEWSLETTERS_ASYNC_SUBSCRIPTION_ENABLED must be defined as true for
-	 * this feature to be available.
-	 *
-	 * @param array          $contact {
-	 *          Contact information.
-	 *
-	 *    @type string   $email    Contact email address.
-	 *    @type string   $name     Contact name. Optional.
-	 *    @type string[] $metadata Contact additional metadata. Optional.
-	 * }
-	 * @param string[]|false $lists   Array of list IDs to subscribe the contact to. If empty or false, contact will be created but not subscribed to any lists.
-	 * @param bool           $async   Whether to add the contact asynchronously. Default is false.
-	 *
-	 * @return array|WP_Error|true Contact data if it was added, or error otherwise. True if async.
-	 */
-	public static function subscribe_contact( $contact, $lists = false, $async = false ) {
-		$provider = Newspack_Newsletters::get_service_provider();
-
-		if ( defined( 'NEWSPACK_NEWSLETTERS_ASYNC_SUBSCRIPTION_ENABLED' ) && NEWSPACK_NEWSLETTERS_ASYNC_SUBSCRIPTION_ENABLED && true === $async ) {
-			self::add_subscription_intent( $contact, $lists );
-			return true;
-		}
-
-		$existing_contact = self::get_contact_data( $contact['email'], true );
-		$is_updating      = \is_wp_error( $existing_contact ) ? false : true;
-
-		$result = Newspack_Newsletters_Contacts::upsert( $contact, $lists, $existing_contact );
-
-		if ( is_wp_error( $result ) ) {
-			return $result;
-		}
-
-		/**
-		 * Fires after a contact subscribes.
-		 *
-		 * @param string              $provider The provider name.
-		 * @param array               $contact  {
-		 *    Contact information.
-		 *
-		 *    @type string   $email    Contact email address.
-		 *    @type string   $name     Contact name. Optional.
-		 *    @type string[] $metadata Contact additional metadata. Optional.
-		 * }
-		 * @param string[]|false      $lists    Array of list IDs to subscribe the contact to.
-		 * @param array|WP_Error      $result   Array with data if the contact was added or error if failed.
-		 * @param bool|null           $is_updating Whether the contact is being updated. If false, the contact is being created.
-		 */
-		do_action( 'newspack_newsletters_contact_subscribed', $provider->service, $contact, $lists, $result, $is_updating );
-
-		return $result;
+		_deprecated_function( __METHOD__, '2.21', 'Newspack_Newsletters_Contacts::subscribe_contact' );
+		return Newspack_Newsletters_Contacts::subscribe_contact( $contact, $lists, $async );
 	}
 
 	/**

--- a/includes/class-newspack-newsletters-subscription.php
+++ b/includes/class-newspack-newsletters-subscription.php
@@ -461,6 +461,11 @@ class Newspack_Newsletters_Subscription {
 				]
 			);
 		}
+
+		$provider = Newspack_Newsletters::get_service_provider();
+		if ( empty( $provider ) ) {
+			return;
+		}
 		foreach ( $intents as $intent ) {
 			if ( empty( $intent ) ) {
 				continue;
@@ -473,6 +478,7 @@ class Newspack_Newsletters_Subscription {
 				self::remove_subscription_intent( $intent['id'] );
 				continue;
 			}
+
 			$contact = $intent['contact'];
 			$email   = $contact['email'];
 			$lists   = $intent['lists'];

--- a/includes/class-newspack-newsletters-subscription.php
+++ b/includes/class-newspack-newsletters-subscription.php
@@ -356,8 +356,8 @@ class Newspack_Newsletters_Subscription {
 	 * @return array|WP_Error|true Contact data if it was added, or error otherwise. True if async.
 	 */
 	public static function add_contact( $contact, $lists = false, $async = false ) {
-		_deprecated_function( __METHOD__, '2.21', 'Newspack_Newsletters_Contacts::subscribe_contact' );
-		return Newspack_Newsletters_Contacts::subscribe_contact( $contact, $lists, $async, 'deprecated' );
+		_deprecated_function( __METHOD__, '2.21', 'Newspack_Newsletters_Contacts::subscribe' );
+		return Newspack_Newsletters_Contacts::subscribe( $contact, $lists, $async, 'deprecated' );
 	}
 
 	/**
@@ -607,7 +607,7 @@ class Newspack_Newsletters_Subscription {
 
 		// Adding is actually upserting, so no need to check if the hook is called for an existing user.
 		try {
-			Newspack_Newsletters_Contacts::subscribe_contact(
+			Newspack_Newsletters_Contacts::subscribe(
 				[
 					'email'    => $email,
 					'metadata' => $metadata,

--- a/includes/class-newspack-newsletters-subscription.php
+++ b/includes/class-newspack-newsletters-subscription.php
@@ -505,19 +505,7 @@ class Newspack_Newsletters_Subscription {
 				}
 
 				/**
-				 * Fires after a contact subscribes.
-				 *
-				 * @param string              $provider The provider name.
-				 * @param array               $contact  {
-				 *    Contact information.
-				 *
-				 *    @type string   $email    Contact email address.
-				 *    @type string   $name     Contact name. Optional.
-				 *    @type string[] $metadata Contact additional metadata. Optional.
-				 * }
-				 * @param string[]|false      $lists    Array of list IDs to subscribe the contact to.
-				 * @param array|WP_Error      $result   Array with data if the contact was added or error if failed.
-				 * @param bool|null           $is_updating Whether the contact is being updated. If false, the contact is being created.
+				 * This hook is documented at includes/class-newspack-newsletters-contacts.php.
 				 */
 				do_action( 'newspack_newsletters_contact_subscribed', $provider->service, $contact, $lists, $result, $is_updating, $context );
 			}

--- a/includes/class-newspack-newsletters-subscription.php
+++ b/includes/class-newspack-newsletters-subscription.php
@@ -484,10 +484,7 @@ class Newspack_Newsletters_Subscription {
 			$lists   = $intent['lists'];
 			$context = $intent['context'];
 
-			$existing_contact = self::get_contact_data( $contact['email'], true );
-			$is_updating      = \is_wp_error( $existing_contact ) ? false : true;
-
-			$result = Newspack_Newsletters_Contacts::upsert( $contact, $lists, $context . ' (ASYNC)', $existing_contact );
+			$result = Newspack_Newsletters_Contacts::subscribe( $contact, $lists, false, $context . ' (ASYNC)' );
 
 			$user = get_user_by( 'email', $email );
 			if ( \is_wp_error( $result ) ) {
@@ -503,11 +500,6 @@ class Newspack_Newsletters_Subscription {
 				if ( $user ) {
 					delete_user_meta( $user->ID, 'newspack_newsletters_subscription_error' );
 				}
-
-				/**
-				 * This hook is documented at includes/class-newspack-newsletters-contacts.php.
-				 */
-				do_action( 'newspack_newsletters_contact_subscribed', $provider->service, $contact, $lists, $result, $is_updating, $context );
 			}
 		}
 	}

--- a/includes/class-newspack-newsletters-subscription.php
+++ b/includes/class-newspack-newsletters-subscription.php
@@ -601,7 +601,7 @@ class Newspack_Newsletters_Subscription {
 
 		// Adding is actually upserting, so no need to check if the hook is called for an existing user.
 		try {
-			Newspack_Newsletters_Contacts::upsert(
+			Newspack_Newsletters_Contacts::subscribe_contact(
 				[
 					'email'    => $email,
 					'metadata' => $metadata,

--- a/includes/service-providers/class-newspack-newsletters-service-provider.php
+++ b/includes/service-providers/class-newspack-newsletters-service-provider.php
@@ -518,7 +518,7 @@ Details of the error message: "%3$s"
 		if ( is_wp_error( $contact ) ) {
 			// Create contact.
 			// Use Newspack_Newsletters_Contacts::upsert to trigger hooks and call add_contact_handling_local_list if needed.
-			$result = Newspack_Newsletters_Contacts::upsert( [ 'email' => $email ], $lists_to_add, false, $context );
+			$result = Newspack_Newsletters_Contacts::upsert( [ 'email' => $email ], $lists_to_add, $context );
 			if ( is_wp_error( $result ) ) {
 				return $result;
 			}

--- a/src/blocks/subscribe/index.php
+++ b/src/blocks/subscribe/index.php
@@ -498,7 +498,7 @@ function process_form() {
 		\Newspack\Reader_Activation::register_reader( $email, $name, true, $metadata );
 	}
 
-	$result = \Newspack_Newsletters_Contacts::upsert(
+	$result = \Newspack_Newsletters_Contacts::subscribe_contact(
 		[
 			'name'     => $name ?? null,
 			'email'    => $email,

--- a/src/blocks/subscribe/index.php
+++ b/src/blocks/subscribe/index.php
@@ -498,7 +498,7 @@ function process_form() {
 		\Newspack\Reader_Activation::register_reader( $email, $name, true, $metadata );
 	}
 
-	$result = \Newspack_Newsletters_Contacts::subscribe_contact(
+	$result = \Newspack_Newsletters_Contacts::subscribe(
 		[
 			'name'     => $name ?? null,
 			'email'    => $email,

--- a/tests/test-contacts.php
+++ b/tests/test-contacts.php
@@ -6,9 +6,9 @@
  */
 
 /**
- * Tests the Contact_Add class
+ * Tests the Contacts Class.
  */
-class ESP_Add_Contact_Test extends WP_UnitTestCase {
+class Newsletters_Contacts_Test extends WP_UnitTestCase {
 	/**
 	 * Test set up.
 	 */
@@ -19,9 +19,75 @@ class ESP_Add_Contact_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Add a contact to a single list.
+	 * Subscribe a contact to a single list synchronously.
 	 */
-	public function test_add_contact_to_single_list() {
+	public function test_subscribe_contact() {
+		$result = Newspack_Newsletters_Contacts::subscribe_contact(
+			[
+				'email' => 'test@example.com',
+			],
+			[ 'list1' ]
+		);
+		$this->assertEquals(
+			[
+				[
+					'status'  => 'pending',
+					'list_id' => 'list1',
+				],
+			],
+			$result
+		);
+	}
+
+	/**
+	 * Subscribe a contact to a single list assynchronously.
+	 */
+	public function test_subscribe_contact_async() {
+		if ( ! defined( 'NEWSPACK_NEWSLETTERS_ASYNC_SUBSCRIPTION_ENABLED' ) ) {
+			define( 'NEWSPACK_NEWSLETTERS_ASYNC_SUBSCRIPTION_ENABLED', true );
+		}
+		$result = Newspack_Newsletters_Contacts::subscribe_contact(
+			[
+				'email' => 'test@example.com',
+			],
+			[ 'list1' ],
+			true
+		);
+
+		// Async subscription should return true.
+		$this->assertEquals(
+			true,
+			$result
+		);
+
+		// Hook into the async result.
+		$async_result = null;
+		add_action(
+			'newspack_newsletters_contact_subscribed',
+			function( $provider, $contact, $lists, $result, $is_updating, $context ) use ( &$async_result ) {
+				$async_result = $result;
+			},
+			10,
+			6
+		);
+
+		// Manually trigger subscription intents processing.
+		Newspack_Newsletters_Subscription::process_subscription_intents();
+		$this->assertEquals(
+			[
+				[
+					'status'  => 'pending',
+					'list_id' => 'list1',
+				],
+			],
+			$async_result
+		);
+	}
+
+	/**
+	 * Upsert a contact to a single list.
+	 */
+	public function test_upsert_contact_to_single_list() {
 		$result = Newspack_Newsletters_Contacts::upsert(
 			[
 				'email' => 'test@example.com',
@@ -40,9 +106,9 @@ class ESP_Add_Contact_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Add a contact to multiple lists.
+	 * Upsert a contact to multiple lists.
 	 */
-	public function test_add_contact_to_multiple_lists() {
+	public function test_upsert_contact_to_multiple_lists() {
 		$result = Newspack_Newsletters_Contacts::upsert(
 			[
 				'email' => 'test@example.com',
@@ -65,9 +131,9 @@ class ESP_Add_Contact_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Add a contact to lists and sublists.
+	 * Upsert a contact to lists and sublists.
 	 */
-	public function test_add_contact_to_lists_and_sublists() {
+	public function test_upsert_contact_to_lists_and_sublists() {
 		$result = Newspack_Newsletters_Contacts::upsert(
 			[
 				'email' => 'test@example.com',
@@ -93,9 +159,9 @@ class ESP_Add_Contact_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Add a contact to multiple lists and sublists.
+	 * Upsert a contact to multiple lists and sublists.
 	 */
-	public function test_add_contact_to_multiple_lists_and_sublists() {
+	public function test_upsert_contact_to_multiple_lists_and_sublists() {
 		$result = Newspack_Newsletters_Contacts::upsert(
 			[
 				'email' => 'test@example.com',

--- a/tests/test-contacts.php
+++ b/tests/test-contacts.php
@@ -22,7 +22,7 @@ class Newsletters_Contacts_Test extends WP_UnitTestCase {
 	 * Subscribe a contact to a single list synchronously.
 	 */
 	public function test_subscribe_contact() {
-		$result = Newspack_Newsletters_Contacts::subscribe_contact(
+		$result = Newspack_Newsletters_Contacts::subscribe(
 			[
 				'email' => 'test@example.com',
 			],
@@ -46,7 +46,7 @@ class Newsletters_Contacts_Test extends WP_UnitTestCase {
 		if ( ! defined( 'NEWSPACK_NEWSLETTERS_ASYNC_SUBSCRIPTION_ENABLED' ) ) {
 			define( 'NEWSPACK_NEWSLETTERS_ASYNC_SUBSCRIPTION_ENABLED', true );
 		}
-		$result = Newspack_Newsletters_Contacts::subscribe_contact(
+		$result = Newspack_Newsletters_Contacts::subscribe(
 			[
 				'email' => 'test@example.com',
 			],


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR implements a new `Newspack_Newsletters_Contacts::subscribe()` method to differentiate contact updates from intentional newsletter subscriptions. Contact updates should continue to use `::upsert()`, also called by the new `::subscribe()` method.

The async strategy was moved from `::upsert()` to `::subscribe()`, given it's a strategy aimed at improving the UX for the newsletter subscription form. Most `::upsert()` calls are already performed asynchronously via data events, this method should be predictable and up to the caller to handle performance.

Unit test were also updated to include the sync and async usage of the new `::subscribe()` method. The test class was renamed and refactored a bit to reflect its relationship with the `Newspack_Newsletters_Contacts` class.

Related PRs:
- https://github.com/Automattic/newspack-plugin/pull/3304
- https://github.com/Automattic/newspack-blocks/pull/1827

### How to test the changes in this Pull Request:

1. Check out this branch, https://github.com/Automattic/newspack-plugin/pull/3304, and https://github.com/Automattic/newspack-blocks/pull/1827
2. Make sure you have Newspack Newsletters configured and properly connected to an ESP
3. Add a Newsletter Subscription Form and Reader Registration (with newsletter lists) blocks to a page
4. In a fresh session, register using the Reader Registration block and watch the logs from https://github.com/Automattic/newspack-manager/pull/240
5. Confirm the subscription goes through and includes the context for each action
6. In another fresh session, repeat step 4 and 5 with the Newsletter Subscription Form block
7. Using the Donate Block, make a donation with your newly created account
8. Confirm, via logs and the ESP dashboard, that data events is able to update the contact metadata with the donation data

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
