### PR TITLE
fix: "My Account" newsletters subscription

### DIFF
--- a/includes/class-newspack-newsletters-subscription.php
+++ b/includes/class-newspack-newsletters-subscription.php
@@ -1047,10 +1047,10 @@ class Newspack_Newsletters_Subscription {
 		} else {
 			$email  = get_userdata( get_current_user_id() )->user_email;
 			$lists  = isset( $_POST['lists'] ) ? array_map( 'sanitize_text_field', $_POST['lists'] ) : [];
-			if ( self::is_newsletter_subscriber( $email ) ) {
-				$result = Newspack_Newsletters_Contacts::update_lists( $email, $lists, 'User updated their subscriptions on My Account page' );
-			} else {
+			if ( false === self::is_newsletter_subscriber( $email ) ) {
 				$result = Newspack_Newsletters_Contacts::subscribe( [ 'email' => $email ], $lists, false, 'User subscribed on My Account page' );
+			} else {
+				$result = Newspack_Newsletters_Contacts::update_lists( $email, $lists, 'User updated their subscriptions on My Account page' );
 			}
 			if ( is_wp_error( $result ) ) {
 				wc_add_notice( $result->get_error_message(), 'error' );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

From https://github.com/Automattic/newspack-newsletters/pull/1593#pullrequestreview-2222310445

Implements a `Newspack_Newsletters_Subscription::is_newsletter_subscriber()` method and checks whether the newsletter list update should be considered a new subscription.

### How to test the changes in this Pull Request:

1. Register a new reader through the "Sign In" button without subscribing to newsletters
2. Go to "My Account -> Newsletters" and select some lists
3. Confirm "User subscribed on My Account page" is logged
4. On the same page, select another list and confirm "User updated their subscriptions on My Account page" is logged

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
