### PR TITLE
Fix/status if new

### DIFF
--- a/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp-notes.php
+++ b/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp-notes.php
@@ -21,7 +21,7 @@ class Newspack_Newsletters_Mailchimp_Notes {
 	 * @return void
 	 */
 	public static function init() {
-		add_action( 'newspack_newsletters_add_contact', array( __CLASS__, 'handle_upsert' ), 10, 6 );
+		add_action( 'newspack_newsletters_upsert', array( __CLASS__, 'handle_upsert' ), 10, 6 );
 		add_action( 'newspack_newsletters_update_contact_lists', array( __CLASS__, 'handle_update_lists' ), 10, 6 );
 	}
 

--- a/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp.php
+++ b/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp.php
@@ -1365,25 +1365,27 @@ final class Newspack_Newsletters_Mailchimp extends \Newspack_Newsletters_Service
 			return self::$contacts_added[ $cache_key ];
 		}
 
-		$new_contact_status = 'subscribed';
-		$status_if_new_informed = false;
+		$update_payload = [ 'email_address' => $email_address ];
 
-		if ( ! empty( $contact['metadata']['status_if_new'] ) ) {
-			$new_contact_status = $contact['metadata']['status_if_new'];
-			$status_if_new_informed = true;
+		if ( isset( $contact['metadata'] ) && ! empty( $contact['metadata']['status_if_new'] ) ) {
+			$update_payload['status_if_new'] = $contact['metadata']['status_if_new'];
 			unset( $contact['metadata']['status_if_new'] );
 		}
 
-		if ( ! empty( $contact['metadata']['status'] ) ) {
-			$new_contact_status = $contact['metadata']['status'];
+		if ( isset( $contact['metadata'] ) && ! empty( $contact['metadata']['status'] ) ) {
+			$update_payload['status'] = $contact['metadata']['status'];
 			unset( $contact['metadata']['status'] );
 		}
 
-		$new_contact_status = $new_contact_status ?? 'subscribed';
+		// If we're subscribing the contact to a newsletter, they should have some status
+		// because 'non-subscriber' status can't receive newsletters.
+		if ( empty( $update_payload['status'] ) ) {
+			$update_payload['status'] = 'subscribed';
+		}
 
 		try {
-			$mc             = new Mailchimp( $this->api_key() );
-			$update_payload = [ 'email_address' => $email_address ];
+
+			$mc = new Mailchimp( $this->api_key() );
 
 			if ( isset( $contact['metadata'] ) && is_array( $contact['metadata'] ) && ! empty( $contact['metadata'] ) ) {
 				$merge_fields = $this->prepare_merge_fields( $list_id, $contact['metadata'] );
@@ -1429,20 +1431,10 @@ final class Newspack_Newsletters_Mailchimp extends \Newspack_Newsletters_Service
 				}
 			}
 
-			// If we're subscribing the contact to a newsletter, they should have some status
-			// because 'non-subscriber' status can't receive newsletters.
-			if ( ! empty( $list_id ) || ! empty( $sublists ) ) {
-				$update_payload['status_if_new'] = $new_contact_status;
-				if ( ! $status_if_new_informed ) {
-					$update_payload['status'] = $new_contact_status;
-				}
-			}
-
 			// Create or update a list member.
 			$existing_contact = self::get_contact_data( $email_address );
 			if ( is_wp_error( $existing_contact ) ) {
-				$update_payload['status'] = $new_contact_status;
-				$result                   = $mc->post( "lists/$list_id/members", $update_payload );
+				$result = $mc->post( "lists/$list_id/members", $update_payload );
 			} else {
 				$member_id = $existing_contact['id'];
 				$result    = $mc->put( "lists/$list_id/members/$member_id", $update_payload );

--- a/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp.php
+++ b/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp.php
@@ -1379,7 +1379,7 @@ final class Newspack_Newsletters_Mailchimp extends \Newspack_Newsletters_Service
 
 		// If we're subscribing the contact to a newsletter, they should have some status
 		// because 'non-subscriber' status can't receive newsletters.
-		if ( empty( $update_payload['status'] ) ) {
+		if ( empty( $update_payload['status'] ) && empty( $update_payload['status_if_new'] ) ) {
 			$update_payload['status'] = 'subscribed';
 		}
 
@@ -1432,13 +1432,9 @@ final class Newspack_Newsletters_Mailchimp extends \Newspack_Newsletters_Service
 			}
 
 			// Create or update a list member.
-			$existing_contact = self::get_contact_data( $email_address );
-			if ( is_wp_error( $existing_contact ) ) {
-				$result = $mc->post( "lists/$list_id/members", $update_payload );
-			} else {
-				$member_id = $existing_contact['id'];
-				$result    = $mc->put( "lists/$list_id/members/$member_id", $update_payload );
-			}
+			$member_hash = Mailchimp::subscriberHash( $email_address );
+			$result = $mc->put( "lists/$list_id/members/$member_hash", $update_payload );
+
 			if (
 				! $result ||
 				! isset( $result['status'] ) ||

--- a/tests/mocks/class-mailchimp-mock.php
+++ b/tests/mocks/class-mailchimp-mock.php
@@ -155,6 +155,10 @@ class MailChimp {
 		return [];
 	}
 
+	public static function put( $endpoint, $args = [] ) { // phpcs:ignore Squiz.Commenting.FunctionComment.Missing
+		return self::post( $endpoint, $args );
+	}
+
 	public static function post( $endpoint, $args = [] ) { // phpcs:ignore Squiz.Commenting.FunctionComment.Missing
 		if ( ! self::is_api_configured() ) {
 			return [];


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes and improves the handling of `status` and `status_if_new` in Mailchimp

Also fixes the Mailchimp Notes hook

### How to test the changes in this Pull Request:

Test different flows and make sure they work as expected.

Suggestions

1. Enable RAS
2. Set Mailchimp as ESP
3. As an anonymous reader, register to the site
4. Confirm the contact is added to Mailchimp as non-subscriber
5. Confirm there are Notes added to the contact with our logging
6. With the same user, make a Donation
7. Confirm the contact is updated on Mailchimp but is still not subscribed
8. Subscribe to a newsletter via newsletter subscription block
9. confirm that now the contact is subscribed
10. Make another donation
11. Make sure the contact is still subscribed


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
