### PR TITLE
fix(subscription-block): remove default list when misconfigured

### DIFF
--- a/src/blocks/subscribe/index.php
+++ b/src/blocks/subscribe/index.php
@@ -115,10 +115,6 @@ function render_block( $attrs ) {
 	$list_map        = array_flip( $lists );
 	$available_lists = array_values( array_intersect( $attrs['lists'], $lists ) );
 
-	if ( empty( $available_lists ) ) {
-		$available_lists = [ $lists[0] ];
-	}
-
 	/**
 	 * Filters the lists that are about to be displayed in the Subscription block
 	 *


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

1200530782742699-as-1207876225097086

Changes how we handle the subscription form block when a subscription list becomes unavailable. The current behavior defaults to the first list available when none of the configured lists are found, which is not ideal.

If none of the lists are found, the form should not render and the editor should display a notice so it can be revised and fixed:

<img width="842" alt="image" src="https://github.com/user-attachments/assets/3ae0514e-1cbb-44db-89d5-2deaf2759041">

If the form has multiple lists selected and at least 1 one exists, the render is preserved with the lists available. While editing the page, the block should still display a notice to alert the editor that the block is not reflecting all the intended lists.

When adding a Newsletter Subscription Form block for the first time, the default behavior should still be auto-selecting the first available list for convenience.

### How to test the changes in this Pull Request:

1. Check out this branch and make sure you have an ESP connected with at least 3 subscription lists available
2. Edit a page and add the Newsletter Subscription Form block
3. Confirm the first available list is selected by default
4. Deactivate the subscription list in the Newsletters' settings page (make sure you have others enabled as well)
5. Visit the page and confirm the form no longer renders
6. Edit the page and confirm you see the notice as in the image above
7. Change the selection and confirm the notice disappears
8. Save the page, visit, and confirm the form renders
9. Edit the page again and select multiple lists
10. Deactivate one of them in the Newsletters' settings
11. Visit the page and confirm the deactivated list is not listed but others are
12. Edit the page and confirm the selection is preserved and you also get the same notice as above

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1207876225097086