### PR TITLE
fix: check for valid ID before post type check

### DIFF
--- a/includes/class-newspack-newsletters.php
+++ b/includes/class-newspack-newsletters.php
@@ -751,6 +751,9 @@ final class Newspack_Newsletters {
 	 * @param int $id Post ID.
 	 */
 	public static function validate_newsletter_id( $id ) {
+		if ( ! $id ) {
+			return false;
+		}
 		return self::NEWSPACK_NEWSLETTERS_CPT === get_post_type( $id );
 	}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

1200530782742699-as-1208037471056026

Ensure the incoming ID is non-empty before calling `get_post_type( $post_id )`. This prevents the call of an empty `get_post(0)`, which generates an empty post object that can be problematic depending on the context in which the `validate_newsletter_id()` method was called.

### How to test the changes in this Pull Request:

This change hardens the same check, the plugin should work without any change.

To be extra safe, also create a new blog post and confirm it behaves as expected. This is to make sure that Newsletters' hooks are not getting called outside of its scope.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
