### PR TITLE
Feat/linter contacts methods

### DIFF
--- a/phpcs.xml
+++ b/phpcs.xml
@@ -6,6 +6,9 @@
 	<rule ref="WordPress-Docs" />
 	<rule ref="WordPress-VIP-Go" />
 
+	<!-- Newspack Newsletters rules -->
+	<rule ref="phpcsSniffs" />
+
 	<rule ref="WordPress">
 		<exclude name="Generic.Arrays.DisallowShortArraySyntax.Found" />
 		<exclude name="Universal.Arrays.DisallowShortArraySyntax.Found" />

--- a/phpcsSniffs/Sniffs/NewspackNewslettersContactsMethodsSniff.php
+++ b/phpcsSniffs/Sniffs/NewspackNewslettersContactsMethodsSniff.php
@@ -1,0 +1,122 @@
+<?php // phpcs:ignore WordPress.Files.FileName
+/**
+ * Newspack Newsletters Contacts Methods Sniff
+ *
+ * @package newspack-newsletters
+ */
+
+// phpcs:disable WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+
+/**
+ * Sniff for catching classes not marked as abstract or final
+ */
+class NewspackNewslettersContactsMethodsSniff implements PHP_CodeSniffer_Sniff {
+
+	/**
+	 * The error code.
+	 */
+	const ERROR_CODE = 'ForbiddenContactsMethods';
+
+	/**
+	 * The error message.
+	 */
+	const ERROR_MESSAGE = 'Method %s should not be called from class %s. These methods are for internal use only. Use methods in Newspack_Newsletters_Contacts class instead.';
+
+	/**
+	 * Returns the token types that this sniff is interested in.
+	 *
+	 * @return array(int)
+	 */
+	public function register() {
+		return array( T_CLASS, T_STRING );
+	}
+
+	/**
+	 * The methods we are looking for.
+	 *
+	 * These methods can only be called from the allowed classes or the service provider directory.
+	 *
+	 * @var array
+	 */
+	private $methods = [
+		'add_contact',
+		'add_esp_local_list_to_contact',
+		'remove_esp_local_list_from_contact',
+		'add_tag_to_contact',
+		'remove_tag_from_contact',
+		'update_contact_local_lists',
+		'update_contact_lists_handling_local',
+		'add_contact_handling_local_list',
+		'add_contact_with_groups_and_tags',
+		'add_contact_to_provider',
+		'delete_user_subscription',
+		'update_contact_lists',
+	];
+
+	/**
+	 * The allowed classes.
+	 *
+	 * These are the classes from where the methods are allowed to be called.
+	 *
+	 * @var array
+	 */
+	private $allowed_classes = [
+		'Newspack_Newsletters_Subscription',
+		'Newspack_Newsletters_Contacts',
+	];
+
+	/**
+	 * The current class name.
+	 *
+	 * @var string
+	 */
+	private $current_class = '';
+
+	/**
+	 * Processes the tokens that this sniff is interested in.
+	 *
+	 * Will look for calls of the methods defined in $this->methods and check if they are called from the allowed classes.
+	 * They are also allowed to be called from within the service-providers directory.
+	 *
+	 * @param PHP_CodeSniffer_File $phpcs_file The file where the token was found.
+	 * @param int                  $stack_ptr The position in the stack where the token was found.
+	 */
+	public function process( PHP_CodeSniffer_File $phpcs_file, $stack_ptr ) {
+
+		$path_parts = explode( DIRECTORY_SEPARATOR, $phpcs_file->path );
+
+		$possible_provider_dirs = [
+			$path_parts[ count( $path_parts ) - 2 ],
+			$path_parts[ count( $path_parts ) - 3 ],
+		];
+
+		if ( in_array( 'service-providers', $possible_provider_dirs, true ) ) {
+			return;
+		}
+
+		$tokens = $phpcs_file->getTokens();
+		$token = $tokens[ $stack_ptr ];
+
+		if ( $token['code'] === T_CLASS ) {
+			$this->current_class = $tokens[ $stack_ptr + 2 ]['content'];
+			return;
+		}
+
+		if ( in_array( $token['content'], $this->methods, true ) ) {
+			$operator = $tokens[ $stack_ptr - 1 ];
+			if ( $operator['type'] === 'T_DOUBLE_COLON' || $operator['type'] === 'T_OBJECT_OPERATOR' ) {
+
+				if ( ! in_array( $this->current_class, $this->allowed_classes, true ) ) {
+
+					$method_name = $tokens[ $stack_ptr - 2 ]['content'] . $tokens[ $stack_ptr - 1 ]['content'] . $token['content'] . '()';
+
+					$phpcs_file->addError(
+						sprintf( self::ERROR_MESSAGE, $method_name, $this->current_class ),
+						$stack_ptr,
+						self::ERROR_CODE
+					);
+				}
+			}
+		}
+	}
+}

--- a/phpcsSniffs/Sniffs/NewspackNewslettersContactsMethodsSniff.php
+++ b/phpcsSniffs/Sniffs/NewspackNewslettersContactsMethodsSniff.php
@@ -20,7 +20,7 @@ class NewspackNewslettersContactsMethodsSniff implements PHP_CodeSniffer_Sniff {
 	/**
 	 * The error message.
 	 */
-	const ERROR_MESSAGE = 'Method %s should not be called from class %s. These methods are for internal use only. Use methods in Newspack_Newsletters_Contacts class instead.';
+	const ERROR_MESSAGE = 'Method %s is reserved for internal use and should not be called from this scope. Use methods in Newspack_Newsletters_Contacts class instead.';
 
 	/**
 	 * Returns the token types that this sniff is interested in.
@@ -111,7 +111,7 @@ class NewspackNewslettersContactsMethodsSniff implements PHP_CodeSniffer_Sniff {
 					$method_name = $tokens[ $stack_ptr - 2 ]['content'] . $tokens[ $stack_ptr - 1 ]['content'] . $token['content'] . '()';
 
 					$phpcs_file->addError(
-						sprintf( self::ERROR_MESSAGE, $method_name, $this->current_class ),
+						sprintf( self::ERROR_MESSAGE, $method_name ),
 						$stack_ptr,
 						self::ERROR_CODE
 					);

--- a/phpcsSniffs/ruleset.xml
+++ b/phpcsSniffs/ruleset.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0"?>
+<ruleset name="NewspackNewsletters">
+    <description>Add Newspack Newsletters specific rules.</description>
+</ruleset>


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

https://github.com/Automattic/newspack-newsletters/pull/1594 done again after its base epic branch got merged leaving it behind

In the effort of consolidating our data flows, we want to enforce that every contact update goes through the same route, starting at `Newspack_Newsletters_Contacts` class to make sure we have the propper logging.

However, we can't make all the internal methods private or protected.

This PHP Sniffer helps us avoid adding any new code that will bypass our intended flow. We'll need to add this sniffers to other Newspack plugins as well. - TBD how to do that

### How to test the changes in this Pull Request:

1. checkout this branch
2. run `./vendor/bin/phpcs`
3. Confirm you see some error in 2 files. (These errors are fixed in https://github.com/Automattic/newspack-newsletters/pull/1574)
4. Does the message look good?
5. Try to add a method to one of the forbidden methods anywhere in the code.
6. Make sure the sniffer catches it

PS - the linting errors in the CI job are expected until we merge https://github.com/Automattic/newspack-newsletters/pull/1574

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1207942575891805