### PR TITLE
chore: add phpcsSniffs folder to dist ignore

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -42,6 +42,7 @@ node_modules
 /tests
 /bin
 .cache
+phpcsSniffs
 
 # humbug/php-scoper contains some test-related files which are invalid
 vendor/humbug/php-scoper/fixtures


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Adds the phpcsSniffs folder to dist-ignore

### How to test the changes in this Pull Request:

Nothing really

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
