### PR TITLE
fix: add preview text fallback to make sure HTML is removed

### DIFF
--- a/includes/class-newspack-newsletters-renderer.php
+++ b/includes/class-newspack-newsletters-renderer.php
@@ -1266,6 +1266,9 @@ final class Newspack_Newsletters_Renderer {
 		$background_color = get_post_meta( $post->ID, 'background_color', true );
 		$preview_text     = get_post_meta( $post->ID, 'preview_text', true );
 		$custom_css       = get_post_meta( $post->ID, 'custom_css', true );
+		if ( ! $preview_text ) {
+			$preview_text = wp_trim_words( wp_strip_all_tags( $body ), 60 );
+		}
 		if ( ! $background_color ) {
 			$background_color = '#ffffff';
 		}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR adds a fallback for the newsletter preview text that uses part of the body text with the HTML stripped out.

This is to work around an odd issue with Gmail: if you have an image with a link near the beginning of your email, the preview will include the image's alt text or description.

This happens when you draft regular emails from one Gmail account to another -- it's not unique to Newsletters or our plugin. 

See: 1207860156851023-as-1206907385452695

### How to test the changes in this Pull Request:

1. On `trunk`, draft a test newsletter with a linked image at the very top (this can be either an Image Block or Site Logo block). Make sure that the image has either alt text or a description entered in the Media Library.
2. Send a test newsletter (or the actual newsletter) to a Gmail email address.
3. Note the alt text appears in the preview:

![CleanShot 2024-08-13 at 20 48 36](https://github.com/user-attachments/assets/b359de77-9c64-4692-b6a2-08ead28f3f6e)

4. Apply this PR, and repeat steps 1 and 2.
5. Confirm that the preview no longer includes the alt text.
6. Draft a third newsletter, and add text to the Preview field in the right sidebar. 
7. Send that as a test (or real) newsletter, and confirm your custom text is still used in the preview. Note: if your text is short, the rest of the space will still be filled with the body in Gmail, so it may still include alt text/descriptions, but (thankfully!) not as the very first couple words.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
