### PR TITLE
fix(ras-acc): respect social icons padding

### DIFF
--- a/includes/class-newspack-newsletters-renderer.php
+++ b/includes/class-newspack-newsletters-renderer.php
@@ -852,8 +852,9 @@ final class Newspack_Newsletters_Renderer {
 				$social_wrapper_attrs = array(
 					'icon-size'     => '24px',
 					'mode'          => 'horizontal',
-					'padding'       => '0',
 					'border-radius' => '999px',
+					'icon-padding'  => 'is-style-filled-primary-text' === $attrs['className'] ? '0px' : '7px',
+					'padding'       => '0',
 				);
 				if ( isset( $attrs['align'] ) ) {
 					$social_wrapper_attrs['align'] = $attrs['align'];

--- a/includes/class-newspack-newsletters-renderer.php
+++ b/includes/class-newspack-newsletters-renderer.php
@@ -853,16 +853,13 @@ final class Newspack_Newsletters_Renderer {
 					'icon-size'     => '24px',
 					'mode'          => 'horizontal',
 					'border-radius' => '999px',
-					'icon-padding'  => 'is-style-filled-primary-text' === $attrs['className'] ? '0px' : '7px',
+					'icon-padding'  => isset( $attrs['className'] ) && 'is-style-filled-primary-text' === $attrs['className'] ? '0px' : '7px',
 					'padding'       => '0',
 				);
 				if ( isset( $attrs['align'] ) ) {
 					$social_wrapper_attrs['align'] = $attrs['align'];
 				} else {
 					$social_wrapper_attrs['align'] = 'left';
-				}
-				if ( isset( $attrs['padding'] ) ) {
-					$social_wrapper_attrs['padding'] = $attrs['padding'];
 				}
 
 				$markup = '<mj-social ' . self::array_to_attributes( $social_wrapper_attrs ) . '>';

--- a/includes/class-newspack-newsletters-renderer.php
+++ b/includes/class-newspack-newsletters-renderer.php
@@ -854,15 +854,18 @@ final class Newspack_Newsletters_Renderer {
 					'mode'          => 'horizontal',
 					'padding'       => '0',
 					'border-radius' => '999px',
-					'icon-padding'  => '7px',
 				);
 				if ( isset( $attrs['align'] ) ) {
 					$social_wrapper_attrs['align'] = $attrs['align'];
 				} else {
 					$social_wrapper_attrs['align'] = 'left';
 				}
+				if ( isset( $attrs['padding'] ) ) {
+					$social_wrapper_attrs['padding'] = $attrs['padding'];
+				}
+
 				$markup = '<mj-social ' . self::array_to_attributes( $social_wrapper_attrs ) . '>';
-				foreach ( $inner_blocks as $link_block ) {
+				foreach ( $inner_blocks as $index => $link_block ) {
 					if ( isset( $link_block['attrs']['url'] ) ) {
 						$url = $link_block['attrs']['url'];
 						// Handle older version of the block, where innner blocks we named `core/social-link-<service>`.
@@ -875,7 +878,13 @@ final class Newspack_Newsletters_Renderer {
 								'src'              => plugins_url( 'assets/' . $social_icon['icon'], __DIR__ ),
 								'background-color' => $social_icon['color'],
 								'css-class'        => 'social-element',
+								'padding'          => '8px',
 							);
+
+							if ( $index === 0 || $index === count( $inner_blocks ) - 1 ) {
+								$img_attrs['padding-left']  = $index === 0 ? '0' : '8px';
+								$img_attrs['padding-right'] = $index === 0 ? '8px' : '0';
+							}
 
 							$markup .= '<mj-social-element ' . self::array_to_attributes( $img_attrs ) . '/>';
 						}

--- a/tests/test-renderer.php
+++ b/tests/test-renderer.php
@@ -313,7 +313,7 @@ class Newsletters_Renderer_Test extends WP_UnitTestCase {
 					'innerHTML'    => '<div></div>',
 				]
 			),
-			'<mj-section padding="0"><mj-column padding="12px" width="100%"><mj-social icon-size="24px" mode="horizontal" padding="0" border-radius="999px" icon-padding="7px" align="left"><mj-social-element href="https://x.com/hi" src="' . $plugin_path . 'assets/white-x.png" background-color="#000000" css-class="social-element"/></mj-social></mj-column></mj-section>',
+			'<mj-section padding="0"><mj-column padding="12px" width="100%"><mj-social icon-size="24px" mode="horizontal" padding="0" border-radius="999px" align="left"><mj-social-element href="https://x.com/hi" src="' . $plugin_path . 'assets/white-x.png" background-color="#000000" css-class="social-element" padding="8px" padding-left="0" padding-right="8px"/></mj-social></mj-column></mj-section>',
 			'Renders social icons'
 		);
 	}

--- a/tests/test-renderer.php
+++ b/tests/test-renderer.php
@@ -313,7 +313,7 @@ class Newsletters_Renderer_Test extends WP_UnitTestCase {
 					'innerHTML'    => '<div></div>',
 				]
 			),
-			'<mj-section padding="0"><mj-column padding="12px" width="100%"><mj-social icon-size="24px" mode="horizontal" padding="0" border-radius="999px" align="left"><mj-social-element href="https://x.com/hi" src="' . $plugin_path . 'assets/white-x.png" background-color="#000000" css-class="social-element" padding="8px" padding-left="0" padding-right="8px"/></mj-social></mj-column></mj-section>',
+			'<mj-section padding="0"><mj-column padding="12px" width="100%"><mj-social icon-size="24px" mode="horizontal" border-radius="999px" icon-padding="7px" padding="0" align="left"><mj-social-element href="https://x.com/hi" src="' . $plugin_path . 'assets/white-x.png" background-color="#000000" css-class="social-element" padding="8px" padding-left="0" padding-right="8px"/></mj-social></mj-column></mj-section>',
 			'Renders social icons'
 		);
 	}


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes https://app.asana.com/0/1207817176293825/1207990881852220/f

This PR addresses an issue where the renderer was not not respecting the social icons padding set in the editor. This also tweaks the default icons padding to 8px (from 7px) to be in-line with the spacing set in RAS-ACC transactional emails:

Editor:
![Screenshot 2024-08-14 at 14 58 26](https://github.com/user-attachments/assets/f4b556da-a01a-4d64-820a-9a7ca8cfa9db)

Email:
![Screenshot 2024-08-14 at 14 58 34](https://github.com/user-attachments/assets/14ec439d-0d19-41ae-97d2-81db85610404)


### How to test the changes in this Pull Request:

To test this PR, be sure to also checkout the following plugin PR: https://github.com/Automattic/newspack-plugin/pull/3339

See https://github.com/Automattic/newspack-plugin/pull/3339 for testing RAS-ACC specific behavior

1. Add social icons to any newsletter
2. Preview and send the newsletter
3. Confirm the behavior matches what is on `trunk`

Note that social icons in newsletters is currently a bit funky on `trunk`. This PR does not fix this and only focuses on changes for RAS-ACC.

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
