### PR TITLE
fix(activecampaign): default message on request error

### DIFF
--- a/includes/service-providers/active_campaign/class-newspack-newsletters-active-campaign.php
+++ b/includes/service-providers/active_campaign/class-newspack-newsletters-active-campaign.php
@@ -181,9 +181,10 @@ final class Newspack_Newsletters_Active_Campaign extends \Newspack_Newsletters_S
 		}
 		$body = json_decode( $response['body'], true );
 		if ( 1 !== $body['result_code'] ) {
+			$message = ! empty( $body['result_message'] ) ? $body['result_message'] : __( 'An error occurred while communicating with ActiveCampaign.', 'newspack-newsletters' );
 			return new \WP_Error(
 				'newspack_newsletters_active_campaign_api_error',
-				$body['result_message']
+				$message
 			);
 		}
 		return $body;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

1200530782742699-as-1207091852712440

Implements default error message when ActiveCampaign API request fails to deliver one.

<img width="461" alt="image" src="https://github.com/user-attachments/assets/d9c9184e-6f87-4d4b-948e-6a1fb7bbc10b">

### How to test the changes in this Pull Request:

1. Check out `epic/update-editor-uis`
2. Configure Newspack Newsletters to use ActiveCampaign
3. Change your "ActiveCampaign API URL" setting to something incorrect so we can test a more drastic error
4. Draft a new newsletter campaign, make sure to input a list, sender info and save
5. Attempt to send a test email and confirm you see the error notice with `null`
6. Check out this branch, refresh the page and attempt to send another test email
7. Confirm the notice renders "An error occurred while communicating with ActiveCampaign." as in the image above 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
