### PR TITLE
fix(mailchimp): improve sync error messages

### DIFF
--- a/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp.php
+++ b/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp.php
@@ -813,12 +813,12 @@ final class Newspack_Newsletters_Mailchimp extends \Newspack_Newsletters_Service
 			if ( $mc_campaign_id ) {
 				$campaign_result = $this->validate(
 					$mc->patch( "campaigns/$mc_campaign_id", $payload ),
-					__( 'Error updating campaign title.', 'newspack_newsletters' )
+					__( 'Error updating existing campaign draft.', 'newspack_newsletters' )
 				);
 			} else {
 				$campaign_result = $this->validate(
 					$mc->post( 'campaigns', $payload ),
-					__( 'Error setting campaign title.', 'newspack_newsletters' )
+					__( 'Error creating campaign.', 'newspack_newsletters' )
 				);
 				$mc_campaign_id  = $campaign_result['id'];
 				update_post_meta( $post->ID, 'mc_campaign_id', $mc_campaign_id );
@@ -850,7 +850,7 @@ final class Newspack_Newsletters_Mailchimp extends \Newspack_Newsletters_Service
 				'content_result'  => $content_result,
 			];
 		} catch ( Exception $e ) {
-			set_transient( $transient_name, __( 'Error syncing with ESP. ', 'newspack-newsletters' ) . $e->getMessage(), 45 );
+			set_transient( $transient_name, 'Mailchimp: ' . $e->getMessage(), 45 );
 			return new WP_Error( 'newspack_newsletters_mailchimp_error', $e->getMessage() );
 		}
 	}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

1207717004305167-as-1207420748740594

Improves the error messages when Mailchimp is unable to sync.

### How to test the changes in this Pull Request:

1. Checkout `epic/update-editor-uis`
2. Make sure you are connected to Mailchimp
3. Modify line `820` of `includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp.php` so it's a wrong path:

```diff
-					$mc->post( 'campaigns', $payload ),
+					$mc->post( 'campaignsz', $payload ),
```
4. Create a new campaign draft, save and confirm you get the following error notice in the editor:
```
Error syncing with ESP. Error setting campaign title. Invalid path.
```
5. Checkout this branch, apply the same change for line `820`
6. Create a new campaign draft, save and confirm you receive the following error notice:
```
Mailchimp: Error creating campaign. Invalid path.
```

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
