### PR TITLE
feat: woocommerce data sync tools

### DIFF
--- a/includes/plugins/class-woocommerce-sync-admin.php
+++ b/includes/plugins/class-woocommerce-sync-admin.php
@@ -152,7 +152,7 @@ class WooCommerce_Sync_Admin extends WooCommerce_Sync {
 			\wp_die( $result ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 		}
 
-		$redirect = \add_query_arg( [ 'update' => $action ], \remove_query_arg( [ 'action', 'uid', '_wpnonce' ] ) );
+		$redirect = \add_query_arg( [ 'update' => $action ], \remove_query_arg( [ 'action', 'uid', '_wpnonce', 'synced-contacts' ] ) );
 		\wp_safe_redirect( $redirect );
 		exit;
 	}

--- a/includes/plugins/class-woocommerce-sync-admin.php
+++ b/includes/plugins/class-woocommerce-sync-admin.php
@@ -1,0 +1,187 @@
+<?php
+/**
+ * Admin panel tools for the WooCommerce Sync.
+ *
+ * @package Newspack
+ */
+
+namespace Newspack_Newsletters\Plugins;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * WooCommerce Sync Admin Class.
+ */
+class WooCommerce_Sync_Admin extends WooCommerce_Sync {
+
+	const ADMIN_ACTION = 'newspack-newsletters-wc-resync';
+
+	/**
+	 * Initializes hooks.
+	 */
+	public static function init_hooks() {
+		add_action( 'admin_init', [ __CLASS__, 'process_admin_action' ] );
+		add_filter( 'user_row_actions', [ __CLASS__, 'user_row_actions' ], 100, 2 );
+		add_filter( 'bulk_actions-users', [ __CLASS__, 'bulk_actions' ] );
+		add_filter( 'handle_bulk_actions-users', [ __CLASS__, 'handle_bulk_actions' ], 10, 3 );
+		add_action( 'admin_notices', [ __CLASS__, 'admin_notices' ] );
+	}
+
+	/**
+	 * Get url for the admin action.
+	 *
+	 * @param int $user_id User to get the URL for.
+	 *
+	 * @return string Admin URL to perform the admin action.
+	 */
+	private static function get_admin_action_url( $user_id ) {
+		if ( ! \is_admin() ) {
+			return '';
+		}
+		return \add_query_arg(
+			[
+				'action'   => self::ADMIN_ACTION,
+				'uid'      => $user_id,
+				'_wpnonce' => \wp_create_nonce( self::ADMIN_ACTION ),
+			]
+		);
+	}
+
+	/**
+	 * Adds resync action to user row actions.
+	 *
+	 * @param string[] $actions User row actions.
+	 * @param \WP_User $user    User object.
+	 *
+	 * @return string[] User row actions.
+	 */
+	public static function user_row_actions( $actions, $user ) {
+		if ( \current_user_can( 'edit_user', $user->ID ) ) {
+			$url = self::get_admin_action_url( $user->ID );
+			$actions[ self::ADMIN_ACTION ] = '<a href="' . $url . '">' . \esc_html__( 'Resync contact to ESP', 'newspack-newsletters' ) . '</a>';
+		}
+		return $actions;
+	}
+
+	/**
+	 * Bulk actions for users.
+	 *
+	 * @param string[] $actions Bulk actions.
+	 *
+	 * @return string[] Bulk actions.
+	 */
+	public static function bulk_actions( $actions ) {
+		if ( ! current_user_can( 'edit_users' ) ) {
+			return $actions;
+		}
+		$actions[ self::ADMIN_ACTION ] = \esc_html__( 'Resync to the ESP', 'newspack-newsletters' );
+		return $actions;
+	}
+
+	/**
+	 * Handle bulk actions.
+	 *
+	 * @param string $sendback The redirect URL.
+	 * @param string $doaction The action being taken.
+	 * @param array  $items    User IDs.
+	 *
+	 * @return string The redirect URL.
+	 */
+	public static function handle_bulk_actions( $sendback, $doaction, $items ) {
+		if ( 'newspack-newsletters-wc-resync' === $doaction ) {
+			if ( ! \current_user_can( 'edit_users' ) ) {
+				\wp_die( \esc_html__( 'You do not have permission to do that.', 'newspack-newsletters' ) );
+			}
+			$config = [
+				'user_ids' => $items,
+			];
+			$result = self::resync_woo_contacts( $config );
+			if ( \is_wp_error( $result ) ) {
+				\wp_die( $result ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+			}
+			$sendback = \add_query_arg(
+				[
+					'update'          => self::ADMIN_ACTION,
+					'synced-contacts' => count( $items ),
+				],
+				$sendback
+			);
+		}
+		return $sendback;
+	}
+
+	/**
+	 * Process admin action request.
+	 */
+	public static function process_admin_action() {
+
+		if ( ! isset( $_GET['action'] ) || self::ADMIN_ACTION !== $_GET['action'] ) {
+			return;
+		}
+
+		$action = \sanitize_text_field( \wp_unslash( $_GET['action'] ) );
+
+		// If we don't have UID, it's probably a bulk action.
+		if ( ! isset( $_GET['uid'] ) ) {
+			return;
+		}
+
+		if ( ! \check_admin_referer( $action ) ) {
+			\wp_die( \esc_html__( 'Invalid request.', 'newspack-newsletters' ) );
+		}
+
+		$user_id = \absint( \wp_unslash( $_GET['uid'] ) );
+
+		if ( ! \current_user_can( 'edit_user', $user_id ) ) {
+			\wp_die( \esc_html__( 'You do not have permission to do that.', 'newspack-newsletters' ) );
+		}
+
+		$user = \get_user_by( 'id', $user_id );
+
+		if ( ! $user || \is_wp_error( $user ) ) {
+			\wp_die( \esc_html__( 'User not found.', 'newspack-newsletters' ) );
+		}
+
+		$config = [
+			'user_ids' => [ $user_id ],
+		];
+		$result = self::resync_woo_contacts( $config );
+		if ( \is_wp_error( $result ) ) {
+			\wp_die( $result ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+		}
+
+		$redirect = \add_query_arg( [ 'update' => $action ], \remove_query_arg( [ 'action', 'uid', '_wpnonce' ] ) );
+		\wp_safe_redirect( $redirect );
+		exit;
+	}
+
+	/**
+	 * Admin notices.
+	 */
+	public static function admin_notices() {
+		// phpcs:disable WordPress.Security.NonceVerification
+		if ( ! isset( $_GET['update'] ) ) {
+			return;
+		}
+		$update = sanitize_text_field( wp_unslash( $_GET['update'] ) );
+		if ( self::ADMIN_ACTION !== $update ) {
+			return;
+		}
+		$message = __( 'Contact resynced to the ESP.', 'newspack-newsletters' );
+		if ( isset( $_GET['synced-contacts'] ) && 1 < $_GET['synced-contacts'] ) {
+			$synced_contacts = absint( wp_unslash( $_GET['synced-contacts'] ) );
+			$message = sprintf(
+				// translators: %d: number of contacts resynced.
+				__( '%d contacts resynced to the ESP.', 'newspack-newsletters' ),
+				$synced_contacts
+			);
+		}
+		?>
+		<div class="notice notice-success is-dismissible">
+			<p><?php echo esc_html( $message ); ?></p>
+		</div>
+		<?php
+		// phpcs:enable
+	}
+}
+WooCommerce_Sync_Admin::init_hooks();

--- a/includes/plugins/class-woocommerce-sync-cli.php
+++ b/includes/plugins/class-woocommerce-sync-cli.php
@@ -1,0 +1,145 @@
+<?php
+/**
+ * CLI tools for the WooCommerce Sync.
+ *
+ * @package Newspack
+ */
+
+namespace Newspack_Newsletters\Plugins;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * WooCommerce Sync CLI Class.
+ */
+class WooCommerce_Sync_CLI extends WooCommerce_Sync {
+
+	/**
+	 * Initialize hooks.
+	 */
+	public static function init_hooks() {
+		\add_action( 'init', [ __CLASS__, 'wp_cli' ] );
+	}
+
+	/**
+	 * Add CLI commands.
+	 */
+	public static function wp_cli() {
+		if ( ! defined( 'WP_CLI' ) ) {
+			return;
+		}
+
+		\WP_CLI::add_command(
+			'newspack-newsletters woo resync',
+			[ __CLASS__, 'cli_resync_woo_contacts' ],
+			[
+				'shortdesc' => __( 'Resync customer and transaction data to the connected ESP.', 'newspack-newsletters' ),
+				'synopsis'  => [
+					[
+						'type'     => 'flag',
+						'name'     => 'dry-run',
+						'optional' => true,
+					],
+					[
+						'type'     => 'flag',
+						'name'     => 'active-only',
+						'optional' => true,
+					],
+					[
+						'type'     => 'assoc',
+						'name'     => 'migrated-subscriptions',
+						'default'  => false,
+						'optional' => true,
+						'options'  => [ 'stripe', 'piano-csv', 'stripe-csv', false ],
+					],
+					[
+						'type'     => 'assoc',
+						'name'     => 'subscription-ids',
+						'default'  => false,
+						'optional' => true,
+					],
+					[
+						'type'     => 'assoc',
+						'name'     => 'user-ids',
+						'default'  => false,
+						'optional' => true,
+					],
+					[
+						'type'     => 'assoc',
+						'name'     => 'order-ids',
+						'default'  => false,
+						'optional' => true,
+					],
+					[
+						'type'     => 'assoc',
+						'name'     => 'batch-size',
+						'default'  => 10,
+						'optional' => true,
+					],
+					[
+						'type'     => 'assoc',
+						'name'     => 'offset',
+						'default'  => 0,
+						'optional' => true,
+					],
+					[
+						'type'     => 'assoc',
+						'name'     => 'max-batches',
+						'default'  => 0,
+						'optional' => true,
+					],
+				],
+			]
+		);
+	}
+
+	/**
+	 * CLI command for resyncing contact data from WooCommerce customers to the connected ESP.
+	 *
+	 * @param array $args Positional args.
+	 * @param array $assoc_args Associative args.
+	 */
+	public static function cli_resync_woo_contacts( $args, $assoc_args ) {
+		$config = [];
+		$config['is_dry_run']       = ! empty( $assoc_args['dry-run'] );
+		$config['active_only']      = ! empty( $assoc_args['active-only'] );
+		$config['migrated_only']    = ! empty( $assoc_args['migrated-subscriptions'] ) ? $assoc_args['migrated-subscriptions'] : false;
+		$config['subscription_ids'] = ! empty( $assoc_args['subscription-ids'] ) ? explode( ',', $assoc_args['subscription-ids'] ) : false;
+		$config['user_ids']         = ! empty( $assoc_args['user-ids'] ) ? explode( ',', $assoc_args['user-ids'] ) : false;
+		$config['order_ids']        = ! empty( $assoc_args['order-ids'] ) ? explode( ',', $assoc_args['order-ids'] ) : false;
+		$config['batch_size']       = ! empty( $assoc_args['batch-size'] ) ? intval( $assoc_args['batch-size'] ) : 10;
+		$config['offset']           = ! empty( $assoc_args['offset'] ) ? intval( $assoc_args['offset'] ) : 0;
+		$config['max_batches']      = ! empty( $assoc_args['max-batches'] ) ? intval( $assoc_args['max-batches'] ) : 0;
+
+		$processed = static::resync_woo_contacts( $config );
+
+		if ( is_wp_error( $processed ) ) {
+			\WP_CLI::error( $processed->get_error_message() );
+			return;
+		}
+
+		\WP_CLI::line( "\n" );
+		\WP_CLI::success(
+			sprintf(
+				// Translators: total number of resynced contacts.
+				__(
+					'Resynced %d contacts.',
+					'newspack-newsletters'
+				),
+				$processed
+			)
+		);
+	}
+
+	/**
+	 * Log to WP CLI.
+	 *
+	 * @param string $message The message to log.
+	 */
+	protected static function log( $message ) {
+		if ( defined( 'WP_CLI' ) && WP_CLI ) {
+			\WP_CLI::log( $message );
+		}
+	}
+}
+WooCommerce_Sync_CLI::init_hooks();

--- a/includes/plugins/class-woocommerce-sync-cli.php
+++ b/includes/plugins/class-woocommerce-sync-cli.php
@@ -15,6 +15,15 @@ defined( 'ABSPATH' ) || exit;
 class WooCommerce_Sync_CLI extends WooCommerce_Sync {
 
 	/**
+	 * The final results object.
+	 *
+	 * @var array
+	 */
+	protected static $results = [
+		'processed' => 0,
+	];
+
+	/**
 	 * Initialize hooks.
 	 */
 	public static function init_hooks() {
@@ -102,6 +111,226 @@ class WooCommerce_Sync_CLI extends WooCommerce_Sync {
 				],
 			]
 		);
+	}
+
+	/**
+	 * Resync contact data from WooCommerce customers to the connected ESP.
+	 *
+	 * @param array $config {
+	 *   Configuration options.
+	 *
+	 *   @type bool        $config['is_dry_run'] True if a dry run.
+	 *   @type bool        $config['active_only'] True if only active subscriptions should be synced.
+	 *   @type string|bool $config['migrated_only'] If set, only sync subscriptions migrated from the given source.
+	 *   @type array|bool  $config['subscription_ids'] If set, only sync the given subscription IDs.
+	 *   @type array|bool  $config['user_ids'] If set, only sync the given user IDs.
+	 *   @type array|bool  $config['order_ids'] If set, only sync the given order IDs.
+	 *   @type int         $config['batch_size'] Number of contacts to sync per batch.
+	 *   @type int         $config['offset'] Number of contacts to skip.
+	 *   @type int         $config['max_batches'] Maximum number of batches to process.
+	 *   @type bool        $config['is_dry_run'] True if a dry run.
+	 * }
+	 *
+	 * @return int|\WP_Error Number of resynced contacts, or WP_Error if an error occurred.
+	 */
+	protected static function resync_woo_contacts( $config ) {
+		$default_config = [
+			'active_only'      => false,
+			'migrated_only'    => false,
+			'subscription_ids' => false,
+			'user_ids'         => false,
+			'order_ids'        => false,
+			'batch_size'       => 10,
+			'offset'           => 0,
+			'max_batches'      => 0,
+			'is_dry_run'       => false,
+		];
+		$config = \wp_parse_args( $config, $default_config );
+
+		static::log( __( 'Running WooCommerce-to-ESP contact resync...', 'newspack-newsletters' ) );
+
+		$can_sync = static::can_sync_contacts( true );
+		if ( ! $config['is_dry_run'] && $can_sync->has_errors() ) {
+			return $can_sync;
+		}
+
+		// If resyncing only migrated subscriptions.
+		if ( $config['migrated_only'] ) {
+			$config['subscription_ids'] = static::get_migrated_subscriptions( $config['migrated_only'], $config['batch_size'], $config['offset'], $config['active_only'] );
+			if ( \is_wp_error( $config['subscription_ids'] ) ) {
+				return $config['subscription_ids'];
+			}
+			$batches = 0;
+		}
+
+		if ( ! empty( $config['subscription_ids'] ) ) {
+			static::log( __( 'Syncing by subscription ID...', 'newspack-newsletters' ) );
+
+			while ( ! empty( $config['subscription_ids'] ) ) {
+				$subscription_id = array_shift( $config['subscription_ids'] );
+				$subscription    = \wcs_get_subscription( $subscription_id );
+
+				if ( \is_wp_error( $subscription ) ) {
+					static::log(
+						sprintf(
+							// Translators: %d is the subscription ID arg passed to the script.
+							__( 'No subscription with ID %d. Skipping.', 'newspack-newsletters' ),
+							$subscription_id
+						)
+					);
+
+					continue;
+				}
+
+				$result = static::resync_contact( 0, $subscription, $config['is_dry_run'] );
+				if ( \is_wp_error( $result ) ) {
+					static::log(
+						sprintf(
+							// Translators: %1$d is the subscription ID arg passed to the script. %2$s is the error message.
+							__( 'Error resyncing contact info for subscription ID %1$d. %2$s', 'newspack-newsletters' ),
+							$subscription_id,
+							$result->get_error_message()
+						)
+					);
+				}
+
+				// Get the next batch.
+				if ( $config['migrated_only'] && empty( $config['subscription_ids'] ) ) {
+					$batches++;
+
+					if ( $config['max_batches'] && $batches >= $config['max_batches'] ) {
+						break;
+					}
+
+					$next_batch_offset = $config['offset'] + ( $batches * $config['batch_size'] );
+					$config['subscription_ids'] = static::get_migrated_subscriptions( $config['migrated_only'], $config['batch_size'], $next_batch_offset, $config['active_only'] );
+				}
+			}
+		}
+
+		// If order-ids flag is passed, resync contacts for those orders.
+		if ( ! empty( $config['order_ids'] ) ) {
+			static::log( __( 'Syncing by order ID...', 'newspack-newsletters' ) );
+			foreach ( $config['order_ids'] as $order_id ) {
+				$order = new \WC_Order( $order_id );
+
+				if ( \is_wp_error( $order ) ) {
+					static::log(
+						sprintf(
+							// Translators: %d is the order ID arg passed to the script.
+							__( 'No order with ID %d. Skipping.', 'newspack-newsletters' ),
+							$order_id
+						)
+					);
+
+					continue;
+				}
+
+				$result = static::resync_contact( 0, $order, $config['is_dry_run'] );
+				if ( \is_wp_error( $result ) ) {
+					static::log(
+						sprintf(
+							// Translators: %1$d is the order ID arg passed to the script. %2$s is the error message.
+							__( 'Error resyncing contact info for order ID %1$d. %2$s', 'newspack-newsletters' ),
+							$order_id,
+							$result->get_error_message()
+						)
+					);
+				}
+			}
+		}
+
+		// If user-ids flag is passed, resync those users.
+		if ( ! empty( $config['user_ids'] ) ) {
+			static::log( __( 'Syncing by customer user ID...', 'newspack-newsletters' ) );
+			foreach ( $config['user_ids'] as $user_id ) {
+				if ( ! $config['active_only'] || static::user_has_active_subscriptions( $user_id ) ) {
+					$result = static::resync_contact( $user_id, null, $config['is_dry_run'] );
+					if ( \is_wp_error( $result ) ) {
+						static::log(
+							sprintf(
+								// Translators: %1$d is the user ID arg passed to the script. %2$s is the error message.
+								__( 'Error resyncing contact info for user ID %1$d. %2$s', 'newspack-newsletters' ),
+								$user_id,
+								$result->get_error_message()
+							)
+						);
+					}
+				}
+			}
+		}
+
+		// Default behavior: resync all customers and subscribers.
+		if (
+			false === $config['user_ids'] &&
+			false === $config['order_ids'] &&
+			false === $config['subscription_ids'] &&
+			false === $config['migrated_only']
+		) {
+			static::log( __( 'Syncing all customers...', 'newspack-newsletters' ) );
+			$user_ids = static::get_batch_of_customers( $config['batch_size'], $config['offset'] );
+			$batches  = 0;
+
+			while ( $user_ids ) {
+				$user_id = array_shift( $user_ids );
+				if ( ! $config['active_only'] || static::user_has_active_subscriptions( $user_id ) ) {
+					$result = static::resync_contact( $user_id, null, $config['is_dry_run'] );
+					if ( \is_wp_error( $result ) ) {
+						static::log(
+							sprintf(
+								// Translators: $1$s is the contact's email address. %2$s is the error message.
+								__( 'Error resyncing contact info for %1$s. %2$s' ),
+								$customer->get_email(),
+								$result->get_error_message()
+							)
+						);
+					}
+				}
+
+				// Get the next batch.
+				if ( empty( $user_ids ) ) {
+					$batches++;
+
+					if ( $config['max_batches'] && $batches >= $config['max_batches'] ) {
+						break;
+					}
+
+					$user_ids = static::get_batch_of_customers( $config['batch_size'], $config['offset'] + ( $batches * $config['batch_size'] ) );
+				}
+			}
+		}
+
+		return static::$results['processed'];
+	}
+
+	/**
+	 * Get a batch of customer IDs.
+	 *
+	 * @param int $batch_size Number of customers to get.
+	 * @param int $offset     Number to skip.
+	 *
+	 * @return array|false Array of customer IDs, or false if no more to fetch.
+	 */
+	protected static function get_batch_of_customers( $batch_size, $offset = 0 ) {
+		$customer_roles = static::CUSTOMER_ROLES;
+		if ( defined( 'NEWSPACK_NETWORK_READER_ROLE' ) ) {
+			$customer_roles[] = NEWSPACK_NETWORK_READER_ROLE;
+		}
+
+		$query = new \WP_User_Query(
+			[
+				'fields'   => 'ID',
+				'number'   => $batch_size,
+				'offset'   => $offset,
+				'order'    => 'DESC',
+				'orderby'  => 'registered',
+				'role__in' => $customer_roles,
+			]
+		);
+
+		$results = $query->get_results();
+
+		return ! empty( $results ) ? $results : false;
 	}
 
 	/**

--- a/includes/plugins/class-woocommerce-sync-cli.php
+++ b/includes/plugins/class-woocommerce-sync-cli.php
@@ -304,17 +304,17 @@ class WooCommerce_Sync_CLI extends WooCommerce_Sync {
 	}
 
 	/**
-	 * Get a batch of customer IDs.
+	 * Get a batch of reader IDs.
 	 *
-	 * @param int $batch_size Number of customers to get.
+	 * @param int $batch_size Number of readers to get.
 	 * @param int $offset     Number to skip.
 	 *
 	 * @return array|false Array of customer IDs, or false if no more to fetch.
 	 */
-	protected static function get_batch_of_customers( $batch_size, $offset = 0 ) {
-		$customer_roles = static::CUSTOMER_ROLES;
-		if ( defined( 'NEWSPACK_NETWORK_READER_ROLE' ) ) {
-			$customer_roles[] = NEWSPACK_NETWORK_READER_ROLE;
+	protected static function get_batch_of_readers( $batch_size, $offset = 0 ) {
+		$roles = \Newspack\Reader_Activation::get_reader_roles();
+		if ( defined( 'NEWSPACK_NETWORK_READER_ROLE' ) && ! in_array( NEWSPACK_NETWORK_READER_ROLE, $roles, true ) ) {
+			$roles[] = NEWSPACK_NETWORK_READER_ROLE;
 		}
 
 		$query = new \WP_User_Query(
@@ -324,7 +324,7 @@ class WooCommerce_Sync_CLI extends WooCommerce_Sync {
 				'offset'   => $offset,
 				'order'    => 'DESC',
 				'orderby'  => 'registered',
-				'role__in' => $customer_roles,
+				'role__in' => $roles,
 			]
 		);
 

--- a/includes/plugins/class-woocommerce-sync-cli.php
+++ b/includes/plugins/class-woocommerce-sync-cli.php
@@ -22,6 +22,17 @@ class WooCommerce_Sync_CLI extends WooCommerce_Sync {
 	}
 
 	/**
+	 * Log to WP CLI.
+	 *
+	 * @param string $message The message to log.
+	 */
+	protected static function log( $message ) {
+		if ( defined( 'WP_CLI' ) && WP_CLI ) {
+			\WP_CLI::log( $message );
+		}
+	}
+
+	/**
 	 * Add CLI commands.
 	 */
 	public static function wp_cli() {
@@ -129,17 +140,6 @@ class WooCommerce_Sync_CLI extends WooCommerce_Sync {
 				$processed
 			)
 		);
-	}
-
-	/**
-	 * Log to WP CLI.
-	 *
-	 * @param string $message The message to log.
-	 */
-	protected static function log( $message ) {
-		if ( defined( 'WP_CLI' ) && WP_CLI ) {
-			\WP_CLI::log( $message );
-		}
 	}
 }
 WooCommerce_Sync_CLI::init_hooks();

--- a/includes/plugins/class-woocommerce-sync-cli.php
+++ b/includes/plugins/class-woocommerce-sync-cli.php
@@ -131,9 +131,9 @@ class WooCommerce_Sync_CLI extends WooCommerce_Sync {
 	 *   @type bool        $config['is_dry_run'] True if a dry run.
 	 * }
 	 *
-	 * @return int|\WP_Error Number of resynced contacts, or WP_Error if an error occurred.
+	 * @return int|\WP_Error Number of resynced contacts or WP_Error.
 	 */
-	protected static function resync_woo_contacts( $config ) {
+	private static function resync_woo_contacts( $config ) {
 		$default_config = [
 			'active_only'      => false,
 			'migrated_only'    => false,
@@ -310,7 +310,7 @@ class WooCommerce_Sync_CLI extends WooCommerce_Sync {
 	 *
 	 * @return bool
 	 */
-	protected static function user_has_active_subscriptions( $user_id ) {
+	private static function user_has_active_subscriptions( $user_id ) {
 		$subcriptions = array_reduce(
 			array_keys( \wcs_get_users_subscriptions( $user_id ) ),
 			function( $acc, $subscription_id ) {
@@ -339,7 +339,7 @@ class WooCommerce_Sync_CLI extends WooCommerce_Sync {
 	 *
 	 * @return array|\WP_Error Array of subscription IDs or WP_Error.
 	 */
-	protected static function get_migrated_subscriptions( $source, $batch_size, $offset, $active_only ) {
+	private static function get_migrated_subscriptions( $source, $batch_size, $offset, $active_only ) {
 		if (
 			! class_exists( '\Newspack_Subscription_Migrations\Stripe_Sync' ) ||
 			! class_exists( '\Newspack_Subscription_Migrations\CSV_Importers\CSV_Importer' )
@@ -374,19 +374,18 @@ class WooCommerce_Sync_CLI extends WooCommerce_Sync {
 	}
 
 	/**
-	 * Get a batch of reader IDs.
+	 * Get a batch of readers' IDs.
 	 *
 	 * @param int $batch_size Number of readers to get.
 	 * @param int $offset     Number to skip.
 	 *
-	 * @return array|false Array of customer IDs, or false if no more to fetch.
+	 * @return array|false Array of user IDs, or false if no more to fetch.
 	 */
-	protected static function get_batch_of_readers( $batch_size, $offset = 0 ) {
+	private static function get_batch_of_readers( $batch_size, $offset = 0 ) {
 		$roles = \Newspack\Reader_Activation::get_reader_roles();
 		if ( defined( 'NEWSPACK_NETWORK_READER_ROLE' ) && ! in_array( NEWSPACK_NETWORK_READER_ROLE, $roles, true ) ) {
 			$roles[] = NEWSPACK_NETWORK_READER_ROLE;
 		}
-
 		$query = new \WP_User_Query(
 			[
 				'fields'   => 'ID',
@@ -397,9 +396,7 @@ class WooCommerce_Sync_CLI extends WooCommerce_Sync {
 				'role__in' => $roles,
 			]
 		);
-
 		$results = $query->get_results();
-
 		return ! empty( $results ) ? $results : false;
 	}
 
@@ -423,11 +420,10 @@ class WooCommerce_Sync_CLI extends WooCommerce_Sync {
 
 		$processed = static::resync_woo_contacts( $config );
 
-		if ( is_wp_error( $processed ) ) {
+		if ( \is_wp_error( $processed ) ) {
 			\WP_CLI::error( $processed->get_error_message() );
 			return;
 		}
-
 		\WP_CLI::line( "\n" );
 		\WP_CLI::success(
 			sprintf(

--- a/includes/plugins/class-woocommerce-sync-cli.php
+++ b/includes/plugins/class-woocommerce-sync-cli.php
@@ -263,15 +263,15 @@ class WooCommerce_Sync_CLI extends WooCommerce_Sync {
 			}
 		}
 
-		// Default behavior: resync all customers and subscribers.
+		// Default behavior: resync all readers.
 		if (
 			false === $config['user_ids'] &&
 			false === $config['order_ids'] &&
 			false === $config['subscription_ids'] &&
 			false === $config['migrated_only']
 		) {
-			static::log( __( 'Syncing all customers...', 'newspack-newsletters' ) );
-			$user_ids = static::get_batch_of_customers( $config['batch_size'], $config['offset'] );
+			static::log( __( 'Syncing all readers...', 'newspack-newsletters' ) );
+			$user_ids = static::get_batch_of_readers( $config['batch_size'], $config['offset'] );
 			$batches  = 0;
 
 			while ( $user_ids ) {
@@ -298,7 +298,7 @@ class WooCommerce_Sync_CLI extends WooCommerce_Sync {
 						break;
 					}
 
-					$user_ids = static::get_batch_of_customers( $config['batch_size'], $config['offset'] + ( $batches * $config['batch_size'] ) );
+					$user_ids = static::get_batch_of_readers( $config['batch_size'], $config['offset'] + ( $batches * $config['batch_size'] ) );
 				}
 			}
 		}

--- a/includes/plugins/class-woocommerce-sync-cli.php
+++ b/includes/plugins/class-woocommerce-sync-cli.php
@@ -7,6 +7,9 @@
 
 namespace Newspack_Newsletters\Plugins;
 
+use Newspack_Subscription_Migrations\CSV_Importers\CSV_Importer;
+use Newspack_Subscription_Migrations\Stripe_Sync;
+
 defined( 'ABSPATH' ) || exit;
 
 /**

--- a/includes/plugins/class-woocommerce-sync.php
+++ b/includes/plugins/class-woocommerce-sync.php
@@ -118,13 +118,12 @@ abstract class WooCommerce_Sync {
 		}
 
 		$is_order = $user_id_or_order instanceof \WC_Order;
-		$order    = $is_order ? $user_id_or_order : \wc_get_order( $user_id_or_order );
-		if ( ! $is_order && ! $order ) {
+		$order    = $is_order ? $user_id_or_order : false;
+		if ( $is_order && ! $order ) {
 			return new \WP_Error( 'newspack_newsletters_resync_contact', __( 'Order does not exist.', 'newspack-newsletters' ) );
 		}
 		$user_id = $is_order ? $order->get_customer_id() : $user_id_or_order;
-
-		$user = \get_userdata( $user_id );
+		$user    = \get_userdata( $user_id );
 
 		// Backfill Network Registration Site field if needed.
 		if ( $user && defined( 'NEWSPACK_NETWORK_READER_ROLE' ) && defined( 'Newspack_Network\Utils\Users::USER_META_REMOTE_SITE' ) ) {

--- a/includes/plugins/class-woocommerce-sync.php
+++ b/includes/plugins/class-woocommerce-sync.php
@@ -1,7 +1,6 @@
 <?php
 /**
- * WP CLI scripts for managing WooCommerce Reader Revenue data syncing with
- * the connected ESP.
+ * WooCommerce Reader Revenue data syncing with the connected ESP.
  *
  * @package Newspack
  */
@@ -24,18 +23,15 @@ class WooCommerce_Sync {
 	 * The final results object.
 	 *
 	 * @var array
-	 * @codeCoverageIgnore
 	 */
 	protected static $results = [
 		'processed' => 0,
 	];
 
 	/**
-	 * Initialize.
-	 *
-	 * @codeCoverageIgnore
+	 * Initialize hooks.
 	 */
-	public static function init() {
+	public static function init_hooks() {
 		\add_action( 'init', [ __CLASS__, 'wp_cli' ] );
 	}
 
@@ -311,6 +307,7 @@ class WooCommerce_Sync {
 			'batch_size'       => 10,
 			'offset'           => 0,
 			'max_batches'      => 0,
+			'is_dry_run'       => false,
 		];
 		$config = \wp_parse_args( $config, $default_config );
 
@@ -553,4 +550,4 @@ class WooCommerce_Sync {
 		return ! empty( $results ) ? $results : false;
 	}
 }
-WooCommerce_Sync::init();
+WooCommerce_Sync::init_hooks();

--- a/includes/plugins/class-woocommerce-sync.php
+++ b/includes/plugins/class-woocommerce-sync.php
@@ -7,9 +7,6 @@
 
 namespace Newspack_Newsletters\Plugins;
 
-use Newspack_Subscription_Migrations\CSV_Importers\CSV_Importer;
-use Newspack_Subscription_Migrations\Stripe_Sync;
-
 defined( 'ABSPATH' ) || exit;
 
 /**

--- a/includes/plugins/class-woocommerce-sync.php
+++ b/includes/plugins/class-woocommerce-sync.php
@@ -1,0 +1,471 @@
+<?php
+/**
+ * WP CLI scripts for managing WooCommerce Reader Revenue data syncing with
+ * the connected ESP.
+ *
+ * @package Newspack
+ */
+
+namespace Newspack_Newsletters\Plugins;
+
+use Newspack_Subscription_Migrations\CSV_Importers\CSV_Importer;
+use Newspack_Subscription_Migrations\Stripe_Sync;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * WooCommerce Sync Class.
+ */
+class WooCommerce_Sync {
+	// User roles that a customer can have.
+	const CUSTOMER_ROLES = [ 'customer', 'subscriber' ];
+
+	/**
+	 * The final results object.
+	 *
+	 * @var array
+	 * @codeCoverageIgnore
+	 */
+	private static $results = [
+		'processed' => 0,
+	];
+
+	/**
+	 * Initialize.
+	 *
+	 * @codeCoverageIgnore
+	 */
+	public static function init() {
+		\add_action( 'init', [ __CLASS__, 'wp_cli' ] );
+	}
+
+	/**
+	 * Add CLI commands.
+	 */
+	public static function wp_cli() {
+		if ( ! defined( 'WP_CLI' ) ) {
+			return;
+		}
+
+		\WP_CLI::add_command(
+			'newspack-newsletters woo resync',
+			[ __CLASS__, 'resync_woo_contacts' ],
+			[
+				'shortdesc' => __( 'Resync customer and transaction data to the connected ESP.', 'newspack-newsletters' ),
+				'synopsis'  => [
+					[
+						'type'     => 'flag',
+						'name'     => 'dry-run',
+						'optional' => true,
+					],
+					[
+						'type'     => 'flag',
+						'name'     => 'active-only',
+						'optional' => true,
+					],
+					[
+						'type'     => 'assoc',
+						'name'     => 'migrated-subscriptions',
+						'default'  => false,
+						'optional' => true,
+						'options'  => [ 'stripe', 'piano-csv', 'stripe-csv', false ],
+					],
+					[
+						'type'     => 'assoc',
+						'name'     => 'subscription-ids',
+						'default'  => false,
+						'optional' => true,
+					],
+					[
+						'type'     => 'assoc',
+						'name'     => 'user-ids',
+						'default'  => false,
+						'optional' => true,
+					],
+					[
+						'type'     => 'assoc',
+						'name'     => 'order-ids',
+						'default'  => false,
+						'optional' => true,
+					],
+					[
+						'type'     => 'assoc',
+						'name'     => 'batch-size',
+						'default'  => 10,
+						'optional' => true,
+					],
+					[
+						'type'     => 'assoc',
+						'name'     => 'offset',
+						'default'  => 0,
+						'optional' => true,
+					],
+					[
+						'type'     => 'assoc',
+						'name'     => 'max-batches',
+						'default'  => 0,
+						'optional' => true,
+					],
+				],
+			]
+		);
+	}
+
+	/**
+	 * Does the given user have any subscriptions with an active status?
+	 *
+	 * @param int $user_id User ID.
+	 *
+	 * @return bool
+	 */
+	public static function user_has_active_subscriptions( $user_id ) {
+		$subcriptions = array_reduce(
+			array_keys( \wcs_get_users_subscriptions( $user_id ) ),
+			function( $acc, $subscription_id ) {
+				$subscription = \wcs_get_subscription( $subscription_id );
+				if ( $subscription->has_status( [ 'active', 'pending', 'pending-cancel' ] ) ) {
+					$acc[] = $subscription_id;
+				}
+				return $acc;
+			},
+			[]
+		);
+
+		return ! empty( $subcriptions );
+	}
+
+	/**
+	 * Force disable RAS reader data syncing to ESP while running migrations on test/staging sites.
+	 * Don't disable if connected to production manager, or data might be lost from actual reader activity.
+	 *
+	 * @param mixed $value The option value.
+	 *
+	 * @return mixed Filtered option value.
+	 */
+	private static function maybe_disable_esp_syncing( $value ) {
+		// If a production site, don't do anything.
+		if ( method_exists( 'Newspack_Manager', 'is_connected_to_production_manager' ) && \Newspack_Manager::is_connected_to_production_manager() ) {
+			return $value;
+		}
+		// If a staging/test site, disable ESP syncing unless we set a constant. The newspack_reader_activation_sync_esp option value will still be honored, if set.
+		if ( defined( 'NEWSPACK_SUBSCRIPTION_MIGRATIONS_ALLOW_ESP_SYNC' ) && NEWSPACK_SUBSCRIPTION_MIGRATIONS_ALLOW_ESP_SYNC ) {
+			return $value;
+		}
+
+		return false;
+	}
+
+	/**
+	 * Sync contact to the ESP.
+	 *
+	 * @param array $contact The contact data to sync.
+	 */
+	public static function sync_contact( $contact ) {
+		// Only if Reader Activation is available.
+		if ( ! class_exists( 'Newspack\Reader_Activation' ) ) {
+			return;
+		}
+
+		// Only if RAS + ESP sync is enabled.
+		if ( ! \Newspack\Reader_Activation::is_enabled() || ! \Newspack\Reader_Activation::get_setting( 'sync_esp' ) ) {
+			return;
+		}
+
+		// Only if we have the ESP Data Events connectors.
+		if ( ! class_exists( 'Newspack\Data_Events\Connectors\Mailchimp' ) || ! class_exists( 'Newspack\Data_Events\Connectors\ActiveCampaign' ) ) {
+			return;
+		}
+
+		\Newspack_Newsletters_Contacts::upsert( $contact, false, 'WooCommerce Sync' );
+	}
+
+	/**
+	 * CLI command for resyncing contact data from WooCommerce customers to the connected ESP.
+	 *
+	 * @param array $args Positional args.
+	 * @param array $assoc_args Associative args.
+	 */
+	public static function resync_woo_contacts( $args, $assoc_args ) {
+		$is_dry_run       = ! empty( $assoc_args['dry-run'] );
+		$active_only      = ! empty( $assoc_args['active-only'] );
+		$migrated_only    = ! empty( $assoc_args['migrated-subscriptions'] ) ? $assoc_args['migrated-subscriptions'] : false;
+		$subscription_ids = ! empty( $assoc_args['subscription-ids'] ) ? explode( ',', $assoc_args['subscription-ids'] ) : false;
+		$user_ids         = ! empty( $assoc_args['user-ids'] ) ? explode( ',', $assoc_args['user-ids'] ) : false;
+		$order_ids        = ! empty( $assoc_args['order-ids'] ) ? explode( ',', $assoc_args['order-ids'] ) : false;
+		$batch_size       = ! empty( $assoc_args['batch-size'] ) ? intval( $assoc_args['batch-size'] ) : 10;
+		$offset           = ! empty( $assoc_args['offset'] ) ? intval( $assoc_args['offset'] ) : 0;
+		$max_batches      = ! empty( $assoc_args['max-batches'] ) ? intval( $assoc_args['max-batches'] ) : 0;
+
+		\WP_CLI::log(
+			'
+
+Running WooCommerce-to-ESP contact resync...
+
+		'
+		);
+
+		if ( $migrated_only && ! class_exists( '\Newspack_Subscription_Migrations\Stripe_Sync' ) ) {
+			\WP_CLI::error( __( 'The migrated-subscriptions flag requires the Newspack_Subscription_Migrations plugin to installed and active.', 'newspack-newsletters' ) );
+		}
+
+		// If not doing a dry run, make sure the NEWSPACK_SUBSCRIPTION_MIGRATIONS_ALLOW_ESP_SYNC
+		// constant is set or the sync will fail silently.
+		if ( ! $is_dry_run && ! self::maybe_disable_esp_syncing( true ) ) {
+			\WP_CLI::error( __( 'Unable to sync due to disabled ESP sync option. Is the NEWSPACK_SUBSCRIPTION_MIGRATIONS_ALLOW_ESP_SYNC constant defined?', 'newspack-newsletters' ) );
+		}
+
+		// If resyncing only migrated subscriptions.
+		if ( $migrated_only ) {
+			switch ( $migrated_only ) {
+				case 'stripe':
+					$subscription_ids = Stripe_Sync::get_migrated_subscriptions( $batch_size, $offset, $active_only );
+					break;
+				case 'piano-csv':
+					$subscription_ids = CSV_Importer::get_migrated_subscriptions( 'piano', $batch_size, $offset, $active_only );
+					break;
+				case 'stripe-csv':
+					$subscription_ids = CSV_Importer::get_migrated_subscriptions( 'stripe', $batch_size, $offset, $active_only );
+					break;
+				default:
+					\WP_CLI::error( __( 'Invalid subscription migration type ', 'newspack-newsletters' ) . $migrated_only );
+			}
+			$batches = 0;
+		}
+
+		if ( ! empty( $subscription_ids ) ) {
+			\WP_CLI::log( __( 'Syncing by subscription ID...', 'newspack-newsletters' ) ) . "\n\n";
+
+			while ( ! empty( $subscription_ids ) ) {
+				$subscription_id = array_shift( $subscription_ids );
+				$subscription    = \wcs_get_subscription( $subscription_id );
+
+				if ( \is_wp_error( $subscription ) ) {
+					\WP_CLI::log(
+						sprintf(
+							// Translators: %d is the subscription ID arg passed to the script.
+							__( 'No subscription with ID %d. Skipping.', 'newspack-newsletters' ),
+							$subscription_id
+						)
+					);
+
+					continue;
+				}
+
+				self::resync_contact( 0, $subscription, $is_dry_run );
+
+				// Get the next batch.
+				if ( $migrated_only && empty( $subscription_ids ) ) {
+					$batches++;
+
+					if ( $max_batches && $batches >= $max_batches ) {
+						break;
+					}
+
+					$next_batch = $offset + ( $batches * $batch_size );
+					switch ( $migrated_only ) {
+						case 'stripe':
+							$subscription_ids = Stripe_Sync::get_migrated_subscriptions( $batch_size, $next_batch, $active_only );
+							break;
+						case 'piano-csv':
+							$subscription_ids = CSV_Importer::get_migrated_subscriptions( 'piano', $batch_size, $next_batch, $active_only );
+							break;
+						case 'stripe-csv':
+							$subscription_ids = CSV_Importer::get_migrated_subscriptions( 'stripe', $batch_size, $next_batch, $active_only );
+							break;
+						default:
+							\WP_CLI::error( __( 'Invalid subscription migration type ', 'newspack-newsletters' ) . $migrated_only );
+					}
+				}
+			}
+		}
+
+		// If order-ids flag is passed, resync contacts for those orders.
+		if ( ! empty( $order_ids ) ) {
+			\WP_CLI::log( __( 'Syncing by order ID...', 'newspack-newsletters' ) );
+			foreach ( $order_ids as $order_id ) {
+				$order = new \WC_Order( $order_id );
+
+				if ( \is_wp_error( $order ) ) {
+					\WP_CLI::log(
+						sprintf(
+							// Translators: %d is the order ID arg passed to the script.
+							__( 'No order with ID %d. Skipping.', 'newspack-newsletters' ),
+							$order_id
+						)
+					);
+
+					continue;
+				}
+
+				self::resync_contact( 0, $order, $is_dry_run );
+			}
+		}
+
+		// If user-ids flag is passed, resync those users.
+		if ( ! empty( $user_ids ) ) {
+			\WP_CLI::log( __( 'Syncing by customer user ID...', 'newspack-newsletters' ) );
+			foreach ( $user_ids as $user_id ) {
+				if ( ! $active_only || self::user_has_active_subscriptions( $user_id ) ) {
+					self::resync_contact( $user_id, null, $is_dry_run );
+				}
+			}
+		}
+
+		// Default behavior: resync all customers and subscribers.
+		if ( false === $user_ids && false === $order_ids && false === $subscription_ids && false === $migrated_only ) {
+			\WP_CLI::log( __( 'Syncing all customers...', 'newspack-newsletters' ) );
+			$user_ids = self::get_batch_of_customers( $batch_size, $offset );
+			$batches  = 0;
+
+			while ( $user_ids ) {
+				$user_id = array_shift( $user_ids );
+				if ( ! $active_only || self::user_has_active_subscriptions( $user_id ) ) {
+					self::resync_contact( $user_id, null, $is_dry_run );
+				}
+
+				// Get the next batch.
+				if ( empty( $user_ids ) ) {
+					$batches++;
+
+					if ( $max_batches && $batches >= $max_batches ) {
+						break;
+					}
+
+					$user_ids = self::get_batch_of_customers( $batch_size, $offset + ( $batches * $batch_size ) );
+				}
+			}
+		}
+
+		\WP_CLI::line( "\n" );
+		\WP_CLI::success(
+			sprintf(
+				// Translators: total number of resynced contacts.
+				__(
+					'Resynced %d contacts.',
+					'newspack-newsletters'
+				),
+				self::$results['processed']
+			)
+		);
+	}
+
+	/**
+	 * Given a WP user ID for a Woo customer, resync that customer's contact data in the connected ESP.
+	 *
+	 * @param int           $user_id WP user ID for the customer. If given, resync using the customer.
+	 * @param WC_Order|null $order If given, resync using the order instead of the customer.
+	 * @param bool          $is_dry_run True if a dry run.
+	 *
+	 * @return bool True if the contact was resynced successfully, false otherwise.
+	 */
+	public static function resync_contact( $user_id = 0, $order = null, $is_dry_run = false ) {
+		$result            = false;
+		$registration_site = false;
+
+		if ( ! $user_id && ! $order ) {
+			\WP_CLI::log(
+				sprintf(
+				// Translators: %d is the user ID arg passed to the script.
+					__( 'Must pass either a user ID or order. Skipping.', 'newspack-newsletters' ),
+					$user_id
+				)
+			);
+
+			return $result;
+		}
+
+		$user = \get_userdata( $user_id ? $user_id : $order->get_customer_id() );
+
+		// Backfill Network Registration Site field if needed.
+		if ( $user && defined( 'NEWSPACK_NETWORK_READER_ROLE' ) && defined( 'Newspack_Network\Utils\Users::USER_META_REMOTE_SITE' ) ) {
+			if ( ! empty( array_intersect( $user->roles, \Newspack_Network\Utils\Users::get_synced_user_roles() ) ) ) {
+				$registration_site = \esc_url( \get_site_url() ); // Default to current site.
+				$remote_site       = \get_user_meta( $user->ID, \Newspack_Network\Utils\Users::USER_META_REMOTE_SITE, true );
+				if ( ! empty( \wp_http_validate_url( $remote_site ) ) ) {
+					$registration_site = \esc_url( $remote_site );
+				}
+			}
+		}
+
+		$customer = new \WC_Customer( $user_id ? $user_id : $order->get_customer_id() );
+		if ( ! $customer || ! $customer->get_id() ) {
+			\WP_CLI::log(
+				sprintf(
+				// Translators: %d is the user ID arg passed to the script.
+					__( 'Customer with ID %d does not exist. Skipping.', 'newspack-newsletters' ),
+					$user_id
+				)
+			);
+
+			return $result;
+		}
+
+		// Ensure the customer has a billing address.
+		if ( ! $customer->get_billing_email() && $customer->get_email() ) {
+			$customer->set_billing_email( $customer->get_email() );
+			$customer->save();
+		}
+
+		$contact = $user_id ? \Newspack\WooCommerce_Connection::get_contact_from_customer( $customer ) : \Newspack\WooCommerce_Connection::get_contact_from_order( $order );
+		if ( $registration_site ) {
+			$contact['metadata']['network_registration_site'] = $registration_site;
+		}
+		$result = $is_dry_run ? true : self::sync_contact( $contact );
+
+		if ( $result && ! \is_wp_error( $result ) ) {
+			\WP_CLI::log(
+				sprintf(
+					// Translators: %1$s is the resync status and %2$s is the contact's email address.
+					__( '%1$s contact data for %2$s.', 'newspack-newsletters' ),
+					$is_dry_run ? __( 'Would resync', 'newspack-newsletters' ) : __( 'Resynced', 'newspack-newsletters' ),
+					$customer->get_email()
+				)
+			);
+			self::$results['processed']++;
+		}
+
+		if ( \is_wp_error( $result ) ) {
+			\WP_CLI::warning(
+				sprintf(
+					// Translators: $1$s is the contact's email address. %2$s is the error message.
+					__( 'Error resyncing contact info for %1$s. %2$s' ),
+					$customer->get_email(),
+					$result->get_error_message()
+				)
+			);
+		}
+
+		return $result;
+	}
+
+	/**
+	 * Get a batch of customer IDs.
+	 *
+	 * @param int $batch_size Number of customers to get.
+	 * @param int $offset     Number to skip.
+	 *
+	 * @return array|false Array of customer IDs, or false if no more to fetch.
+	 */
+	public static function get_batch_of_customers( $batch_size, $offset = 0 ) {
+		$customer_roles = self::CUSTOMER_ROLES;
+		if ( defined( 'NEWSPACK_NETWORK_READER_ROLE' ) ) {
+			$customer_roles[] = NEWSPACK_NETWORK_READER_ROLE;
+		}
+
+		$query = new \WP_User_Query(
+			[
+				'fields'   => 'ID',
+				'number'   => $batch_size,
+				'offset'   => $offset,
+				'order'    => 'DESC',
+				'orderby'  => 'registered',
+				'role__in' => $customer_roles,
+			]
+		);
+
+		$results = $query->get_results();
+
+		return ! empty( $results ) ? $results : false;
+	}
+}
+WooCommerce_Sync::init();

--- a/includes/plugins/class-woocommerce-sync.php
+++ b/includes/plugins/class-woocommerce-sync.php
@@ -16,9 +16,6 @@ defined( 'ABSPATH' ) || exit;
  * WooCommerce Sync Class.
  */
 abstract class WooCommerce_Sync {
-	// User roles that a customer can have.
-	const CUSTOMER_ROLES = [ 'customer', 'subscriber' ];
-
 	/**
 	 * Log a message to the Newspack logger and/or WP CLI.
 	 *
@@ -78,7 +75,7 @@ abstract class WooCommerce_Sync {
 
 		if ( ! \Newspack\Reader_Activation::get_setting( 'sync_esp' ) ) {
 			$errors->add(
-				'esp_sync_not_enabled',
+				'ras_esp_sync_not_enabled',
 				__( 'ESP sync is not enabled.', 'newspack-newsletters' )
 			);
 		}
@@ -139,7 +136,7 @@ abstract class WooCommerce_Sync {
 	 * @param int    $offset Number to skip.
 	 * @param bool   $active_only Whether to get only active subscriptions.
 	 *
-	 * @return array|\WP_Error Array of subscription IDs, or WP_Error if an error occurred.
+	 * @return array|\WP_Error Array of subscription IDs or WP_Error.
 	 */
 	protected static function get_migrated_subscriptions( $source, $batch_size, $offset, $active_only ) {
 		if (
@@ -244,11 +241,9 @@ abstract class WooCommerce_Sync {
 					$customer->get_email()
 				)
 			);
-			static::$results['processed']++;
-		}
-
-		if ( \is_wp_error( $result ) ) {
-			return $result;
+			if ( ! empty( static::$results ) ) {
+				static::$results['processed']++;
+			}
 		}
 
 		return $result;

--- a/includes/plugins/class-woocommerce-sync.php
+++ b/includes/plugins/class-woocommerce-sync.php
@@ -20,15 +20,6 @@ abstract class WooCommerce_Sync {
 	const CUSTOMER_ROLES = [ 'customer', 'subscriber' ];
 
 	/**
-	 * The final results object.
-	 *
-	 * @var array
-	 */
-	protected static $results = [
-		'processed' => 0,
-	];
-
-	/**
 	 * Log a message to the Newspack logger and/or WP CLI.
 	 *
 	 * @param string $message The message to log.
@@ -63,9 +54,9 @@ abstract class WooCommerce_Sync {
 	}
 
 	/**
-	 * Whether contacts can be synced to the ESP
+	 * Whether contacts can be synced to the ESP.
 	 *
-	 * @param bool $return_errors Optional. Whether to return WP_Error on failure. Default false.
+	 * @param bool $return_errors Optional. Whether to return a WP_Error object. Default false.
 	 *
 	 * @return bool|WP_Error True if contacts can be synced, false otherwise. WP_Error if return_errors is true.
 	 */
@@ -185,197 +176,8 @@ abstract class WooCommerce_Sync {
 	}
 
 	/**
-	 * Resync contact data from WooCommerce customers to the connected ESP.
-	 *
-	 * @param array $config {
-	 *   Configuration options.
-	 *
-	 *   @type bool        $config['is_dry_run'] True if a dry run.
-	 *   @type bool        $config['active_only'] True if only active subscriptions should be synced.
-	 *   @type string|bool $config['migrated_only'] If set, only sync subscriptions migrated from the given source.
-	 *   @type array|bool  $config['subscription_ids'] If set, only sync the given subscription IDs.
-	 *   @type array|bool  $config['user_ids'] If set, only sync the given user IDs.
-	 *   @type array|bool  $config['order_ids'] If set, only sync the given order IDs.
-	 *   @type int         $config['batch_size'] Number of contacts to sync per batch.
-	 *   @type int         $config['offset'] Number of contacts to skip.
-	 *   @type int         $config['max_batches'] Maximum number of batches to process.
-	 *   @type bool        $config['is_dry_run'] True if a dry run.
-	 * }
-	 *
-	 * @return int|\WP_Error Number of resynced contacts, or WP_Error if an error occurred.
-	 */
-	protected static function resync_woo_contacts( $config ) {
-		$default_config = [
-			'active_only'      => false,
-			'migrated_only'    => false,
-			'subscription_ids' => false,
-			'user_ids'         => false,
-			'order_ids'        => false,
-			'batch_size'       => 10,
-			'offset'           => 0,
-			'max_batches'      => 0,
-			'is_dry_run'       => false,
-		];
-		$config = \wp_parse_args( $config, $default_config );
-
-		static::log( __( 'Running WooCommerce-to-ESP contact resync...', 'newspack-newsletters' ) );
-
-		$can_sync = static::can_sync_contacts( true );
-		if ( ! $config['is_dry_run'] && $can_sync->has_errors() ) {
-			return $can_sync;
-		}
-
-		// If resyncing only migrated subscriptions.
-		if ( $config['migrated_only'] ) {
-			$config['subscription_ids'] = static::get_migrated_subscriptions( $config['migrated_only'], $config['batch_size'], $config['offset'], $config['active_only'] );
-			if ( \is_wp_error( $config['subscription_ids'] ) ) {
-				return $config['subscription_ids'];
-			}
-			$batches = 0;
-		}
-
-		if ( ! empty( $config['subscription_ids'] ) ) {
-			static::log( __( 'Syncing by subscription ID...', 'newspack-newsletters' ) );
-
-			while ( ! empty( $config['subscription_ids'] ) ) {
-				$subscription_id = array_shift( $config['subscription_ids'] );
-				$subscription    = \wcs_get_subscription( $subscription_id );
-
-				if ( \is_wp_error( $subscription ) ) {
-					static::log(
-						sprintf(
-							// Translators: %d is the subscription ID arg passed to the script.
-							__( 'No subscription with ID %d. Skipping.', 'newspack-newsletters' ),
-							$subscription_id
-						)
-					);
-
-					continue;
-				}
-
-				$result = static::resync_contact( 0, $subscription, $config['is_dry_run'] );
-				if ( \is_wp_error( $result ) ) {
-					static::log(
-						sprintf(
-							// Translators: %1$d is the subscription ID arg passed to the script. %2$s is the error message.
-							__( 'Error resyncing contact info for subscription ID %1$d. %2$s', 'newspack-newsletters' ),
-							$subscription_id,
-							$result->get_error_message()
-						)
-					);
-				}
-
-				// Get the next batch.
-				if ( $config['migrated_only'] && empty( $config['subscription_ids'] ) ) {
-					$batches++;
-
-					if ( $config['max_batches'] && $batches >= $config['max_batches'] ) {
-						break;
-					}
-
-					$next_batch_offset = $config['offset'] + ( $batches * $config['batch_size'] );
-					$config['subscription_ids'] = static::get_migrated_subscriptions( $config['migrated_only'], $config['batch_size'], $next_batch_offset, $config['active_only'] );
-				}
-			}
-		}
-
-		// If order-ids flag is passed, resync contacts for those orders.
-		if ( ! empty( $config['order_ids'] ) ) {
-			static::log( __( 'Syncing by order ID...', 'newspack-newsletters' ) );
-			foreach ( $config['order_ids'] as $order_id ) {
-				$order = new \WC_Order( $order_id );
-
-				if ( \is_wp_error( $order ) ) {
-					static::log(
-						sprintf(
-							// Translators: %d is the order ID arg passed to the script.
-							__( 'No order with ID %d. Skipping.', 'newspack-newsletters' ),
-							$order_id
-						)
-					);
-
-					continue;
-				}
-
-				$result = static::resync_contact( 0, $order, $config['is_dry_run'] );
-				if ( \is_wp_error( $result ) ) {
-					static::log(
-						sprintf(
-							// Translators: %1$d is the order ID arg passed to the script. %2$s is the error message.
-							__( 'Error resyncing contact info for order ID %1$d. %2$s', 'newspack-newsletters' ),
-							$order_id,
-							$result->get_error_message()
-						)
-					);
-				}
-			}
-		}
-
-		// If user-ids flag is passed, resync those users.
-		if ( ! empty( $config['user_ids'] ) ) {
-			static::log( __( 'Syncing by customer user ID...', 'newspack-newsletters' ) );
-			foreach ( $config['user_ids'] as $user_id ) {
-				if ( ! $config['active_only'] || static::user_has_active_subscriptions( $user_id ) ) {
-					$result = static::resync_contact( $user_id, null, $config['is_dry_run'] );
-					if ( \is_wp_error( $result ) ) {
-						static::log(
-							sprintf(
-								// Translators: %1$d is the user ID arg passed to the script. %2$s is the error message.
-								__( 'Error resyncing contact info for user ID %1$d. %2$s', 'newspack-newsletters' ),
-								$user_id,
-								$result->get_error_message()
-							)
-						);
-					}
-				}
-			}
-		}
-
-		// Default behavior: resync all customers and subscribers.
-		if (
-			false === $config['user_ids'] &&
-			false === $config['order_ids'] &&
-			false === $config['subscription_ids'] &&
-			false === $config['migrated_only']
-		) {
-			static::log( __( 'Syncing all customers...', 'newspack-newsletters' ) );
-			$user_ids = static::get_batch_of_customers( $config['batch_size'], $config['offset'] );
-			$batches  = 0;
-
-			while ( $user_ids ) {
-				$user_id = array_shift( $user_ids );
-				if ( ! $config['active_only'] || static::user_has_active_subscriptions( $user_id ) ) {
-					$result = static::resync_contact( $user_id, null, $config['is_dry_run'] );
-					if ( \is_wp_error( $result ) ) {
-						static::log(
-							sprintf(
-								// Translators: $1$s is the contact's email address. %2$s is the error message.
-								__( 'Error resyncing contact info for %1$s. %2$s' ),
-								$customer->get_email(),
-								$result->get_error_message()
-							)
-						);
-					}
-				}
-
-				// Get the next batch.
-				if ( empty( $user_ids ) ) {
-					$batches++;
-
-					if ( $config['max_batches'] && $batches >= $config['max_batches'] ) {
-						break;
-					}
-
-					$user_ids = static::get_batch_of_customers( $config['batch_size'], $config['offset'] + ( $batches * $config['batch_size'] ) );
-				}
-			}
-		}
-
-		return static::$results['processed'];
-	}
-
-	/**
-	 * Given a WP user ID for a Woo customer, resync that customer's contact data in the connected ESP.
+	 * Given a WP user ID for a Woo customer or order ID, resync that customer's
+	 * contact data in the connected ESP.
 	 *
 	 * @param int           $user_id WP user ID for the customer. If given, resync using the customer.
 	 * @param WC_Order|null $order If given, resync using the order instead of the customer.
@@ -450,35 +252,5 @@ abstract class WooCommerce_Sync {
 		}
 
 		return $result;
-	}
-
-	/**
-	 * Get a batch of customer IDs.
-	 *
-	 * @param int $batch_size Number of customers to get.
-	 * @param int $offset     Number to skip.
-	 *
-	 * @return array|false Array of customer IDs, or false if no more to fetch.
-	 */
-	protected static function get_batch_of_customers( $batch_size, $offset = 0 ) {
-		$customer_roles = static::CUSTOMER_ROLES;
-		if ( defined( 'NEWSPACK_NETWORK_READER_ROLE' ) ) {
-			$customer_roles[] = NEWSPACK_NETWORK_READER_ROLE;
-		}
-
-		$query = new \WP_User_Query(
-			[
-				'fields'   => 'ID',
-				'number'   => $batch_size,
-				'offset'   => $offset,
-				'order'    => 'DESC',
-				'orderby'  => 'registered',
-				'role__in' => $customer_roles,
-			]
-		);
-
-		$results = $query->get_results();
-
-		return ! empty( $results ) ? $results : false;
 	}
 }

--- a/includes/plugins/class-woocommerce-sync.php
+++ b/includes/plugins/class-woocommerce-sync.php
@@ -26,7 +26,7 @@ class WooCommerce_Sync {
 	 * @var array
 	 * @codeCoverageIgnore
 	 */
-	private static $results = [
+	protected static $results = [
 		'processed' => 0,
 	];
 
@@ -156,7 +156,7 @@ class WooCommerce_Sync {
 	 *
 	 * @return bool
 	 */
-	public static function user_has_active_subscriptions( $user_id ) {
+	protected static function user_has_active_subscriptions( $user_id ) {
 		$subcriptions = array_reduce(
 			array_keys( \wcs_get_users_subscriptions( $user_id ) ),
 			function( $acc, $subscription_id ) {
@@ -180,7 +180,7 @@ class WooCommerce_Sync {
 	 *
 	 * @return mixed Filtered option value.
 	 */
-	private static function maybe_disable_esp_syncing( $value ) {
+	protected static function maybe_disable_esp_syncing( $value ) {
 		// If a production site, don't do anything.
 		if ( method_exists( 'Newspack_Manager', 'is_connected_to_production_manager' ) && \Newspack_Manager::is_connected_to_production_manager() ) {
 			return $value;
@@ -197,8 +197,10 @@ class WooCommerce_Sync {
 	 * Sync contact to the ESP.
 	 *
 	 * @param array $contact The contact data to sync.
+	 *
+	 * @return void|\WP_Error WP_Error if an error occurred.
 	 */
-	public static function sync_contact( $contact ) {
+	protected static function sync_contact( $contact ) {
 		// Only if Reader Activation is available.
 		if ( ! class_exists( 'Newspack\Reader_Activation' ) ) {
 			return;
@@ -216,8 +218,6 @@ class WooCommerce_Sync {
 		if ( \is_wp_error( $result ) ) {
 			return $result;
 		}
-
-		return true;
 	}
 
 	/**
@@ -225,7 +225,7 @@ class WooCommerce_Sync {
 	 *
 	 * @param string $message The message to log.
 	 */
-	private static function log( $message ) {
+	protected static function log( $message ) {
 		if ( class_exists( 'Newspack\Logger' ) ) {
 			\Newspack\Logger::log( $message, 'NEWSPACK-NEWSLETTERS' );
 		}
@@ -247,7 +247,7 @@ class WooCommerce_Sync {
 	 *
 	 * @return array|\WP_Error Array of subscription IDs, or WP_Error if an error occurred.
 	 */
-	private static function get_migrated_subscriptions( $source, $batch_size, $offset, $active_only ) {
+	protected static function get_migrated_subscriptions( $source, $batch_size, $offset, $active_only ) {
 		if (
 			! class_exists( '\Newspack_Subscription_Migrations\Stripe_Sync' ) ||
 			! class_exists( '\Newspack_Subscription_Migrations\CSV_Importers\CSV_Importer' )
@@ -301,7 +301,7 @@ class WooCommerce_Sync {
 	 *
 	 * @return int|\WP_Error Number of resynced contacts, or WP_Error if an error occurred.
 	 */
-	private static function resync_woo_contacts( $config ) {
+	protected static function resync_woo_contacts( $config ) {
 		$default_config = [
 			'active_only'      => false,
 			'migrated_only'    => false,
@@ -443,7 +443,7 @@ class WooCommerce_Sync {
 	 *
 	 * @return bool True if the contact was resynced successfully, false otherwise.
 	 */
-	public static function resync_contact( $user_id = 0, $order = null, $is_dry_run = false ) {
+	protected static function resync_contact( $user_id = 0, $order = null, $is_dry_run = false ) {
 		$result            = false;
 		$registration_site = false;
 
@@ -531,7 +531,7 @@ class WooCommerce_Sync {
 	 *
 	 * @return array|false Array of customer IDs, or false if no more to fetch.
 	 */
-	public static function get_batch_of_customers( $batch_size, $offset = 0 ) {
+	protected static function get_batch_of_customers( $batch_size, $offset = 0 ) {
 		$customer_roles = self::CUSTOMER_ROLES;
 		if ( defined( 'NEWSPACK_NETWORK_READER_ROLE' ) ) {
 			$customer_roles[] = NEWSPACK_NETWORK_READER_ROLE;

--- a/newspack-newsletters.php
+++ b/newspack-newsletters.php
@@ -73,6 +73,7 @@ require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/tracking/class-admin.
 require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/class-newspack-newsletters.php';
 require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/plugins/class-woocommerce-memberships.php';
 require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/plugins/class-woocommerce-sync.php';
+require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/plugins/class-woocommerce-sync-cli.php';
 require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/plugins/class-woocommerce-sync-admin.php';
 
 // This MUST be initialized after Newspack_Newsletter class.

--- a/newspack-newsletters.php
+++ b/newspack-newsletters.php
@@ -73,6 +73,7 @@ require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/tracking/class-admin.
 require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/class-newspack-newsletters.php';
 require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/plugins/class-woocommerce-memberships.php';
 require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/plugins/class-woocommerce-sync.php';
+require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/plugins/class-woocommerce-sync-admin.php';
 
 // This MUST be initialized after Newspack_Newsletter class.
 \Newspack\Newsletters\Subscription_Lists::init();

--- a/newspack-newsletters.php
+++ b/newspack-newsletters.php
@@ -72,6 +72,7 @@ require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/tracking/class-data-e
 require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/tracking/class-admin.php';
 require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/class-newspack-newsletters.php';
 require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/plugins/class-woocommerce-memberships.php';
+require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/plugins/class-woocommerce-sync.php';
 
 // This MUST be initialized after Newspack_Newsletter class.
 \Newspack\Newsletters\Subscription_Lists::init();


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Moves the logic for syncing Woo customers and orders to the ESP from the `newspack-subscription-migrations` plugin to here.

The original class was refactored so it provides generic methods to be extended by the existing CLI and new admin functionality.

Some changes to the generic logic are worth mentioning:

 - `can_sync_contacts( bool $return_errors )` was implemented so it can be called across CLI and admin functionality with proper error handling
 - `get_batch_of_customers()` was changed to `get_batch_of_readers()`. It's now using `\Newspack\Reader_Activation::get_reader_roles()` because although they are customers, every WP user can be a customer and the goal is to sync RAS readers
 - The private `sync( $contact )` method (previously `sync_contact()`) was modified to support any ESP through the `Newspack_Newsletters_Contacts::upsert()` method. For that, [a new helper method is proposed for RAS](https://github.com/Automattic/newspack-plugin/pull/3355) so we can get the master list given any provider

The CLI command, originally `wp newspack woo resync` is now `newspack-newsletters woo resync` but preserves all the original functionality and args support. The exception is for the flag `--migrated-subscriptions`, which requires the `newspack-subscription-migrations` plugin to be installed, otherwise it returns an error.

The new functionality allows an admin user to sync contacts through the dashboard user table, both individually and through the bulk action dropdown:

| Single | Bulk |
| --- | --- |
| <img width="376" alt="image" src="https://github.com/user-attachments/assets/8ce4e39a-42f7-460b-99ec-46c778715560"> | <img width="255" alt="image" src="https://github.com/user-attachments/assets/07a46a1c-db4e-4f7e-b8b4-19a850e45294"> |

### How to test the changes in this Pull Request:

1. Check out this PR and https://github.com/Automattic/newspack-plugin/pull/3355

#### CLI

1. Run `wp newspack-newsletters woo resync --dry-run` for a full dry run
2. Confirm the command runs successfully, going through all the readers in your database
3. Choose a reader and run `wp newspack-newsletters woo resync --user-ids=USER_ID` with their user ID
4. Confirm via PHP logs that `[Newspack_Newsletters_Contacts::upsert]: Adding contact to list(s): LIST_ID. Provider is PROVIDER.` is called and you can inspect the normalized contact data
5. Do the same but now with 2 user IDs: `wp newspack-newsletters woo resync --user-ids=USER_ID1,USER_ID2`
6. Confirm via PHP logs the 2 entries as in step 4
7. Grab 2 Woo Subscription IDs and run: `wp newspack-newsletters woo resync --subscription-ids=ID1,ID2`
8. Confirm the command runs without issues and the PHP log entries for the `::upsert()` is correct
9. Grab 2 Woo Order IDs and run: `wp newspack-newsletters woo resync --order-ids=ID1,ID2`
10. Confirm the command runs without issues and the PHP log entries for the `::upsert()` is correct
11. Cancel a reader subscription and run a sync for active subs only, along with a reader with an active subscription: `wp newspack-newsletters woo resync --active-only --user-ids=USER_ID1,USER_ID2`
12. Confirm only the reader with an active sub got synced
13. Test dry run syncs modifying `--offset`, `--max-batches`, and `--batch-size` to confirm these values are applied correctly

#### Admin

1. Navigate to "Users", in WP dashboard
2. Hover the rows and confirm you see a "Resync contact to ESP" row action link
3. Click and confirm you get a success message and the PHP logs show `::upsert()` was called correctly
4. Select multiple readers, click on the Bulk actions dropdown, select "Resync to the ESP", and apply
5. Confirm you get a success message and the PHP logs show `::upsert()` was called correctly for every selected contact

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
