### PR TITLE
feat(mailchimp): parse contact name into merge fields

### DIFF
--- a/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp.php
+++ b/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp.php
@@ -1405,6 +1405,15 @@ final class Newspack_Newsletters_Mailchimp extends \Newspack_Newsletters_Service
 			$this->get_status_for_payload( $contact )
 		);
 
+		// Parse full name into first + last.
+		if ( isset( $contact['name'] ) ) {
+			$name_fragments = explode( ' ', $contact['name'], 2 );
+			$contact['metadata']['First Name'] = $name_fragments[0];
+			if ( isset( $name_fragments[1] ) ) {
+				$contact['metadata']['Last Name'] = $name_fragments[1];
+			}
+		}
+
 		try {
 
 			$mc = new Mailchimp( $this->api_key() );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This is part of the refactor in progress here: https://github.com/Automattic/newspack-plugin/pull/3362

Incoming `$contact['name']` should be transformed to populate the `First Name` and `Last Name` merge fields.

### How to test the changes in this Pull Request:

1. Checkout this branch and https://github.com/Automattic/newspack-plugin/pull/3362
2. With RAS configured, visit your site in a fresh session
3. Donate with a new reader account
4. Confirm the sync goes through with "First Name" and "Last Name" merge fields populated

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
