### PR TITLE
feat: send list classes

### DIFF
--- a/includes/class-newspack-newsletters-subscription.php
+++ b/includes/class-newspack-newsletters-subscription.php
@@ -14,9 +14,6 @@ use Newspack\Newsletters\Reader_Activation;
  * Manages Settings Subscription Class.
  */
 class Newspack_Newsletters_Subscription {
-
-	const API_NAMESPACE = 'newspack-newsletters/v1';
-
 	const EMAIL_VERIFIED_META    = 'newspack_newsletters_email_verified';
 	const EMAIL_VERIFIED_REQUEST = 'newspack_newsletters_email_verification_request';
 	const EMAIL_VERIFIED_CONFIRM = 'newspack_newsletters_email_verification';
@@ -62,7 +59,7 @@ class Newspack_Newsletters_Subscription {
 	 */
 	public static function register_api_endpoints() {
 		register_rest_route(
-			self::API_NAMESPACE,
+			Newspack_Newsletters::API_NAMESPACE,
 			'/lists_config',
 			[
 				'methods'             => \WP_REST_Server::READABLE,
@@ -71,21 +68,21 @@ class Newspack_Newsletters_Subscription {
 			]
 		);
 		register_rest_route(
-			self::API_NAMESPACE,
+			Newspack_Newsletters::API_NAMESPACE,
 			'/lists',
 			[
 				'methods'             => \WP_REST_Server::READABLE,
 				'callback'            => [ __CLASS__, 'api_get_lists' ],
-				'permission_callback' => [ __CLASS__, 'api_permission_callback' ],
+				'permission_callback' => [ 'Newspack_Newsletters', 'api_permission_callback' ],
 			]
 		);
 		register_rest_route(
-			self::API_NAMESPACE,
+			Newspack_Newsletters::API_NAMESPACE,
 			'/lists',
 			[
 				'methods'             => \WP_REST_Server::EDITABLE,
 				'callback'            => [ __CLASS__, 'api_update_lists' ],
-				'permission_callback' => [ __CLASS__, 'api_permission_callback' ],
+				'permission_callback' => [ 'Newspack_Newsletters', 'api_permission_callback' ],
 				'args'                => [
 					'lists' => [
 						'type'     => 'array',
@@ -111,15 +108,6 @@ class Newspack_Newsletters_Subscription {
 				],
 			]
 		);
-	}
-
-	/**
-	 * Whether the current user can manage subscription lists.
-	 *
-	 * @return bool Whether the current user can manage subscription lists.
-	 */
-	public static function api_permission_callback() {
-		return current_user_can( 'manage_options' );
 	}
 
 	/**
@@ -229,7 +217,7 @@ class Newspack_Newsletters_Subscription {
 	public static function get_lists_config() {
 		$provider = Newspack_Newsletters::get_service_provider();
 		if ( empty( $provider ) ) {
-			return new WP_Error( 'newspack_newsletters_invalid_provider', __( 'Provider is not set.' ) );
+			return new WP_Error( 'newspack_newsletters_invalid_provider', __( 'Provider is not set.', 'newspack-newsletters' ) );
 		}
 
 		$saved_lists  = Subscription_Lists::get_configured_for_current_provider();
@@ -262,11 +250,11 @@ class Newspack_Newsletters_Subscription {
 	public static function update_lists( $lists ) {
 		$provider = Newspack_Newsletters::get_service_provider();
 		if ( empty( $provider ) ) {
-			return new WP_Error( 'newspack_newsletters_invalid_provider', __( 'Provider is not set.' ) );
+			return new WP_Error( 'newspack_newsletters_invalid_provider', __( 'Provider is not set.', 'newspack-newsletters' ) );
 		}
 		$lists = self::sanitize_lists( $lists );
 		if ( empty( $lists ) ) {
-			return new WP_Error( 'newspack_newsletters_invalid_lists', __( 'Invalid list configuration.' ) );
+			return new WP_Error( 'newspack_newsletters_invalid_lists', __( 'Invalid list configuration.', 'newspack-newsletters' ) );
 		}
 
 		return Subscription_Lists::update_lists( $lists );
@@ -321,16 +309,16 @@ class Newspack_Newsletters_Subscription {
 	 */
 	public static function get_contact_data( $email_address, $return_details = false ) {
 		if ( ! $email_address || empty( $email_address ) ) {
-			return new WP_Error( 'newspack_newsletters_invalid_email', __( 'Missing email address.' ) );
+			return new WP_Error( 'newspack_newsletters_invalid_email', __( 'Missing email address.', 'newspack-newsletters' ) );
 		}
 
 		$provider = Newspack_Newsletters::get_service_provider();
 		if ( empty( $provider ) ) {
-			return new WP_Error( 'newspack_newsletters_invalid_provider', __( 'Provider is not set.' ) );
+			return new WP_Error( 'newspack_newsletters_invalid_provider', __( 'Provider is not set.', 'newspack-newsletters' ) );
 		}
 
 		if ( ! method_exists( $provider, 'get_contact_data' ) ) {
-			return new WP_Error( 'newspack_newsletters_not_implemented', __( 'Provider does not handle the contact-exists check.' ) );
+			return new WP_Error( 'newspack_newsletters_not_implemented', __( 'Provider does not handle the contact-exists check.', 'newspack-newsletters' ) );
 		}
 
 		return $provider->get_contact_data( $email_address, $return_details );

--- a/includes/class-newspack-newsletters.php
+++ b/includes/class-newspack-newsletters.php
@@ -18,6 +18,7 @@ final class Newspack_Newsletters {
 	const EMAIL_HTML_META                   = 'newspack_email_html';
 	const NEWSPACK_NEWSLETTERS_PALETTE_META = 'newspack_newsletters_color_palette';
 	const PUBLIC_POST_ID_META               = 'newspack_nl_public_post_id';
+	const API_NAMESPACE                     = 'newspack-newsletters/v1';
 
 	/**
 	 * Supported fonts.
@@ -832,6 +833,15 @@ final class Newspack_Newsletters {
 		}
 
 		return $wp_error->has_errors() ? $wp_error : self::api_get_settings();
+	}
+
+	/**
+	 * Whether the current user can manage admin settings.
+	 *
+	 * @return bool Whether the current user can manage admin settings.
+	 */
+	public static function api_permission_callback() {
+		return current_user_can( 'manage_options' );
 	}
 
 	/**

--- a/includes/class-send-list.php
+++ b/includes/class-send-list.php
@@ -1,0 +1,213 @@
+<?php
+/**
+ * Newspack Newsletters Send List
+ *
+ * @package Newspack
+ */
+
+namespace Newspack\Newsletters;
+
+use Newspack_Newsletters;
+use WP_Post;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class used to represent one Send_List.
+ *
+ * A Send_List can be either a top-level list or a sublist.
+ * A sublist must specify a parent list ID.
+ */
+class Send_List {
+	/**
+	 * The configuration associated with this Send_List.
+	 *
+	 * @var array
+	 */
+	protected $config;
+
+	/**
+	 * Initializes a new Send_List.
+	 *
+	 * @param array $config The configuration for the Send_List.
+	 * @throws \InvalidArgumentException In case the Send_List object can't be built from the given config data.
+	 */
+	public function __construct( $config ) {
+		$schema = self::get_config_schema();
+		$errors = [];
+
+		foreach ( $schema['properties'] as $key => $property ) {
+			// If the property is required but not set, throw an error.
+			if ( ! empty( $property['required'] ) && ! isset( $config[ $key ] ) ) {
+				$errors[] = __( 'Missing required config: ', 'newspack-newsletters' ) . $key;
+				continue;
+			}
+
+			// No need to continue if an optional key isn't set.
+			if ( ! isset( $config[ $key ] ) ) {
+				continue;
+			}
+
+			// If the passed value isn't in the enum, throw an error.
+			if ( isset( $property['enum'] ) && isset( $config[ $key ] ) && ! in_array( $config[ $key ], $property['enum'], true ) ) {
+				$errors[] = __( 'Invalid value for config: ', 'newspack-newsletters' ) . $key;
+				continue;
+			}
+
+			// Cast value to the expected type.
+			settype( $config[ $key ], $property['type'] );
+
+			// Set the property.
+			$this->set( $key, $config[ $key ] );
+		}
+
+		if ( ! empty( $errors ) ) {
+			throw new \InvalidArgumentException( esc_html( __( 'Error creating send list: ', 'newspack-newsletters' ) . implode( ' | ', $errors ) ) );
+		}
+
+		$this->set_label_and_value();
+	}
+
+	/**
+	 * Get the config data schema for a single Send_List.
+	 */
+	public static function get_config_schema() {
+		return [
+			'type'                 => 'object',
+			'additionalProperties' => false,
+			'properties'           => [
+				// The slug of the ESP for which this list or sublist originates.
+				'provider'    => [
+					'name'     => 'provider',
+					'type'     => 'string',
+					'required' => true,
+					'enum'     => Newspack_Newsletters::get_supported_providers(),
+				],
+				// The type of list. Can be either 'list' or 'sublist'. If the latter, must specify a `parent` property.
+				'type'        => [
+					'name'     => 'type',
+					'type'     => 'string',
+					'required' => true,
+					'enum'     => [
+						'list',
+						'sublist',
+					],
+				],
+				// The type of entity this list or sublist is associated with in the ESP. Controls which ESP API endpoints to use to fetch/update.
+				'entity_type' => [
+					'name'     => 'entity_type',
+					'type'     => 'string',
+					'required' => true,
+				],
+				// The ID of the list or sublist as identified in the ESP.
+				'id'          => [
+					'name'     => 'id',
+					'type'     => 'string',
+					'required' => true,
+				],
+				'value'       => [
+					'name'     => 'value',
+					'type'     => 'string',
+					'required' => false,
+				],
+				// The name of the list or sublist as identified in the ESP.
+				'name'        => [
+					'name'     => 'name',
+					'type'     => 'string',
+					'required' => true,
+				],
+				'label'       => [
+					'name'     => 'label',
+					'type'     => 'string',
+					'required' => false,
+				],
+				// If the list is also a Subscription List, it could have a locally edited name.
+				'local_name'  => [
+					'name'     => 'local_name',
+					'type'     => 'string',
+					'required' => false,
+				],
+				// If available, the number of contacts associated with this list or sublist.
+				'count'       => [
+					'name'     => 'count',
+					'type'     => 'integer',
+					'required' => false,
+				],
+				// If this Send_List is a sublist, this property must indicate the ID of the parent list.
+				'parent_id'   => [
+					'name'     => 'parent_id',
+					'type'     => 'string',
+					'required' => false,
+				],
+				// If it can be calculated, the URL to view this list or sublist in the ESP's dashboard.
+				'edit_link'   => [
+					'name'     => 'edit_link',
+					'type'     => 'string',
+					'required' => false,
+				],
+			],
+		];
+	}
+
+	/**
+	 * Get the Send_List configuration.
+	 *
+	 * @return array
+	 */
+	public function get_config() {
+		$schema = self::get_config_schema();
+		$config  = [];
+		foreach ( $schema['properties'] as $key => $property ) {
+			$config[ $key ] = $this->get( $key ) ?? null;
+		}
+
+		return array_filter( $config );
+	}
+
+	/**
+	 * Get a specific property's value.
+	 *
+	 * @param string $key The property to get.
+	 *
+	 * @return mixed The property value or null if not set/not a supported property.
+	 */
+	public function get( $key ) {
+		return $this->{ $key } ?? null;
+	}
+
+	/**
+	 * Set a property's value.
+	 *
+	 * @param string $key The property to get.
+	 * @param mixed  $value The value to set.
+	 *
+	 * @return mixed The property value or null if not set/not a supported property.
+	 */
+	public function set( $key, $value ) {
+		$schema = $this->get_config_schema();
+		if ( ! isset( $schema['properties'][ $key ] ) ) {
+			return null;
+		}
+		$this->{ $key } = $value;
+		return $this->get( $key );
+	}
+
+	/**
+	 * Set the label and value properties for autocomplete inputs.
+	 */
+	public function set_label_and_value() {
+		$entity_type = '[' . strtoupper( $this->get( 'entity_type' ) ) . ']';
+		$count       = $this->get( 'count' );
+		$name        = $this->get( 'name' );
+
+		$contact_count = null !== $count ?
+			sprintf(
+				// Translators: If available, show a contact count alongside the suggested item. %d is the number of contacts in the suggested item.
+				_n( '(%s contact)', '(%s contacts)', $count, 'newspack-newsletters' ),
+				number_format( $count )
+			) : '';
+
+		$this->set( 'value', $this->get( 'id' ) );
+		$this->set( 'label', trim( "$entity_type $name $contact_count" ) );
+	}
+}

--- a/includes/class-send-list.php
+++ b/includes/class-send-list.php
@@ -14,6 +14,9 @@ defined( 'ABSPATH' ) || exit;
 
 /**
  * Class used to represent one Send_List.
+ * 
+ * A Send List is any list that can be used as a segment of contacts that you can send a Newsletter campaign to
+ * The difference between Send_List and Subscription_List is that Send Lists are all the existing lists, audiences, tags, groups, segments, etc in the provider. We don't store them locally. Some of these can also be Subscription Lists, but not all are.
  *
  * A Send_List can be either a top-level list or a sublist.
  * A sublist can optionally specify a parent list ID (required for Mailchimp).

--- a/includes/class-send-list.php
+++ b/includes/class-send-list.php
@@ -14,7 +14,7 @@ defined( 'ABSPATH' ) || exit;
 
 /**
  * Class used to represent one Send_List.
- * 
+ *
  * A Send List is any list that can be used as a segment of contacts that you can send a Newsletter campaign to
  * The difference between Send_List and Subscription_List is that Send Lists are all the existing lists, audiences, tags, groups, segments, etc in the provider. We don't store them locally. Some of these can also be Subscription Lists, but not all are.
  *
@@ -27,7 +27,7 @@ class Send_List {
 	 *
 	 * @var array
 	 */
-	protected $config;
+	protected $config = [];
 
 	/**
 	 * Initializes a new Send_List.
@@ -163,9 +163,9 @@ class Send_List {
 	 * @return mixed|WP_Error The property value or null if not set/not a supported property.
 	 */
 	private function get( $key ) {
-		$value  = $this->{ $key } ?? null;
+		$value  = $this->config[ $key ] ?? null;
 		$schema = $this->get_config_schema();
-		if ( ! empty( $schema['properties'][ $key ]['required'] ) && null === $this->{ $key } ) {
+		if ( ! empty( $schema['properties'][ $key ]['required'] ) && empty( $this->config[ $key ] ) ) {
 			return new WP_Error( 'newspack_newsletters_send_list_missing_required_property_' . $key, __( 'Could not get required property: ', 'newspack-newsletters' ) . $key );
 		}
 
@@ -196,7 +196,7 @@ class Send_List {
 		// Cast value to the expected type.
 		settype( $value, $property['type'] );
 
-		$this->{ $key } = $value;
+		$this->config[ $key ] = $value;
 		return $this->get( $key );
 	}
 
@@ -325,12 +325,7 @@ class Send_List {
 	 * @return array
 	 */
 	public function to_array() {
-		$schema = self::get_config_schema();
-		$config  = [];
-		foreach ( $schema['properties'] as $key => $property ) {
-			$config[ $key ] = $this->get( $key ) ?? null;
-		}
-		$config = array_filter( $config ); // Remove empty values.
+		$config = $this->config;
 
 		// Ensure label + value properties are set for JS components.
 		$config['label'] = $this->get_label();

--- a/includes/class-send-list.php
+++ b/includes/class-send-list.php
@@ -293,7 +293,7 @@ class Send_List {
 	 *
 	 * @param string $value The new name.
 	 */
-	public function set_contact_count( $value ) {
+	public function set_count( $value ) {
 		return $this->set( 'count', $value );
 	}
 

--- a/includes/class-send-list.php
+++ b/includes/class-send-list.php
@@ -229,6 +229,13 @@ class Send_List {
 	}
 
 	/**
+	 * Get the parent list's ID for this Send_List.
+	 */
+	public function get_parent_id() {
+		return $this->get( 'parent_id' );
+	}
+
+	/**
 	 * Get the type for this Send_List: list or sublist.
 	 */
 	public function get_type() {
@@ -272,6 +279,22 @@ class Send_List {
 	 */
 	public function set_local_name( $value ) {
 		return $this->set( 'local_name', $value );
+	}
+
+	/**
+	 * Get the contact count for this send list.
+	 */
+	public function get_count() {
+		return $this->get( 'count' );
+	}
+
+	/**
+	 * Update the contact count for this send list.
+	 *
+	 * @param string $value The new name.
+	 */
+	public function set_contact_count( $value ) {
+		return $this->set( 'count', $value );
 	}
 
 	/**

--- a/includes/class-send-list.php
+++ b/includes/class-send-list.php
@@ -8,7 +8,7 @@
 namespace Newspack\Newsletters;
 
 use Newspack_Newsletters;
-use WP_Post;
+use WP_Error;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -16,7 +16,7 @@ defined( 'ABSPATH' ) || exit;
  * Class used to represent one Send_List.
  *
  * A Send_List can be either a top-level list or a sublist.
- * A sublist must specify a parent list ID.
+ * A sublist can optionally specify a parent list ID (required for Mailchimp).
  */
 class Send_List {
 	/**
@@ -27,19 +27,39 @@ class Send_List {
 	protected $config;
 
 	/**
+	 * If there were errors building the Send_List object due to invalid config, this will contain the error messages.
+	 *
+	 * @var WP_Error
+	 */
+	protected $errors;
+
+	/**
 	 * Initializes a new Send_List.
 	 *
-	 * @param array $config The configuration for the Send_List.
-	 * @throws \InvalidArgumentException In case the Send_List object can't be built from the given config data.
+	 * @param array $config {
+	 *   The configuration for the Send_list.
+	 *
+	 *   @type string $provider    The slug of the ESP for which this list or sublist originates (required).
+	 *   @type string $type        The type of list. Can be either 'list' or 'sublist'. If the latter, must specify a `parent` property (required).
+	 *   @type string $entity_type The type of entity this list or sublist is associated with in the ESP. Controls which ESP API endpoints to use to fetch/update (required).
+	 *   @type string $id          The ID of the list or sublist in the ESP (required).
+	 *   @type string $value       The value to use for autocomplete inputs. If not passed, will match `id`.
+	 *   @type string $parent_id   If this is a sublist of another list, the ID of the parent list.
+	 *   @type string $name        The name of the list or sublist as identified in the ESP (required).
+	 *   @type string $local_name  If the list is also a Subscription List, it could have a locally edited name.
+	 *   @type string $label       The label to use for autocomplete inputs. If not set, will be generated from other properties.
+	 *   @type int    $count       If available, the number of contacts associated with this list or sublist.
+	 *   @type string $edit_link   If available, the URL to edit this list or sublist in the ESP.
+	 * }
 	 */
 	public function __construct( $config ) {
-		$schema = self::get_config_schema();
-		$errors = [];
+		$this->errors = new WP_Error();
+		$schema       = self::get_config_schema();
 
 		foreach ( $schema['properties'] as $key => $property ) {
 			// If the property is required but not set, throw an error.
 			if ( ! empty( $property['required'] ) && ! isset( $config[ $key ] ) ) {
-				$errors[] = __( 'Missing required config: ', 'newspack-newsletters' ) . $key;
+				$this->errors->add( 'newspack_newsletters_send_list_invalid_config', __( 'Missing required config property: ', 'newspack-newsletters' ) . $key );
 				continue;
 			}
 
@@ -48,42 +68,28 @@ class Send_List {
 				continue;
 			}
 
-			// If the passed value isn't in the enum, throw an error.
-			if ( isset( $property['enum'] ) && isset( $config[ $key ] ) && ! in_array( $config[ $key ], $property['enum'], true ) ) {
-				$errors[] = __( 'Invalid value for config: ', 'newspack-newsletters' ) . $key;
-				continue;
-			}
-
-			// Cast value to the expected type.
-			settype( $config[ $key ], $property['type'] );
-
 			// Set the property.
 			$this->set( $key, $config[ $key ] );
 		}
-
-		if ( ! empty( $errors ) ) {
-			throw new \InvalidArgumentException( esc_html( __( 'Error creating send list: ', 'newspack-newsletters' ) . implode( ' | ', $errors ) ) );
-		}
-
-		$this->set_label_and_value();
 	}
 
 	/**
 	 * Get the config data schema for a single Send_List.
+	 * See __construct() method docblock for details.
+	 *
+	 * @return array
 	 */
 	public static function get_config_schema() {
 		return [
 			'type'                 => 'object',
 			'additionalProperties' => false,
 			'properties'           => [
-				// The slug of the ESP for which this list or sublist originates.
 				'provider'    => [
 					'name'     => 'provider',
 					'type'     => 'string',
 					'required' => true,
 					'enum'     => Newspack_Newsletters::get_supported_providers(),
 				],
-				// The type of list. Can be either 'list' or 'sublist'. If the latter, must specify a `parent` property.
 				'type'        => [
 					'name'     => 'type',
 					'type'     => 'string',
@@ -93,13 +99,11 @@ class Send_List {
 						'sublist',
 					],
 				],
-				// The type of entity this list or sublist is associated with in the ESP. Controls which ESP API endpoints to use to fetch/update.
 				'entity_type' => [
 					'name'     => 'entity_type',
 					'type'     => 'string',
 					'required' => true,
 				],
-				// The ID of the list or sublist as identified in the ESP.
 				'id'          => [
 					'name'     => 'id',
 					'type'     => 'string',
@@ -110,7 +114,6 @@ class Send_List {
 					'type'     => 'string',
 					'required' => false,
 				],
-				// The name of the list or sublist as identified in the ESP.
 				'name'        => [
 					'name'     => 'name',
 					'type'     => 'string',
@@ -121,25 +124,21 @@ class Send_List {
 					'type'     => 'string',
 					'required' => false,
 				],
-				// If the list is also a Subscription List, it could have a locally edited name.
 				'local_name'  => [
 					'name'     => 'local_name',
 					'type'     => 'string',
 					'required' => false,
 				],
-				// If available, the number of contacts associated with this list or sublist.
 				'count'       => [
 					'name'     => 'count',
 					'type'     => 'integer',
 					'required' => false,
 				],
-				// If this Send_List is a sublist, this property must indicate the ID of the parent list.
 				'parent_id'   => [
 					'name'     => 'parent_id',
 					'type'     => 'string',
 					'required' => false,
 				],
-				// If it can be calculated, the URL to view this list or sublist in the ESP's dashboard.
 				'edit_link'   => [
 					'name'     => 'edit_link',
 					'type'     => 'string',
@@ -150,52 +149,143 @@ class Send_List {
 	}
 
 	/**
-	 * Get the Send_List configuration.
-	 *
-	 * @return array
-	 */
-	public function get_config() {
-		$schema = self::get_config_schema();
-		$config  = [];
-		foreach ( $schema['properties'] as $key => $property ) {
-			$config[ $key ] = $this->get( $key ) ?? null;
-		}
-
-		return array_filter( $config );
-	}
-
-	/**
-	 * Get a specific property's value.
+	 * Helper method to get a specific property's value.
+	 * Not for public use. Use specific property getters instead.
 	 *
 	 * @param string $key The property to get.
 	 *
-	 * @return mixed The property value or null if not set/not a supported property.
+	 * @return mixed|WP_Error The property value or null if not set/not a supported property.
 	 */
-	public function get( $key ) {
-		return $this->{ $key } ?? null;
+	private function get( $key ) {
+		// Clear previous errors for this key.
+		$this->errors->remove( 'newspack_newsletters_send_list_missing_required_property_' . $key );
+		$value  = $this->{ $key } ?? null;
+		$schema = $this->get_config_schema();
+		if ( ! empty( $schema['properties'][ $key ]['required'] ) && null === $this->{ $key } ) {
+			$error_message = new WP_Error( 'newspack_newsletters_send_list_missing_required_property_' . $key, __( 'Could not get required property: ', 'newspack-newsletters' ) . $key );
+			$error_message->export_to( $this->get_errors() );
+			return $error_message;
+		}
+
+		return $value;
 	}
 
 	/**
-	 * Set a property's value.
+	 * Helper method to set a property's value.
+	 * Not for public use. Use specific property setters instead.
 	 *
 	 * @param string $key The property to get.
 	 * @param mixed  $value The value to set.
 	 *
-	 * @return mixed The property value or null if not set/not a supported property.
+	 * @return mixed|WP_Error The property value or WP_Error if not set/not a supported property.
 	 */
-	public function set( $key, $value ) {
+	private function set( $key, $value ) {
+		// Clear previous errors for this key.
+		$this->errors->remove( 'newspack_newsletters_send_list_invalid_property_' . $key );
 		$schema = $this->get_config_schema();
 		if ( ! isset( $schema['properties'][ $key ] ) ) {
-			return null;
+			$error_message = new WP_Error( 'newspack_newsletters_send_list_invalid_property_' . $key, __( 'Could not set invalid property: ', 'newspack-newsletters' ) . $key );
+			$error_message->export_to( $this->get_errors() );
+			return $error_message;
 		}
+
+		// If the passed value isn't in the enum, throw an error.
+		$this->errors->remove( 'newspack_newsletters_send_list_invalid_property_value_' . $key );
+		$property = $schema['properties'][ $key ];
+		if ( isset( $property['enum'] ) && ! in_array( $value, $property['enum'], true ) ) {
+			$error_message = new WP_Error( 'newspack_newsletters_send_list_invalid_property_value_' . $key, __( 'Invalid value for property: ', 'newspack-newsletters' ) . $key );
+			$error_message->export_to( $this->get_errors() );
+			return $error_message;
+		}
+
+		// Cast value to the expected type.
+		settype( $value, $property['type'] );
+
 		$this->{ $key } = $value;
 		return $this->get( $key );
 	}
 
 	/**
-	 * Set the label and value properties for autocomplete inputs.
+	 * Get any errors associated with this Send_List.
+	 *
+	 * @return WP_Error
 	 */
-	public function set_label_and_value() {
+	public function get_errors() {
+		return $this->errors;
+	}
+
+	/**
+	 * Get the provider for this Send_List.
+	 */
+	public function get_provider() {
+		return $this->get( 'provider' );
+	}
+
+	/**
+	 * Get the ID for this Send_List.
+	 */
+	public function get_id() {
+		return $this->get( 'id' );
+	}
+
+	/**
+	 * Get the type for this Send_List: list or sublist.
+	 */
+	public function get_type() {
+		return $this->get( 'type' );
+	}
+
+	/**
+	 * Get the entity type for this Send_List.
+	 */
+	public function get_entity_type() {
+		return $this->get( 'entity_type' );
+	}
+
+	/**
+	 * Get the name for this Send_List.
+	 */
+	public function get_name() {
+		return $this->get( 'name' );
+	}
+
+	/**
+	 * Update the name for this Send_List.
+	 *
+	 * @param string $value The new name.
+	 */
+	public function set_name( $value ) {
+		return $this->set( 'name', $value );
+	}
+
+	/**
+	 * Get the local name for this Send_List, if the entity is also a Subscription_List.
+	 */
+	public function get_local_name() {
+		return $this->get( 'local_name' );
+	}
+
+	/**
+	 * Update the local name for this Send_List, if the entity is also a Subscription_List.
+	 *
+	 * @param string $value The new name.
+	 */
+	public function set_local_name( $value ) {
+		return $this->set( 'local_name', $value );
+	}
+
+	/**
+	 * Get a manually set or dynamic label for autocomplete inputs.
+	 * If not manually set, generate from entity_type, name, and count and store.
+	 *
+	 * @return string
+	 */
+	public function get_label() {
+		$stored_label = $this->get( 'label' );
+		if ( ! empty( $stored_label ) ) {
+			return $stored_label;
+		}
+
 		$entity_type = '[' . strtoupper( $this->get( 'entity_type' ) ) . ']';
 		$count       = $this->get( 'count' );
 		$name        = $this->get( 'name' );
@@ -207,7 +297,39 @@ class Send_List {
 				number_format( $count )
 			) : '';
 
-		$this->set( 'value', $this->get( 'id' ) );
-		$this->set( 'label', trim( "$entity_type $name $contact_count" ) );
+		return trim( "$entity_type $name $contact_count" );
+	}
+
+	/**
+	 * Get the value for autocomplete inputs. Defaults to the id.
+	 *
+	 * @return string
+	 */
+	public function get_value() {
+		return $this->get( 'value' ) ?? $this->get( 'id' );
+	}
+
+	/**
+	 * Convert the Send_List to an array for use with the REST API.
+	 *
+	 * @return array
+	 */
+	public function to_array() {
+		$schema = self::get_config_schema();
+		$config  = [];
+		foreach ( $schema['properties'] as $key => $property ) {
+			$config[ $key ] = $this->get( $key ) ?? null;
+		}
+		$config = array_filter( $config ); // Remove empty values.
+
+		// Ensure label + value properties are set for JS components.
+		if ( ! isset( $config['label'] ) ) {
+			$config['label'] = $this->get_label();
+		}
+		if ( ! isset( $config['value'] ) ) {
+			$config['value'] = $this->get_value();
+		}
+
+		return $config;
 	}
 }

--- a/includes/class-send-list.php
+++ b/includes/class-send-list.php
@@ -15,8 +15,11 @@ defined( 'ABSPATH' ) || exit;
 /**
  * Class used to represent one Send_List.
  *
- * A Send List is any list that can be used as a segment of contacts that you can send a Newsletter campaign to
- * The difference between Send_List and Subscription_List is that Send Lists are all the existing lists, audiences, tags, groups, segments, etc in the provider. We don't store them locally. Some of these can also be Subscription Lists, but not all are.
+ * A Send List is any entity that can be used as a collection of contacts
+ * that you can send a Newsletter campaign to via a connected ESP.
+ * The difference between Send_List and Subscription_List objects is that Send Lists
+ * are all the existing lists, audiences, tags, groups, segments, etc in the provider.
+ * We don't store Send Lists locally. Some Send Lists are also Subscription Lists, but not all are.
  *
  * A Send_List can be either a top-level list or a sublist.
  * A sublist can optionally specify a parent list ID (required for Mailchimp).

--- a/includes/class-send-lists.php
+++ b/includes/class-send-lists.php
@@ -1,0 +1,175 @@
+<?php
+/**
+ * Newspack Newsletters Send Lists.
+ *
+ * @package Newspack
+ */
+
+namespace Newspack\Newsletters;
+
+use Newspack_Newsletters;
+use Newspack_Newsletters_Settings;
+use Newspack_Newsletters_Subscription;
+use WP_Error;
+use WP_Post;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Main Newspack Newsletters Send_Lists class.
+ *
+ * A Send_List is a collection of contacts which can be sent newsletter content.
+ * A Send_List can be a top-level list or a sublist of a list.
+ * Each Send_List corresponds to an entity in a supported ESP, but
+ * shares the same data schema for interactions within this plugin.
+ */
+class Send_Lists {
+	/**
+	 * Initialize this class and register hooks.
+	 *
+	 * @return void
+	 */
+	public static function init() {
+		if ( ! self::should_initialize_send_lists() ) {
+			return;
+		}
+
+		add_action( 'rest_api_init', [ __CLASS__, 'register_api_endpoints' ] );
+	}
+
+	/**
+	 * Check if we should initialize Send lists.
+	 *
+	 * @return boolean
+	 */
+	public static function should_initialize_send_lists() {
+		// If Service Provider is not configured yet.
+		if ( 'manual' === Newspack_Newsletters::service_provider() || ! Newspack_Newsletters::is_service_provider_configured() ) {
+			return false;
+		}
+
+		return true;
+	}
+
+	/**
+	 * Register the endpoints needed to fetch send lists.
+	 */
+	public static function register_api_endpoints() {
+		register_rest_route(
+			Newspack_Newsletters::API_NAMESPACE,
+			'/send-lists',
+			[
+				'methods'             => \WP_REST_Server::READABLE,
+				'callback'            => [ __CLASS__, 'api_get_send_lists' ],
+				'permission_callback' => [ 'Newspack_Newsletters', 'api_permission_callback' ],
+				'args'                => [
+					'ids'       => [
+						'type' => [ 'array', 'string' ],
+					],
+					'search'    => [
+						'type' => [ 'array', 'string' ],
+					],
+					'type'      => [
+						'type' => 'string',
+					],
+					'parent_id' => [
+						'type' => 'string',
+					],
+					'provider'  => [
+						'type' => 'string',
+					],
+					'limit'     => [
+						'type' => [ 'integer', 'string' ],
+					],
+				],
+			]
+		);
+	}
+
+	/**
+	 * Get default arguments for the send lists API. Supported keys;
+	 *
+	 * - ids: ID or array of send IDs to fetch. If passed, will take precedence over `search`.
+	 * - search: Search term or array of search terms to filter send lists. If `ids` is passed, will be ignored.
+	 * - type: Type of send list to filter. Supported terms are 'list' or 'sublist', otherwise all types will be fetched.
+	 * - parent_id: Parent ID to filter by when fetching sublists. If `type` is 'list`, will be ignored.
+	 * - limit: Limit the number of send lists to return.
+	 *
+	 * @return array
+	 */
+	public static function get_default_args() {
+		return [
+			'ids'       => null,
+			'search'    => null,
+			'type'      => null,
+			'parent_id' => null,
+			'limit'     => null,
+		];
+	}
+
+	/**
+	 * Check if an ID or array of IDs to search matches the given ID.
+	 *
+	 * @param array|string $ids ID or array of IDs to search.
+	 * @param string       $id ID to match against.
+	 *
+	 * @return boolean
+	 */
+	public static function matches_id( $ids, $id ) {
+		if ( is_array( $ids ) ) {
+			return in_array( $id, $ids, false ); // phpcs:ignore WordPress.PHP.StrictInArray.FoundNonStrictFalse
+		}
+		return $id === $ids;
+	}
+
+	/**
+	 * Check if the given search term matches any of the given strings.
+	 *
+	 * @param array|string $search Search term or array of terms.
+	 * @param array        $matches An array of strings to match against.
+	 *
+	 * @return boolean
+	 */
+	public static function matches_search( $search, $matches = [] ) {
+		if ( empty( $search ) ) {
+			return true;
+		}
+		if ( ! is_array( $search ) ) {
+			$search = [ $search ];
+		}
+		foreach ( $search as $to_match ) {
+			$to_match = strtolower( strval( $to_match ) );
+			foreach ( $matches as $match ) {
+				if ( stripos( strtolower( strval( $match ) ), $to_match ) !== false ) {
+					return true;
+				}
+			}
+		}
+		return false;
+	}
+
+	/**
+	 * API handler to fetch send lists for the given provider.
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 *
+	 * @return WP_REST_Response|WP_Error WP_REST_Response on success, or WP_Error object on failure.
+	 */
+	public static function api_get_send_lists( $request ) {
+		$provider_slug = $request['provider'] ?? null;
+		$provider      = $provider_slug ? Newspack_Newsletters::get_service_provider_instance( $provider_slug ) : Newspack_Newsletters::get_service_provider();
+		if ( empty( $provider ) ) {
+			return new WP_Error( 'newspack_newsletters_invalid_provider', __( 'Invalid provider, or provider not set.', 'newspack-newsletters' ) );
+		}
+
+		$defaults      = self::get_default_args();
+		$args          = [];
+		foreach ( $defaults as $key => $value ) {
+			$args[ $key ] = $request[ $key ] ?? $value;
+		}
+
+		return \rest_ensure_response(
+			$provider->get_send_lists( $args )
+		);
+	}
+}

--- a/includes/class-send-lists.php
+++ b/includes/class-send-lists.php
@@ -119,25 +119,29 @@ class Send_Lists {
 		if ( is_array( $ids ) ) {
 			return in_array( $id, $ids, false ); // phpcs:ignore WordPress.PHP.StrictInArray.FoundNonStrictFalse
 		}
-		return $id === $ids;
+		return (string) $id === (string) $ids;
 	}
 
 	/**
 	 * Check if the given search term matches any of the given strings.
 	 *
-	 * @param array|string $search Search term or array of terms.
-	 * @param array        $matches An array of strings to match against.
+	 * @param null|array|string $search Search term or array of terms. If null, return true.
+	 * @param array             $matches An array of strings to match against.
 	 *
 	 * @return boolean
 	 */
 	public static function matches_search( $search, $matches = [] ) {
-		if ( empty( $search ) ) {
+		if ( null === $search ) {
 			return true;
 		}
 		if ( ! is_array( $search ) ) {
 			$search = [ $search ];
 		}
 		foreach ( $search as $to_match ) {
+			// Don't try to match values that will convert to empty strings, or that we can't convert to a string.
+			if ( ! $to_match || is_array( $to_match ) ) {
+				continue;
+			}
 			$to_match = strtolower( strval( $to_match ) );
 			foreach ( $matches as $match ) {
 				if ( stripos( strtolower( strval( $match ) ), $to_match ) !== false ) {

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -36,6 +36,9 @@ require $_tests_dir . '/includes/bootstrap.php';
 // Trait used to test Subscription Lists.
 require_once 'trait-lists-setup.php';
 
+// Trait used to test Send Lists.
+require_once 'trait-send-lists-setup.php';
+
 // MailChimp mock.
 require_once 'mocks/class-mailchimp-mock.php';
 

--- a/tests/test-send-list.php
+++ b/tests/test-send-list.php
@@ -22,21 +22,14 @@ class Send_List_Test extends WP_UnitTestCase {
 		$sublist = new Send_List( self::$configs['valid_sublist'] );
 		$this->assertInstanceOf( Send_List::class, $list );
 		$this->assertInstanceOf( Send_List::class, $sublist );
-		$this->assertFalse( $list->get_errors()->has_errors() );
-		$this->assertFalse( $sublist->get_errors()->has_errors() );
 	}
 
 	/**
 	 * Test constructor with invalid input.
 	 */
 	public function test_constructor_with_invalid() {
-		$list   = new Send_List( self::$configs['invalid'] );
-		$errors = $list->get_errors();
-		$this->assertTrue( $errors->has_errors() );
-		$error_codes = $errors->get_error_codes();
-		$this->assertContains( 'newspack_newsletters_send_list_invalid_property_value_provider', $error_codes );
-		$this->assertContains( 'newspack_newsletters_send_list_invalid_property_value_type', $error_codes );
-		$this->assertContains( 'newspack_newsletters_send_list_invalid_config', $error_codes );
+		$this->expectException( \InvalidArgumentException::class );
+		$list = new Send_List( self::$configs['invalid'] );
 	}
 
 	/**
@@ -55,7 +48,6 @@ class Send_List_Test extends WP_UnitTestCase {
 		foreach ( $list_config as $key => $value ) {
 			$this->assertArrayHasKey( $key, $schema['properties'] );
 		}
-		$this->assertFalse( $list->get_errors()->has_errors() );
 	}
 
 	/**

--- a/tests/test-send-list.php
+++ b/tests/test-send-list.php
@@ -1,0 +1,76 @@
+<?php
+/**
+ * Class Newsletters Test Send_List
+ *
+ * @package Newspack_Newsletters
+ */
+
+use Newspack\Newsletters\Send_List;
+
+/**
+ * Tests the Send_List class
+ */
+class Send_List_Test extends WP_UnitTestCase {
+
+	use Send_Lists_Setup;
+
+	/**
+	 * Test constructor.
+	 */
+	public function test_constructor() {
+		$list    = new Send_List( self::$configs['valid_list'] );
+		$sublist = new Send_List( self::$configs['valid_sublist'] );
+		$this->assertInstanceOf( Send_List::class, $list );
+		$this->assertInstanceOf( Send_List::class, $sublist );
+	}
+
+	/**
+	 * Test constructor with invalid input.
+	 */
+	public function test_constructor_with_invalid() {
+		$this->expectException( \InvalidArgumentException::class );
+		$list = new Send_List( self::$configs['invalid'] );
+	}
+
+
+	/**
+	 * Test get_config_schema.
+	 */
+	public function test_get_config_schema() {
+		$config = self::$configs['valid_list'];
+		$config['unsupported_prop'] = 'unsupported';
+
+		$list       = new Send_List( $config );
+		$list_config = $list->get_config();
+		$schema     = $list->get_config_schema();
+
+		// Unsupported props are ignored.
+		$this->assertArrayNotHasKey( 'unsupported_prop', $list_config );
+		foreach ( $list_config as $key => $value ) {
+			$this->assertArrayHasKey( $key, $schema['properties'] );
+		}
+	}
+
+	/**
+	 * Test get method.
+	 */
+	public function test_get() {
+		$config   = self::$configs['valid_sublist'];
+		$sublist = new Send_List( $config );
+		$this->assertSame( $config['provider'], $sublist->get( 'provider' ) );
+	}
+
+	/**
+	 * Test type casting.
+	 */
+	public function test_type() {
+		$config          = self::$configs['valid_list'];
+		$config['id']    = 123; // Integer.
+		$config['count'] = '100'; // String.
+		$list           = new Send_List( $config );
+		$schema         = $list->get_config_schema();
+		foreach ( $config as $key => $value ) {
+			$this->assertSame( gettype( $list->get( $key ) ), $schema['properties'][ $key ]['type'] );
+		}
+	}
+}

--- a/tests/test-send-list.php
+++ b/tests/test-send-list.php
@@ -22,42 +22,53 @@ class Send_List_Test extends WP_UnitTestCase {
 		$sublist = new Send_List( self::$configs['valid_sublist'] );
 		$this->assertInstanceOf( Send_List::class, $list );
 		$this->assertInstanceOf( Send_List::class, $sublist );
+		$this->assertFalse( $list->get_errors()->has_errors() );
+		$this->assertFalse( $sublist->get_errors()->has_errors() );
 	}
 
 	/**
 	 * Test constructor with invalid input.
 	 */
 	public function test_constructor_with_invalid() {
-		$this->expectException( \InvalidArgumentException::class );
-		$list = new Send_List( self::$configs['invalid'] );
+		$list   = new Send_List( self::$configs['invalid'] );
+		$errors = $list->get_errors();
+		$this->assertTrue( $errors->has_errors() );
+		$error_codes = $errors->get_error_codes();
+		$this->assertContains( 'newspack_newsletters_send_list_invalid_property_value_provider', $error_codes );
+		$this->assertContains( 'newspack_newsletters_send_list_invalid_property_value_type', $error_codes );
+		$this->assertContains( 'newspack_newsletters_send_list_invalid_config', $error_codes );
 	}
 
-
 	/**
-	 * Test get_config_schema.
+	 * Test config with unsupported properties.
 	 */
 	public function test_get_config_schema() {
 		$config = self::$configs['valid_list'];
 		$config['unsupported_prop'] = 'unsupported';
 
-		$list       = new Send_List( $config );
-		$list_config = $list->get_config();
-		$schema     = $list->get_config_schema();
+		$list        = new Send_List( $config );
+		$list_config = $list->to_array();
+		$schema      = $list->get_config_schema();
 
 		// Unsupported props are ignored.
 		$this->assertArrayNotHasKey( 'unsupported_prop', $list_config );
 		foreach ( $list_config as $key => $value ) {
 			$this->assertArrayHasKey( $key, $schema['properties'] );
 		}
+		$this->assertFalse( $list->get_errors()->has_errors() );
 	}
 
 	/**
-	 * Test get method.
+	 * Test get methods.
 	 */
 	public function test_get() {
 		$config   = self::$configs['valid_sublist'];
 		$sublist = new Send_List( $config );
-		$this->assertSame( $config['provider'], $sublist->get( 'provider' ) );
+		$this->assertSame( $config['provider'], $sublist->get_provider() );
+		$this->assertSame( $config['id'], $sublist->get_id() );
+		$this->assertSame( $config['type'], $sublist->get_type() );
+		$this->assertSame( $config['entity_type'], $sublist->get_entity_type() );
+		$this->assertSame( $config['name'], $sublist->get_name() );
 	}
 
 	/**
@@ -69,8 +80,28 @@ class Send_List_Test extends WP_UnitTestCase {
 		$config['count'] = '100'; // String.
 		$list           = new Send_List( $config );
 		$schema         = $list->get_config_schema();
-		foreach ( $config as $key => $value ) {
-			$this->assertSame( gettype( $list->get( $key ) ), $schema['properties'][ $key ]['type'] );
+		$list_config    = $list->to_array();
+		foreach ( $list_config as $key => $value ) {
+			$this->assertSame( gettype( $value ), $schema['properties'][ $key ]['type'] );
 		}
+	}
+
+	/**
+	 * Test dynamic and manually-set label + value properties.
+	 */
+	public function test_dynamic_properties() {
+		$list        = new Send_List( self::$configs['valid_list'] );
+		$list_config = $list->to_array();
+		$this->assertSame( '[AUDIENCE] Valid List (100 contacts)', $list_config['label'] );
+		$this->assertSame( $list_config['id'], $list_config['value'] );
+
+		$config          = self::$configs['valid_sublist'];
+		$config['label'] = 'Custom Label';
+		$config['value'] = 'Custom Value';
+
+		$sublist        = new Send_List( $config );
+		$sublist_config = $sublist->to_array();
+		$this->assertSame( 'Custom Label', $sublist_config['label'] );
+		$this->assertSame( 'Custom Value', $sublist_config['value'] );
 	}
 }

--- a/tests/test-send-lists.php
+++ b/tests/test-send-lists.php
@@ -21,6 +21,8 @@ class Send_Lists_Test extends WP_UnitTestCase {
 	public function test_match_by_id() {
 		$this->assertTrue( Send_Lists::matches_id( '123', '123' ) ); // Single ID matches.
 		$this->assertTrue( Send_Lists::matches_id( [ '123', '456' ], '123' ) ); // Array of IDs matches.
+		$this->assertTrue( Send_Lists::matches_id( 123, '123' ) ); // Type-insensitive single ID matches.
+		$this->assertTrue( Send_Lists::matches_id( [ 123, 456 ], '123' ) ); // Type-insensitive array of ID matches.
 		$this->assertFalse( Send_Lists::matches_id( '456', '123' ) ); // Single of ID doesn't match.
 		$this->assertFalse( Send_Lists::matches_id( [ '456', '789' ], '123' ) ); // Array of IDs doesn't match.
 	}
@@ -29,9 +31,13 @@ class Send_Lists_Test extends WP_UnitTestCase {
 	 * Test matching by search term(s).
 	 */
 	public function test_match_by_search() {
+		$this->assertTrue( Send_Lists::matches_search( null, [ 'search term', 'another term' ] ) ); // Null term (default value meaning no filtering) matches.
 		$this->assertTrue( Send_Lists::matches_search( 'search', [ 'search term', 'another term' ] ) ); // Single term matches.
 		$this->assertTrue( Send_Lists::matches_search( [ 'search', 'no match' ], [ 'search term', 'another term' ] ) ); // Single term matches.
+		$this->assertTrue( Send_Lists::matches_search( 123, [ '123 term', 'another term' ] ) ); // Terms are cast as strings when comparing.
 		$this->assertFalse( Send_Lists::matches_search( 'no match', [ 'search term', 'another term' ] ) ); // Single of ID doesn't match.
 		$this->assertFalse( Send_Lists::matches_search( [ 'no match', 'another no match' ], [ 'search term', 'another term' ] ) ); // Array of IDs doesn't match.
+		$this->assertFalse( Send_Lists::matches_search( [ false, 0, '' ], [ 'search term', 'another term' ] ) ); // Non-null falsy values don't match.
+		$this->assertFalse( Send_Lists::matches_search( [ [ 'invalid_type' ] ], [ 'search term', 'another term' ] ) ); // Array values don't match.
 	}
 }

--- a/tests/test-send-lists.php
+++ b/tests/test-send-lists.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * Class Newsletters Test Send_Lists
+ *
+ * @package Newspack_Newsletters
+ */
+
+use Newspack\Newsletters\Send_List;
+use Newspack\Newsletters\Send_Lists;
+
+/**
+ * Tests the Send_List class
+ */
+class Send_Lists_Test extends WP_UnitTestCase {
+
+	use Send_Lists_Setup;
+
+	/**
+	 * Test matching by item ID.
+	 */
+	public function test_match_by_id() {
+		$this->assertTrue( Send_Lists::matches_id( '123', '123' ) ); // Single ID matches.
+		$this->assertTrue( Send_Lists::matches_id( [ '123', '456' ], '123' ) ); // Array of IDs matches.
+		$this->assertFalse( Send_Lists::matches_id( '456', '123' ) ); // Single of ID doesn't match.
+		$this->assertFalse( Send_Lists::matches_id( [ '456', '789' ], '123' ) ); // Array of IDs doesn't match.
+	}
+
+	/**
+	 * Test matching by search term(s).
+	 */
+	public function test_match_by_search() {
+		$this->assertTrue( Send_Lists::matches_search( 'search', [ 'search term', 'another term' ] ) ); // Single term matches.
+		$this->assertTrue( Send_Lists::matches_search( [ 'search', 'no match' ], [ 'search term', 'another term' ] ) ); // Single term matches.
+		$this->assertFalse( Send_Lists::matches_search( 'no match', [ 'search term', 'another term' ] ) ); // Single of ID doesn't match.
+		$this->assertFalse( Send_Lists::matches_search( [ 'no match', 'another no match' ], [ 'search term', 'another term' ] ) ); // Array of IDs doesn't match.
+	}
+}

--- a/tests/trait-send-lists-setup.php
+++ b/tests/trait-send-lists-setup.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * Class Newsletters Test Send_List
+ *
+ * @package Newspack_Newsletters
+ */
+
+use Newspack\Newsletters\Send_List;
+use Newspack\Newsletters\Send_Lists;
+
+/**
+ * Traits for the Send_List and Send_Lists test classes
+ */
+trait Send_Lists_Setup {
+	/**
+	 * Array of send list config objects for testing.
+	 *
+	 * @var array
+	 */
+	public static $configs = [
+		// Missing required properties, plus invalid values.
+		'invalid'         => [
+			'provider' => 'invalid_provider',
+			'type'     => 'invalid_type',
+		],
+		'valid_list'      => [
+			'provider'    => 'mailchimp',
+			'type'        => 'list',
+			'id'          => '123',
+			'name'        => 'Valid List',
+			'entity_type' => 'Audience',
+			'count'       => 100,
+		],
+		// Missing parent ID.
+		'invalid_sublist' => [
+			'provider'    => 'mailchimp',
+			'type'        => 'sublist',
+			'id'          => '456',
+			'name'        => 'Valid Sublist',
+			'entity_type' => 'Group',
+			'count'       => 50,
+		],
+		'valid_sublist'   => [
+			'provider'    => 'mailchimp',
+			'type'        => 'sublist',
+			'id'          => '456',
+			'parent'      => '123',
+			'name'        => 'Valid Sublist',
+			'entity_type' => 'Group',
+			'count'       => 50,
+		],
+	];
+}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Implements a new `Send_List` class for abstacting ESP-specific list and sublist data into a single schema. Also implements a `Send_Lists` class for shared util methods and REST API routes (the latter currently won't work because this PR doesn't include the `get_send_lists()` methods on each provider class).

To support the new REST API routes, moves the `newsletters/v1` namespace and the API permissions callback to the main `Newspack_Newsletters` class, so these can be shared outside of the `Newspack_Newsletters_Subscription` class.

### How to test the changes in this Pull Request:

1. Confirm that all tests pass (and review the tests for expected `Send_List` behavior)
2. In `wp_shell`, try the new constructor:

```bash
> $send_list = new Newspack\Newsletters\Send_List( [ 'id' => '123', 'name' => 'My Send List', 'type' => 'list', 'entity_type' => 'something', 'count' => 100, 'provider' => 'mailchimp' ] )
= Newspack\Newsletters\Send_List {#14997
    +"provider": "mailchimp",
    +"type": "list",
    +"entity_type": "something",
    +"id": "123",
    +"name": "My Send List",
    +"count": 100,
    +"value": "123",
    +"label": "[SOMETHING] My Send List (100 contacts)",
  }
```

3. Try out the new methods:

```bash
> $send_list->get_id()
= "123"

> $send_list->get_label()
= "[SOMETHING] My Send List (100 contacts)"

> $send_list->set_name( 'My Send List (renamed)' )
= "My Send List (renamed)"

> $send_list->get_name()
= "My Send List (renamed)"

> Newspack\Newsletters\Send_Lists::matches_search( 'renamed', [ $send_list->get( 'name' ) ] )
= true

> Newspack\Newsletters\Send_Lists::matches_id( [ 123 ], $send_list->get( 'id' ) )
= true

> $send_list->to_array()
= [
    "provider" => "mailchimp",
    "type" => "list",
    "entity_type" => "something",
    "id" => "123",
    "name" => "My Send List",
    "count" => 100,
    "label" => "[SOMETHING] My Send List (100 contacts)",
    "value" => "123",
  ]
```

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1207992056607959