### PR TITLE
fix: ensure Newsletters plugin blocks are grouped under Newspack category

### DIFF
--- a/includes/class-newspack-newsletters-editor.php
+++ b/includes/class-newspack-newsletters-editor.php
@@ -49,6 +49,7 @@ final class Newspack_Newsletters_Editor {
 		add_action( 'the_post', [ __CLASS__, 'strip_editor_modifications' ] );
 		add_action( 'after_setup_theme', [ __CLASS__, 'newspack_font_sizes' ], 11 );
 		add_action( 'enqueue_block_editor_assets', [ __CLASS__, 'enqueue_block_editor_assets' ] );
+		add_filter( 'block_categories_all', [ __CLASS__, 'add_custom_block_category' ] );
 		add_filter( 'allowed_block_types_all', [ __CLASS__, 'newsletters_allowed_block_types' ], 10, 2 );
 		add_action( 'rest_post_query', [ __CLASS__, 'maybe_filter_excerpt_length' ], 10, 2 );
 		add_action( 'rest_post_query', [ __CLASS__, 'maybe_exclude_sponsored_posts' ], 10, 2 );
@@ -247,6 +248,24 @@ final class Newspack_Newsletters_Editor {
 				],
 			]
 		);
+	}
+
+	/**
+	 * Add the "Newspack" block category.
+	 *
+	 * @param array $block_categories Default block categories.
+	 * @return array
+	 */
+	public static function add_custom_block_category( $block_categories ) {
+		array_unshift(
+			$block_categories,
+			[
+				'slug'  => 'newspack',
+				'title' => 'Newspack',
+			]
+		);
+
+		return $block_categories;
 	}
 
 	/**

--- a/includes/class-newspack-newsletters-settings.php
+++ b/includes/class-newspack-newsletters-settings.php
@@ -576,7 +576,7 @@ class Newspack_Newsletters_Settings {
 	/**
 	 * Update settings.
 	 *
-	 * @param string $settings Update.
+	 * @param array $settings Update.
 	 */
 	public static function update_settings( $settings ) {
 		foreach ( $settings as $key => $value ) {

--- a/src/editor/blocks/posts-inserter/block.json
+++ b/src/editor/blocks/posts-inserter/block.json
@@ -1,6 +1,6 @@
 {
 	"name": "newspack-newsletters/posts-inserter",
-	"category": "widgets",
+	"category": "newspack",
 	"supports": [
 		"align"
 	],

--- a/src/editor/blocks/share/index.js
+++ b/src/editor/blocks/share/index.js
@@ -15,7 +15,7 @@ import { SHARE_BLOCK_NAME } from './consts';
 export default () => {
 	registerBlockType( SHARE_BLOCK_NAME, {
 		title: __( 'Share Newsletter', 'newspack-newsletters' ),
-		category: 'text',
+		category: 'newspack',
 		icon: <Icon icon={ customLink } />,
 		attributes: {
 			content: {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

A minor fix for editor blocks registered by this plugin: ensures that the blocks are grouped together under a single block category in the Inserter. Also fixes a PHPCS warning in the Settings class.

### How to test the changes in this Pull Request:

1. Check out this PR, add a block to a Newsletter post and confirm that the Newspack blocks appear together under the "Newspack" category:

<img width="342" alt="Screenshot 2024-08-29 at 10 48 37 AM" src="https://github.com/user-attachments/assets/fa10875f-2609-4c39-916f-6696e057f29a">

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
