### PR TITLE
fix: default sender/send-to for saved layouts

### DIFF
--- a/includes/class-newspack-newsletters-layouts.php
+++ b/includes/class-newspack-newsletters-layouts.php
@@ -77,7 +77,7 @@ final class Newspack_Newsletters_Layouts {
 		\register_meta( 'post', 'font_body', $meta_default_params );
 		\register_meta( 'post', 'background_color', $meta_default_params );
 		\register_meta( 'post', 'custom_css', $meta_default_params );
-		\register_meta( 'post', 'layout_defaults', $meta_default_params );
+		\register_meta( 'post', 'campaign_defaults', $meta_default_params );
 	}
 
 	/**

--- a/includes/class-newspack-newsletters.php
+++ b/includes/class-newspack-newsletters.php
@@ -182,6 +182,10 @@ final class Newspack_Newsletters {
 		];
 		$fields = [
 			[
+				'name'               => 'stringifiedCampaignDefaults',
+				'register_meta_args' => $default_register_meta_args,
+			],
+			[
 				'name'               => 'newsletter_send_errors',
 				'register_meta_args' => [
 					'show_in_rest' => [
@@ -813,11 +817,11 @@ final class Newspack_Newsletters {
 		$user_layouts  = array_map(
 			function ( $post ) {
 				$post->meta = [
-					'background_color' => get_post_meta( $post->ID, 'background_color', true ),
-					'font_body'        => get_post_meta( $post->ID, 'font_body', true ),
-					'font_header'      => get_post_meta( $post->ID, 'font_header', true ),
-					'custom_css'       => get_post_meta( $post->ID, 'custom_css', true ),
-					'layout_defaults'  => get_post_meta( $post->ID, 'layout_defaults', true ),
+					'background_color'  => get_post_meta( $post->ID, 'background_color', true ),
+					'font_body'         => get_post_meta( $post->ID, 'font_body', true ),
+					'font_header'       => get_post_meta( $post->ID, 'font_header', true ),
+					'custom_css'        => get_post_meta( $post->ID, 'custom_css', true ),
+					'campaign_defaults' => get_post_meta( $post->ID, 'campaign_defaults', true ),
 				];
 				return $post;
 			},

--- a/src/components/init-modal/screens/layout-picker/index.js
+++ b/src/components/init-modal/screens/layout-picker/index.js
@@ -8,7 +8,7 @@ import { find } from 'lodash';
  * WordPress dependencies
  */
 import { parse } from '@wordpress/blocks';
-import { Fragment, useState, useEffect } from '@wordpress/element';
+import { useState, useEffect } from '@wordpress/element';
 import { useDispatch } from '@wordpress/data';
 import { Button, Spinner } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
@@ -39,8 +39,8 @@ export default function LayoutPicker() {
 
 	const insertLayout = layoutId => {
 		const { post_content, meta = {} } = find( layouts, { ID: layoutId } ) || {};
-		if ( meta.layout_defaults !== undefined ) {
-			meta.stringifiedLayoutDefaults = meta.layout_defaults;
+		if ( meta.campaign_defaults && 'string' === typeof meta.campaign_defaults ) {
+			meta.stringifiedCampaignDefaults = meta.campaign_defaults;
 		}
 		editPost( { meta: { template_id: layoutId, ...meta } } );
 		resetEditorBlocks( post_content ? parse( post_content ) : [] );
@@ -60,7 +60,7 @@ export default function LayoutPicker() {
 	}, [ layouts.length ] );
 
 	return (
-		<Fragment>
+		<>
 			<div className="newspack-newsletters-modal__content">
 				<div className="newspack-newsletters-modal__content__sidebar">
 					<div className="newspack-newsletters-modal__content__sidebar-wrapper">
@@ -136,6 +136,6 @@ export default function LayoutPicker() {
 					{ __( 'Use Selected Layout', 'newspack-newsletters' ) }
 				</Button>
 			</div>
-		</Fragment>
+		</>
 	);
 }

--- a/src/newsletter-editor/layout/index.js
+++ b/src/newsletter-editor/layout/index.js
@@ -67,10 +67,11 @@ export default compose( [
 		};
 	} ),
 	withDispatch( dispatch => {
-		const { editPost } = dispatch( 'core/editor' );
+		const { editPost, savePost } = dispatch( 'core/editor' );
 		const { saveEntityRecord } = dispatch( 'core' );
 		return {
 			editPost,
+			savePost,
 			saveLayout: payload =>
 				saveEntityRecord( 'postType', LAYOUT_CPT_SLUG, {
 					status: 'publish',
@@ -79,7 +80,16 @@ export default compose( [
 		};
 	} ),
 ] )(
-	( { editPost, layoutId, saveLayout, postBlocks, postTitle, isEditedPostEmpty, layoutMeta } ) => {
+	( {
+		editPost,
+		savePost,
+		layoutId,
+		saveLayout,
+		postBlocks,
+		postTitle,
+		isEditedPostEmpty,
+		layoutMeta
+	} ) => {
 		const [ warningModalVisible, setWarningModalVisible ] = useState( false );
 		const { layouts, isFetchingLayouts } = useLayoutsState();
 
@@ -111,6 +121,8 @@ export default compose( [
 				post_title: updatedLayout.title.raw,
 				post_type: LAYOUT_CPT_SLUG,
 			} );
+
+			savePost();
 		};
 
 		const postContent = useMemo( () => serialize( postBlocks ), [ postBlocks ] );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

To be reviewed after #1632 (the base for this PR)

Fixes auto-population of saved sender and send-to info when creating a new newsletter from a custom layout containing that info.

Note that this is a **BREAKING CHANGE** as layouts that were saved prior to the introduction of the new sender and send-to meta fields will no longer auto-populate this info from the old `newsletterData` meta fields. However, it should be possible to set sender and send-to info and update the existing layouts to restore those defaults for new newsletters going forward.

### How to test the changes in this Pull Request:

1. Create a new newsletter and save as a new custom layout for each ESP. In each layout, set a sender name/email and send list and sublist (for those ESPs that support sublists).
2. Create a new newsletter using the custom layouts created in step 1. Confirm that the sender and send-to info are prepopulated from the saved layouts. 
3. Save and send this newsletter, and confirm that the campaign sends correctly with the right sender and send-to info.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
