### PR TITLE
fix: handle encoded URLs and block patterns in redirect check

### DIFF
--- a/includes/tracking/class-click.php
+++ b/includes/tracking/class-click.php
@@ -160,7 +160,7 @@ final class Click {
 		if (
 			false === stripos( $newsletter_content, $url_without_query_args ) &&
 			false === stripos( $newsletter_content, urlencode( $url_without_query_args ) ) && // URL might be encoded via a block pattern.
-			! $is_admin_user // Admin user might be testing the link from a preview.
+			! $is_admin_user // Allow redirect for logged-in editor or admin users.
 		) {
 			\wp_die( 'Invalid URL', '', 400 );
 			exit;
@@ -182,7 +182,7 @@ final class Click {
 			exit;
 		}
 
-		// Only track the link if the user is not an admin user.
+		// Don't track if the user is a logged-in editor or admin user.
 		if ( ! $is_admin_user ) {
 			self::track_click( $newsletter_id, $email_address, $url );
 		}

--- a/includes/tracking/class-click.php
+++ b/includes/tracking/class-click.php
@@ -155,13 +155,12 @@ final class Click {
 
 		// Double-check and make sure the URL is actually a URL within the email.
 		$url_without_query_args = untrailingslashit( strtok( $url, '?' ) );
-		$newsletter_content     = get_post_meta( $newsletter_id, 'newspack_email_html', true );
+		$newsletter_content     = (string) get_post_meta( $newsletter_id, 'newspack_email_html', true );
+		$is_admin_user          = current_user_can( 'edit_others_posts' );
 		if (
-			! $newsletter_content ||
-			(
-				false === stripos( $newsletter_content, $url_without_query_args ) &&
-				false === stripos( $newsletter_content, urlencode( $url_without_query_args ) ) // URL might be encoded via a block pattern.
-			)
+			false === stripos( $newsletter_content, $url_without_query_args ) &&
+			false === stripos( $newsletter_content, urlencode( $url_without_query_args ) ) && // URL might be encoded via a block pattern.
+			! $is_admin_user // Admin user might be testing the link from a preview.
 		) {
 			\wp_die( 'Invalid URL', '', 400 );
 			exit;
@@ -183,7 +182,10 @@ final class Click {
 			exit;
 		}
 
-		self::track_click( $newsletter_id, $email_address, $url );
+		// Only track the link if the user is not an admin user.
+		if ( ! $is_admin_user ) {
+			self::track_click( $newsletter_id, $email_address, $url );
+		}
 
 		if ( $with_redirect ) {
 			\wp_redirect( $url ); // phpcs:ignore WordPress.Security.SafeRedirect.wp_redirect_wp_redirect

--- a/includes/tracking/class-click.php
+++ b/includes/tracking/class-click.php
@@ -155,8 +155,14 @@ final class Click {
 
 		// Double-check and make sure the URL is actually a URL within the email.
 		$url_without_query_args = untrailingslashit( strtok( $url, '?' ) );
-		$newsletter_content     = get_post_field( 'post_content', $newsletter_id, 'raw' );
-		if ( '' === $newsletter_content || false === stripos( $newsletter_content, $url_without_query_args ) ) {
+		$newsletter_content     = get_post_meta( $newsletter_id, 'newspack_email_html', true );
+		if (
+			! $newsletter_content ||
+			(
+				false === stripos( $newsletter_content, $url_without_query_args ) &&
+				false === stripos( $newsletter_content, urlencode( $url_without_query_args ) ) // URL might be encoded via a block pattern.
+			)
+		) {
 			\wp_die( 'Invalid URL', '', 400 );
 			exit;
 		}

--- a/includes/tracking/class-pixel.php
+++ b/includes/tracking/class-pixel.php
@@ -148,11 +148,6 @@ final class Pixel {
 	 * @return void
 	 */
 	public static function track_seen( $newsletter_id, $tracking_id, $email_address ) {
-		// Don't track for logged-in editor or admin users.
-		if ( current_user_can( 'edit_others_posts' ) ) {
-			return;
-		}
-
 		$newsletter_tracking_id = \get_post_meta( $newsletter_id, 'tracking_id', true );
 
 		// Bail if tracking ID mismatch.

--- a/includes/tracking/class-pixel.php
+++ b/includes/tracking/class-pixel.php
@@ -148,6 +148,11 @@ final class Pixel {
 	 * @return void
 	 */
 	public static function track_seen( $newsletter_id, $tracking_id, $email_address ) {
+		// Don't track for logged-in editor or admin users.
+		if ( current_user_can( 'edit_others_posts' ) ) {
+			return;
+		}
+
 		$newsletter_tracking_id = \get_post_meta( $newsletter_id, 'tracking_id', true );
 
 		// Bail if tracking ID mismatch.

--- a/tests/test-tracking.php
+++ b/tests/test-tracking.php
@@ -54,13 +54,18 @@ class Newsletters_Tracking_Test extends WP_UnitTestCase {
 	 * Test tracking click.
 	 */
 	public function test_tracking_click() {
+		$content  = "<!-- wp:paragraph -->\n<p><a href=\"https://google.com\">Link</a><\/p>\n<!-- \/wp:paragraph -->";
 		$post_id  = $this->factory->post->create(
 			[
 				'post_type'    => \Newspack_Newsletters::NEWSPACK_NEWSLETTERS_CPT,
 				'post_title'   => 'A newsletter with link.',
-				'post_content' => "<!-- wp:paragraph -->\n<p><a href=\"https://google.com\">Link</a><\/p>\n<!-- \/wp:paragraph -->",
+				'post_content' => $content,
 			]
 		);
+
+		// Ensure the newspack_email_html meta is set.
+		update_post_meta( $post_id, 'newspack_email_html', $content );
+
 		$post     = \get_post( $post_id );
 		$rendered = Newspack_Newsletters_Renderer::post_to_mjml_components( $post );
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes a bug in the click handler for URLs within newsletter content. Fixes the following scenarios:

1. When inserting a link in a synced block pattern and then inserting the synced block into a post, the contents of the synced block is not rendered in the raw post content, only a block ref like `<!-- wp:block {"ref":604} /-->`. This PR checks if the link is contained in the final rendered HTML instead, which is stored in the `newspack_email_html` meta field.
2. If you're copying and pasting links from another email, or using a block pattern, the link ends up being saved with the full redirect wrapper, e.g. `https://url?np_newsletters_click=1&id=546&url=https%3A%2F%2Fnewspack.com%2Fabout%2F%3Futm_medium%3Demail&em=*|EMAIL|*` instead of simply `https://newspack.com/about/`. This PR checks the newsletter content for both unencoded and encoded forms of the URL (`https%3A%2F%2Fnewspack.com%2Fabout`) to account for this scenario.
3. While authoring a newsletter, if you preview the newsletter without first saving, any links in unsaved content won't be present in the saved newsletter content for the check, and will return the `Invalid URL` error. This PR accounts for this scenario by letting the redirect happen if `current_user_can( 'edit_others_posts' )` passes.
4. Not an error per se, but currently both `seen` and `click` events are tracked for logged-in editor/admin users, which might be inflating the numbers. This PR does not track either if `current_user_can( 'edit_others_posts' )` passes.

### How to test the changes in this Pull Request:

1. In `release`, while editing a newsletter post, create a synced block pattern containing a link to any URL and save it.
2. Insert the synced block pattern into another newsletter post.
3. Send a test to yourself and click the link inside the synced block pattern. Observe that the redirect fails with an `Invalid URL` error.
4. Also preview the newsletter from inside the editor and observe that the redirect fails here, too.
5. Also add a different link anywhere in the newsletter content, then preview without saving, and observe that this link also fails to redirect.
6. Check out this branch. Confirm that the links from inside the test email and the preview both redirect correctly now. 
7. Repeat step 5 (previewing an unsaved link) and confirm that the link does redirect.
8. Confirm that the "clicked" count for the post has not changed since you're logged in as an admin user.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1207688164534491