### PR TITLE
fix: handle missing Mailchimp API key

### DIFF
--- a/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp-usage-reports.php
+++ b/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp-usage-reports.php
@@ -16,22 +16,13 @@ class Newspack_Newsletters_Mailchimp_Usage_Reports {
 	const REPORTS_OPTION_NAME = 'newspack_newsletters_mailchimp_usage_reports';
 
 	/**
-	 * Retrieves the main Mailchimp instance
-	 *
-	 * @return Newspack_Newsletters_Mailchimp
-	 */
-	private static function get_mc_instance() {
-		return Newspack_Newsletters_Mailchimp::instance();
-	}
-
-	/**
 	 * Retrieves an instance of the Mailchimp api
 	 *
 	 * @return DrewM\MailChimp\MailChimp|WP_Error
 	 */
 	private static function get_mc_api() {
 		try {
-			return new Mailchimp( self::get_mc_instance()->api_key() );
+			return new Mailchimp( Newspack_Newsletters_Mailchimp::instance()->api_key() );
 		} catch ( Exception $e ) {
 			return new WP_Error(
 				'newspack_newsletters_mailchimp_error',

--- a/tests/test-mailchimp-cached-data.php
+++ b/tests/test-mailchimp-cached-data.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * Class Newsletters Test Mailchimp Cached Data
+ *
+ * @package Newspack_Newsletters
+ */
+
+/**
+ * Tests the Mailchimp Cached Data Class.
+ */
+class Newsletters_Mailchimp_Cached_Data_Test extends WP_UnitTestCase {
+	/**
+	 * Setup.
+	 */
+	public function set_up() {
+		// Reset the API key.
+		delete_option( 'newspack_mailchimp_api_key' );
+	}
+
+	/**
+	 * Test the API setup.
+	 */
+	public function test_mailchimp_cached_data_api_setup() {
+		// This tests if an empty API key won't cause the code to error out.
+		$segments = Newspack_Newsletters_Mailchimp_Cached_Data::fetch_segments( 'list1' );
+		$this->assertEquals( [], $segments );
+	}
+}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes an issue with fetching MC data while an API key is not set. 

### How to test the changes in this Pull Request:

1. On `trunk`,
1. Remove the `newspack_mailchimp_api_key` option
2. Run `wp eval "\Newspack_Newsletters_Mailchimp_Cached_Data::fetch_segments( '<mc-list-id>' );"`* - observe a PHP Fatal is logged
3. Switch to this branch, trigger the command again, observe no error logged

\* you can find a valid MC list id by looking up a `post_type=newspack_nl_list` post's `_remote_id` post meta

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->