### PR TITLE
Assorted error handling fixes

### DIFF
--- a/includes/class-newspack-newsletters-renderer.php
+++ b/includes/class-newspack-newsletters-renderer.php
@@ -1012,8 +1012,8 @@ final class Newspack_Newsletters_Renderer {
 			 * Embed block.
 			 */
 			case 'core/embed':
-				$oembed = _wp_oembed_get_object();
-				$data   = $oembed->get_data( $attrs['url'] );
+				$oembed = apply_filters( 'newspack_newsletters_get_oembed_object', _wp_oembed_get_object() );
+				$data = $oembed->get_data( $attrs['url'] );
 
 				if ( ! $data || empty( $data->type ) ) {
 					break;
@@ -1063,7 +1063,7 @@ final class Newspack_Newsletters_Renderer {
 							'height' => $data->height,
 							'href'   => $attrs['url'],
 						);
-						$markup   .= '<mj-image ' . self::array_to_attributes( $img_attrs ) . ' />';
+						$markup .= '<mj-image ' . self::array_to_attributes( $img_attrs ) . ' />';
 						if ( ! empty( $caption ) ) {
 							$markup .= '<mj-text ' . self::array_to_attributes( $caption_attrs ) . '>' . esc_html( $caption ) . ' - ' . esc_html( $data->provider_name ) . '</mj-text>';
 						}

--- a/includes/class-newspack-newsletters-renderer.php
+++ b/includes/class-newspack-newsletters-renderer.php
@@ -1012,6 +1012,11 @@ final class Newspack_Newsletters_Renderer {
 			 * Embed block.
 			 */
 			case 'core/embed':
+				/**
+				 * Filters the retrieval of the WP oEmbed object. Used for testing purposes
+				 *
+				 * @param WP_oEmbed $oembed WP_oEmbed object.
+				 */
 				$oembed = apply_filters( 'newspack_newsletters_get_oembed_object', _wp_oembed_get_object() );
 				$data = $oembed->get_data( $attrs['url'] );
 

--- a/includes/service-providers/active_campaign/class-newspack-newsletters-active-campaign-usage-reports.php
+++ b/includes/service-providers/active_campaign/class-newspack-newsletters-active-campaign-usage-reports.php
@@ -144,10 +144,14 @@ class Newspack_Newsletters_Active_Campaign_Usage_Reports {
 	 */
 	private function get_campaign_data( $last_n_days ) {
 		$last_campaigns_data = get_option( self::LAST_CAMPAIGNS_DATA_OPTION_NAME );
-		$campaigns_data      = self::get_default_campaign_data();
 
 		$current_campaign_data = $this->get_current_campaign_data( $last_n_days );
+		if ( \is_wp_error( $current_campaign_data ) ) {
+			return $current_campaign_data;
+		}
 		update_option( self::LAST_CAMPAIGNS_DATA_OPTION_NAME, $current_campaign_data );
+
+		$campaigns_data = self::get_default_campaign_data();
 
 		if ( ! $last_campaigns_data ) {
 			// No data about campaigns yet, so there is nothing to compare the new data with.

--- a/includes/service-providers/constant_contact/class-newspack-newsletters-constant-contact-sdk.php
+++ b/includes/service-providers/constant_contact/class-newspack-newsletters-constant-contact-sdk.php
@@ -644,7 +644,7 @@ final class Newspack_Newsletters_Constant_Contact_SDK {
 	public function upsert_contact( $email_address, $data = [] ) {
 		$contact = $this->get_contact( $email_address );
 		$body    = [];
-		if ( $contact ) {
+		if ( $contact && ! \is_wp_error( $contact ) ) {
 			$body = [
 				'email_address'    => get_object_vars( $contact->email_address ),
 				'list_memberships' => $contact->list_memberships,

--- a/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp-usage-reports.php
+++ b/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp-usage-reports.php
@@ -99,7 +99,7 @@ class Newspack_Newsletters_Mailchimp_Usage_Reports {
 	 * Get usage reports for last n days.
 	 *
 	 * @param int $days_in_past How many days in past.
-	 * @return Newspack_Newsletters_Service_Provider_Usage_Report[] Usage reports.
+	 * @return Newspack_Newsletters_Service_Provider_Usage_Report[]|WP_Error Usage reports or error.
 	 */
 	public static function get_usage_reports( $days_in_past ) {
 
@@ -179,10 +179,13 @@ class Newspack_Newsletters_Mailchimp_Usage_Reports {
 	/**
 	 * Creates a usage report.
 	 *
-	 * @return Newspack_Newsletters_Service_Provider_Usage_Report Usage report.
+	 * @return Newspack_Newsletters_Service_Provider_Usage_Report|WP_Error Usage report or error.
 	 */
 	public static function get_usage_report() {
 		$reports = self::get_usage_reports( 1 );
+		if ( \is_wp_error( $reports ) ) {
+			return $reports;
+		}
 		return reset( $reports );
 	}
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,9 +9,7 @@
 			"version": "3.1.0",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@uiw/react-codemirror": "^3.2.10",
 				"classnames": "^2.5.1",
-				"csslint": "^1.0.5",
 				"mjml-browser": "^4.15.3",
 				"newspack-components": "^3.0.0",
 				"qs": "^6.13.0"
@@ -5733,20 +5731,6 @@
 				"url": "https://opencollective.com/typescript-eslint"
 			}
 		},
-		"node_modules/@uiw/react-codemirror": {
-			"version": "3.2.10",
-			"license": "MIT",
-			"dependencies": {
-				"@babel/runtime": "^7.18.9",
-				"codemirror": "^5.65.8"
-			},
-			"peerDependencies": {
-				"@babel/runtime": ">=7.11.0",
-				"codemirror": ">=5.49.2",
-				"react": ">=16.8.0",
-				"react-dom": ">=16.8.0"
-			}
-		},
 		"node_modules/@ungap/structured-clone": {
 			"version": "1.2.0",
 			"dev": true,
@@ -9102,13 +9086,6 @@
 				"url": "https://github.com/chalk/wrap-ansi?sponsor=1"
 			}
 		},
-		"node_modules/clone": {
-			"version": "2.1.2",
-			"license": "MIT",
-			"engines": {
-				"node": ">=0.8"
-			}
-		},
 		"node_modules/clone-deep": {
 			"version": "0.2.4",
 			"dev": true,
@@ -9162,10 +9139,6 @@
 				"iojs": ">= 1.0.0",
 				"node": ">= 0.12.0"
 			}
-		},
-		"node_modules/codemirror": {
-			"version": "5.65.16",
-			"license": "MIT"
 		},
 		"node_modules/collect-v8-coverage": {
 			"version": "1.0.2",
@@ -9836,20 +9809,6 @@
 			},
 			"engines": {
 				"node": ">=4"
-			}
-		},
-		"node_modules/csslint": {
-			"version": "1.0.5",
-			"license": "MIT",
-			"dependencies": {
-				"clone": "~2.1.0",
-				"parserlib": "~1.1.1"
-			},
-			"bin": {
-				"csslint": "dist/cli.js"
-			},
-			"engines": {
-				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/cssnano": {
@@ -20954,10 +20913,6 @@
 			"funding": {
 				"url": "https://github.com/inikulin/parse5?sponsor=1"
 			}
-		},
-		"node_modules/parserlib": {
-			"version": "1.1.1",
-			"license": "MIT"
 		},
 		"node_modules/parseurl": {
 			"version": "1.3.3",

--- a/package.json
+++ b/package.json
@@ -39,9 +39,7 @@
 		"url": "https://github.com/Automattic/newspack-newsletters/issues"
 	},
 	"dependencies": {
-		"@uiw/react-codemirror": "^3.2.10",
 		"classnames": "^2.5.1",
-		"csslint": "^1.0.5",
 		"mjml-browser": "^4.15.3",
 		"newspack-components": "^3.0.0",
 		"qs": "^6.13.0"

--- a/src/newsletter-editor/styling/index.js
+++ b/src/newsletter-editor/styling/index.js
@@ -3,6 +3,7 @@
 /**
  * WordPress dependencies
  */
+import { PlainText } from '@wordpress/block-editor';
 import { compose, useInstanceId } from '@wordpress/compose';
 import { ColorPicker, BaseControl, Panel, PanelBody, PanelRow } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
@@ -11,28 +12,9 @@ import { useEffect, useRef } from '@wordpress/element';
 import SelectControlWithOptGroup from '../../components/select-control-with-optgroup/';
 
 /**
- * External dependencies
- */
-import { CSSLint } from 'csslint';
-import CodeMirror from '@uiw/react-codemirror';
-// eslint-disable-next-line import/no-extraneous-dependencies
-import 'codemirror/mode/css/css';
-// eslint-disable-next-line import/no-extraneous-dependencies
-import 'codemirror/addon/lint/lint';
-// eslint-disable-next-line import/no-extraneous-dependencies
-import 'codemirror/addon/lint/lint.css';
-// eslint-disable-next-line import/no-extraneous-dependencies
-import 'codemirror/addon/lint/css-lint';
-
-/**
  * Internal dependencies
  */
 import './style.scss';
-
-/**
- * Add CSSLint to global scope for CodeMirror.
- */
-window.CSSLint = window.CSSLint || CSSLint;
 
 const fontOptgroups = [
 	{
@@ -264,18 +246,12 @@ export const Styling = compose( [
 						) }
 						hideLabelFromVision
 					>
-						<CodeMirror
+						<PlainText
 							className="components-textarea-control__input"
 							value={ customCss }
-							height={ 250 }
-							onChange={ instance => editPost( { meta: { custom_css: instance.getValue() } } ) }
-							options={ {
-								gutters: [ 'CodeMirror-lint-markers' ],
-								height: 'auto',
-								indentWithTabs: true,
-								mode: 'css',
-								lint: true,
-							} }
+							onChange={ content => editPost( { meta: { custom_css: content } } ) }
+							aria-label={ __( 'Custom CSS', 'newspack-newsletters' ) }
+							placeholder={ __( 'Write custom CSS…', 'newspack-newsletters' ) }
 						/>
 					</BaseControl>
 				</PanelRow>

--- a/src/newsletter-editor/styling/style.scss
+++ b/src/newsletter-editor/styling/style.scss
@@ -26,8 +26,28 @@
 		.components-base-control {
 			max-width: 100%;
 		}
-		.CodeMirror {
-			border: 1px solid wp-colors.$gray-700;
+		.block-editor-plain-text {
+			background: #fff !important;
+			border: 1px solid #1e1e1e !important;
+			border-radius: 2px !important;
+			box-shadow: none !important;
+			box-sizing: border-box;
+			color: #1e1e1e !important;
+			direction: ltr;
+			font-family: Menlo, Consolas, monaco, monospace !important;
+			font-size: 16px !important;
+			max-height: 250px;
+			padding: 12px !important;
+		}
+		@media (min-width: 600px) {
+			.block-editor-plain-text {
+				font-size: 13px !important;
+			}
+		}
+		.block-editor-plain-text:focus {
+			border-color: var(--wp-admin-theme-color) !important;
+			box-shadow: 0 0 0 1px var(--wp-admin-theme-color) !important;
+			outline: 2px solid #0000 !important;
 		}
 	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Adds error handling in a few places to avoid triggering PHP Fatals, and updates the tests so they don't rely on network.

- Improves handling of a variable. `Newspack_Newsletters_Constant_Contact_SDK::get_contact` can return `false` or `WP_Error` in case of failure, and the `upsert_contact` method was not handling the latter case. 
- Improves error handling of Mailchimp usage reports, if the API key is not provided
- Updates the `test_render_embed_blocks` test not to rely on the network
- Improves error handling in ActiveCampaign usage reports, in case of a network error
- Fixes the failed CI builds (#1642)

Submitting as a hotfix because the lack of error handling triggers PHP Fatals, which pollute our logs. 

### How to test the changes in this Pull Request:

- Smoke test, this should be self-explanatory. 
- Observe all tests are passing

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->