### PR TITLE
fix(mailchimp): remove cache and improve logs when preparing merge fields

### DIFF
--- a/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp.php
+++ b/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp.php
@@ -1236,12 +1236,14 @@ final class Newspack_Newsletters_Mailchimp extends \Newspack_Newsletters_Service
 	 * by sarching for existing merge fields and creating new ones as needed.
 	 *
 	 * @param string $audience_id Audience ID.
-	 * @param array  $data        The contact metadata.
+	 * @param array  $contact     The contact.
 	 *
 	 * @return array Merge fields.
 	 */
-	private function prepare_merge_fields( $audience_id, $data ) {
+	private function prepare_merge_fields( $audience_id, $contact ) {
+		$mc           = new Mailchimp( $this->api_key() );
 		$merge_fields = [];
+		$data         = $contact['metadata'];
 
 		// Strip arrays and statuses.
 		$data = array_filter(
@@ -1254,14 +1256,27 @@ final class Newspack_Newsletters_Mailchimp extends \Newspack_Newsletters_Service
 
 		// Get and match existing merge fields.
 		try {
-			$existing_fields = Newspack_Newsletters_Mailchimp_Cached_Data::get_merge_fields( $audience_id );
+			$existing_fields = $mc->get(
+				"lists/$audience_id/merge-fields",
+				[
+					'count' => 1000,
+				],
+				60
+			)['merge_fields'];
 		} catch ( \Exception $e ) {
-			Newspack_Newsletters_Logger::log(
-				sprintf(
-					// Translators: %1$s is the error message.
-					__( 'Error getting merge fields: %1$s', 'newspack-newsletters' ),
-					$existing_fields->get_error_message()
-				)
+			do_action(
+				'newspack_log',
+				'newspack_mailchimp_prepare_merge_fields',
+				sprintf( 'Error getting merge fields: %s', $e->getMessage() ),
+				[
+					'type'       => 'error',
+					'data'       => [
+						'audience_id' => $audience_id,
+						'error'       => $e->getMessage(),
+					],
+					'user_email' => $contact['email'],
+					'file'       => 'newspack_mailchimp',
+				]
 			);
 			return [];
 		}
@@ -1283,13 +1298,19 @@ final class Newspack_Newsletters_Mailchimp extends \Newspack_Newsletters_Service
 			if ( ! isset( $list_merge_fields[ $field['name'] ] ) ) {
 				$list_merge_fields[ $field['name'] ] = $field['tag'];
 			} else {
-				Newspack_Newsletters_Logger::log(
-					sprintf(
-						// Translators: %1$s is the merge field name, %2$s is the field's unique tag.
-						__( 'Warning: Duplicate merge field %1$s found with tag %2$s.', 'newspack-newsletters' ),
-						$field['name'],
-						$field['tag']
-					)
+				do_action(
+					'newspack_log',
+					'newspack_mailchimp_prepare_merge_fields',
+					sprintf( 'Duplicate merge field %1$s found with tag %2$s.', $field['name'], $field['tag'] ),
+					[
+						'type'       => 'error',
+						'data'       => [
+							'audience_id' => $audience_id,
+							'field'       => $field,
+						],
+						'user_email' => $contact['email'],
+						'file'       => 'newspack_mailchimp',
+					]
 				);
 			}
 		}
@@ -1304,35 +1325,46 @@ final class Newspack_Newsletters_Mailchimp extends \Newspack_Newsletters_Service
 
 		// Create remaining fields.
 		$remaining_fields = array_keys( $data );
-		$mc             = new Mailchimp( $this->api_key() );
 		foreach ( $remaining_fields as $field_name ) {
-			$created_field = $mc->post(
-				"lists/$audience_id/merge-fields",
+			$field_data = [
+				'name' => $field_name,
+				'type' => $this->get_merge_field_type( $data[ $field_name ] ),
+			];
+			$created_field = $mc->post( "lists/$audience_id/merge-fields", $field_data );
+			if ( empty( $created_field['merge_id'] ) ) {
+				$message = sprintf(
+					// Translators: %1$s is the merge field key, %2$s is the error message.
+					__( 'Failed to create merge field %1$s. Error response: %2$s', 'newspack-newsletters' ),
+					$field_name,
+					$created_field['detail'] ?? 'Unknown error'
+				);
+			} else {
+				$message = sprintf(
+					// Translators: %1$s is the merge field key, %2$s is the merge field tag.
+					__( 'Created merge field %1$s with tag %2$s.', 'newspack-newsletters' ),
+					$field_name,
+					$created_field['tag']
+				);
+			}
+			do_action(
+				'newspack_log',
+				'newspack_mailchimp_prepare_merge_fields',
+				$message,
 				[
-					'name' => $field_name,
-					'type' => $this->get_merge_field_type( $data[ $field_name ] ),
+					'type'       => $created_field['merge_id'] ? 'debug' : 'error',
+					'data'       => [
+						'audience_id'   => $audience_id,
+						'field_data'    => $field_data,
+						'created_field' => $created_field,
+					],
+					'user_email' => $contact['email'],
+					'file'       => 'newspack_mailchimp',
 				]
 			);
-			// Skip field if it failed to create.
-			if ( empty( $created_field['merge_id'] ) ) {
-				Newspack_Newsletters_Logger::log(
-					sprintf(
-					// Translators: %1$s is the merge field key, %2$s is the error message.
-						__( 'Failed to create merge field %1$s. Error response: %2$s', 'newspack-newsletters' ),
-						$field_name,
-						$created_field['detail'] ?? 'Unknown error'
-					)
-				);
-				continue;
+			// Add the field to the merge fields array if it was created.
+			if ( ! empty( $created_field['merge_id'] ) ) {
+				$merge_fields[ $created_field['tag'] ] = $data[ $field_name ];
 			}
-			Newspack_Newsletters_Logger::log(
-				sprintf(
-					// Translators: %1$s is the merge field key, %2$s is the error message.
-					__( 'Created merge field %1$s.', 'newspack-newsletters' ),
-					$field_name
-				)
-			);
-			$merge_fields[ $created_field['tag'] ] = $data[ $field_name ];
 		}
 
 		return $merge_fields;

--- a/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp.php
+++ b/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp.php
@@ -1351,7 +1351,7 @@ final class Newspack_Newsletters_Mailchimp extends \Newspack_Newsletters_Service
 				'newspack_mailchimp_prepare_merge_fields',
 				$message,
 				[
-					'type'       => $created_field['merge_id'] ? 'debug' : 'error',
+					'type'       => empty( $created_field['merge_id'] ) ? 'error' : 'debug',
 					'data'       => [
 						'audience_id'   => $audience_id,
 						'field_data'    => $field_data,

--- a/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp.php
+++ b/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp.php
@@ -1442,7 +1442,7 @@ final class Newspack_Newsletters_Mailchimp extends \Newspack_Newsletters_Service
 			$mc = new Mailchimp( $this->api_key() );
 
 			if ( isset( $contact['metadata'] ) && is_array( $contact['metadata'] ) && ! empty( $contact['metadata'] ) ) {
-				$merge_fields = $this->prepare_merge_fields( $list_id, $contact['metadata'] );
+				$merge_fields = $this->prepare_merge_fields( $list_id, $contact );
 				if ( ! empty( $merge_fields ) ) {
 					$update_payload['merge_fields'] = $merge_fields;
 				}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

We should always fetch the most recent merge fields when deciding whether a new merge field should be created, which is not possible behind a cache layer. We're currently having issues with duplicate fields being created due to outdated data coming from cache.

This PR removes the cache layer when fetching merge fields on `prepare_merge_fields()` and improves logs to benefit from the new logging strategy via the `newspack_log` action hook.

The base is `alpha` so we can get this out for the next release.

### How to test the changes in this Pull Request:

1. Make sure you have RAS configured with Mailchimp as your ESP
2. Edit your Mailchimp audience, delete a basic RAS merge field (`NP_Account`), and create new random merge fields until it reaches the limit of 30
3. Sign in as a reader and confirm the following is logged after `reader_logged_in` is dispatched:

```
Failed to create merge field NP_Account. Error response: You have exceeded the maximum number of 30 merge fields for this list.
```

4. Delete the random merge fields you've just created and manually create two fields named `NP_Account`
5. Sign in as the reader again and confirm you get a log similar to the following:

```
Duplicate merge field NP_Account found with tag MMERGE25.	
```

6. Delete the 2 `NP_Account` merge fields
7. Sign in as the reader once more and confirm, after `reader_logged_in` dispatch, that the merge field is created and populated with the user ID

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
