### PR TITLE
fix: dont send metadata on subscribe

### DIFF
--- a/includes/class-newspack-newsletters-contacts.php
+++ b/includes/class-newspack-newsletters-contacts.php
@@ -55,6 +55,7 @@ class Newspack_Newsletters_Contacts {
 		// When subscribing, we only want to keep the status and name metadata.
 		// Additional metadata can only be added when upserting a contact.
 		// This method is specific for handling Newsletter subscription, in which case there is no additional metadata being passed.
+		// Any additional metadata will be passes to the logs and filters though, so other actions can act upon it.
 		$accepted_metadata = [ 'status', 'name' ];
 		$subscribe_contact = $contact;
 		if ( ! empty( $subscribe_contact['metadata'] ) ) {

--- a/includes/class-newspack-newsletters-contacts.php
+++ b/includes/class-newspack-newsletters-contacts.php
@@ -52,7 +52,14 @@ class Newspack_Newsletters_Contacts {
 		$existing_contact = Newspack_Newsletters_Subscription::get_contact_data( $contact['email'], true );
 		$is_updating      = \is_wp_error( $existing_contact ) ? false : true;
 
-		$result = self::upsert( $contact, $lists, $context, $existing_contact );
+		// When subscribing, we only want to keep the status and name metadata.
+		// Additional metadata can only be added when upserting a contact.
+		// This method is specific for handling Newsletter subscription, in which case there is no additional metadata being passed.
+		$accepted_metadata = [ 'status', 'name' ];
+		$subscribe_contact = $contact;
+		$subscribe_contact['metadata'] = array_intersect_key( $subscribe_contact['metadata'], array_flip( $accepted_metadata ) );
+
+		$result = self::upsert( $subscribe_contact, $lists, $context, $existing_contact );
 
 		if ( is_wp_error( $result ) ) {
 			return $result;

--- a/includes/class-newspack-newsletters-contacts.php
+++ b/includes/class-newspack-newsletters-contacts.php
@@ -57,7 +57,9 @@ class Newspack_Newsletters_Contacts {
 		// This method is specific for handling Newsletter subscription, in which case there is no additional metadata being passed.
 		$accepted_metadata = [ 'status', 'name' ];
 		$subscribe_contact = $contact;
-		$subscribe_contact['metadata'] = array_intersect_key( $subscribe_contact['metadata'], array_flip( $accepted_metadata ) );
+		if ( ! empty( $subscribe_contact['metadata'] ) ) {
+			$subscribe_contact['metadata'] = array_intersect_key( $subscribe_contact['metadata'], array_flip( $accepted_metadata ) );
+		}
 
 		$result = self::upsert( $subscribe_contact, $lists, $context, $existing_contact );
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

This is an alternative to https://github.com/Automattic/newspack-plugin/pull/3415

### How to test the changes in this Pull Request:

You will also need to configure GA4 backend events on Newspack > Analytics > Custom events

1. On `trunk`
2. Subscribing to a newsletter via a Subscription block (or also via the post-checkout modal form)
3. Confirm fields such as `current_page_url` and `newsletters_subscription_method` being added to the ESP.
4. Checkout this branch
5. delete the unfiltered fields from your ESP
6. Disable RAS (`wp option delete newspack_reader_activation_enabled`)
7. Subscribe to a newsletter via a newsletter form block
8. Confirm the fields are not created this time
9. Watching the logs, confirm you see the `np_newsletter_subscribed` GA4 event being sent and that it correctly includes the `newsletters_subscription_method` param
10. Watch the newsletters logs and confirm you only see one entry saying "User subscribed via Newsletters Subscription block"
11. Turn RAS on (`wp option set newspack_reader_activation_enabled 1`)
12. Subscribe to a newsletter via a newsletter form block
13. Confirm that now you see the prefixed RAS fields created
14. Confirm GA4 events are still fine (and reader registered is also fired)
15. Confirm in newsletter logs that you see the other sync events
16. Confirm all metadata in the contact looks as expected


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
