### PR TITLE
fix: active campaign usage report, fetch campaigns in batches

### DIFF
--- a/includes/service-providers/active_campaign/class-newspack-newsletters-active-campaign-usage-reports.php
+++ b/includes/service-providers/active_campaign/class-newspack-newsletters-active-campaign-usage-reports.php
@@ -29,6 +29,13 @@ class Newspack_Newsletters_Active_Campaign_Usage_Reports {
 	private $ac_instance;
 
 	/**
+	 * Number of campaigns to fetch in a single request.
+	 *
+	 * @var integer
+	 */
+	public $campaign_fetch_batch_size = 20;
+
+	/**
 	 * Constructor with dependency injection for the sake of tests.
 	 *
 	 * @param Newspack_Newsletters_Active_Campaign $active_campaign Active Campaign instance.
@@ -178,23 +185,50 @@ class Newspack_Newsletters_Active_Campaign_Usage_Reports {
 	 * @param int $last_n_days Number of last days to get the data about.
 	 */
 	private function get_current_campaign_data( $last_n_days ) {
-		$ac               = $this->ac_instance;
-		$params           = [
-			'query' => [
-				'limit'  => 100, // Assuming there will be no more than 100 campaigns in the requested period (last n days).
-				'orders' => [ 'sdate' => 'DESC' ],
-			],
-		];
-		$campaigns_result = $ac->api_v3_request( 'campaigns', 'GET', $params );
-		$cutoff_datetime  = strtotime( '-' . $last_n_days . ' days' );
+		$ac = $this->ac_instance;
 
-		if ( \is_wp_error( $campaigns_result ) ) {
-			return $campaigns_result;
+		$cutoff_datetime = strtotime( '-' . $last_n_days . ' days' );
+
+		// Avoid timeouts by fetching campaigns in batches.
+		$batch_size       = $this->campaign_fetch_batch_size;
+		$batch            = 0;
+		$campaigns_result = [];
+
+		while ( $batch < 5 ) { // Assuming there will be no more than 100 campaigns in the requested period (last n days).
+			$offset = $batch_size * $batch;
+			$params = [
+				'query' => [
+					'limit'  => $batch_size,
+					'offset' => $offset,
+					'orders' => [ 'sdate' => 'DESC' ],
+				],
+			];
+
+			$campaigns_response = $ac->api_v3_request( 'campaigns', 'GET', $params );
+
+			if ( \is_wp_error( $campaigns_response ) ) {
+				return $campaigns_response;
+			}
+
+			$campaigns_result = array_merge( $campaigns_result, $campaigns_response['campaigns'] );
+
+			// if oldest campaign is older than the cutoff date, break out.
+			$oldest_campaign = end( $campaigns_response['campaigns'] );
+			$campaign_send_date = strtotime( $oldest_campaign['sdate'] );
+			if ( $campaign_send_date < $cutoff_datetime ) {
+				break;
+			}
+
+			if ( count( $campaigns_response['campaigns'] ) < $batch_size ) {
+				break;
+			}
+
+			$batch++;
 		}
 
 		$campaigns_data = [];
 
-		foreach ( $campaigns_result['campaigns'] as $campaign ) {
+		foreach ( $campaigns_result as $campaign ) {
 			if (
 				! isset( $campaign['sdate'] )
 				|| 5 != $campaign['status'] // Status "5" is "completed. See https://www.activecampaign.com/api/example.php?call=campaign_list.

--- a/includes/service-providers/active_campaign/class-newspack-newsletters-active-campaign-usage-reports.php
+++ b/includes/service-providers/active_campaign/class-newspack-newsletters-active-campaign-usage-reports.php
@@ -194,7 +194,7 @@ class Newspack_Newsletters_Active_Campaign_Usage_Reports {
 		$batch            = 0;
 		$campaigns_result = [];
 
-		while ( $batch < 5 ) { // Assuming there will be no more than 100 campaigns in the requested period (last n days).
+		while ( $batch < ceil( 100 / $batch_size ) ) { // Assuming there will be no more than 100 campaigns in the requested period (last n days).
 			$offset = $batch_size * $batch;
 			$params = [
 				'query' => [

--- a/tests/test-active-campaign-usage-report.php
+++ b/tests/test-active-campaign-usage-report.php
@@ -86,7 +86,7 @@ class Newspack_Newsletters_Active_Campaign_Test_Wrapper {
 						'uniquelinkclicks' => 99,
 					],
 				];
-				$response['campaigns']     = $campaigns;
+				$response['campaigns']     = [ $campaigns[ (int) $params['query']['offset'] ] ]; // return one item per page.
 				$response['meta']['total'] = count( $campaigns );
 				break;
 		}
@@ -109,7 +109,9 @@ class ActiveCampaignUsageReportsTest extends WP_UnitTestCase {
 		$expected_report->unsubscribes   = 0; // unsubs also rely on prior data.
 		$expected_report->total_contacts = 2;
 
-		$actual_report = ( new Newspack_Newsletters_Active_Campaign_Usage_Reports( new Newspack_Newsletters_Active_Campaign_Test_Wrapper() ) )->get_usage_report();
+		$usage_report_object = new Newspack_Newsletters_Active_Campaign_Usage_Reports( new Newspack_Newsletters_Active_Campaign_Test_Wrapper() );
+		$usage_report_object->campaign_fetch_batch_size = 1;
+		$actual_report = $usage_report_object->get_usage_report();
 
 		$this->assertEquals( $expected_report->to_array(), $actual_report->to_array() );
 	}
@@ -147,7 +149,9 @@ class ActiveCampaignUsageReportsTest extends WP_UnitTestCase {
 		$expected_report->unsubscribes   = 1;
 		$expected_report->total_contacts = 2;
 
-		$actual_report = ( new Newspack_Newsletters_Active_Campaign_Usage_Reports( new Newspack_Newsletters_Active_Campaign_Test_Wrapper() ) )->get_usage_report();
+		$usage_report_object = new Newspack_Newsletters_Active_Campaign_Usage_Reports( new Newspack_Newsletters_Active_Campaign_Test_Wrapper() );
+		$usage_report_object->campaign_fetch_batch_size = 1;
+		$actual_report = $usage_report_object->get_usage_report();
 
 		$this->assertEquals( $expected_report->to_array(), $actual_report->to_array() );
 	}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Active Campaign usage reports started to error because of timeouts in the requests to the AC API. 

Let's fetch campaign data in batches to avoid that.

### How to test the changes in this Pull Request:

With a site connected to an AC account with enough data, make a dump of the DB.

Fetch usage report on `release`.

Restore the DB dump, so we have the same "prior data" in the options tables.

Fetch usage report on this branch.

Make sure we get the same results

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
