### PR TITLE
fix(mailchimp): allow contacts to resubscribe after unsubscribing

### DIFF
--- a/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp.php
+++ b/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp.php
@@ -1373,24 +1373,30 @@ final class Newspack_Newsletters_Mailchimp extends \Newspack_Newsletters_Service
 	/**
 	 * Gets the status and/or status_if_new keys based on the contact data.
 	 *
-	 * @param array $contact      {
-	 *   Contact data.
+	 * @param array  $contact      {
+	 *    Contact data.
 	 *
 	 *    @type string   $email    Contact email address.
 	 *    @type string   $name     Contact name. Optional.
 	 *    @type string[] $metadata Contact additional metadata. Optional.
 	 * }
+	 * @param string $list_id List (Audience) to add the contact to, if any.
 	 *
 	 * @return array The status and/or status_if_new keys to be added to the payload
 	 */
-	private function get_status_for_payload( $contact ) {
+	private function get_status_for_payload( $contact, $list_id = null ) {
 		$return = [];
-		if ( isset( $contact['metadata'] ) && ! empty( $contact['metadata']['status_if_new'] ) ) {
+		if ( ! empty( $contact['metadata']['status_if_new'] ) ) {
 			$return['status_if_new'] = $contact['metadata']['status_if_new'];
 		}
 
-		if ( isset( $contact['metadata'] ) && ! empty( $contact['metadata']['status'] ) ) {
+		if ( ! empty( $contact['metadata']['status'] ) ) {
 			$return['status'] = $contact['metadata']['status'];
+		}
+
+		// Check if the contact has unsubscribed before. Mailchimp requires a double opt-in to resubscribe, so we set the status to 'pending'.
+		if ( $list_id && ! empty( $contact['existing_contact_data']['lists'][ $list_id ]['status'] ) && 'unsubscribed' === $contact['existing_contact_data']['lists'][ $list_id ]['status'] ) {
+			$return['status'] = 'pending';
 		}
 
 		// If we're subscribing the contact to a newsletter, they should have some status
@@ -1434,7 +1440,7 @@ final class Newspack_Newsletters_Mailchimp extends \Newspack_Newsletters_Service
 
 		$update_payload = array_merge(
 			$update_payload,
-			$this->get_status_for_payload( $contact )
+			$this->get_status_for_payload( $contact, $list_id )
 		);
 
 		// Parse full name into first + last.

--- a/tests/test-mailchimp-contact-methods.php
+++ b/tests/test-mailchimp-contact-methods.php
@@ -138,55 +138,74 @@ class MailchimpContactMethodsTest extends WP_UnitTestCase {
 	 */
 	public function get_status_payload_data() {
 		return [
-			'empty'              => [
+			'empty'                  => [
 				[],
+				null,
 				[ 'status' => 'subscribed' ],
 			],
-			'empty_metadata'     => [
+			'empty_metadata'         => [
 				[
 					'metadata' => [],
 				],
+				null,
 				[ 'status' => 'subscribed' ],
 			],
-			'empty_status'       => [
+			'empty_status'           => [
 				[
 					'metadata' => [
 						'status' => '',
 					],
 				],
+				null,
 				[ 'status' => 'subscribed' ],
 			],
-			'only_status'        => [
+			'only_status'            => [
 				[
 					'metadata' => [
 						'status' => 'transactional',
 					],
 				],
+				null,
 				[
 					'status' => 'transactional',
 				],
 			],
-			'only status if new' => [
+			'only status if new'     => [
 				[
 					'metadata' => [
 						'status_if_new' => 'transactional',
 					],
 				],
+				null,
 				[
 					'status_if_new' => 'transactional',
 				],
 			],
-			'both'               => [
+			'both'                   => [
 				[
 					'metadata' => [
 						'status_if_new' => 'transactional',
 						'status'        => 'subscribed',
 					],
 				],
+				null,
 				[
 					'status_if_new' => 'transactional',
 					'status'        => 'subscribed',
 				],
+			],
+			'status_if_unsubscribed' => [
+				[
+					'existing_contact_data' => [
+						'lists' => [
+							'list1' => [
+								'status' => 'unsubscribed',
+							],
+						],
+					],
+				],
+				'list1',
+				[ 'status' => 'pending' ],
 			],
 		];
 	}
@@ -194,14 +213,15 @@ class MailchimpContactMethodsTest extends WP_UnitTestCase {
 	/**
 	 * Test get_status_for_payload
 	 *
-	 * @param array $input    Input data.
-	 * @param array $expected Expected output.
+	 * @param array       $arg1     Input data.
+	 * @param string|null $arg2     Input data.
+	 * @param array       $expected Expected output.
 	 * @dataProvider get_status_payload_data
 	 */
-	public function test_get_status_for_payload( $input, $expected ) {
+	public function test_get_status_for_payload( $arg1, $arg2, $expected ) {
 		$method = self::get_private_method( 'get_status_for_payload' );
 		$service = Newspack_Newsletters_Mailchimp::instance();
-		$this->assertSame( $expected, $method->invoke( $service, $input ) );
+		$this->assertSame( $expected, $method->invoke( $service, $arg1, $arg2 ) );
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

If a contact unsubscribes from a Mailchimp list, the Mailchimp API doesn't allow us to automatically resubscribe that contact without a manual double opt-in flow. See details: https://mailchimp.com/help/resubscribe-a-contact/

If the contact attempts to resubscribe to a list they've previously unsubscribed from, this PR adds a check for this at the `add_contact()` stage to compare the requested list ID against prior lists with an `unsubscribed` status for the contact. If the contact has previously unsubscribed from the list, we set their status to `pending` instead of `subscribed` in order to trigger the double opt-in flow, avoiding an error and signup failure.

### How to test the changes in this Pull Request:

1. On `trunk`, on a site connected to Mailchimp as the ESP, sign up as a reader with a real email address for newsletters via any means on the site.
2. Send a newsletter campaign via Mailchimp or the Newsletters editor that the reader will receive.
3. Once you receive the email in the reader's inbox, click the "Unsubscribe" link at the bottom and confirm.
4. In a new session, attempt to resubscribe to the same newsletter lists using the same reader email.
5. Observe an error message that blocks the signup: `"Failed to add contact to list. <reader's email> is in a compliance state due to unsubscribe, bounce, or compliance review and cannot be subscribed."`
6. Check out this branch and attempt to resubscribe again.
7. This time confirm that the request succeeds in the block UI, and that you receive a double opt-in confirmation in the reader's inbox to resubscribe.

<img width="580" alt="Screenshot 2024-09-12 at 11 31 14 AM" src="https://github.com/user-attachments/assets/9383888d-cef2-4f35-a108-060b2a6bb35c">
<img width="630" alt="Screenshot 2024-09-12 at 11 32 18 AM" src="https://github.com/user-attachments/assets/f472fc50-c4c8-480c-ac16-ddc3a3a246a7">

8. Click the "Yes, subscribe me" button and confirm that the contact in the Mailchimp account gets reset to "Subscribed" status.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1208276826833844