### PR TITLE
fix: a typo that came after a refactor

### DIFF
--- a/includes/service-providers/class-newspack-newsletters-service-provider.php
+++ b/includes/service-providers/class-newspack-newsletters-service-provider.php
@@ -486,7 +486,7 @@ Details of the error message: "%3$s"
 	public function upsert_contact( $contact, $lists ) {
 
 		if ( empty( $lists ) ) {
-			return $provider->add_contact( $contact );
+			return $this->add_contact( $contact );
 		}
 
 		foreach ( $lists as $list ) {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

fixes a [regression](https://github.com/Automattic/newspack-newsletters/pull/1620/files#diff-746392f50a90cb7179a3928b87ef9cc9d8062f62480df31e02293ad5527dc1f3R489) introduced by #1620 

When the code was moved from one class to another, I forgot to update the object in one place.

### How to test the changes in this Pull Request:

Trust your eyes

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
