### PR TITLE
refactor: consolidate ESP data getters into Redux store

### DIFF
--- a/src/editor/mjml/index.js
+++ b/src/editor/mjml/index.js
@@ -11,7 +11,7 @@ import { refreshEmailHtml } from '../../newsletter-editor/utils';
 /**
  * Internal dependencies
  */
-import { fetchNewsletterData, updateNewsletterDataError } from '../../newsletter-editor/store';
+import { fetchNewsletterData, fetchSyncErrors } from '../../newsletter-editor/store';
 import { getServiceProvider } from '../../service-providers';
 
 /**
@@ -119,13 +119,7 @@ function MJML() {
 						fetchNewsletterData( postId );
 
 						// Check for sync errors after refreshing the HTML.
-						apiFetch( {
-							path: `/newspack-newsletters/v1/${ postId }/sync-error`,
-						} ).then( ( error ) => {
-							if ( error?.message ) {
-								updateNewsletterDataError( error );
-							}
-						} );
+						fetchSyncErrors( postId );
 					}
 				} );
 		}

--- a/src/newsletter-editor/sidebar/autocomplete.js
+++ b/src/newsletter-editor/sidebar/autocomplete.js
@@ -6,6 +6,11 @@ import { BaseControl, FormTokenField, Button, ButtonGroup } from '@wordpress/com
 import { useState } from '@wordpress/element';
 import { Icon, external } from '@wordpress/icons';
 
+/**
+ * Internal dependencies
+ */
+import { useIsRetrieving, useNewsletterDataError } from '../store';
+
 // The autocomplete field for send lists and sublists.
 const Autocomplete = ( {
 	availableItems,
@@ -15,9 +20,11 @@ const Autocomplete = ( {
 	onInputChange,
 	reset,
 	selectedInfo,
-	inFlight,
 } ) => {
 	const [ isEditing, setIsEditing ] = useState( false );
+	const isRetrieving = useIsRetrieving();
+	const error = useNewsletterDataError();
+
 	if ( selectedInfo && ! isEditing ) {
 		return (
 			<div className="newspack-newsletters__send-to">
@@ -37,7 +44,7 @@ const Autocomplete = ( {
 				</p>
 				<ButtonGroup>
 					<Button
-						disabled={ inFlight }
+						disabled={ isRetrieving }
 						onClick={ () => setIsEditing( true ) }
 						size="small"
 						variant="secondary"
@@ -45,7 +52,7 @@ const Autocomplete = ( {
 						{ __( 'Edit', 'newspack-newsletters' ) }
 					</Button>
 					<Button
-						disabled={ inFlight }
+						disabled={ isRetrieving }
 						onClick={ reset }
 						size="small"
 						variant="secondary"
@@ -54,7 +61,7 @@ const Autocomplete = ( {
 					</Button>
 					{ selectedInfo?.edit_link && (
 						<Button
-							disabled={ inFlight }
+							disabled={ isRetrieving }
 							href={ selectedInfo.edit_link }
 							size="small"
 							target="_blank"
@@ -74,7 +81,7 @@ const Autocomplete = ( {
 		<div className="newspack-newsletters__send-to">
 			<BaseControl
 				id="newspack-newsletters__send-to-autocomplete-input"
-				help={ inFlight && sprintf(
+				help={ isRetrieving && sprintf(
 					// Translators: Message shown while fetching list or sublist info. %s is the provider's label for the given entity type (list or sublist).
 					__( 'Fetching %s info…', 'newspack-newsletters' ),
 					label.toLowerCase()
@@ -99,11 +106,16 @@ const Autocomplete = ( {
 					__experimentalExpandOnFocus={ true }
 					__experimentalShowHowTo={ false }
 				/>
+				{ error && (
+					<p className="newspack-newsletters__error">
+						{ error?.message || __( 'Error fetching send lists.', 'newspack-newsletters' ) }
+					</p>
+				) }
 			</BaseControl>
 			{ selectedInfo && (
 				<ButtonGroup>
 					<Button
-						disabled={ inFlight }
+						disabled={ isRetrieving }
 						onClick={ () => setIsEditing( false ) }
 						variant="secondary"
 						size="small"

--- a/src/newsletter-editor/sidebar/index.js
+++ b/src/newsletter-editor/sidebar/index.js
@@ -16,9 +16,11 @@ import { once } from 'lodash';
  * Internal dependencies
  */
 import Sender from './sender';
+import SendTo from './send-to';
 import { getServiceProvider } from '../../service-providers';
 import withApiHandler from '../../components/with-api-handler';
 import { fetchNewsletterData, useIsRetrieving, useNewsletterData, useNewsletterDataError } from '../store';
+import { isSupportedESP } from '../utils';
 import './style.scss';
 
 const Sidebar = ( {
@@ -190,6 +192,11 @@ const Sidebar = ( {
 				senderName={ senderName }
 				updateMeta={ updateMeta }
 			/>
+			{
+				isSupportedESP() && (
+					<SendTo />
+				)
+			}
 		</div>
 	);
 };

--- a/src/newsletter-editor/sidebar/index.js
+++ b/src/newsletter-editor/sidebar/index.js
@@ -18,7 +18,7 @@ import { once } from 'lodash';
 import Sender from './sender';
 import { getServiceProvider } from '../../service-providers';
 import withApiHandler from '../../components/with-api-handler';
-import { fetchNewsletterData, useNewsletterData, useNewsletterDataError } from '../store';
+import { fetchNewsletterData, useIsRetrieving, useNewsletterData, useNewsletterDataError } from '../store';
 import './style.scss';
 
 const Sidebar = ( {
@@ -38,6 +38,7 @@ const Sidebar = ( {
 	stringifiedCampaignDefaults,
 	postId,
 } ) => {
+	const isRetrieving = useIsRetrieving();
 	const newsletterData = useNewsletterData();
 	const newsletterDataError = useNewsletterDataError();
 	const campaign = newsletterData?.campaign;
@@ -121,12 +122,12 @@ const Sidebar = ( {
 				</Notice>
 				<Button
 					variant="primary"
-					disabled={ inFlight }
+					disabled={ inFlight || isRetrieving }
 					onClick={ () => {
 						fetchNewsletterData( postId );
 					} }
 				>
-					{ __( 'Retrieve campaign data', 'newspack-newsletter' ) }
+					{ isRetrieving ? __( 'Retrieving campaign data…', 'newspack-newsletter' ) : __( 'Retrieve campaign data', 'newspack-newsletter' ) }
 				</Button>
 			</div>
 		);

--- a/src/newsletter-editor/sidebar/send-to.js
+++ b/src/newsletter-editor/sidebar/send-to.js
@@ -45,10 +45,19 @@ const SendTo = () => {
 	}, [] );
 
 	useEffect( () => {
-		if ( listId && newsletterData?.sublists ) {
-			if ( 1 >= newsletterData.sublists.length ) {
-				fetchSendLists( { type: 'sublist', parent_id: listId } );
-			}
+		// If we have a selected list ID but no list info, fetch it.
+		if ( listId && ! selectedList ) {
+			fetchSendLists( { ids: [ listId ] } );
+		}
+
+		// If we have a selected sublist ID but no sublist info, fetch it.
+		if ( listId && sublistId && ! selectedSublist ) {
+			fetchSendLists( { ids: [ sublistId ], type: 'sublist', parent_id: listId } );
+		}
+
+		// Prefetch sublist info when selecting a new list ID.
+		if ( listId && ! sublistId && newsletterData?.sublists && 1 >= newsletterData.sublists.length ) {
+			fetchSendLists( { type: 'sublist', parent_id: listId } );
 		}
 	}, [ newsletterData, listId, sublistId ] );
 
@@ -124,13 +133,13 @@ const SendTo = () => {
 					if ( ! selectedSuggestion?.id ) {
 						return setError(
 							sprintf(
-								// Translators: Error shown when we can't find info on the selected sublist. %s is the ESP's label for the list entity.
+								// Translators: Error shown when we can't find info on the selected list. %s is the ESP's label for the list entity.
 								__( 'Invalid %s selection.', 'newspack-newsletters' ),
 								listLabel
 							)
 						);
 					}
-					updateMeta( { send_list_id: selectedSuggestion.id.toString() } );
+					updateMeta( { send_list_id: selectedSuggestion.id.toString(), send_sublist_id: null } );
 				} }
 				onFocus={ () => {
 					if ( 1 >= lists?.length ) {

--- a/src/newsletter-editor/sidebar/send-to.js
+++ b/src/newsletter-editor/sidebar/send-to.js
@@ -26,13 +26,6 @@ const SendTo = () => {
 		};
 	} );
 
-	// Cancel any queued fetches on unmount.
-	useEffect( () => {
-		return () => {
-			fetchSendLists.cancel();
-		}
-	}, [] );
-
 	const editPost = useDispatch( 'core/editor' ).editPost;
 	const updateMeta = ( meta ) => editPost( { meta } );
 
@@ -43,6 +36,21 @@ const SendTo = () => {
 	const sublistLabel = labels?.sublist || __( 'sublist', 'newspack-newsletters' );
 	const selectedList = lists.find( item => item.id === listId );
 	const selectedSublist = sublists?.find( item => item.id === sublistId );
+
+	// Cancel any queued fetches on unmount.
+	useEffect( () => {
+		return () => {
+			fetchSendLists.cancel();
+		}
+	}, [] );
+
+	useEffect( () => {
+		if ( listId && ! sublistId && newsletterData?.sublists ) {
+			if ( 1 >= newsletterData.sublists.length ) {
+				fetchSendLists( { type: 'sublist', parent_id: listId } );
+			}
+		}
+	}, [ newsletterData, listId, sublistId ] );
 
 	const renderSelectedSummary = () => {
 		if ( ! selectedList?.name || ( selectedSublist && ! selectedSublist.name ) ) {

--- a/src/newsletter-editor/sidebar/send-to.js
+++ b/src/newsletter-editor/sidebar/send-to.js
@@ -45,7 +45,7 @@ const SendTo = () => {
 	}, [] );
 
 	useEffect( () => {
-		if ( listId && ! sublistId && newsletterData?.sublists ) {
+		if ( listId && newsletterData?.sublists ) {
 			if ( 1 >= newsletterData.sublists.length ) {
 				fetchSendLists( { type: 'sublist', parent_id: listId } );
 			}

--- a/src/newsletter-editor/sidebar/style.scss
+++ b/src/newsletter-editor/sidebar/style.scss
@@ -62,6 +62,10 @@
 		}
 	}
 
+	&__error {
+		color: wp-colors.$alert-red;
+	}
+
 	&__error input.components-text-control__input {
 		border-color: wp-colors.$alert-red;
 	}

--- a/src/newsletter-editor/store.js
+++ b/src/newsletter-editor/store.js
@@ -100,6 +100,10 @@ export const updateNewsletterDataError = error =>
 
 // Dispatcher to fetch newsletter data from the server.
 export const fetchNewsletterData = async postId => {
+	const isRetrieving = coreSelect( STORE_NAMESPACE ).getIsRetrieving();
+	if ( isRetrieving ) {
+		return;
+	}
 	updateIsRetrieving( true );
 	updateNewsletterDataError( null );
 	try {
@@ -116,6 +120,10 @@ export const fetchNewsletterData = async postId => {
 
 // Dispatcher to fetch any errors from the most recent sync attempt.
 export const fetchSyncErrors = async postId => {
+	const isRetrieving = coreSelect( STORE_NAMESPACE ).getIsRetrieving();
+	if ( isRetrieving ) {
+		return;
+	}
 	updateIsRetrieving( true );
 	updateNewsletterDataError( null );
 	try {
@@ -128,6 +136,7 @@ export const fetchSyncErrors = async postId => {
 	} catch ( error ) {
 		updateNewsletterDataError( error );
 	}
+	updateIsRetrieving( false );
 }
 
 // Dispatcher to fetch send lists and sublists from the connected ESP and update the newsletterData in store.
@@ -142,7 +151,7 @@ export const fetchSendLists = debounce( async ( opts ) => {
 			...opts,
 		};
 
-		const newsletterData = coreSelect( STORE_NAMESPACE ).getData()
+		const newsletterData = coreSelect( STORE_NAMESPACE ).getData();
 		const sendLists = 'list' === args.type ? [ ...newsletterData?.lists ] || [] : [ ...newsletterData?.sublists ] || [];
 
 		// If we already have a matching result, no need to fetch more.
@@ -174,6 +183,10 @@ export const fetchSendLists = debounce( async ( opts ) => {
 		const updatedSendLists = [ ...sendLists ];
 
 		// If no existing items found, fetch from the ESP.
+		const isRetrieving = coreSelect( STORE_NAMESPACE ).getIsRetrieving();
+		if ( isRetrieving ) {
+			return;
+		}
 		updateIsRetrieving( true );
 		const response = await apiFetch( {
 			path: addQueryArgs(

--- a/src/newsletter-editor/store.js
+++ b/src/newsletter-editor/store.js
@@ -111,7 +111,17 @@ export const fetchNewsletterData = async postId => {
 		const response = await apiFetch( {
 			path: `/newspack-newsletters/v1/${ name }/${ postId }/retrieve`,
 		} );
-		updateNewsletterData( response );
+
+		// If we've already fetched list or sublist info, retain it.
+		const newsletterData = coreSelect( STORE_NAMESPACE ).getData();
+		const updatedNewsletterData = { ...response };
+		if ( newsletterData?.lists ) {
+			updatedNewsletterData.lists = newsletterData.lists;
+		}
+		if ( newsletterData?.sublists ) {
+			updatedNewsletterData.sublists = newsletterData.sublists;
+		}
+		updateNewsletterData( updatedNewsletterData );
 	} catch ( error ) {
 		updateNewsletterDataError( error );
 	}

--- a/src/newsletter-editor/store.js
+++ b/src/newsletter-editor/store.js
@@ -1,5 +1,10 @@
 /**
  * A Redux store for ESP newsletter data to be used across editor components.
+ * This store is a centralized place for all data fetched from or updated via the ESP's API.
+ *
+ * Import use* hooks to read store data from any component.
+ * Import fetch* hooks to fetch updated ESP data from any component.
+ * Import update* hooks to update store data from any component.
  */
 
 /**

--- a/src/newsletter-editor/utils.js
+++ b/src/newsletter-editor/utils.js
@@ -1,3 +1,5 @@
+/* global newspack_email_editor_data */
+
 /**
  * WordPress dependencies
  */
@@ -14,12 +16,15 @@ import mjml2html from 'mjml-browser';
  */
 import { getServiceProvider } from '../service-providers';
 
-export const getEditPostPayload = newsletterData => {
-	return {
-		meta: {
-			newsletterData,
-		},
-	};
+/**
+ * Is the current ESP a supported, connected ESP?
+ *
+ * @return {boolean} True if the ESP is supported and connected.
+ */
+export const isSupportedESP = () => {
+	const { supported_esps: suppportedESPs } = newspack_email_editor_data || {};
+	const { name: serviceProviderName } = getServiceProvider();
+	return serviceProviderName && 'manual' !== serviceProviderName && suppportedESPs?.includes( serviceProviderName );
 };
 
 /**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Just some reorganization to consolidate things. All newsletter data fetched from or written to via the connected ESP's API should be routed through our `newspack/newsletters` Redux store. This now includes:

- Fetching `newsletterData` from the ESP
- Fetching send lists or sublists from the ESP (this has been moved from the `NewsletterEdit` component to the store with its own actions, dispatchers, and hook functions, so there's no longer a need to pass the function down the component tree)
- Fetching sync errors from the most recent sync attempt with the ESP (this has been moved from the `MJML` component to the store, too)

Hopefully this reduces the effort to trace where this ESP data is coming from or updated no matter where you are in the editor component hierarchy.

### How to test the changes in this Pull Request:

There should be no major changes in functionality or behavior compared with #1632, except that we're now able to more explicitly show error messages in the `<SendTo />` component if it fails to fetch send lists for any reason. All other changes are purely conceptual and organizational.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
