### PR TITLE
fix: automatically retry failed scheduled sends

### DIFF
--- a/includes/service-providers/class-newspack-newsletters-service-provider.php
+++ b/includes/service-providers/class-newspack-newsletters-service-provider.php
@@ -468,7 +468,7 @@ Details of the error message: "%3$s"
 					),
 					$post->post_title,
 					get_edit_post_link( $post_id ),
-					$error_message
+					$result->get_error_message()
 				);
 
 				\wp_mail( // phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.wp_mail_wp_mail

--- a/includes/service-providers/class-newspack-newsletters-service-provider.php
+++ b/includes/service-providers/class-newspack-newsletters-service-provider.php
@@ -249,7 +249,7 @@ abstract class Newspack_Newsletters_Service_Provider implements Newspack_Newslet
 					'newspack_log',
 					'newspack_esp_scheduled_send_error',
 					sprintf(
-						'Error scheduling send for post ID: %d',
+						'Error sending scheduled newsletter ID: %d',
 						$post->ID
 					),
 					[

--- a/includes/service-providers/class-newspack-newsletters-service-provider.php
+++ b/includes/service-providers/class-newspack-newsletters-service-provider.php
@@ -481,7 +481,7 @@ Error message(s) received:
 						'newspack-newsletters'
 					),
 					$post->post_title,
-					get_edit_post_link( $post_id ),
+					admin_url( 'post.php?post=' . $post_id . '&action=edit' ),
 					$errors
 				);
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Implements an auto-retry system for scheduled newsletter sends, and adds logging for scheduled send failures.

#831 fixed handling for failed scheduled sends by resetting the post to `draft` status if a scheduled send failed to happen, but by resetting to `draft` status the newsletter must be manually sent or rescheduled. This PR will attempt to automatically retry the send in exponentially increasing intervals up to a maximum of 10 times.

### How to test the changes in this Pull Request:

1. Check out this branch.
2. Add `return new WP_Error( 'newspack_newsletters_error', 'Temporary error' );` to the first line of the `Newspack_Newsletters_Service_Provider::send_newsletter()` method to force a failure upon scheduled send.
3. Schedule a newsletter to be sent at some point in the near future.
4. Refresh the newsletter in the editor after the scheduled send time has passed and confirm you see an error message about the failed send at the top of the editor that says "Error sending newsletter: Temporary error". Also confirm that the post remains in "Future" status with a scheduled send time of some minutes in the future.
5. Wait a while or bump the `MAX_SCHEDULED_RETRIES` number down to something like 3 and wait a bit less, then refresh the newsletter in the editor again. Confirm that the post has reverted to "Draft" status with the error message "Failed to send 10 times. Please check the provider connection and try sending again."
6. Schedule the newsletter to be sent again at some point in the future, then wait for it to fail once.
7. Remove the temporary error message you added in step 2 and wait for the next attempt—this time confirm the scheduled send succeeds and that the newsletter post successfully transitions to "Private" or "Published" status.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
