### PR TITLE
feat: add link to campaign in provider

### DIFF
--- a/includes/service-providers/active_campaign/class-newspack-newsletters-active-campaign.php
+++ b/includes/service-providers/active_campaign/class-newspack-newsletters-active-campaign.php
@@ -799,6 +799,14 @@ final class Newspack_Newsletters_Active_Campaign extends \Newspack_Newsletters_S
 				'sublists'                          => $send_sublists,
 			];
 
+			if ( $campaign_id ) {
+				$newsletter_data['link'] = sprintf(
+					'https://%s.activehosted.com/app/campaigns/%d',
+					explode( '.', str_replace( 'https://', '', $this->api_credentials()['url'] ) )[0],
+					$campaign_id
+				);
+			}
+
 			// Handle legacy sender meta.
 			$from_name   = get_post_meta( $post_id, 'senderName', true );
 			$from_email  = get_post_meta( $post_id, 'senderEmail', true );

--- a/includes/service-providers/constant_contact/class-newspack-newsletters-constant-contact.php
+++ b/includes/service-providers/constant_contact/class-newspack-newsletters-constant-contact.php
@@ -487,6 +487,25 @@ final class Newspack_Newsletters_Constant_Contact extends \Newspack_Newsletters_
 	}
 
 	/**
+	 * Get the campaign link.
+	 *
+	 * @param object $campaign Campaign object.
+	 *
+	 * @return string Campaign link.
+	 */
+	private static function get_campaign_link( $campaign ) {
+		if ( empty( $campaign->campaign_activities ) ) {
+			return '';
+		}
+		$activity_index = array_search( 'primary_email', array_column( $campaign->campaign_activities, 'role' ) );
+		if ( false === $activity_index ) {
+			return '';
+		}
+		$activity = $campaign->campaign_activities[ $activity_index ];
+		return sprintf( 'https://app.constantcontact.com/pages/ace/v1#/%s', $activity->campaign_activity_id );
+	}
+
+	/**
 	 * Retrieve a campaign.
 	 *
 	 * @param integer $post_id Numeric ID of the Newsletter post.
@@ -526,6 +545,7 @@ final class Newspack_Newsletters_Constant_Contact extends \Newspack_Newsletters_
 			$newsletter_data = [
 				'campaign'              => $campaign,
 				'campaign_id'           => $cc_campaign_id,
+				'link'                  => $this->get_campaign_link( $campaign ),
 				'allowed_sender_emails' => $this->get_verified_email_addresses(), // Get allowed email addresses for sender UI.
 				'email_settings_url'    => 'https://app.constantcontact.com/pages/myaccount/settings/emails',
 			];

--- a/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp.php
+++ b/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp.php
@@ -437,7 +437,7 @@ final class Newspack_Newsletters_Mailchimp extends \Newspack_Newsletters_Service
 				$mc->get(
 					"campaigns/$mc_campaign_id",
 					[
-						'fields' => 'id,type,status,emails_sent,content_type,recipients,settings',
+						'fields' => 'id,web_id,type,status,emails_sent,content_type,recipients,settings',
 					]
 				),
 				__( 'Error retrieving Mailchimp campaign.', 'newspack_newsletters' )
@@ -494,6 +494,7 @@ final class Newspack_Newsletters_Mailchimp extends \Newspack_Newsletters_Service
 				'folders'                => Newspack_Newsletters_Mailchimp_Cached_Data::get_folders(),
 				'allowed_sender_domains' => $this->get_verified_domains(),
 				'merge_fields'           => $list_id ? Newspack_Newsletters_Mailchimp_Cached_Data::get_merge_fields( $list_id ) : [],
+				'link'                   => sprintf( 'https://%s.admin.mailchimp.com/campaigns/edit?id=%d', explode( '-', $this->api_key() )[1], $campaign['web_id'] ),
 			];
 
 			// Reconcile campaign settings with info fetched from the ESP for a true two-way sync.

--- a/src/newsletter-editor/campaign-link/index.js
+++ b/src/newsletter-editor/campaign-link/index.js
@@ -3,7 +3,6 @@
  */
 import { __, sprintf } from '@wordpress/i18n';
 import { Button } from '@wordpress/components';
-import { PluginPostStatusInfo } from '@wordpress/edit-post';
 
 /**
  * Internal dependencies
@@ -13,23 +12,21 @@ import { useNewsletterData } from '../../newsletter-editor/store';
 
 export default function CampaignLink() {
 	const newsletterData = useNewsletterData();
-  if ( ! newsletterData.link ) {
-    return null;
-  }
+	if ( ! newsletterData.link ) {
+		return null;
+	}
 	return (
-		<PluginPostStatusInfo>
-			<Button
-				variant="secondary"
-				href={ newsletterData.link }
-				target="_blank"
-				rel="noopener noreferrer"
-			>
-				{ sprintf(
-            // translators: %s: service provider name.
-            __('View Campaign in %s', 'newspack-newsletters'),
-            getServiceProvider().displayName
-        ) }
-			</Button>
-		</PluginPostStatusInfo>
+		<Button
+			variant="secondary"
+			href={ newsletterData.link }
+			target="_blank"
+			rel="noopener noreferrer"
+		>
+			{ sprintf(
+					// translators: %s: service provider name.
+					__('View Campaign in %s', 'newspack-newsletters'),
+					getServiceProvider().displayName
+			) }
+		</Button>
 	);
 }

--- a/src/newsletter-editor/campaign-link/index.js
+++ b/src/newsletter-editor/campaign-link/index.js
@@ -24,7 +24,7 @@ export default function CampaignLink() {
 		>
 			{ sprintf(
 					// translators: %s: service provider name.
-					__('View Campaign in %s', 'newspack-newsletters'),
+					__( 'View Campaign in %s', 'newspack-newsletters' ),
 					getServiceProvider().displayName
 			) }
 		</Button>

--- a/src/newsletter-editor/campaign-link/index.js
+++ b/src/newsletter-editor/campaign-link/index.js
@@ -1,0 +1,35 @@
+/**
+ * WordPress dependencies
+ */
+import { __, sprintf } from '@wordpress/i18n';
+import { Button } from '@wordpress/components';
+import { PluginPostStatusInfo } from '@wordpress/edit-post';
+
+/**
+ * Internal dependencies
+ */
+import { getServiceProvider } from '../../service-providers';
+import { useNewsletterData } from '../../newsletter-editor/store';
+
+export default function CampaignLink() {
+	const newsletterData = useNewsletterData();
+  if ( ! newsletterData.link ) {
+    return null;
+  }
+	return (
+		<PluginPostStatusInfo>
+			<Button
+				variant="secondary"
+				href={ newsletterData.link }
+				target="_blank"
+				rel="noopener noreferrer"
+			>
+				{ sprintf(
+            // translators: %s: service provider name.
+            __('View Campaign in %s', 'newspack-newsletters'),
+            getServiceProvider().displayName
+        ) }
+			</Button>
+		</PluginPostStatusInfo>
+	);
+}

--- a/src/newsletter-editor/campaign-link/index.js
+++ b/src/newsletter-editor/campaign-link/index.js
@@ -16,17 +16,19 @@ export default function CampaignLink() {
 		return null;
 	}
 	return (
-		<Button
-			variant="secondary"
-			href={ newsletterData.link }
-			target="_blank"
-			rel="noopener noreferrer"
-		>
-			{ sprintf(
-					// translators: %s: service provider name.
-					__( 'View Campaign in %s', 'newspack-newsletters' ),
-					getServiceProvider().displayName
-			) }
-		</Button>
+		<p>
+			<Button
+				variant="secondary"
+				href={ newsletterData.link }
+				target="_blank"
+				rel="noopener noreferrer"
+			>
+				{ sprintf(
+						// translators: %s: service provider name.
+						__( 'View Campaign in %s', 'newspack-newsletters' ),
+						getServiceProvider().displayName
+				) }
+			</Button>
+		</p>
 	);
 }

--- a/src/newsletter-editor/index.js
+++ b/src/newsletter-editor/index.js
@@ -8,6 +8,7 @@ import {
 	PluginDocumentSettingPanel,
 	PluginSidebar,
 	PluginSidebarMoreMenuItem,
+	PluginPostStatusInfo,
 } from '@wordpress/edit-post';
 import { registerPlugin } from '@wordpress/plugins';
 import { styles } from '@wordpress/icons';
@@ -120,7 +121,9 @@ function NewsletterEdit( { apiFetchWithErrorHandling, setInFlightForAsync, inFli
 				{ stylingTitle }
 			</PluginSidebarMoreMenuItem>
 
-			<CampaignLink />
+			<PluginPostStatusInfo>
+				<CampaignLink />
+			</PluginPostStatusInfo>
 
 			<PluginDocumentSettingPanel
 				name="newsletters-settings-panel"

--- a/src/newsletter-editor/index.js
+++ b/src/newsletter-editor/index.js
@@ -26,6 +26,7 @@ import registerEditorPlugin from './editor/';
 import withApiHandler from '../components/with-api-handler';
 import { registerStore, fetchNewsletterData, useNewsletterDataError } from './store';
 import { isSupportedESP } from './utils';
+import CampaignLink from './campaign-link';
 import './debug-send';
 
 registerStore();
@@ -118,6 +119,8 @@ function NewsletterEdit( { apiFetchWithErrorHandling, setInFlightForAsync, inFli
 			<PluginSidebarMoreMenuItem target={ stylingId } icon={ styles }>
 				{ stylingTitle }
 			</PluginSidebarMoreMenuItem>
+
+			<CampaignLink />
 
 			<PluginDocumentSettingPanel
 				name="newsletters-settings-panel"

--- a/src/newsletter-editor/index.js
+++ b/src/newsletter-editor/index.js
@@ -122,20 +122,20 @@ function NewsletterEdit( { apiFetchWithErrorHandling, setInFlightForAsync, inFli
 			</PluginSidebarMoreMenuItem>
 
 			<PluginPostStatusInfo>
-				<CampaignLink />
+				{ isConnected && <PublicSettings /> }
 			</PluginPostStatusInfo>
 
 			<PluginDocumentSettingPanel
 				name="newsletters-settings-panel"
-				title={ __( 'Newsletter', 'newspack-newsletters' ) }
+				title={ __( 'Newsletter Campaign', 'newspack-newsletters' ) }
 			>
+				<CampaignLink />
 				<Sidebar
 					inFlight={ inFlight }
 					isConnected={ isConnected }
 					oauthUrl={ oauthUrl }
 					onAuthorize={ verifyToken }
 				/>
-				{ isConnected && <PublicSettings /> }
 			</PluginDocumentSettingPanel>
 			{ isSupportedESP() && (
 				<PluginDocumentSettingPanel

--- a/src/service-providers/active_campaign/index.js
+++ b/src/service-providers/active_campaign/index.js
@@ -56,6 +56,7 @@ const isCampaignSent = ( newsletterData, postStatus = 'draft' ) => {
 }
 
 export default {
+	displayName: 'ActiveCampaign',
 	renderPreSendInfo,
 	isCampaignSent
 };

--- a/src/service-providers/campaign_monitor/index.js
+++ b/src/service-providers/campaign_monitor/index.js
@@ -64,6 +64,7 @@ const isCampaignSent = ( newsletterData, postStatus = 'draft' ) => {
 
 
 export default {
+	displayName: 'Campaign Monitor',
 	renderPreSendInfo,
 	isCampaignSent
 };

--- a/src/service-providers/constant_contact/index.js
+++ b/src/service-providers/constant_contact/index.js
@@ -69,6 +69,7 @@ const isCampaignSent = ( newsletterData, postStatus = 'draft' ) => {
 }
 
 export default {
+	displayName: 'Constant Contact',
 	hasOauth,
 	renderPreSendInfo,
 	isCampaignSent,

--- a/src/service-providers/mailchimp/index.js
+++ b/src/service-providers/mailchimp/index.js
@@ -2,7 +2,6 @@
  * WordPress dependencies
  */
 import { __, sprintf, _n } from '@wordpress/i18n';
-import { Fragment } from '@wordpress/element';
 
 /**
  * External dependencies
@@ -91,6 +90,7 @@ const isCampaignSent = ( newsletterData, postStatus = 'draft' ) => {
 }
 
 export default {
+	displayName: 'Mailchimp',
 	ProviderSidebar,
 	renderPreSendInfo,
 	isCampaignSent


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:


Add a link to view/edit the campaign in the provider:

<img width="263" alt="image" src="https://github.com/user-attachments/assets/e5b08338-3e20-4430-b848-fc0c9796de54">

It works for Mailchimp, ActiveCampaign, and Constant Contact.

Campaign Monitor is not included because we don't sync the newsletter campaign data with the provider. It's only pushed when sending the campaign.

### How to test the changes in this Pull Request:

1. For each ESP, start a draft and save
2. Note that the button appears once the campaign is synced to the ESP

For ActiveCampaign, the campaign is only synced once you have filled sender info and a list, so it should only become available after saving these fields.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
