### PR TITLE
fix: parse legacy layout defaults

### DIFF
--- a/includes/class-newspack-newsletters-layouts.php
+++ b/includes/class-newspack-newsletters-layouts.php
@@ -231,6 +231,12 @@ final class Newspack_Newsletters_Layouts {
 					if ( ! empty( $campaign_info['sublist_id'] ) ) {
 						$campaign_defaults['send_sublist_id'] = $campaign_info['sublist_id'];
 					}
+					if ( ! empty( $campaign_info['senderName'] ) ) {
+						$campaign_defaults['senderName'] = $campaign_info['senderName'];
+					}
+					if ( ! empty( $campaign_info['senderEmail'] ) ) {
+						$campaign_defaults['senderEmail'] = $campaign_info['senderEmail'];
+					}
 					if ( ! empty( $campaign_defaults ) ) {
 						$campaign_defaults = wp_json_encode( $campaign_defaults );
 						update_post_meta( $post->ID, 'campaign_defaults', $campaign_defaults );

--- a/includes/class-newspack-newsletters-layouts.php
+++ b/includes/class-newspack-newsletters-layouts.php
@@ -224,7 +224,7 @@ final class Newspack_Newsletters_Layouts {
 						$campaign_defaults['senderEmail'] = $legacy_meta['senderEmail'];
 					}
 					$provider      = Newspack_Newsletters::get_service_provider();
-					$campaign_info = $provider->extract_campaign_info( $legacy_meta['newsletterData']['campaign'] ?? null );
+					$campaign_info = $provider->extract_campaign_info( $legacy_meta['newsletterData'] ?? null );
 					if ( ! empty( $campaign_info['list_id'] ) ) {
 						$campaign_defaults['send_list_id'] = $campaign_info['list_id'];
 					}

--- a/includes/class-newspack-newsletters-layouts.php
+++ b/includes/class-newspack-newsletters-layouts.php
@@ -191,5 +191,62 @@ final class Newspack_Newsletters_Layouts {
 		}
 		return $layouts;
 	}
+
+	/**
+	 * Get all layouts.
+	 */
+	public static function get_layouts() {
+		$layouts_query = new WP_Query(
+			[
+				'post_type'      => self::NEWSPACK_NEWSLETTERS_LAYOUT_CPT,
+				'posts_per_page' => -1,
+			]
+		);
+		$user_layouts  = array_map(
+			function ( $post ) {
+				$post->meta = [
+					'background_color'  => get_post_meta( $post->ID, 'background_color', true ),
+					'font_body'         => get_post_meta( $post->ID, 'font_body', true ),
+					'font_header'       => get_post_meta( $post->ID, 'font_header', true ),
+					'custom_css'        => get_post_meta( $post->ID, 'custom_css', true ),
+					'campaign_defaults' => get_post_meta( $post->ID, 'campaign_defaults', true ),
+				];
+
+				// Migrate layout defaults from legacy meta, if it exists.
+				$campaign_defaults = $post->meta['campaign_defaults'];
+				$legacy_meta       = json_decode( get_post_meta( $post->ID, 'layout_defaults', true ), true );
+				if ( empty( $campaign_defaults ) && ! empty( $legacy_meta ) ) {
+					$campaign_defaults = [];
+					if ( ! empty( $legacy_meta['senderName'] ) ) {
+						$campaign_defaults['senderName'] = $legacy_meta['senderName'];
+					}
+					if ( ! empty( $legacy_meta['senderEmail'] ) ) {
+						$campaign_defaults['senderEmail'] = $legacy_meta['senderEmail'];
+					}
+					$provider      = Newspack_Newsletters::get_service_provider();
+					$campaign_info = $provider->extract_campaign_info( $legacy_meta['newsletterData']['campaign'] ?? null );
+					if ( ! empty( $campaign_info['list_id'] ) ) {
+						$campaign_defaults['send_list_id'] = $campaign_info['list_id'];
+					}
+					if ( ! empty( $campaign_info['sublist_id'] ) ) {
+						$campaign_defaults['send_sublist_id'] = $campaign_info['sublist_id'];
+					}
+					if ( ! empty( $campaign_defaults ) ) {
+						$campaign_defaults = wp_json_encode( $campaign_defaults );
+						update_post_meta( $post->ID, 'campaign_defaults', $campaign_defaults );
+						$post->meta['campaign_defaults'] = $campaign_defaults;
+					}
+				}
+
+				return $post;
+			},
+			$layouts_query->get_posts()
+		);
+		return array_merge(
+			$user_layouts,
+			self::get_default_layouts(),
+			apply_filters( 'newspack_newsletters_templates', [] )
+		);
+	}
 }
 Newspack_Newsletters_Layouts::instance();

--- a/includes/class-newspack-newsletters.php
+++ b/includes/class-newspack-newsletters.php
@@ -683,7 +683,7 @@ final class Newspack_Newsletters {
 	 */
 	public static function rest_api_init() {
 		\register_rest_route(
-			'newspack-newsletters/v1',
+			self::API_NAMESPACE,
 			'layouts',
 			[
 				'methods'             => \WP_REST_Server::READABLE,
@@ -692,7 +692,7 @@ final class Newspack_Newsletters {
 			]
 		);
 		\register_rest_route(
-			'newspack-newsletters/v1',
+			self::API_NAMESPACE,
 			'settings',
 			[
 				'methods'             => \WP_REST_Server::READABLE,
@@ -701,7 +701,7 @@ final class Newspack_Newsletters {
 			]
 		);
 		\register_rest_route(
-			'newspack-newsletters/v1',
+			self::API_NAMESPACE,
 			'settings',
 			[
 				'methods'             => \WP_REST_Server::EDITABLE,
@@ -715,7 +715,7 @@ final class Newspack_Newsletters {
 			]
 		);
 		\register_rest_route(
-			'newspack-newsletters/v1',
+			self::API_NAMESPACE,
 			'color-palette',
 			[
 				'methods'             => \WP_REST_Server::EDITABLE,
@@ -725,7 +725,7 @@ final class Newspack_Newsletters {
 		);
 
 		\register_rest_route(
-			'newspack-newsletters/v1',
+			self::API_NAMESPACE,
 			'post-mjml',
 			[
 				'methods'             => \WP_REST_Server::EDITABLE,
@@ -808,32 +808,7 @@ final class Newspack_Newsletters {
 	 * Retrieve Layouts.
 	 */
 	public static function api_get_layouts() {
-		$layouts_query = new WP_Query(
-			[
-				'post_type'      => Newspack_Newsletters_Layouts::NEWSPACK_NEWSLETTERS_LAYOUT_CPT,
-				'posts_per_page' => -1,
-			]
-		);
-		$user_layouts  = array_map(
-			function ( $post ) {
-				$post->meta = [
-					'background_color'  => get_post_meta( $post->ID, 'background_color', true ),
-					'font_body'         => get_post_meta( $post->ID, 'font_body', true ),
-					'font_header'       => get_post_meta( $post->ID, 'font_header', true ),
-					'custom_css'        => get_post_meta( $post->ID, 'custom_css', true ),
-					'campaign_defaults' => get_post_meta( $post->ID, 'campaign_defaults', true ),
-				];
-				return $post;
-			},
-			$layouts_query->get_posts()
-		);
-		$layouts       = array_merge(
-			$user_layouts,
-			Newspack_Newsletters_Layouts::get_default_layouts(),
-			apply_filters( 'newspack_newsletters_templates', [] )
-		);
-
-		return \rest_ensure_response( $layouts );
+		return \rest_ensure_response( Newspack_Newsletters_Layouts::get_layouts() );
 	}
 
 	/**

--- a/includes/service-providers/active_campaign/class-newspack-newsletters-active-campaign.php
+++ b/includes/service-providers/active_campaign/class-newspack-newsletters-active-campaign.php
@@ -735,6 +735,44 @@ final class Newspack_Newsletters_Active_Campaign extends \Newspack_Newsletters_S
 	}
 
 	/**
+	 * Given legacy newsletterData, extract sender and send-to info.
+	 *
+	 * @param array $newsletter_data Newsletter data from the ESP.
+	 * @return array {
+	 *    Extracted sender and send-to info. All keys are optional and will be
+	 *    returned only if found in the campaign data.
+	 *
+	 *    @type string $senderName Sender name.
+	 *    @type string $senderEmail Sender email.
+	 *    @type string $list_id List ID.
+	 *    @type string $sublist_id Sublist ID.
+	 * }
+	 */
+	public function extract_campaign_info( $newsletter_data ) {
+		$campaign_info = [];
+
+		// Sender info.
+		if ( ! empty( $newsletter_data['from_name'] ) ) {
+			$campaign_info['from_name'] = $newsletter_data['from_name'];
+		}
+		if ( ! empty( $newsletter_data['from_email'] ) ) {
+			$campaign_info['senderEmail'] = $newsletter_data['from_email'];
+		}
+
+		// List.
+		if ( ! empty( $newsletter_data['list_id'] ) ) {
+			$campaign_info['list_id'] = $newsletter_data['list_id'];
+		}
+
+		// Segment.
+		if ( ! empty( $newsletter_data['segment_id'] ) ) {
+			$campaign_info['sublist_id'] = $newsletter_data['segment_id'];
+		}
+
+		return $campaign_info;
+	}
+
+	/**
 	 * Retrieve a campaign.
 	 *
 	 * @param int  $post_id    Numeric ID of the Newsletter post.

--- a/includes/service-providers/active_campaign/class-newspack-newsletters-active-campaign.php
+++ b/includes/service-providers/active_campaign/class-newspack-newsletters-active-campaign.php
@@ -753,7 +753,7 @@ final class Newspack_Newsletters_Active_Campaign extends \Newspack_Newsletters_S
 
 		// Sender info.
 		if ( ! empty( $newsletter_data['from_name'] ) ) {
-			$campaign_info['from_name'] = $newsletter_data['from_name'];
+			$campaign_info['senderName'] = $newsletter_data['from_name'];
 		}
 		if ( ! empty( $newsletter_data['from_email'] ) ) {
 			$campaign_info['senderEmail'] = $newsletter_data['from_email'];
@@ -942,7 +942,7 @@ final class Newspack_Newsletters_Active_Campaign extends \Newspack_Newsletters_S
 		if ( is_wp_error( $campaign_data ) ) {
 			return $campaign_data;
 		}
-		$campaign_messages = explode( ',', $campaign_data[0]['messageslist'] ); 
+		$campaign_messages = explode( ',', $campaign_data[0]['messageslist'] );
 		$message_id        = ! empty( $campaign_messages ) ? reset( $campaign_messages ) : 0;
 
 		$test_result = $this->api_v1_request(

--- a/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp.php
+++ b/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp.php
@@ -452,9 +452,9 @@ final class Newspack_Newsletters_Mailchimp extends \Newspack_Newsletters_Service
 	}
 
 	/**
-	 * Given a campaign object from the ESP, extract sender and send-to info.
+	 * Given a campaign object from the ESP or legacy newsletterData, extract sender and send-to info.
 	 *
-	 * @param array $campaign Campaign data from the ESP.
+	 * @param array $newsletter_data Newsletter data from the ESP.
 	 * @return array {
 	 *    Extracted sender and send-to info. All keys are optional and will be
 	 *    returned only if found in the campaign data.
@@ -465,11 +465,11 @@ final class Newspack_Newsletters_Mailchimp extends \Newspack_Newsletters_Service
 	 *    @type string $sublist_id Sublist ID.
 	 * }
 	 */
-	public function extract_campaign_info( $campaign ) {
-		$campaign_info = [];
-		if ( ! $campaign ) {
+	public function extract_campaign_info( $newsletter_data ) {
+		$campaign_info = [];if ( empty( $newsletter_data['campaign'] ) ) {
 			return $campaign_info;
 		}
+		$campaign = $newsletter_data['campaign'];
 
 		// Sender info.
 		if ( ! empty( $campaign['settings']['from_name'] ) ) {
@@ -479,12 +479,12 @@ final class Newspack_Newsletters_Mailchimp extends \Newspack_Newsletters_Service
 			$campaign_info['senderEmail'] = $campaign['settings']['reply_to'];
 		}
 
-		// Send list.
+		// Audience.
 		if ( ! empty( $campaign['recipients']['list_id'] ) ) {
 			$campaign_info['list_id'] = $campaign['recipients']['list_id'];
 		}
 
-		// Send sublist.
+		// Group, segment, or tag.
 		if ( ! empty( $campaign['recipients']['segment_opts'] ) ) {
 			$segment_opts  = $campaign['recipients']['segment_opts'];
 			$target_id_raw = $segment_opts['saved_segment_id'] ?? null;
@@ -539,7 +539,7 @@ final class Newspack_Newsletters_Mailchimp extends \Newspack_Newsletters_Service
 				}
 			}
 
-			$campaign_info   = $this->extract_campaign_info( $campaign );
+			$campaign_info   = $this->extract_campaign_info( [ 'campaign' => $campaign ] );
 			$list_id         = $campaign_info['list_id'] ?? null;
 			$send_list_id    = get_post_meta( $post_id, 'send_list_id', true );
 			$send_sublist_id = get_post_meta( $post_id, 'send_sublist_id', true );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

This PR parses legacy `newsletterData` metadata on preexisting custom newsletter layouts to migrate sender and send-to settings to the newer, leaner, cross-ESP-compatible `campaign_defaults` meta field for layout CPT posts. This should make #1658 NOT a breaking change, as publishers' preexisting custom layouts will be able to seamlessly their data.

### How to test the changes in this Pull Request:

1. On `trunk` or `release`, create a new newsletter, set sender email + name and list/sublist options, then save as a new custom layout.
2. Check out this branch, then create a new newsletter using the custom layout from step 1. Confirm that the Sender Name/Email and Send To options are prepopulated from the layout settings.
3. Repeat for Mailchimp, ActiveCampaign, and ~Constant Contact~ (Campaign Monitor is not handled as there is no preexisting legacy data to handle for this ESP). EDIT: also, Constant Contact does not seem to work as creating a new campaign always seems to set the top-level list by default, but this is also the case in `trunk`, so I think this is non-blocking for now.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
