### PR TITLE
fix: ignore (but log) local list errors when updating contact lists

### DIFF
--- a/includes/service-providers/class-newspack-newsletters-service-provider.php
+++ b/includes/service-providers/class-newspack-newsletters-service-provider.php
@@ -687,6 +687,7 @@ Error message(s) received:
 								'file'       => 'newspack_' . $this->service,
 							]
 						);
+						continue;
 					}
 					$list_settings = $list->get_provider_settings( $this->service );
 

--- a/includes/service-providers/class-newspack-newsletters-service-provider.php
+++ b/includes/service-providers/class-newspack-newsletters-service-provider.php
@@ -649,8 +649,8 @@ Error message(s) received:
 			return true;
 		}
 		if ( static::$support_local_lists ) {
-			$lists_to_add            = $this->update_contact_local_lists( $email, $lists_to_add, 'add', true );
-			$lists_to_remove         = $this->update_contact_local_lists( $email, $lists_to_remove, 'remove', true );
+			$lists_to_add    = $this->update_contact_local_lists( $email, $lists_to_add, 'add', true );
+			$lists_to_remove = $this->update_contact_local_lists( $email, $lists_to_remove, 'remove', true );
 		}
 		return $this->update_contact_lists( $email, $lists_to_add, $lists_to_remove );
 	}

--- a/includes/service-providers/class-newspack-newsletters-service-provider.php
+++ b/includes/service-providers/class-newspack-newsletters-service-provider.php
@@ -687,6 +687,7 @@ Error message(s) received:
 								'file'       => 'newspack_' . $this->service,
 							]
 						);
+						unset( $lists[ $key ] );
 						continue;
 					}
 					$list_settings = $list->get_provider_settings( $this->service );

--- a/includes/service-providers/class-newspack-newsletters-service-provider.php
+++ b/includes/service-providers/class-newspack-newsletters-service-provider.php
@@ -649,8 +649,8 @@ Error message(s) received:
 			return true;
 		}
 		if ( static::$support_local_lists ) {
-			$lists_to_add    = $this->update_contact_local_lists( $email, $lists_to_add, 'add', true );
-			$lists_to_remove = $this->update_contact_local_lists( $email, $lists_to_remove, 'remove', true );
+			$lists_to_add    = $this->update_contact_local_lists( $email, $lists_to_add, 'add' );
+			$lists_to_remove = $this->update_contact_local_lists( $email, $lists_to_remove, 'remove' );
 		}
 		return $this->update_contact_lists( $email, $lists_to_add, $lists_to_remove );
 	}

--- a/includes/service-providers/class-newspack-newsletters-service-provider.php
+++ b/includes/service-providers/class-newspack-newsletters-service-provider.php
@@ -673,15 +673,12 @@ Error message(s) received:
 						do_action(
 							'newspack_log',
 							'newspack_esp_update_contact_lists_error',
-							sprintf(
-								'Error handling local list: %s',
-								$list_id
-							),
+							__( 'Local list not properly configured for the provider', 'newspack-newsletters' ),
 							[
 								'type'       => 'error',
 								'data'       => [
 									'provider' => $this->service,
-									'errors'   => __( 'List not properly configured for the provider', 'newspack-newsletters' ),
+									'list_id'  => $list_id,
 								],
 								'user_email' => $email,
 								'file'       => 'newspack_' . $this->service,
@@ -702,15 +699,12 @@ Error message(s) received:
 					do_action(
 						'newspack_log',
 						'newspack_esp_update_contact_lists_error',
-						sprintf(
-							'Error handling local list: %s',
-							$list_id
-						),
+						__( 'Local list not found', 'newspack-newsletters' ),
 						[
 							'type'       => 'error',
 							'data'       => [
 								'provider' => $this->service,
-								'errors'   => __( 'List not found', 'newspack-newsletters' ),
+								'list_id'  => $list_id,
 							],
 							'user_email' => $email,
 							'file'       => 'newspack_' . $this->service,

--- a/includes/service-providers/class-newspack-newsletters-service-provider.php
+++ b/includes/service-providers/class-newspack-newsletters-service-provider.php
@@ -649,13 +649,47 @@ Error message(s) received:
 			return true;
 		}
 		if ( static::$support_local_lists ) {
-			$lists_to_add    = $this->update_contact_local_lists( $email, $lists_to_add, 'add' );
-			$lists_to_remove = $this->update_contact_local_lists( $email, $lists_to_remove, 'remove' );
-			if ( is_wp_error( $lists_to_add ) ) {
-				return $lists_to_add;
+			$added_result   = $this->update_contact_local_lists( $email, $lists_to_add, 'add', true );
+			$removed_result = $this->update_contact_local_lists( $email, $lists_to_remove, 'remove', true );
+
+			// If there are errors, log them but allow processing to continue.
+			if ( is_wp_error( $added_result ) ) {
+				do_action(
+					'newspack_log',
+					'newspack_esp_update_contact_lists_error',
+					sprintf(
+						'Error adding contact to lists: %s',
+						implode( ', ', $lists_to_add )
+					),
+					[
+						'type'       => 'error',
+						'data'       => [
+							'provider' => $this->service,
+							'errors'   => $added_result->get_error_messages(),
+						],
+						'user_email' => $email,
+						'file'       => 'newspack_' . $this->service,
+					]
+				);
 			}
-			if ( is_wp_error( $lists_to_remove ) ) {
-				return $lists_to_remove;
+			if ( is_wp_error( $removed_result ) ) {
+				do_action(
+					'newspack_log',
+					'newspack_esp_update_contact_lists_error',
+					sprintf(
+						'Error adding contact to lists: %s',
+						implode( ', ', $lists_to_remove )
+					),
+					[
+						'type'       => 'error',
+						'data'       => [
+							'provider' => $this->service,
+							'errors'   => $removed_result->get_error_messages(),
+						],
+						'user_email' => $email,
+						'file'       => 'newspack_' . $this->service,
+					]
+				);
 			}
 		}
 		return $this->update_contact_lists( $email, $lists_to_add, $lists_to_remove );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

This addresses something we've seen out in the wild where the `Newspack_Newsletters\Plugins\Woocommerce_Memberships::handle_membership_status_change()` method can fail a bit too easily if there are old local subscription lists hanging around on the site. This PR will log any errors that result from updating a user's local subscription lists, but will not halt the operation for those errors, which should allow updates for other non-local lists to continue. Such errors could happen in cases like the following:

- If you set up a subscription list (local or otherwise) with a membership plan and then change the connected ESP platform or account (this is the easiest way to replicate the issue and the basis of the testing instructions below)
- If you set up a local subscription list with a membership plan and then subsequently delete the corresponding tag in the connected ESP
- If you set up a local subscription list with a membership plan and then delete the local subscription list without removing it from the membership plan

### How to test the changes in this Pull Request:

1. On `trunk`, connect your site to an ESP and create a local subscription list in **Engagement > Newsletters**. Then, switch your ESP to another platform and create another local subscription list for this ESP.
2. Create a membership plan restricting content and tied to subscription product ownership and add the subscription lists for both ESPs.
3. As a reader, purchase the required subscription product.
4. As an admin, change the reader's subscription to "On Hold", "Cancelled", or "Expired" status.
5. Observe that the reader is likely not unsubscribed from the subscription list. This is because unlike the error handling for non-local subscription lists in the ESP classes' `update_contact_lists()` methods (which gather errors that occur and report them all after processing all passed lists), any error encountered when updating local subscription lists will halt the update process. Processing restricted subscription lists for other ESPs will throw errors because they're not configured for the current ESP.
6. Check out this branch.
7. As an admin, reactivate the reader's subscription, then deactivate again with an inactive status.
8. This time, confirm that the reader is removed from the restricted list.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1206548767599372