### PR TITLE
Fix: Dynamically fetch message ID in ActiveCampaign test emails

### DIFF
--- a/includes/service-providers/active_campaign/class-newspack-newsletters-active-campaign.php
+++ b/includes/service-providers/active_campaign/class-newspack-newsletters-active-campaign.php
@@ -659,6 +659,24 @@ final class Newspack_Newsletters_Active_Campaign extends \Newspack_Newsletters_S
 			return $campaign;
 		}
 		add_post_meta( $post_id, 'ac_test_campaign', $campaign['id'] );
+
+		/** Get the latest message ID from the temporary campaign. */
+		$campaign_data = $this->api_v1_request(
+			'campaign_list',
+			'GET',
+			[
+				'query' => [
+					'action' => 'test',
+					'ids'    => $campaign['id'],
+				],
+			]
+		);
+		if ( is_wp_error( $campaign_data ) ) {
+			return $campaign_data;
+		}
+		$campaign_messages = explode( ',', $campaign_data[0]['messageslist'] ); 
+		$message_id        = ! empty( $campaign_messages ) ? reset( $campaign_messages ) : 0;
+
 		$test_result = $this->api_v1_request(
 			'campaign_send',
 			'GET',
@@ -667,7 +685,7 @@ final class Newspack_Newsletters_Active_Campaign extends \Newspack_Newsletters_S
 					'type'       => 'html',
 					'action'     => 'test',
 					'campaignid' => $campaign['id'],
-					'messageid'  => $sync_result['message_id'],
+					'messageid'  => $message_id,
 					'email'      => implode( ',', $emails ),
 				],
 			]


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

**Note: This is a hotfix PR.**

This PR fixes an issue I discovered on some client sites which is also reproducible in my local environment. 

When a new temporary campaign is created in ActiveCampaign to send a test email, it uses [the message ID saved onto the post](https://github.com/Automattic/newspack-newsletters/blob/616666ced5b44c15e67a67eaed4b4bc7721a8c31/includes/service-providers/active_campaign/class-newspack-newsletters-active-campaign.php#L777). This message is not necessarily associated with the temporary campaign, so the test send will fail.

I'm not sure if the approach I took here is the way to go, or if it would be better to somehow associate the message from the "real" campaign with the temporary campaign, so that this check isn't needed. Let me know what you think.

### How to test the changes in this Pull Request:

1. This part happens naturally for every new newsletter on my local running only the trunk version of Plugin, Blocks, Ads, and Newsletters, but it did not happen in @adekbadek's testing. Start a new newsletter from a template, add all the necessary information, save it as draft, and send a test email.
2. Before applying this patch you should get a "Sending test campaign failed: Message not sent" error:
<img width="1239" alt="Screenshot 2024-10-03 at 2 20 24 PM" src="https://github.com/user-attachments/assets/efeb285d-12ae-414d-9ff2-03f5079bbc37">
4. After applying this patch it should successfully send:
<img width="1245" alt="Screenshot 2024-10-03 at 2 21 05 PM" src="https://github.com/user-attachments/assets/d293632b-3635-41f2-a798-300f8725a4a0">

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
