### PR TITLE
fix: fetching and display of sync errors after saving

### DIFF
--- a/includes/service-providers/active_campaign/class-newspack-newsletters-active-campaign.php
+++ b/includes/service-providers/active_campaign/class-newspack-newsletters-active-campaign.php
@@ -1066,7 +1066,7 @@ final class Newspack_Newsletters_Active_Campaign extends \Newspack_Newsletters_S
 		// Retrieve and store campaign data.
 		$data = $this->retrieve( $post->ID, true );
 		if ( is_wp_error( $data ) ) {
-			set_transient( $transient_name, __( 'Error syncing with ESP. ', 'newspack-newsletters' ) . $data->get_error_message(), 45 );
+			set_transient( $transient_name, __( 'ActiveCampaign sync error: ', 'newspack-newsletters' ) . $data->get_error_message(), 45 );
 			return $data;
 		} else {
 			$data = array_merge( $data, $sync_data );

--- a/includes/service-providers/constant_contact/class-newspack-newsletters-constant-contact.php
+++ b/includes/service-providers/constant_contact/class-newspack-newsletters-constant-contact.php
@@ -884,7 +884,7 @@ final class Newspack_Newsletters_Constant_Contact extends \Newspack_Newsletters_
 
 			return $campaign_result;
 		} catch ( Exception $e ) {
-			set_transient( $transient_name, __( 'Error syncing with ESP. ', 'newspack-newsletters' ) . $e->getMessage(), 45 );
+			set_transient( $transient_name, 'Constant Contact campaign sync error: ' . wp_specialchars_decode( $e->getMessage(), ENT_QUOTES ), 45 );
 			return new WP_Error( 'newspack_newsletters_constant_contact_error', $e->getMessage() );
 		}
 	}

--- a/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp.php
+++ b/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp.php
@@ -13,6 +13,8 @@ use Newspack\Newsletters\Subscription_Lists;
 use Newspack\Newsletters\Send_Lists;
 use Newspack\Newsletters\Send_List;
 
+use function cli\err;
+
 /**
  * Main Newspack Newsletters Class.
  */
@@ -1146,13 +1148,11 @@ final class Newspack_Newsletters_Mailchimp extends \Newspack_Newsletters_Service
 
 			if ( $mc_campaign_id ) {
 				$campaign_result = $this->validate(
-					$mc->patch( "campaigns/$mc_campaign_id", $payload ),
-					__( 'Error updating existing campaign draft.', 'newspack_newsletters' )
+					$mc->patch( "campaigns/$mc_campaign_id", $payload )
 				);
 			} else {
 				$campaign_result = $this->validate(
-					$mc->post( 'campaigns', $payload ),
-					__( 'Error creating campaign.', 'newspack_newsletters' )
+					$mc->post( 'campaigns', $payload )
 				);
 				$mc_campaign_id  = $campaign_result['id'];
 				update_post_meta( $post->ID, 'mc_campaign_id', $mc_campaign_id );
@@ -1177,7 +1177,7 @@ final class Newspack_Newsletters_Mailchimp extends \Newspack_Newsletters_Service
 				'content_result'  => $content_result,
 			];
 		} catch ( Exception $e ) {
-			set_transient( $transient_name, 'Mailchimp: ' . $e->getMessage(), 45 );
+			set_transient( $transient_name, 'Mailchimp campaign sync error: ' . wp_specialchars_decode( $e->getMessage(), ENT_QUOTES ), 45 );
 			return new WP_Error( 'newspack_newsletters_mailchimp_error', $e->getMessage() );
 		}
 	}

--- a/src/editor/mjml/index.js
+++ b/src/editor/mjml/index.js
@@ -112,11 +112,13 @@ function MJML() {
 					if ( isSupportedESP ) {
 						return fetchNewsletterData( postId );
 					}
+					return true;
 				} ).then ( () => {
 					// Check for sync errors after refreshing the HTML.
 					if ( isSupportedESP ) {
 						return fetchSyncErrors( postId );
 					}
+					return true;
 				} )
 				.catch( e => {
 					updateNewsletterDataError( e );

--- a/src/editor/mjml/index.js
+++ b/src/editor/mjml/index.js
@@ -11,7 +11,7 @@ import { refreshEmailHtml } from '../../newsletter-editor/utils';
 /**
  * Internal dependencies
  */
-import { fetchNewsletterData, fetchSyncErrors } from '../../newsletter-editor/store';
+import { fetchNewsletterData, fetchSyncErrors, updateNewsletterDataError } from '../../newsletter-editor/store';
 import { getServiceProvider } from '../../service-providers';
 
 /**
@@ -105,7 +105,7 @@ function MJML() {
 					} );
 				} )
 				.catch( e => {
-					console.warn( e ); // eslint-disable-line no-console
+					updateNewsletterDataError( e );
 				} )
 				.finally( () => {
 					unlockPostSaving( 'newspack-newsletters-refresh-html' );
@@ -116,10 +116,10 @@ function MJML() {
 					const isSupportedESP = serviceProviderName && 'manual' !== serviceProviderName && supportedESPs?.includes( serviceProviderName );
 					if ( isSupportedESP ) {
 						// Rehydrate ESP newsletter data after completing sync.
-						fetchNewsletterData( postId );
-
-						// Check for sync errors after refreshing the HTML.
-						fetchSyncErrors( postId );
+						fetchNewsletterData( postId ).then( () => {
+							// Check for sync errors after refreshing the HTML.
+							fetchSyncErrors( postId );
+						} );
 					}
 				} );
 		}

--- a/src/newsletter-editor/store.js
+++ b/src/newsletter-editor/store.js
@@ -126,6 +126,7 @@ export const fetchNewsletterData = async postId => {
 		updateNewsletterDataError( error );
 	}
 	updateIsRetrieving( false );
+	return true;
 };
 
 // Dispatcher to fetch any errors from the most recent sync attempt.
@@ -147,6 +148,7 @@ export const fetchSyncErrors = async postId => {
 		updateNewsletterDataError( error );
 	}
 	updateIsRetrieving( false );
+	return true;
 }
 
 // Dispatcher to fetch send lists and sublists from the connected ESP and update the newsletterData in store.


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes a race condition with concurrent fetch requests in the Redux store that can prevent sync errors from being displayed, and improves the sync error messaging, especially for Mailchimp, which often returns errors in an additional `errors` array instead of in a single error message.

### How to test the changes in this Pull Request:

1. On `trunk`, in a test site connected to Mailchimp, create a new newsletter.
2. Set the "Sender Name" to something with invalid characters, such as `$ Invalid @ Sender ! Name #`
3. Open the devtools console > Network tab and filter XHR requests by `newsletters/v1`. Save the newsletter as a draft and observe that after the save completes, a `post-mjml` POST request is fired, followed by a `retrieve` GET request, but possibly no `sync-error` request (because the `fetchNewsletterData` and `fetchSyncErrors` dispatchers are fired at the same time, the async response from `fetchNewsletterData` will overwrite the `fetchSyncErrors` request in the Redux store). Also observe that no error message is shown in the editor after this sequence of requests.
4. Check out this branch, repeat steps 2-3 and this time confirm that the save request is followed by a `post-mjml` POST request, a `retrieve` request, AND a `sync-error` request, like so:

<img width="385" alt="Screenshot 2024-10-14 at 3 44 59 PM" src="https://github.com/user-attachments/assets/e3834982-167e-4347-8618-b1e6545040af">

5. Also confirm that a post-sync error message is shown in the editor with details of why the sync failed:

<img width="1351" alt="Screenshot 2024-10-14 at 3 40 54 PM" src="https://github.com/user-attachments/assets/8eeac8ab-4656-4420-8111-919eca7a08b9">


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1208078373408288