### PR TITLE
fix: bugs from Newsletters editor data refactor

### DIFF
--- a/includes/service-providers/active_campaign/class-newspack-newsletters-active-campaign.php
+++ b/includes/service-providers/active_campaign/class-newspack-newsletters-active-campaign.php
@@ -626,7 +626,7 @@ final class Newspack_Newsletters_Active_Campaign extends \Newspack_Newsletters_S
 						'provider'    => $this->service,
 						'type'        => 'sublist',
 						'id'          => $segment['id'],
-						'parent'      => $args['parent'] ?? null,
+						'parent_id'   => $args['parent_id'] ?? null,
 						'name'        => $segment_name,
 						'entity_type' => 'segment',
 						'count'       => $segment['subscriber_count'] ?? null,

--- a/includes/service-providers/active_campaign/class-newspack-newsletters-active-campaign.php
+++ b/includes/service-providers/active_campaign/class-newspack-newsletters-active-campaign.php
@@ -790,19 +790,24 @@ final class Newspack_Newsletters_Active_Campaign extends \Newspack_Newsletters_S
 			$campaign_id     = get_post_meta( $post_id, 'ac_campaign_id', true );
 			$send_list_id    = get_post_meta( $post_id, 'send_list_id', true );
 			$send_sublist_id = get_post_meta( $post_id, 'send_sublist_id', true );
+			$newsletter_data = [
+				'campaign'                          => true, // Satisfy the JS API.
+				'campaign_id'                       => $campaign_id,
+				'supports_multiple_test_recipients' => true,
+			];
 
 			// Handle legacy send-to meta.
 			if ( ! $send_list_id ) {
 				$legacy_list_id = get_post_meta( $post_id, 'ac_list_id', true );
 				if ( $legacy_list_id ) {
-					$newsletter_data['list_id'] = $legacy_list_id;
+					$newsletter_data['send_list_id'] = $legacy_list_id;
 					$send_list_id               = $legacy_list_id;
 				}
 			}
 			if ( ! $send_sublist_id ) {
 				$legacy_sublist_id = get_post_meta( $post_id, 'ac_segment_id', true );
 				if ( $legacy_sublist_id ) {
-					$newsletter_data['sublist_id'] = $legacy_sublist_id;
+					$newsletter_data['send_sublist_id'] = $legacy_sublist_id;
 					$send_sublist_id               = $legacy_sublist_id;
 				}
 			}
@@ -816,6 +821,7 @@ final class Newspack_Newsletters_Active_Campaign extends \Newspack_Newsletters_S
 			if ( is_wp_error( $send_lists ) ) {
 				throw new Exception( wp_kses_post( $send_lists->get_error_message() ) );
 			}
+			$newsletter_data['lists'] = $send_lists;
 			$send_sublists = $send_list_id || $send_sublist_id ?
 				$this->get_send_lists(
 					[
@@ -829,13 +835,7 @@ final class Newspack_Newsletters_Active_Campaign extends \Newspack_Newsletters_S
 			if ( is_wp_error( $send_sublists ) ) {
 				throw new Exception( wp_kses_post( $send_sublists->get_error_message() ) );
 			}
-			$newsletter_data = [
-				'campaign'                          => true, // Satisfy the JS API.
-				'campaign_id'                       => $campaign_id,
-				'supports_multiple_test_recipients' => true,
-				'lists'                             => $send_lists,
-				'sublists'                          => $send_sublists,
-			];
+			$newsletter_data['sublists'] = $send_sublists;
 
 			if ( $campaign_id ) {
 				$newsletter_data['link'] = sprintf(

--- a/includes/service-providers/campaign_monitor/class-newspack-newsletters-campaign-monitor.php
+++ b/includes/service-providers/campaign_monitor/class-newspack-newsletters-campaign-monitor.php
@@ -221,9 +221,9 @@ final class Newspack_Newsletters_Campaign_Monitor extends \Newspack_Newsletters_
 		$segments = array_map(
 			function ( $item ) {
 				return [
-					'id'     => $item->SegmentID, // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
-					'name'   => $item->Title, // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
-					'parent' => $item->ListID, // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+					'id'        => $item->SegmentID, // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+					'name'      => $item->Title, // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+					'parent_id' => $item->ListID, // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
 				];
 			},
 			$segments->response

--- a/includes/service-providers/campaign_monitor/class-newspack-newsletters-campaign-monitor.php
+++ b/includes/service-providers/campaign_monitor/class-newspack-newsletters-campaign-monitor.php
@@ -400,7 +400,7 @@ final class Newspack_Newsletters_Campaign_Monitor extends \Newspack_Newsletters_
 			if ( ! $send_list_id ) {
 				$legacy_list_id = get_post_meta( $post_id, 'cm_list_id', true ) ?? get_post_meta( $post_id, 'cm_segment_id', true );
 				if ( $legacy_list_id ) {
-					$newsletter_data['list_id'] = $legacy_list_id;
+					$newsletter_data['send_list_id'] = $legacy_list_id;
 				}
 			}
 

--- a/includes/service-providers/class-newspack-newsletters-service-provider.php
+++ b/includes/service-providers/class-newspack-newsletters-service-provider.php
@@ -62,6 +62,7 @@ abstract class Newspack_Newsletters_Service_Provider implements Newspack_Newslet
 			add_action( 'rest_api_init', [ $this->controller, 'register_routes' ] );
 		}
 		add_action( 'pre_post_update', [ $this, 'pre_post_update' ], 10, 2 );
+		add_action( 'save_post', [ $this, 'save_post' ], 10, 2 );
 		add_action( 'transition_post_status', [ $this, 'transition_post_status' ], 10, 3 );
 		add_action( 'updated_post_meta', [ $this, 'updated_post_meta' ], 10, 4 );
 		add_action( 'wp_insert_post', [ $this, 'insert_post' ], 10, 3 );
@@ -142,6 +143,22 @@ abstract class Newspack_Newsletters_Service_Provider implements Newspack_Newslet
 				wp_die( esc_html( $result->get_error_message() ), '', esc_html( $result->get_error_code() ) );
 			}
 		}
+	}
+
+	/**
+	 * Delete layout defaults meta after saving the post.
+	 * We don't want layout defaults overwriting saved values unless the layout has just been set.
+	 *
+	 * @param int $post_id The ID of the post being saved.
+	 * @return void
+	 */
+	public function save_post( $post_id ) {
+		$post_type = get_post_type( $post_id );
+		if ( Newspack_Newsletters::NEWSPACK_NEWSLETTERS_CPT !== $post_type ) {
+			return;
+		}
+
+		delete_post_meta( $post_id, 'stringifiedCampaignDefaults' );
 	}
 
 	/**

--- a/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp-cached-data.php
+++ b/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp-cached-data.php
@@ -586,7 +586,7 @@ final class Newspack_Newsletters_Mailchimp_Cached_Data {
 		}
 		$response = ( self::get_mc_instance() )->validate(
 			$mc->get(
-				"lists/$list_id/segment/$segment_id",
+				"lists/$list_id/segments/$segment_id",
 				[
 					'fields' => 'id,name,member_count,type,options,list_id',
 				],

--- a/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp.php
+++ b/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp.php
@@ -725,7 +725,7 @@ final class Newspack_Newsletters_Mailchimp extends \Newspack_Newsletters_Service
 									'id'          => $interest['id'],
 									'name'        => $interest['name'],
 									'entity_type' => $entity_type,
-									'parent'      => $interest['list_id'],
+									'parent_id'   => $interest['list_id'],
 									'count'       => $interest['subscriber_count'],
 								];
 								if ( $admin_url && $audience['web_id'] ) {
@@ -749,7 +749,7 @@ final class Newspack_Newsletters_Mailchimp extends \Newspack_Newsletters_Service
 						'id'          => $tag['id'],
 						'name'        => $tag['name'],
 						'entity_type' => $entity_type,
-						'parent'      => $tag['list_id'],
+						'parent_id'   => $tag['list_id'],
 						'count'       => $tag['member_count'],
 					];
 					if ( $admin_url && $audience['web_id'] ) {
@@ -770,7 +770,7 @@ final class Newspack_Newsletters_Mailchimp extends \Newspack_Newsletters_Service
 						'id'          => $segment['id'],
 						'name'        => $segment['name'],
 						'entity_type' => $entity_type,
-						'parent'      => $segment['list_id'],
+						'parent_id'   => $segment['list_id'],
 						'count'       => $segment['member_count'],
 					];
 					if ( $admin_url && $audience['web_id'] ) {
@@ -1044,12 +1044,12 @@ final class Newspack_Newsletters_Mailchimp extends \Newspack_Newsletters_Service
 				$sublist = $this->get_send_lists(
 					[
 						'ids'       => [ $send_sublist_id ],
-						'limit'     => 1,
+						'limit'     => 1000,
 						'parent_id' => $send_list_id,
 						'type'      => 'sublist',
 					]
 				);
-				if ( ! empty( $sublist[0]->get_entity_type() ) ) {
+				if ( ! empty( $sublist ) && ! empty( $sublist[0]->get_entity_type() ) ) {
 					$sublist_type = $sublist[0]->get_entity_type();
 					switch ( $sublist_type ) {
 						case 'group':

--- a/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp.php
+++ b/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp.php
@@ -560,11 +560,11 @@ final class Newspack_Newsletters_Mailchimp extends \Newspack_Newsletters_Service
 				$newsletter_data['senderEmail'] = $campaign_info['senderEmail']; // If campaign has different sender info set, update ours.
 			}
 			if ( $list_id && $list_id !== $send_list_id ) {
-				$newsletter_data['list_id'] = $list_id; // If campaign has a different list selected, update ours.
-				$send_list_id               = $list_id;
+				$newsletter_data['send_list_id'] = $list_id; // If campaign has a different list selected, update ours.
+				$send_list_id                    = $list_id;
 
 				if ( ! empty( $campaign_info['sublist_id'] ) && $campaign_info['sublist_id'] !== $send_sublist_id ) {
-						$newsletter_data['sublist_id'] = $campaign_info['sublist_id']; // If campaign has a different sublist selected, update ours.
+						$newsletter_data['send_sublist_id'] = $campaign_info['sublist_id']; // If campaign has a different sublist selected, update ours.
 						$send_sublist_id = $campaign_info['sublist_id'];
 				}
 			}

--- a/src/newsletter-editor/sidebar/autocomplete.js
+++ b/src/newsletter-editor/sidebar/autocomplete.js
@@ -35,8 +35,8 @@ const Autocomplete = ( {
 						{ selectedInfo?.hasOwnProperty( 'count' )
 							? ' • ' +
 							sprintf(
-									// Translators: If available, show a contact count alongside the selected item's type. %d is the number of contacts in the item.
-									_n( '%d contact', '%d contacts', selectedInfo.count, 'newspack-newsletters' ),
+									// Translators: If available, show a contact count alongside the selected item's type. %s is the number of contacts in the item.
+									_n( '%s contact', '%s contacts', selectedInfo.count, 'newspack-newsletters' ),
 									selectedInfo.count.toLocaleString()
 							)
 							: '' }

--- a/src/newsletter-editor/sidebar/index.js
+++ b/src/newsletter-editor/sidebar/index.js
@@ -67,22 +67,24 @@ const Sidebar = ( {
 	}, [ newsletterData ] );
 
 	useEffect( () => {
-		const campaignDefaults = 'string' === typeof stringifiedCampaignDefaults ? JSON.parse( stringifiedCampaignDefaults ) : stringifiedCampaignDefaults;
-		const updatedMeta = {};
-		if ( campaignDefaults?.senderEmail ) {
-			updatedMeta.senderEmail = campaignDefaults.senderEmail;
-		}
-		if ( campaignDefaults?.senderName ) {
-			updatedMeta.senderName = campaignDefaults.senderName;
-		}
-		if ( campaignDefaults?.send_list_id ) {
-			updatedMeta.send_list_id = campaignDefaults.send_list_id;
-		}
-		if ( campaignDefaults?.send_sublist_id ) {
-			updatedMeta.send_sublist_id = campaignDefaults.send_sublist_id;
-		}
-		if ( Object.keys( updatedMeta ).length ) {
-			updateMeta( updatedMeta );
+		if ( stringifiedCampaignDefaults ) {
+			const campaignDefaults = 'string' === typeof stringifiedCampaignDefaults ? JSON.parse( stringifiedCampaignDefaults ) : stringifiedCampaignDefaults;
+			const updatedMeta = {};
+			if ( campaignDefaults?.senderEmail ) {
+				updatedMeta.senderEmail = campaignDefaults.senderEmail;
+			}
+			if ( campaignDefaults?.senderName ) {
+				updatedMeta.senderName = campaignDefaults.senderName;
+			}
+			if ( campaignDefaults?.send_list_id ) {
+				updatedMeta.send_list_id = campaignDefaults.send_list_id;
+			}
+			if ( campaignDefaults?.send_sublist_id ) {
+				updatedMeta.send_sublist_id = campaignDefaults.send_sublist_id;
+			}
+			if ( Object.keys( updatedMeta ).length ) {
+				updateMeta( updatedMeta );
+			}
 		}
 	}, [ stringifiedCampaignDefaults ] );
 

--- a/src/newsletter-editor/sidebar/index.js
+++ b/src/newsletter-editor/sidebar/index.js
@@ -19,7 +19,7 @@ import Sender from './sender';
 import SendTo from './send-to';
 import { getServiceProvider } from '../../service-providers';
 import withApiHandler from '../../components/with-api-handler';
-import { fetchNewsletterData, useIsRetrieving, useNewsletterData, useNewsletterDataError } from '../store';
+import { fetchNewsletterData, updateNewsletterData, useIsRetrieving, useNewsletterData, useNewsletterDataError } from '../store';
 import { isSupportedESP } from '../utils';
 import './style.scss';
 
@@ -49,22 +49,36 @@ const Sidebar = ( {
 	// Reconcile stored campaign data with data fetched from ESP.
 	useEffect( () => {
 		const updatedMeta = {};
+		const updatedNewsletterData = { ...newsletterData };
+
 		if ( newsletterData?.senderEmail ) {
 			updatedMeta.senderEmail = newsletterData.senderEmail;
+			delete updatedNewsletterData.senderEmail;
 		}
 		if ( newsletterData?.senderName ) {
 			updatedMeta.senderName = newsletterData.senderName;
+			delete updatedNewsletterData.senderName;
 		}
 		if ( newsletterData?.send_list_id ) {
 			updatedMeta.send_list_id = newsletterData.send_list_id;
+			delete updatedNewsletterData.send_list_id;
 		}
 		if ( newsletterData?.send_sublist_id ) {
 			updatedMeta.send_sublist_id = newsletterData.send_sublist_id;
+			delete updatedNewsletterData.send_sublist_id;
 		}
 		if ( Object.keys( updatedMeta ).length ) {
 			updateMeta( updatedMeta );
 		}
-	}, [ newsletterData ] );
+		if ( Object.keys( updatedNewsletterData ).length ) {
+			updateNewsletterData( updatedNewsletterData );
+		}
+	}, [
+		newsletterData?.senderEmail,
+		newsletterData?.senderName,
+		newsletterData?.send_list_id,
+		newsletterData?.send_sublist_id
+	] );
 
 	useEffect( () => {
 		if ( stringifiedCampaignDefaults ) {

--- a/src/newsletter-editor/sidebar/send-to.js
+++ b/src/newsletter-editor/sidebar/send-to.js
@@ -13,6 +13,7 @@ import { useEffect, useState } from '@wordpress/element';
  */
 import Autocomplete from './autocomplete';
 import { fetchSendLists, useNewsletterData } from '../store';
+import { usePrevious } from '../utils';
 
 // The container for list + sublist autocomplete fields.
 const SendTo = () => {
@@ -36,6 +37,7 @@ const SendTo = () => {
 	const sublistLabel = labels?.sublist || __( 'sublist', 'newspack-newsletters' );
 	const selectedList = lists.find( item => item.id === listId );
 	const selectedSublist = sublists?.find( item => item.id === sublistId );
+	const prevListId = usePrevious( listId );
 
 	// Cancel any queued fetches on unmount.
 	useEffect( () => {
@@ -58,6 +60,11 @@ const SendTo = () => {
 		// Prefetch sublist info when selecting a new list ID.
 		if ( listId && ! sublistId && newsletterData?.sublists && 1 >= newsletterData.sublists.length ) {
 			fetchSendLists( { type: 'sublist', parent_id: listId } );
+		}
+
+		// If selecting a new list entirely.
+		if ( listId && listId !== prevListId ) {
+			fetchSendLists( { type: 'sublist', parent_id: listId }, true );
 		}
 	}, [ newsletterData, listId, sublistId ] );
 

--- a/src/newsletter-editor/sidebar/send-to.js
+++ b/src/newsletter-editor/sidebar/send-to.js
@@ -35,8 +35,8 @@ const SendTo = () => {
 	const { labels } = newspack_newsletters_data || {};
 	const listLabel = labels?.list || __( 'list', 'newspack-newsletters' );
 	const sublistLabel = labels?.sublist || __( 'sublist', 'newspack-newsletters' );
-	const selectedList = lists.find( item => item.id === listId );
-	const selectedSublist = sublists?.find( item => item.id === sublistId );
+	const selectedList = listId ? lists.find( item => item.id.toString() === listId.toString() ) : null;
+	const selectedSublist = sublistId ? sublists?.find( item => item.id.toString() === sublistId.toString() ) : null;
 	const prevListId = usePrevious( listId );
 
 	// Cancel any queued fetches on unmount.
@@ -57,14 +57,10 @@ const SendTo = () => {
 			fetchSendLists( { ids: [ sublistId ], type: 'sublist', parent_id: listId } );
 		}
 
-		// Prefetch sublist info when selecting a new list ID.
-		if ( listId && ! sublistId && newsletterData?.sublists && 1 >= newsletterData.sublists.length ) {
-			fetchSendLists( { type: 'sublist', parent_id: listId } );
-		}
-
 		// If selecting a new list entirely.
-		if ( listId && listId !== prevListId ) {
+		if ( listId && prevListId && listId !== prevListId ) {
 			fetchSendLists( { type: 'sublist', parent_id: listId }, true );
+			updateMeta( { send_sublist_id: null } );
 		}
 	}, [ newsletterData, listId, sublistId ] );
 

--- a/src/newsletter-editor/sidebar/send-to.js
+++ b/src/newsletter-editor/sidebar/send-to.js
@@ -125,7 +125,7 @@ const SendTo = () => {
 				</Notice>
 			) }
 			{
-				( newsletterData?.fetched_list || newsletterData?.fetched_sublist ) && (
+				( newsletterData?.send_list_id || newsletterData?.send_sublist_id ) && (
 					<Notice status="success" isDismissible={ false }>
 						{ __( 'Updated send-to info fetched from ESP.', 'newspack-newsletters' ) }
 					</Notice>

--- a/src/newsletter-editor/store.js
+++ b/src/newsletter-editor/store.js
@@ -150,7 +150,7 @@ export const fetchSyncErrors = async postId => {
 }
 
 // Dispatcher to fetch send lists and sublists from the connected ESP and update the newsletterData in store.
-export const fetchSendLists = debounce( async ( opts ) => {
+export const fetchSendLists = debounce( async ( opts, replace = false ) => {
 	updateNewsletterDataError( null );
 	try {
 		const { name } = getServiceProvider();
@@ -190,7 +190,7 @@ export const fetchSendLists = debounce( async ( opts ) => {
 		}
 
 		const updatedNewsletterData = { ...newsletterData };
-		const updatedSendLists = [ ...sendLists ];
+		const updatedSendLists = replace ? [] : [ ...sendLists ];
 
 		// If no existing items found, fetch from the ESP.
 		const isRetrieving = coreSelect( STORE_NAMESPACE ).getIsRetrieving();

--- a/src/newsletter-editor/utils.js
+++ b/src/newsletter-editor/utils.js
@@ -4,6 +4,7 @@
  * WordPress dependencies
  */
 import apiFetch from '@wordpress/api-fetch';
+import { useEffect, useRef } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 
 /**
@@ -84,3 +85,16 @@ export const refreshEmailHtml = async ( postId, postTitle, postContent ) => {
 	return html;
 };
 
+/**
+ * Custom hook to fetch a previous state or prop value.
+ *
+ * @param {string} value of the prop or state to fetch.
+ * @return {*} The previous value of the prop or state.
+ */
+export const usePrevious = value => {
+	const ref = useRef();
+	useEffect( () => {
+		ref.current = value;
+	},[ value ] );
+	return ref.current;
+}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

This PR fixes several bugs in the Newsletters editor data refactor done in #1658 that became more apparent now that we've been able to test with various publisher accounts and real data.

### How to test the changes in this Pull Request:

#### Handling for large contact counts in Send List summary (9d95c3c)

In the send list summaries for selected lists/sublists, we use `Number.toLocaleString()` to show large numbers in a localized string format for human readability, e.g. `10,000 contacts` instead of `10000 contacts`. However, we're erroneously using the `%d` placeholder in the summary string, which expects a true number instead of a stringified number, so these large numbers aren't getting populated as intended. This PR fixes it by using `%s` instead.

1. On `trunk`, using Mailchimp, temporarily change [this line](https://github.com/Automattic/newspack-newsletters/blob/trunk/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp.php#L702) to hardcode a very large number such as `1000000` for the `count` value
2. Create or edit a newsletter
3. Select an audience/list and save the draft
4. Observe that the summary shown for the selected audience shows `%d` instead of the contact count number, and a JS console error `[sprintf] expecting number but found string`:

<img width="187" alt="Screenshot 2024-10-14 at 5 42 39 PM" src="https://github.com/user-attachments/assets/079e66ca-d135-47c4-a045-0a9a450e4900">
<img width="550" alt="Screenshot 2024-10-14 at 4 59 23 PM" src="https://github.com/user-attachments/assets/20a762ea-5b81-4e95-b8ba-78107c115e11">

5. Check out this branch, refresh the editor, and confirm that the number is shown as a localized string like `1,000,000 contacts`

<img width="216" alt="Screenshot 2024-10-14 at 5 55 12 PM" src="https://github.com/user-attachments/assets/8b2f9c4e-784c-4d08-83d7-d236291d00d3">

#### Handling for Mailchimp accounts with multiple audiences (60ee0f3 and f59cece)

When fetching sublist info in the editor, we retain all previously fetched sublists in the Redux store and add newly fetched sublists to the store—this way, on subsequent searches or sidebar component mounts, we don't have to go all the way to the REST API again to rebuild this info on the store. However, for all ESPs, sublists are unique to a top-level list, so if you select a new top-level list and then interact with the sublist field, we shouldn't expect to see info for sublists that were previously fetched for the old list. This PR ensures that when selecting a top-level list, we empty out all existing sublist info in the store and post meta. It also avoids an infinite loop if you select an audience that has no tags/groups/segments at all.

1. Connect your test site to a Mailchimp account with multiple audiences and many sublist entities (DM me if you need access to one)
2. On `trunk`, create or edit a newsletter and select an audience. Confirm that the sublist suggestions shown in the sublist autocomplete field match the selected audience.
3. Change the audience to a different audience. This time, observe that the sublist suggestions shown in the sublist autocomplete field DO NOT match the newly selected audience unless you save and refresh the editor page first.
4. Check out this branch and repeat steps 2-3, and confirm that the sublist suggestions in the autocomplete field update to match the selected audience whenever you select a new audience.

#### Handling for Mailchimp accounts with many sublist entities (more than 10 per audience) (35d1aba)

Unique to Mailchimp, when setting the sublist for a campaign via their API, the shape of the payload we pass depends on the type of sublist we're setting (tag, segment, or group). Since the sublist is saved to the post only as an ID, we need to fetch info about the sublist to know what the payload should look like, so we use `$provider->get_send_lists()` to fetch the sublist's info by ID. However, this will only look for cached sublist info, and if we've previously only fetched a limited number of sublists to the cache (as might happen if you load up the editor after the previous cache has been invalidated, and we prefetch only 10 segments in the first fetch), the info we're looking for might not yet be in the cache. This PR fixes this scenario by ensuring we fetch info for up to 1000 sublists from the Mailchimp API when we go to build the sync payload.

1. Connect your test site to a Mailchimp account with multiple audiences and many sublist entities (DM me if you need access to one)
2. On `trunk`, create or edit a newsletter and select an audience.
3. Select a sublist that's shown towards the bottom of the list of Groups or Tags in the Mailchimp account > Audience dashboard page.
4. Save the newsletter with the selected audience + sublist and observe that a.) the sync fails (campaign data in MC is not updated to match the saved info) and b.) the PHP debug log shows a warning: `PHP Warning:  Undefined array key 0 in /srv/htdocs/wp-content/plugins/newspack-newsletters/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp.php on line 1054`
5. Check out this branch, repeat steps 2-4, and confirm that the sync succeeds and the PHP warning doesn't happen

#### Overzealous overwriting by layout campaign defaults (19ce5c8)

When setting a newsletter post to a custom newsletter layout with saved sender and send-to info (either on new post creation or by resetting the layout via the Layout sidebar), we expect the defaults stored in the layout to overwrite whatever sender/send-to meta the post has already. However, after the layout has been set, we don't want the layout defaults to overwrite anything anymore. This PR fixes things by ensuring that layout defaults are only taken into account immediately after selecting a new layout, and then cleared from the post upon the next manual save.

1. On `trunk`, using any ESP, create a new layout from a post with saved sender and send-to info.
2. Create a new newsletter post using this layout, or reset an existing post to this layout. Confirm that the sender/send-to info are preset to the layout defaults.
3. Change the sender and send-to info for this post to something different from the layout defaults.
4. Save the post and then refresh the editor. Observe that the sender and send-to info has reverted to the layout defaults instead of what you most recently saved.
5. Check out this branch and repeat steps 2-4, but this time confirm that the sender and send-to info that you updated in step 3 persist after saving and refreshing the post.

#### Migrating legacy meta for AC (9aff88c)

We went through a lot of iterations of newsletter data schema and handling of "legacy" meta fields. Along the way it looks like this handling broke for ActiveCampaign lists and sublists. This PR fixes things for AC and also ensures that send list/sublist properties in the Redux store are always named the same thing across all ESPs.

1. On the latest [production release](https://github.com/Automattic/newspack-newsletters/releases/tag/v3.2.0), using ActiveCampaign, create a newsletter post and set a send list and segment, then save. (You'll know you're using the right version if the list and segment UIs are still dropdowns instead of autocomplete fields.)
2. Check out `trunk` and refresh this newsletter post in the editor. Observe that the send list and segment are not populated.
3. Check out this branch and refresh once again. Confirm that send list and segment are populated with the correct selections from step 1.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
