### PR TITLE
feat: display list remote name on settings page

### DIFF
--- a/includes/class-newspack-newsletters-settings.php
+++ b/includes/class-newspack-newsletters-settings.php
@@ -328,7 +328,7 @@ class Newspack_Newsletters_Settings {
 								/>
 							</td>
 							<td class="name">
-								<label for="<?php echo esc_attr( $checkbox_id ); ?>"><?php echo esc_html( $list['name'] ); ?></strong>
+								<label for="<?php echo esc_attr( $checkbox_id ); ?>"><?php echo esc_html( $list['remote_name'] ); ?></strong>
 								<br/>
 								<small>
 									<?php echo esc_html( $list['type_label'] ); ?>

--- a/includes/class-subscription-list.php
+++ b/includes/class-subscription-list.php
@@ -548,6 +548,7 @@ class Subscription_List {
 			'type_label'  => $this->get_type_label(),
 			'edit_link'   => $this->get_edit_link(),
 			'active'      => $this->is_active(),
+			'remote_name' => $this->get_remote_name(),
 		];
 	}
 }

--- a/includes/class-subscription-lists.php
+++ b/includes/class-subscription-lists.php
@@ -466,8 +466,18 @@ class Subscription_Lists {
 		$subscriber_count = ! empty( $list['member_count'] ) ? (int) $list['member_count'] : 0; // Tags have member_count instead of subscriber_count.
 		$saved_list       = Subscription_List::from_public_id( $list['id'] );
 		if ( $saved_list ) {
-			// Update remote name, in case it's changed in the ESP.
-			$saved_list->set_remote_name( $list['title'] );
+
+			$has_customized_title = $saved_list->get_title() !== $saved_list->get_remote_name();
+
+			if ( $list['title'] !== $saved_list->get_remote_name() ) {
+				// The remote name has changed, let's update it locally.
+				$saved_list->set_remote_name( $list['title'] );
+
+				// Only update the title if it was not customized by the user.
+				if ( ! $has_customized_title ) {
+					$saved_list->update( [ 'title' => $list['title'] ] );
+				}
+			}
 
 			// Update subscriber count, if available.
 			if ( 0 > $subscriber_count ) {
@@ -551,20 +561,14 @@ class Subscription_Lists {
 		$existing_ids = [];
 
 		foreach ( $lists as $list ) {
-			if ( Subscription_List::is_local_public_id( $list['id'] ) ) {
-				// Local lists will be fetched here.
-				$stored_list = Subscription_List::from_public_id( $list['id'] );
-			} else {
-				// Remote lists will be either fetched or created here.
-				$stored_list = self::get_or_create_remote_list( $list );
-			}
+
+			$stored_list = Subscription_List::from_public_id( $list['id'] );
 
 			if ( ! $stored_list instanceof Subscription_List ) {
 				continue;
 			}
 
 			$existing_ids[] = $stored_list->get_id();
-
 			$stored_list->update( $list );
 
 		}

--- a/includes/class-subscription-lists.php
+++ b/includes/class-subscription-lists.php
@@ -564,6 +564,11 @@ class Subscription_Lists {
 
 			$stored_list = Subscription_List::from_public_id( $list['id'] );
 
+			// If a remote list was not found, create one.
+			if ( ! $stored_list instanceof Subscription_List && ! Subscription_List::is_local_public_id( $list['id'] ) ) {
+				$stored_list = self::get_or_create_remote_list( $list );
+			}
+
 			if ( ! $stored_list instanceof Subscription_List ) {
 				continue;
 			}

--- a/tests/test-subscription-lists.php
+++ b/tests/test-subscription-lists.php
@@ -127,7 +127,7 @@ class Subscription_Lists_Test extends WP_UnitTestCase {
 		// existing.
 		$existing = [
 			'id'    => 'xyz-' . self::$posts['remote_mailchimp'],
-			'title' => 'Remote mailchimp new title',
+			'title' => 'Test List 5',
 		];
 		$list     = Subscription_Lists::get_or_create_remote_list( $existing );
 		$this->assertSame( self::$posts['remote_mailchimp'], $list->get_id() );
@@ -150,6 +150,36 @@ class Subscription_Lists_Test extends WP_UnitTestCase {
 
 		$count_after_new = count( Subscription_Lists::get_all() );
 		$this->assertSame( $count + 1, $count_after_new );
+	}
+
+	/**
+	 * Test update title on fetch from ESP
+	 */
+	public function test_update_title_when_fetching_from_esp() {
+
+		$existing = [
+			'id'    => 'xyz-' . self::$posts['remote_mailchimp'],
+			'title' => 'Remote mailchimp new title',
+		];
+		$list     = Subscription_Lists::get_or_create_remote_list( $existing );
+
+		$this->assertSame( self::$posts['remote_mailchimp'], $list->get_id() );
+		$this->assertSame( 'Remote mailchimp new title', $list->get_title() );
+		$this->assertSame( 'Remote mailchimp new title', $list->get_remote_name() );
+
+		// Now we edit the local title.
+		$list->update( [ 'title' => 'Customized title' ] );
+
+		$existing = [
+			'id'    => 'xyz-' . self::$posts['remote_mailchimp'],
+			'title' => 'Remote mailchimp super new title',
+		];
+
+		$list = Subscription_Lists::get_or_create_remote_list( $existing );
+
+		$this->assertSame( self::$posts['remote_mailchimp'], $list->get_id() );
+		$this->assertSame( 'Customized title', $list->get_title(), 'The local name should not be updated if it was customized' );
+		$this->assertSame( 'Remote mailchimp super new title', $list->get_remote_name(), 'The remote name should always be updated' );
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Displays the List's remote name on the settings page and expose it in the API. This makes sure the user will always see the name that is set on the remote ESP in their list.

### How to test the changes in this Pull Request:

1. Configure Newsletters with an ESP with several lists 
2. Visit Newsletters > Settings and make sure you see al the lists there
3. Make sure you have at least two lists that comes from the ESP (for example 2 mailchimp groups)
4. On Newsletters > Settings, customize the title of one of those lists
5. Go to the ESP dashboard and rename one of the lists
6. Back to the site, make sure you see the updated name in the Settings page
7. Confirm that the customizable title was updated only in the list that was not edited before. The list for which you had set up a custom title remained with the old title
8. Checkout https://github.com/Automattic/newspack-plugin/pull/3478 and go to Newspack > Engagement > Newsletters
9. Confirm the same behavior there


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1208541768174006