### PR TITLE
fix(mailchimp): unsetting sublists in synced campaign

### DIFF
--- a/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp-cached-data.php
+++ b/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp-cached-data.php
@@ -525,7 +525,7 @@ final class Newspack_Newsletters_Mailchimp_Cached_Data {
 	 */
 	public static function handle_cron() {
 		Newspack_Newsletters_Logger::log( 'Mailchimp cache: Handling cron request to refresh cache' );
-		$lists = self::get_lists();
+		$lists = self::fetch_lists(); // Force a cache refresh.
 
 		foreach ( $lists as $list ) {
 			Newspack_Newsletters_Logger::log( 'Mailchimp cache: Dispatching request to refresh cache for list ' . $list['id'] );

--- a/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp-cached-data.php
+++ b/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp-cached-data.php
@@ -262,7 +262,7 @@ final class Newspack_Newsletters_Mailchimp_Cached_Data {
 	 * @param string $list_id The List ID.
 	 * @return boolean
 	 */
-	private static function is_cache_expired( $list_id = null ) {
+	private static function is_cache_expired( $list_id = 'lists' ) {
 		$cache_date = get_option( self::get_cache_date_key( $list_id ) );
 		return $cache_date && ( time() - $cache_date ) > 20 * MINUTE_IN_SECONDS;
 	}

--- a/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp.php
+++ b/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp.php
@@ -1091,6 +1091,8 @@ final class Newspack_Newsletters_Mailchimp extends \Newspack_Newsletters_Service
 							break;
 					}
 				}
+			} else {
+				$payload['recipients']['segment_opts'] = (object) [];
 			}
 		}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

#1658 had a bug in the `get_sync_payload` method for Mailchimp. If you intend to send a newsletter campaign to the entire list, the sync payload must include a `segment_opts` param with a value of an empty object, otherwise the campaign recipients won't be updated.

Also fixes a bug in the handling for cached list data in which the cache for audiences is never expired.

### How to test the changes in this Pull Request:

1. On `trunk`, using Mailchimp, create a new newsletter post and set an audience and a sublist, then save.
2. Clear the sublist and save. Observe that in the synced campaign in Mailchimp, the recipients are still set to the sublist selected in step 1.
3. Check out this branch and resave the newsletter without any sublist. Confirm that the synced campaign in Mailchimp is updated to send to all contacts in the selected audience.
4. To test the cache expiration for audiences, note the contact count shown for your audience in the editor sidebar. Add some contacts to your list, wait >20 minutes (or run `wp option delete newspack_nl_mailchimp_cache_date_lists` to invalidate the cache immediately) and refresh the editor, then confirm that the contact count is updated.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
