### PR TITLE
feat: disable newsletter tracking

### DIFF
--- a/includes/tracking/class-click.php
+++ b/includes/tracking/class-click.php
@@ -116,7 +116,7 @@ final class Click {
 	 * @return void
 	 */
 	public static function track_click( $newsletter_id, $email_address, $url ) {
-		if ( ! $newsletter_id || ! $email_address ) {
+		if ( ! $newsletter_id || ! $email_address || ! Admin::is_tracking_click_enabled() ) {
 			return;
 		}
 

--- a/includes/tracking/class-pixel.php
+++ b/includes/tracking/class-pixel.php
@@ -148,6 +148,11 @@ final class Pixel {
 	 * @return void
 	 */
 	public static function track_seen( $newsletter_id, $tracking_id, $email_address ) {
+
+		if ( ! Admin::is_tracking_pixel_enabled() ) {
+			return;
+		}
+
 		$newsletter_tracking_id = \get_post_meta( $newsletter_id, 'tracking_id', true );
 
 		// Bail if tracking ID mismatch.


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Actually turns off tracking when it's turned off, even for campaigns that have been sent while the tracking was active

### How to test the changes in this Pull Request:

1. Turn tracking on and send a test newsletter
2. Confirm tracking is working
3. Make sure the newsletter has a link and that the redirect is working
4. Turn tracking off
5. Confirm that the redirect is still working, but it's not counting


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
