### PR TITLE
fix: lists cache flushing

### DIFF
--- a/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp-cached-data.php
+++ b/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp-cached-data.php
@@ -253,7 +253,8 @@ final class Newspack_Newsletters_Mailchimp_Cached_Data {
 	 * @return string The cache key
 	 */
 	private static function get_cache_date_key( $list_id = 'lists' ) {
-		return self::OPTION_PREFIX . '_date_' . $list_id;
+		$suffix = empty( $list_id ) ? 'lists' : $list_id;
+		return self::OPTION_PREFIX . '_date_' . $suffix;
 	}
 
 	/**
@@ -525,7 +526,7 @@ final class Newspack_Newsletters_Mailchimp_Cached_Data {
 	 */
 	public static function handle_cron() {
 		Newspack_Newsletters_Logger::log( 'Mailchimp cache: Handling cron request to refresh cache' );
-		$lists = self::get_lists();
+		$lists = self::fetch_lists(); // Force a cache refresh.
 
 		foreach ( $lists as $list ) {
 			Newspack_Newsletters_Logger::log( 'Mailchimp cache: Dispatching request to refresh cache for list ' . $list['id'] );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes two issues with flushing the cache for listings.

First, the `is_cache_expired` method, when called without an argument, will call `get_cache_date_key( NULL )`. In this case, NULL is considered an argument with causes `get_cache_date_key()` not to use the default `lists` value, and we end up returning an invalid cache key.

The result is that the check to see if the Lists cache was expired was returning `false` for ever.

Second, when we trigger a cache refresh via cron, the lists were not being refreshed right away. We would refresh each lists cache but based on a cached list of lists. 

### How to test the changes in this Pull Request:

1. Configure the plugin and make sure you have lists cached
2. Enter a different api key for another account
3. run `wp cron event run newspack_nl_mailchimp_refresh_cache` and make sure the cache is properly refreshed

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
