### PR TITLE
Feat: Information Architecture for Newsletters

### DIFF
--- a/includes/class-newspack-newsletters-ads.php
+++ b/includes/class-newspack-newsletters-ads.php
@@ -176,7 +176,6 @@ final class Newspack_Newsletters_Ads {
 	 * Add ads page link.
 	 * 
 	 * Note: replaced by Newspack Plugin release for Information Architecture.  See Newspack Plugin => Newsletters_Wizard.
-	 * 
 	 */
 	public static function add_ads_page() {
 		add_submenu_page(

--- a/includes/class-newspack-newsletters-ads.php
+++ b/includes/class-newspack-newsletters-ads.php
@@ -174,6 +174,9 @@ final class Newspack_Newsletters_Ads {
 
 	/**
 	 * Add ads page link.
+	 * 
+	 * Note: replaced by Newspack Plugin release for Information Architecture.  See Newspack Plugin => Newsletters_Wizard.
+	 * 
 	 */
 	public static function add_ads_page() {
 		add_submenu_page(
@@ -259,6 +262,8 @@ final class Newspack_Newsletters_Ads {
 				'hierarchical'      => true,
 				'show_in_rest'      => true,
 				'show_admin_column' => true,
+				// See filter usage in Newspack Plugin release for Information Architecture.
+				'show_in_menu'      => apply_filters( 'newspack_ia_nl_advertiser_tax_show_in_menu', true ),
 			]
 		);
 	}

--- a/includes/class-newspack-newsletters-ads.php
+++ b/includes/class-newspack-newsletters-ads.php
@@ -232,7 +232,7 @@ final class Newspack_Newsletters_Ads {
 		];
 		register_post_type( self::CPT, $cpt_args );
 
-		// Note: see overrides in Newspack Plugin release for Information Architecture > Newsletters_Wizard
+		// Note: see overrides in Newspack Plugin release for Information Architecture.  See Newspack Plugin => Newsletters_Wizard.
 		register_taxonomy(
 			self::ADVERTISER_TAX,
 			[ self::CPT, Newspack_Newsletters::NEWSPACK_NEWSLETTERS_CPT ],

--- a/includes/class-newspack-newsletters-ads.php
+++ b/includes/class-newspack-newsletters-ads.php
@@ -232,6 +232,7 @@ final class Newspack_Newsletters_Ads {
 		];
 		register_post_type( self::CPT, $cpt_args );
 
+		// Note: see overrides in Newspack Plugin release for Information Architecture > Newsletters_Wizard
 		register_taxonomy(
 			self::ADVERTISER_TAX,
 			[ self::CPT, Newspack_Newsletters::NEWSPACK_NEWSLETTERS_CPT ],
@@ -262,8 +263,6 @@ final class Newspack_Newsletters_Ads {
 				'hierarchical'      => true,
 				'show_in_rest'      => true,
 				'show_admin_column' => true,
-				// See filter usage in Newspack Plugin release for Information Architecture.
-				'show_in_menu'      => apply_filters( 'newspack_ia_nl_advertiser_tax_show_in_menu', true ),
 			]
 		);
 	}

--- a/includes/class-newspack-newsletters-settings.php
+++ b/includes/class-newspack-newsletters-settings.php
@@ -31,6 +31,9 @@ class Newspack_Newsletters_Settings {
 	 * @return string URL to settings page.
 	 */
 	public static function get_settings_url() {
+
+		// @ TODO: how to test?
+
 		$url = admin_url( 'edit.php?post_type=newspack_nl_cpt&page=newspack-newsletters-settings-admin' );
 
 		/**
@@ -214,6 +217,9 @@ class Newspack_Newsletters_Settings {
 
 	/**
 	 * Add options page
+	 * 
+	 * Note: callback if replaced if Newspack Plugin is active with Information Architecture. See Newspack Plugin > Newsletters_Wizard.
+	 * 
 	 */
 	public static function add_plugin_page() {
 		add_submenu_page(

--- a/includes/class-newspack-newsletters-settings.php
+++ b/includes/class-newspack-newsletters-settings.php
@@ -219,7 +219,6 @@ class Newspack_Newsletters_Settings {
 	 * Add options page
 	 * 
 	 * Note: callback is replaced by Newspack Plugin release for Information Architecture.  See Newspack Plugin => Newsletters_Wizard.
-	 * 
 	 */
 	public static function add_plugin_page() {
 		add_submenu_page(

--- a/includes/class-newspack-newsletters-settings.php
+++ b/includes/class-newspack-newsletters-settings.php
@@ -218,7 +218,7 @@ class Newspack_Newsletters_Settings {
 	/**
 	 * Add options page
 	 * 
-	 * Note: callback if replaced if Newspack Plugin is active with Information Architecture. See Newspack Plugin > Newsletters_Wizard.
+	 * Note: callback is replaced by Newspack Plugin release for Information Architecture.  See Newspack Plugin => Newsletters_Wizard.
 	 * 
 	 */
 	public static function add_plugin_page() {

--- a/includes/class-newspack-newsletters.php
+++ b/includes/class-newspack-newsletters.php
@@ -516,6 +516,7 @@ final class Newspack_Newsletters {
 			'show_in_rest'     => true,
 			'supports'         => $supports,
 			'taxonomies'       => [ 'category', 'post_tag' ],
+			// Note: Menu icon and position is updated by Newspack Plugin > Information Architecture.  See Newspack Plugin > Newsletters_Wizard.
 			'menu_icon'        => 'data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIGhlaWdodD0iMjQiIHZpZXdCb3g9IjAgMCAyNCAyNCIgd2lkdGg9IjI0Ij48cGF0aCB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIGQ9Ik0yMS45OSA4YzAtLjcyLS4zNy0xLjM1LS45NC0xLjdMMTIgMSAyLjk1IDYuM0MyLjM4IDYuNjUgMiA3LjI4IDIgOHYxMGMwIDEuMS45IDIgMiAyaDE2YzEuMSAwIDItLjkgMi0ybC0uMDEtMTB6TTEyIDEzTDMuNzQgNy44NCAxMiAzbDguMjYgNC44NEwxMiAxM3oiIGZpbGw9IiNhMGE1YWEiLz48L3N2Zz4K',
 		];
 		\register_post_type( self::NEWSPACK_NEWSLETTERS_CPT, $cpt_args );

--- a/includes/class-newspack-newsletters.php
+++ b/includes/class-newspack-newsletters.php
@@ -505,6 +505,7 @@ final class Newspack_Newsletters {
 			$supports[] = 'comments';
 		}
 
+		// Note: Menu icon and position is updated by Newspack Plugin > Information Architecture.  See Newspack Plugin > Newsletters_Wizard.		
 		$cpt_args = [
 			'has_archive'      => $public_slug,
 			'labels'           => $labels,
@@ -516,7 +517,6 @@ final class Newspack_Newsletters {
 			'show_in_rest'     => true,
 			'supports'         => $supports,
 			'taxonomies'       => [ 'category', 'post_tag' ],
-			// Note: Menu icon and position is updated by Newspack Plugin > Information Architecture.  See Newspack Plugin > Newsletters_Wizard.
 			'menu_icon'        => 'data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIGhlaWdodD0iMjQiIHZpZXdCb3g9IjAgMCAyNCAyNCIgd2lkdGg9IjI0Ij48cGF0aCB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIGQ9Ik0yMS45OSA4YzAtLjcyLS4zNy0xLjM1LS45NC0xLjdMMTIgMSAyLjk1IDYuM0MyLjM4IDYuNjUgMiA3LjI4IDIgOHYxMGMwIDEuMS45IDIgMiAyaDE2YzEuMSAwIDItLjkgMi0ybC0uMDEtMTB6TTEyIDEzTDMuNzQgNy44NCAxMiAzbDguMjYgNC44NEwxMiAxM3oiIGZpbGw9IiNhMGE1YWEiLz48L3N2Zz4K',
 		];
 		\register_post_type( self::NEWSPACK_NEWSLETTERS_CPT, $cpt_args );

--- a/includes/class-newspack-newsletters.php
+++ b/includes/class-newspack-newsletters.php
@@ -505,7 +505,7 @@ final class Newspack_Newsletters {
 			$supports[] = 'comments';
 		}
 
-		// Note: Menu icon and position is updated by Newspack Plugin > Information Architecture.  See Newspack Plugin > Newsletters_Wizard.		
+		// Note: Menu icon and position is updated by Newspack Plugin release for Information Architecture.  See Newspack Plugin => Newsletters_Wizard.
 		$cpt_args = [
 			'has_archive'      => $public_slug,
 			'labels'           => $labels,
@@ -1031,7 +1031,7 @@ final class Newspack_Newsletters {
 	/**
 	 * Enqueue style to handle Newspack branding.
 	 * 
-	 * Note: this callback is removed when Newspack Plugin's Information Architeture is active ( see Newspack Plugin > Newsletters_Wizard ).
+	 * Note: this callback is removed by Newspack Plugin release for Information Architecture.  See Newspack Plugin => Newsletters_Wizard.
 	 */
 	public static function branding_scripts() {
 		$screen = get_current_screen();

--- a/includes/class-newspack-newsletters.php
+++ b/includes/class-newspack-newsletters.php
@@ -1030,6 +1030,8 @@ final class Newspack_Newsletters {
 
 	/**
 	 * Enqueue style to handle Newspack branding.
+	 * 
+	 * Note: this callback is removed when Newspack Plugin's Information Architeture is active ( see Newspack Plugin > Newsletters_Wizard ).
 	 */
 	public static function branding_scripts() {
 		$screen = get_current_screen();

--- a/includes/tracking/class-admin.php
+++ b/includes/tracking/class-admin.php
@@ -65,7 +65,6 @@ final class Admin {
 	 * Add settings page submenu.
 	 * 
 	 * Note: callback replaced by Newspack Plugin release for Information Architecture.  See Newspack Plugin => Newsletters_Wizard.
-	 * 
 	 */
 	public static function add_settings_page() {
 		\add_submenu_page(

--- a/includes/tracking/class-admin.php
+++ b/includes/tracking/class-admin.php
@@ -63,6 +63,9 @@ final class Admin {
 
 	/**
 	 * Add settings page submenu.
+	 * 
+	 * Note: callback replaced when Newspack Plugin active with Information Architecture. See Newspack Plugin > Newsletters_Wizard.
+	 * 
 	 */
 	public static function add_settings_page() {
 		\add_submenu_page(

--- a/includes/tracking/class-admin.php
+++ b/includes/tracking/class-admin.php
@@ -64,7 +64,7 @@ final class Admin {
 	/**
 	 * Add settings page submenu.
 	 * 
-	 * Note: callback replaced when Newspack Plugin active with Information Architecture. See Newspack Plugin > Newsletters_Wizard.
+	 * Note: callback replaced by Newspack Plugin release for Information Architecture.  See Newspack Plugin => Newsletters_Wizard.
 	 * 
 	 */
 	public static function add_settings_page() {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

This PR supports the main PR ( https://github.com/Automattic/newspack-plugin/pull/3490 ) in order to clean up the existing Newsletters menu items when the Information Architecture (IA) project is released.

The current Newsletter menu and header can be seen in this screenshot:

![newsletters-menu-and-header](https://github.com/user-attachments/assets/16ac31ff-a59a-4d1b-8cf3-8e504d0e7288)

* Newsletters has a unique Newspack header at the top.
* The menu has an "Add New" link that can also be found on the "All Newsletters" screen.
* The menu links to what looks like "Newsletters" categories and tags, but they are the same categories and tags for Posts.

My recommendation is to remove menu items: Add New, Categories and Tags.  Though, this is NOT a requirement for the Information Architecture Project.  The IA Wizard code in the main PR (link above) already hides these links, so nothing is required here.  Mainly it's just a recommendation to make the Newsletters plugin closer to what IA looks anyway 😃 

You'll also see some "Note" comments added to the docblocks for callback functions that the IA code will "replace/remove".  These comments are not required, but they might be helpful for developers if they are expecting a callback to run, but the IA Wizard in the Newspack Plugin is actually removing or replacing it.

Finally, there is one "todo" in the `includes/class-newspack-newsletters-settings.php` file in the `get_settings_url()` function.  I haven't had the time to test that.  I'd recommend that a team member who knows how the Newsletters plugin works should verify that function is working correctly when the IA Newsletters Wizard is active (see main PR link above).

### How to test the changes in this Pull Request:

This pull request is mainly some "recommendations" and code comments, but there is one thing to test.  In order to test the "todo" for the "get_settings_url()" (see paragraph above), please do the following:

1. Go to the main PR link above and follow it's testing steps.
2. Verify that the "get_settings_url()" works properly with the main PR active.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
