### PR TITLE
fix: avoid race condition between post-save sync & test

### DIFF
--- a/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp.php
+++ b/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp.php
@@ -958,7 +958,6 @@ final class Newspack_Newsletters_Mailchimp extends \Newspack_Newsletters_Service
 			);
 		}
 		try {
-
 			$sync_result = $this->sync( get_post( $post_id ) );
 			if ( ! $sync_result ) {
 				return new WP_Error(

--- a/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp.php
+++ b/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp.php
@@ -958,17 +958,6 @@ final class Newspack_Newsletters_Mailchimp extends \Newspack_Newsletters_Service
 			);
 		}
 		try {
-			$sync_result = $this->sync( get_post( $post_id ) );
-			if ( ! $sync_result ) {
-				return new WP_Error(
-					'newspack_newsletters_mailchimp_error',
-					__( 'Unable to synchronize with Mailchimp.', 'newspack-newsletters' )
-				);
-			}
-			if ( is_wp_error( $sync_result ) ) {
-				return $sync_result;
-			}
-
 			$mc      = new Mailchimp( $this->api_key() );
 			$payload = [
 				'test_emails' => $emails,

--- a/src/newsletter-editor/store.js
+++ b/src/newsletter-editor/store.js
@@ -28,7 +28,9 @@ export const STORE_NAMESPACE = 'newspack/newsletters';
 
 const DEFAULT_STATE = {
 	isRetrieving: false,
+	isRefreshingHtml: false,
 	newsletterData: {},
+	shouldSendTest: false,
 	error: null,
 };
 const createAction = type => payload => ( { type, payload } );
@@ -36,6 +38,8 @@ const reducer = ( state = DEFAULT_STATE, { type, payload = {} } ) => {
 	switch ( type ) {
 		case 'SET_IS_RETRIEVING':
 			return { ...state, isRetrieving: payload };
+		case 'SET_IS_REFRESHING_HTML':
+			return { ...state, isRefreshingHtml: payload };
 		case 'SET_DATA':
 			const updatedNewsletterData = { ...state.newsletterData, ...payload };
 			return { ...state, newsletterData: updatedNewsletterData };
@@ -49,12 +53,14 @@ const reducer = ( state = DEFAULT_STATE, { type, payload = {} } ) => {
 const actions = {
 	// Regular actions.
 	setIsRetrieving: createAction( 'SET_IS_RETRIEVING' ),
+	setIsRefreshingHtml: createAction( 'SET_IS_REFRESHING_HTML' ),
 	setData: createAction( 'SET_DATA' ),
 	setError: createAction( 'SET_ERROR' ),
 };
 
 const selectors = {
 	getIsRetrieving: state => state.isRetrieving,
+	getIsRefreshingHtml: state => state.isRefreshingHtml,
 	getData: state => state.newsletterData || {},
 	getError: state => state.error,
 };
@@ -74,6 +80,12 @@ export const useIsRetrieving = () =>
 		select( STORE_NAMESPACE ).getIsRetrieving()
 	);
 
+// Hook to use the refresh HTML status from any editor component.
+export const useIsRefreshingHtml = () =>
+	useSelect( select =>
+		select( STORE_NAMESPACE ).getIsRefreshingHtml()
+	);
+
 // Hook to use the newsletter data from any editor component.
 export const useNewsletterData = () =>
 	useSelect( select =>
@@ -86,9 +98,14 @@ export const useNewsletterDataError = () =>
 		select( STORE_NAMESPACE ).getError()
 	);
 
+
 // Dispatcher to update retrieval status in the store.
 export const updateIsRetrieving = isRetrieving =>
 	dispatch( STORE_NAMESPACE ).setIsRetrieving( isRetrieving );
+
+// Dispatcher to update refreshing HTML status in the store.
+export const updateIsRefreshingHtml = isRetrieving =>
+	dispatch( STORE_NAMESPACE ).setIsRefreshingHtml( isRetrieving );
 
 // Dispatcher to update newsletter data in the store.
 export const updateNewsletterData = data =>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Avoids a potential race condition when sending a test email. Sending a test email triggers a save, but because the campaign is synced _after_ a save instead of on save (so that we can regenerate MJML first), and the `test` endpoint also triggers a sync, it's possible that the test request can fire its sync and send the test email before the post-save sync completes. This can result in the test email being sent with old data and content.

Until this fix is deployed, editors can avoid this race condition by manually saving before sending a test email.

### How to test the changes in this Pull Request:

1. To make the race condition more likely to happen, try adding `sleep( 5 );` before [this line](https://github.com/Automattic/newspack-newsletters/blob/trunk/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp.php#L1120) in whichever ESP class you're testing with. This will force the post-save-sync to take 5 seconds longer to start.
2. On `trunk`, make some changes to a newsletter draft's content but don't save. Then, send yourself a test email without saving first. The content in the sent test should match the content from _before_ you clicked "Send a Test Email".
  - If you open your dev tools > Network tab, you can see the race condition happening in real time:
    a.  After clicking "Send a Test Email" there should be an XHR `POST` request to an endpoint with the post ID of the post you're editing. This is the "save" request.
    b. Immediately after the save request finishes, you should see another `POST` request to the `test` endpoint to trigger a test email.
    c. Sometime after that (since you added the `sleep` delay above) you should see a `POST` request to `post-mjml`, then `GET` requests to `retrieve` and `sync-errors`. This series of requests is the post-save sync.

3. Check out this branch and repeat step 2. This time, confirm that the test email's content always matches the state of the content even if you sent a test without saving first.
  - In the dev tools > Network tab, you should now see that the `POST` request to the `test` endpoint doesn't start until after the last `sync-errors` request, which means that we're now waiting until the post-save sync completes before sending a test email. Because of this we can remove the extra `sync` that gets triggered by the `test` endpoint handler (MC only).

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
