### PR TITLE
fix: preview & send buttons on WP 6.7

### DIFF
--- a/src/components/send-button/index.js
+++ b/src/components/send-button/index.js
@@ -298,7 +298,7 @@ export default compose( [
 		}
 
 		return (
-			<Fragment>
+			<div style={{ display: 'flex' }}>
 				<PreviewHTMLButton />
 				<Button
 					className="editor-post-publish-button"
@@ -366,7 +366,7 @@ export default compose( [
 						</div>
 					</Modal>
 				) }
-			</Fragment>
+			</div>
 		);
 	}
 );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

WP 6.7 updates some styling, which breaks our custom buttons:

| 6.6 | 6.7 | 
|--------------|-----------|
| <img width="217" alt="image" src="https://github.com/user-attachments/assets/3f48a1f4-0843-4470-acc3-eb5d95617eb8"> | <img width="175" alt="image" src="https://github.com/user-attachments/assets/0a9dd24c-fef7-4b66-81cc-0330f1b9b204"> |

This PR fixes that, while ensuring compatibility with 6.6.

### How to test the changes in this Pull Request:

1. On `trunk`, switch WP to 6.7 (`wp core update --version=6.7-beta3`)
2. Open a newsletter or create a new on, observe broken UI
3. Switch to this branch, observe UI is now fine

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->