### PR TITLE
fix: strip Mailchimp merge tags from email preview text

### DIFF
--- a/includes/class-newspack-newsletters-renderer.php
+++ b/includes/class-newspack-newsletters-renderer.php
@@ -1269,11 +1269,8 @@ final class Newspack_Newsletters_Renderer {
 		 */
 		$body             = self::post_to_mjml_components( $post ); // phpcs:ignore WordPressVIPMinimum.Variables.VariableAnalysis.UnusedVariable
 		$background_color = get_post_meta( $post->ID, 'background_color', true );
-		$preview_text     = get_post_meta( $post->ID, 'preview_text', true );
+		$preview_text     = self::get_preview_text( $post );
 		$custom_css       = get_post_meta( $post->ID, 'custom_css', true );
-		if ( ! $preview_text ) {
-			$preview_text = wp_trim_words( wp_strip_all_tags( $body ), 60 );
-		}
 		if ( ! $background_color ) {
 			$background_color = '#ffffff';
 		}
@@ -1281,6 +1278,33 @@ final class Newspack_Newsletters_Renderer {
 		ob_start();
 		include __DIR__ . '/email-template.mjml.php';
 		return ob_get_clean();
+	}
+
+	/**
+	 * Retrieve or build a preview text string.
+	 * Strip all HTML + merge tags, and truncate to 60 words.
+	 *
+	 * @param WP_Post $post The post.
+	 *
+	 * @return string The preview text.
+	 */
+	public static function get_preview_text( $post ) {
+		$preview_text = get_post_meta( $post->ID, 'preview_text', true );
+		if ( ! $preview_text ) {
+			$preview_text = wp_trim_words( wp_strip_all_tags( get_the_content( null, false, $post ) ), 60 );
+		}
+		return self::strip_all_merge_tags( $preview_text );
+	}
+
+	/**
+	 * Strip all Mailchimp merge tag strings from a string.
+	 *
+	 * @param string $string The string.
+	 *
+	 * @return string The string with all merge tags stripped.
+	 */
+	public static function strip_all_merge_tags( $string ) {
+		return preg_replace( '/\*\|[^|]+\|\*/', '', $string );
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

If you don't fill in the preview text field, preview text will be generated from the first 60 words of post content. However, if that generated preview text contains an unclosed [Mailchimp conditional merge tag](https://mailchimp.com/help/use-conditional-merge-tag-blocks/), with an `ELSE` statement in between, this will break Mailchimp's email renderer, potentially resulting in a totally blank email being sent. Not good!

To avoid this issue, this PR strips _all_ Mailchimp merge tags from the preview text string, generated or not. 

### How to test the changes in this Pull Request:

1. On `release`, using Mailchimp as the connected ESP, create a new newsletter and add a conditional `IF...ELSE` merge tag block at the beginning of the post content. Make sure the preview text will contain the `IF` and `ELSE` tags before the first 60 words, but after that is long enough to push the closing tag out of the first 60 words, e.g.:

```
*|IF:MMERGE7=|*

Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque ut lorem at ex hendrerit finibus. Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas.

*|ELSEIF:MMERGE7=Testing|*

Suspendisse posuere enim et libero vehicula, non faucibus tortor vehicula. Nam sit amet iaculis sem, et porta elit. Phasellus pretium aliquet ligula at elementum. Proin vitae mauris eget ex aliquet vulputate. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin non scelerisque neque. Etiam iaculis ligula non pellentesque dignissim. Sed at ultricies massa, eget varius nisl.

*|END:IF|*
```

2. Save the draft and send yourself a test email. It should appear completely blank. You can also view the raw HTML of the email (`wp post meta get <post ID> newspack_email_html`) and see that the beginning of the content contains the unclosed `IF...ELSE` tags.

<img width="1119" alt="Screenshot 2024-10-24 at 3 30 24 PM" src="https://github.com/user-attachments/assets/64088334-8234-439a-9bb4-e9e93c12fed8">

3. Check out this branch, refresh the editor and save again, then send another test email. Confirm that the email's content renders correctly and that the beginning of the raw HTML contains the preview text but stripped of the `IF...ELSE` tags.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1208622148217455