### PR TITLE
fix: check for error type before logging

### DIFF
--- a/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp-cached-data.php
+++ b/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp-cached-data.php
@@ -556,8 +556,8 @@ final class Newspack_Newsletters_Mailchimp_Cached_Data {
 			),
 			__( 'Error retrieving Mailchimp lists.', 'newspack_newsletters' )
 		);
-		if ( is_wp_error( $lists_response ) || empty( $lists_response['lists'] ) ) {
-			Newspack_Newsletters_Logger::log( 'Mailchimp cache: Error refreshing cache: ' . ( is_wp_error( $lists_response ) ? $lists_response->getMessage() : __( 'Error retrieving Mailchimp lists.', 'newspack_newsletters' ) ) );
+		if ( method_exists( $lists_response, 'getMessage' ) || empty( $lists_response['lists'] ) ) {
+			Newspack_Newsletters_Logger::log( 'Mailchimp cache: Error refreshing cache: ' . ( method_exists( $lists_response, 'getMessage' ) ? $lists_response->getMessage() : __( 'Error retrieving Mailchimp lists.', 'newspack_newsletters' ) ) );
 			return is_wp_error( $lists_response ) ? $lists_response : [];
 		}
 

--- a/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp-cached-data.php
+++ b/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp-cached-data.php
@@ -556,8 +556,8 @@ final class Newspack_Newsletters_Mailchimp_Cached_Data {
 			),
 			__( 'Error retrieving Mailchimp lists.', 'newspack_newsletters' )
 		);
-		if ( method_exists( $lists_response, 'getMessage' ) || empty( $lists_response['lists'] ) ) {
-			Newspack_Newsletters_Logger::log( 'Mailchimp cache: Error refreshing cache: ' . ( method_exists( $lists_response, 'getMessage' ) ? $lists_response->getMessage() : __( 'Error retrieving Mailchimp lists.', 'newspack_newsletters' ) ) );
+		if ( is_wp_error( $lists_response ) || empty( $lists_response['lists'] ) ) {
+			Newspack_Newsletters_Logger::log( 'Mailchimp cache: Error refreshing cache: ' . ( $lists_response->get_message() ?? __( 'Error retrieving Mailchimp lists.', 'newspack_newsletters' ) ) );
 			return is_wp_error( $lists_response ) ? $lists_response : [];
 		}
 

--- a/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp-cached-data.php
+++ b/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp-cached-data.php
@@ -525,7 +525,12 @@ final class Newspack_Newsletters_Mailchimp_Cached_Data {
 	 */
 	public static function handle_cron() {
 		Newspack_Newsletters_Logger::log( 'Mailchimp cache: Handling cron request to refresh cache' );
-		$lists = self::fetch_lists(); // Force a cache refresh.
+		try {
+			$lists = self::fetch_lists(); // Force a cache refresh.
+		} catch ( Exception $e ) {
+			Newspack_Newsletters_Logger::log( 'Mailchimp cache: Error refreshing lists cache: ' . $e->getMessage() );
+			return;
+		}
 
 		foreach ( $lists as $list ) {
 			Newspack_Newsletters_Logger::log( 'Mailchimp cache: Dispatching request to refresh cache for list ' . $list['id'] );
@@ -556,10 +561,6 @@ final class Newspack_Newsletters_Mailchimp_Cached_Data {
 			),
 			__( 'Error retrieving Mailchimp lists.', 'newspack_newsletters' )
 		);
-		if ( is_wp_error( $lists_response ) || empty( $lists_response['lists'] ) ) {
-			Newspack_Newsletters_Logger::log( 'Mailchimp cache: Error refreshing cache: ' . ( is_wp_error( $lists_response ) ? $lists_response->get_message() : __( 'Error retrieving Mailchimp lists.', 'newspack_newsletters' ) ) );
-			return is_wp_error( $lists_response ) ? $lists_response : [];
-		}
 
 		// Cache the lists (only if we got them all).
 		if ( ! $limit ) {

--- a/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp-cached-data.php
+++ b/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp-cached-data.php
@@ -557,7 +557,7 @@ final class Newspack_Newsletters_Mailchimp_Cached_Data {
 			__( 'Error retrieving Mailchimp lists.', 'newspack_newsletters' )
 		);
 		if ( is_wp_error( $lists_response ) || empty( $lists_response['lists'] ) ) {
-			Newspack_Newsletters_Logger::log( 'Mailchimp cache: Error refreshing cache: ' . ( $lists_response->getMessage() ?? __( 'Error retrieving Mailchimp lists.', 'newspack_newsletters' ) ) );
+			Newspack_Newsletters_Logger::log( 'Mailchimp cache: Error refreshing cache: ' . ( is_wp_error( $lists_response ) ? $lists_response->getMessage() : __( 'Error retrieving Mailchimp lists.', 'newspack_newsletters' ) ) );
 			return is_wp_error( $lists_response ) ? $lists_response : [];
 		}
 

--- a/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp-cached-data.php
+++ b/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp-cached-data.php
@@ -557,7 +557,7 @@ final class Newspack_Newsletters_Mailchimp_Cached_Data {
 			__( 'Error retrieving Mailchimp lists.', 'newspack_newsletters' )
 		);
 		if ( is_wp_error( $lists_response ) || empty( $lists_response['lists'] ) ) {
-			Newspack_Newsletters_Logger::log( 'Mailchimp cache: Error refreshing cache: ' . ( $lists_response->get_message() ?? __( 'Error retrieving Mailchimp lists.', 'newspack_newsletters' ) ) );
+			Newspack_Newsletters_Logger::log( 'Mailchimp cache: Error refreshing cache: ' . ( is_wp_error( $lists_response ) ? $lists_response->get_message() : __( 'Error retrieving Mailchimp lists.', 'newspack_newsletters' ) ) );
 			return is_wp_error( $lists_response ) ? $lists_response : [];
 		}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes a potential fatal. We log an error if a `$lists_response` variable is a WP error OR if it lacks a `lists` key, but in that latter case (not an error and lacks the key) a fatal will be thrown.

### How to test the changes in this Pull Request:

A code review should be sufficient, but to test you can add a line `$lists_response = [];` before [this line](https://github.com/Automattic/newspack-newsletters/blob/trunk/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp-cached-data.php#L559), then visit a newsletter post in the editor to trigger the fatal on `release` and confirm that the fatal doesn't happen on this branch.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
