### PR TITLE
fix(mailchimp): avoid duplicate audiences in Mailchimp UIs

### DIFF
--- a/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp.php
+++ b/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp.php
@@ -618,14 +618,17 @@ final class Newspack_Newsletters_Mailchimp extends \Newspack_Newsletters_Service
 	 * @return array|WP_Error List of subscription lists or error.
 	 */
 	public function get_lists( $audiences_only = false ) {
-		$lists = Newspack_Newsletters_Mailchimp_Cached_Data::get_lists();
-		if ( $audiences_only || is_wp_error( $lists ) ) {
-			return $lists;
+		$audiences = Newspack_Newsletters_Mailchimp_Cached_Data::get_lists();
+		if ( $audiences_only || is_wp_error( $audiences ) ) {
+			return $audiences;
 		}
+		$lists = [];
 
 		// In addition to Audiences, we also automatically fetch all groups and tags and offer them as Subscription Lists.
 		// Build the final list inside the loop so groups are added after the list they belong to and we can then represent the hierarchy in the UI.
-		foreach ( $lists as $list ) {
+		foreach ( $audiences as $list ) {
+
+			$lists[]        = $list;
 			$all_categories = Newspack_Newsletters_Mailchimp_Cached_Data::get_interest_categories( $list['id'] );
 			$all_categories = $all_categories['categories'] ?? [];
 			$all_tags       = Newspack_Newsletters_Mailchimp_Cached_Data::get_tags( $list['id'] ) ?? [];

--- a/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp.php
+++ b/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp.php
@@ -626,8 +626,6 @@ final class Newspack_Newsletters_Mailchimp extends \Newspack_Newsletters_Service
 		// In addition to Audiences, we also automatically fetch all groups and tags and offer them as Subscription Lists.
 		// Build the final list inside the loop so groups are added after the list they belong to and we can then represent the hierarchy in the UI.
 		foreach ( $lists as $list ) {
-
-			$lists[]        = $list;
 			$all_categories = Newspack_Newsletters_Mailchimp_Cached_Data::get_interest_categories( $list['id'] );
 			$all_categories = $all_categories['categories'] ?? [];
 			$all_tags       = Newspack_Newsletters_Mailchimp_Cached_Data::get_tags( $list['id'] ) ?? [];


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes a minor UI bug for Mailchimp users only. An errant line is causing MC audiences to appear twice in UIs that show audiences, including the Newsletters settings page and the Newspack > Engagement wizard pages. This fixes the duplicate display. The bug is minor and doesn't affect functionality—selecting either version of the audience will save the data correctly.

### How to test the changes in this Pull Request:

1. On `trunk`, visit Newsletters > Settings and Newspack > Engagement > Newsletters and observe that each audience appears twice: once at the very top of the list, and another time alongside its sublists below.
2. Check out this branch, refresh, and confirm that each audience appears only once with its sublists nested below.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
