### PR TITLE
fix: dont html encode ampersands in subject

### DIFF
--- a/includes/service-providers/active_campaign/class-newspack-newsletters-active-campaign.php
+++ b/includes/service-providers/active_campaign/class-newspack-newsletters-active-campaign.php
@@ -1050,7 +1050,7 @@ final class Newspack_Newsletters_Active_Campaign extends \Newspack_Newsletters_S
 				'p[' . $send_list_id . ']' => 1,
 				'fromemail'                => $from_email,
 				'fromname'                 => $from_name,
-				'subject'                  => $post->post_title,
+				'subject'                  => html_entity_decode( $post->post_title ),
 			],
 			$message_data
 		);

--- a/includes/service-providers/campaign_monitor/class-newspack-newsletters-campaign-monitor.php
+++ b/includes/service-providers/campaign_monitor/class-newspack-newsletters-campaign-monitor.php
@@ -490,8 +490,8 @@ final class Newspack_Newsletters_Campaign_Monitor extends \Newspack_Newsletters_
 		}
 
 		$args = [
-			'Subject'   => get_the_title( $post_id ),
-			'Name'      => get_the_title( $post_id ) . ' ' . gmdate( 'h:i:s A' ), // Name must be unique.
+			'Subject'   => html_entity_decode( get_the_title( $post_id ) ),
+			'Name'      => html_entity_decode( get_the_title( $post_id ) ) . ' ' . gmdate( 'h:i:s A' ), // Name must be unique.
 			'FromName'  => get_post_meta( $post_id, 'senderName', true ),
 			'FromEmail' => get_post_meta( $post_id, 'senderEmail', true ),
 			'ReplyTo'   => get_post_meta( $post_id, 'senderEmail', true ),

--- a/includes/service-providers/constant_contact/class-newspack-newsletters-constant-contact.php
+++ b/includes/service-providers/constant_contact/class-newspack-newsletters-constant-contact.php
@@ -655,7 +655,7 @@ final class Newspack_Newsletters_Constant_Contact extends \Newspack_Newsletters_
 			$activity = [
 				'format_type'      => 5,
 				'email_content'    => $content,
-				'subject'          => $post->post_title,
+				'subject'          => html_entity_decode( $post->post_title ),
 				'contact_list_ids' => $campaign->activity->contact_list_ids,
 				'from_name'        => $from_name,
 				'from_email'       => $reply_to,

--- a/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp.php
+++ b/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp.php
@@ -1004,7 +1004,7 @@ final class Newspack_Newsletters_Mailchimp extends \Newspack_Newsletters_Service
 			'type'         => 'regular',
 			'content_type' => 'template',
 			'settings'     => [
-				'subject_line' => $post->post_title,
+				'subject_line' => html_entity_decode( $post->post_title ),
 				'title'        => $this->get_campaign_name( $post ),
 			],
 		];

--- a/src/newsletter-editor/sidebar/index.js
+++ b/src/newsletter-editor/sidebar/index.js
@@ -4,7 +4,7 @@
 import { __ } from '@wordpress/i18n';
 import { compose } from '@wordpress/compose';
 import { withSelect, withDispatch } from '@wordpress/data';
-import { useEffect } from '@wordpress/element';
+import { useEffect, useRef, useState } from '@wordpress/element';
 import { Button, Notice, Spinner, TextControl, TextareaControl } from '@wordpress/components';
 
 /**
@@ -40,11 +40,24 @@ const Sidebar = ( {
 	stringifiedCampaignDefaults,
 	postId,
 } ) => {
+	const [ plainTextTitle, setPlainTextTitle ] = useState( title );
 	const isRetrieving = useIsRetrieving();
 	const newsletterData = useNewsletterData();
 	const newsletterDataError = useNewsletterDataError();
 	const campaign = newsletterData?.campaign;
 	const updateMeta = ( toUpdate ) => editPost( { meta: toUpdate } );
+	const entityConverter = useRef( null );
+
+	// Create a temp textarea element that we can use to convert HTML entities like &amp; to unicode characters.
+	useEffect( () => {
+		if ( entityConverter.current ) {
+			entityConverter.current.innerHTML = title;
+			setPlainTextTitle( entityConverter.current.value );
+		} else {
+			entityConverter.current = document.createElement( 'textarea' );
+		}
+		return () => entityConverter?.current?.remove && entityConverter.current.remove(); // Clean up temp element from DOM on unmount.
+	}, [ title ] );
 
 	// Reconcile stored campaign data with data fetched from ESP.
 	useEffect( () => {
@@ -184,7 +197,7 @@ const Sidebar = ( {
 			<TextControl
 				label={ __( 'Subject', 'newspack-newsletters' ) }
 				className="newspack-newsletters__subject-textcontrol"
-				value={ title.replace('&amp;', '&') }
+				value={ plainTextTitle }
 				disabled={ inFlight }
 				onChange={ value => editPost( { title: value } ) }
 			/>

--- a/src/newsletter-editor/sidebar/index.js
+++ b/src/newsletter-editor/sidebar/index.js
@@ -184,7 +184,7 @@ const Sidebar = ( {
 			<TextControl
 				label={ __( 'Subject', 'newspack-newsletters' ) }
 				className="newspack-newsletters__subject-textcontrol"
-				value={ title }
+				value={ title.replace('&amp;', '&') }
 				disabled={ inFlight }
 				onChange={ value => editPost( { title: value } ) }
 			/>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes a small issue where ampersands are HTML encoded in the Subject.

Not sure if there's a better way to do it. But it's weird because the only character that is being HTML encoded is the ampersand, so loading a library to html_decode everything looked unnecessary.

### How to test the changes in this Pull Request:

1. In `trunk` edit a newsletters
2. add a `&` to the title and see that `$amp;` is added to the Subject input in the Newsletter sidebar
3. Checkout this branch and do the same
4. See that `&` is preserved as is

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
