### PR TITLE
fix: avoid Redux usage and related errors in non-newsletter email editors

### DIFF
--- a/src/components/send-button/index.js
+++ b/src/components/send-button/index.js
@@ -18,8 +18,9 @@ import { get } from 'lodash';
  * Internal dependencies
  */
 import { getServiceProvider } from '../../service-providers';
-import { refreshEmailHtml, validateNewsletter } from '../../newsletter-editor/utils';
+import { validateNewsletter } from '../../newsletter-editor/utils';
 import { useNewsletterData } from '../../newsletter-editor/store';
+import { refreshEmailHtml } from '../../editor/mjml';
 import './style.scss';
 
 function PreviewHTML() {

--- a/src/newsletter-editor/index.js
+++ b/src/newsletter-editor/index.js
@@ -90,7 +90,7 @@ function NewsletterEdit( { apiFetchWithErrorHandling, setInFlightForAsync, inFli
 	// Handle error messages from retrieve/sync requests with connected ESP.
 	useEffect( () => {
 		if ( newsletterDataError ) {
-			createNotice( 'error', newsletterDataError?.message || __( 'Error communicating with service provider.', 'newspack-newseltters' ), {
+			createNotice( 'error', newsletterDataError?.message || __( 'Error communicating with service provider.', 'newspack-newsletters' ), {
 				id: 'newspack-newsletters-newsletter-data-error',
 				isDismissible: true,
 			} );

--- a/src/newsletter-editor/utils.js
+++ b/src/newsletter-editor/utils.js
@@ -3,14 +3,8 @@
 /**
  * WordPress dependencies
  */
-import apiFetch from '@wordpress/api-fetch';
 import { useEffect, useRef } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-
-/**
- * External dependencies
- */
-import mjml2html from 'mjml-browser';
 
 /**
  * Internal dependencies
@@ -60,30 +54,6 @@ export const validateNewsletter = ( meta = {} ) => {
  * @return {boolean} True if it contains a valid email string.
  */
 export const hasValidEmail = string => /\S+@\S+/.test( string );
-
-/**
- * Refresh the email-compliant HTML for a post.
- *
- * @param {number} postId      The current post ID.
- * @param {string} postTitle   The current post title.
- * @param {string} postContent The current post content.
- * @return {Promise<string>} The refreshed email HTML.
- */
-export const refreshEmailHtml = async ( postId, postTitle, postContent ) => {
-	const mjml = await apiFetch( {
-		path: `/newspack-newsletters/v1/post-mjml`,
-		method: 'POST',
-		data: {
-			post_id: postId,
-			title: postTitle,
-			content: postContent,
-		},
-	} );
-
-	// Once received MJML markup, convert it to email-compliant HTML and save as post meta.
-	const { html } = mjml2html( mjml, { keepComments: false, minify: true } );
-	return html;
-};
 
 /**
  * Custom hook to fetch a previous state or prop value.


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

#1679 introduced errors in non-newsletter CPT email editors. All email editors use the MJML component to convert post block content into MJML and then into email-compliant HTML. Only the newsletter CPT editor registers a Redux store to handle newsletter campaign data, so store methods should only be called while editing a newsletter CPT post while connected to a supported ESP.

This PR makes the `MJML` component more standalone once again, and only lets it call Redux store methods when it detects a supported ESP connection (which will only happen in the newsletter editor, not other email editors). It also does some light refactoring of this component to avoid a Promise chain in favor of a less verbose and more readable `async` function.

### How to test the changes in this Pull Request:

1. On `trunk`, edit a custom Newspack email (such as the custom receipt in Reader Revenue > Emails, or the RAS emails in Engagement > Reader Activation) and a newsletter ad. In both cases, observe an error notice: `Uncaught TypeError: Cannot read properties of undefined (reading 'getIsRefreshingHtml')`
2. Check out this branch and refresh both editors and confirm that the error doesn't appear.
3. Smoke test making edits to the custom email and the newsletter ad and confirm that the changes are persisted.
4. Smoke test sending a test email from the custom email editor and confirm that the changes are reflected in the sent test email.
5. Smoke test updating a newsletter post, saving, sending a test email, and confirm that all changes made are reflected in test emails and in synced campaign in the connected ESP.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1208638777229783