### PR TITLE
fix: move Preview, Send buttons to match Publish button location

### DIFF
--- a/src/newsletter-editor/editor/index.js
+++ b/src/newsletter-editor/editor/index.js
@@ -102,7 +102,7 @@ const Editor = compose( [
 			const publishButton = document.getElementsByClassName(
 				'editor-post-publish-button__button'
 			)[ 0 ];
-			publishButton.parentNode.insertBefore( publishEl, publishButton );
+			publishButton.parentNode.insertBefore( publishEl, publishButton.nextSibling );
 		}, [] );
 
 		// Set color palette option.


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

In WordPress 6.7, the Preview/Publish button on posts and pages is getting moved so it's second last, right before the `...` Options kebab menu.

This PR switches the order of the Preview Email/Send buttons in the Newsletters plugin so they match the new Preview/Publish location. There isn't any backwards compatibility (the buttons end up moved in 6.6.x as well); we should be able to time this pretty well so we don't have a large gap between when this goes out and when 6.7 is released, but please let me know if you see any issue with that!

See 1208604228632024-as-1208604368072448

### How to test the changes in this Pull Request:

1. Start on a test site running the latest WP 6.7 RC.
2. Edit a post or page and note the order of the buttons in the top-right corner of the editor:

![CleanShot 2024-10-31 at 13 47 10](https://github.com/user-attachments/assets/4d136b02-e5fa-4301-a364-10b9b88ad90a)

4. Edit or add a new Newsletter and note the order of the same buttons in that editor:

![CleanShot 2024-10-31 at 13 49 46](https://github.com/user-attachments/assets/d674ec3e-89ae-4e14-a654-88e0effbdfe6)

5. Apply this PR and run `npm run build`.
6. Confirm that the button order now matches posts/pages, with the Preview/Send buttons further down the list:

![CleanShot 2024-10-31 at 13 48 07](https://github.com/user-attachments/assets/6932248c-074d-47c2-b4e0-d14f6b6b0ede)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
