### PR TITLE
fix(mailchimp): fatal error with invalid API keys

### DIFF
--- a/includes/class-newspack-newsletters-settings.php
+++ b/includes/class-newspack-newsletters-settings.php
@@ -287,6 +287,11 @@ class Newspack_Newsletters_Settings {
 	private static function render_lists_table() {
 		$lists = Newspack_Newsletters_Subscription::get_lists();
 		if ( is_wp_error( $lists ) || empty( $lists ) ) {
+			?>
+			<div class="notice notice-error">
+				<p><?php echo esc_html( is_wp_error( $lists ) ? $lists->get_error_message() : __( 'No list data found.', 'newspack-newsletters' ) ); ?></p>
+			</div>
+			<?php
 			return;
 		}
 		?>

--- a/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp-cached-data.php
+++ b/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp-cached-data.php
@@ -310,7 +310,7 @@ final class Newspack_Newsletters_Mailchimp_Cached_Data {
 	 * @param string|null $list_id The List ID, or null for all lists.
 	 * @param string      $error The error message.
 	 */
-	private static function maybe_add_error( $list_id = null, $error ) {
+	private static function maybe_add_error( $list_id = null, $error = '' ) {
 		Newspack_Newsletters_Logger::log(
 			sprintf(
 				'Mailchimp cache: handling error while fetching cache for %s',
@@ -319,6 +319,9 @@ final class Newspack_Newsletters_Mailchimp_Cached_Data {
 		);
 		if ( ! $list_id ) {
 			$list_id = 'lists';
+		}
+		if ( ! $error ) {
+			$error = __( 'Unknown error', 'newspack_newsletters' );
 		}
 		$cache_date = get_option( self::get_cache_date_key( $list_id ) );
 		if ( $cache_date && ( time() - $cache_date ) > self::SURFACE_ERRORS_AFTER ) {

--- a/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp-cached-data.php
+++ b/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp-cached-data.php
@@ -525,10 +525,18 @@ final class Newspack_Newsletters_Mailchimp_Cached_Data {
 	 */
 	public static function handle_cron() {
 		Newspack_Newsletters_Logger::log( 'Mailchimp cache: Handling cron request to refresh cache' );
+		delete_option( self::get_lists_cache_key() );
+		delete_option( self::get_cache_date_key() );
+
 		try {
 			$lists = self::fetch_lists(); // Force a cache refresh.
 		} catch ( Exception $e ) {
 			Newspack_Newsletters_Logger::log( 'Mailchimp cache: Error refreshing lists cache: ' . $e->getMessage() );
+			return;
+		}
+
+		if ( is_wp_error( $lists ) ) {
+			Newspack_Newsletters_Logger::log( 'Mailchimp cache: Error refreshing lists cache: ' . $lists->get_error_message() );
 			return;
 		}
 
@@ -549,7 +557,7 @@ final class Newspack_Newsletters_Mailchimp_Cached_Data {
 	public static function fetch_lists( $limit = null ) {
 		$mc = self::get_mc_api();
 		if ( \is_wp_error( $mc ) ) {
-			return [];
+			return $mc;
 		}
 		$lists_response = ( self::get_mc_instance() )->validate(
 			$mc->get(

--- a/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp-cached-data.php
+++ b/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp-cached-data.php
@@ -288,10 +288,14 @@ final class Newspack_Newsletters_Mailchimp_Cached_Data {
 	/**
 	 * Clears the cache errors for a given list
 	 *
-	 * @param string $list_id The List ID.
+	 * @param string|null $list_id The List ID, or null for all lists.
 	 * @return void
 	 */
-	private static function clear_errors( $list_id ) {
+	private static function clear_errors( $list_id = null ) {
+		if ( ! $list_id ) {
+			delete_option( self::ERRORS_OPTION );
+			return;
+		}
 		$errors = get_option( self::ERRORS_OPTION, [] );
 		if ( isset( $errors[ $list_id ] ) ) {
 			unset( $errors[ $list_id ] );
@@ -303,11 +307,16 @@ final class Newspack_Newsletters_Mailchimp_Cached_Data {
 	/**
 	 * Stores the last error for a given list, if the cache is older than self::SURFACE_ERRORS_AFTER
 	 *
-	 * @param string $list_id The List ID.
-	 * @param string $error The error message.
+	 * @param string|null $list_id The List ID, or null for all lists.
+	 * @param string      $error The error message.
 	 */
-	private static function maybe_add_error( $list_id, $error ) {
-		Newspack_Newsletters_Logger::log( 'Mailchimp cache: handling error while fetching cache for list ' . $list_id );
+	private static function maybe_add_error( $list_id = null, $error ) {
+		Newspack_Newsletters_Logger::log(
+			sprintf(
+				'Mailchimp cache: handling error while fetching cache for %s',
+				$list_id ? 'list ' . $list_id : 'all lists'
+			)
+		);
 		$cache_date = get_option( self::get_cache_date_key( $list_id ) );
 		if ( $cache_date && ( time() - $cache_date ) > self::SURFACE_ERRORS_AFTER ) {
 			$errors             = get_option( self::ERRORS_OPTION, [] );
@@ -528,6 +537,7 @@ final class Newspack_Newsletters_Mailchimp_Cached_Data {
 		Newspack_Newsletters_Logger::log( 'Mailchimp cache: Invalidating cached data' );
 		delete_option( self::get_cache_date_key() );
 		delete_option( self::get_lists_cache_key() );
+		self::clear_errors();
 	}
 
 	/**
@@ -541,6 +551,7 @@ final class Newspack_Newsletters_Mailchimp_Cached_Data {
 			$lists = self::fetch_lists(); // Force a cache refresh.
 		} catch ( Exception $e ) {
 			Newspack_Newsletters_Logger::log( 'Mailchimp cache: Error refreshing lists cache: ' . $e->getMessage() );
+			self::maybe_add_error( null, $e->getMessage() );
 			return;
 		}
 

--- a/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp-cached-data.php
+++ b/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp-cached-data.php
@@ -82,6 +82,9 @@ final class Newspack_Newsletters_Mailchimp_Cached_Data {
 		add_action( 'wp_ajax_' . self::AJAX_ACTION, [ __CLASS__, 'handle_dispatch_refresh' ] );
 		add_action( 'wp_ajax_nopriv_' . self::AJAX_ACTION, [ __CLASS__, 'handle_dispatch_refresh' ] );
 
+		// Invalidate all cached data if API key changes.
+		add_action( 'update_option_newspack_mailchimp_api_key', [ __CLASS__, 'invalidate_cache' ] );
+
 		add_action( self::CRON_HOOK, [ __CLASS__, 'handle_cron' ] );
 		add_filter( 'cron_schedules', [ __CLASS__, 'add_cron_interval' ] ); // phpcs:ignore
 
@@ -519,24 +522,25 @@ final class Newspack_Newsletters_Mailchimp_Cached_Data {
 	}
 
 	/**
+	 * Invalidate cached data by clearing the cache date key for all lists.
+	 */
+	public static function invalidate_cache() {
+		Newspack_Newsletters_Logger::log( 'Mailchimp cache: Invalidating cached data' );
+		delete_option( self::get_cache_date_key() );
+		delete_option( self::get_lists_cache_key() );
+	}
+
+	/**
 	 * Handles the cron job and triggers the async requests to refresh the cache for all lists
 	 *
 	 * @return void
 	 */
 	public static function handle_cron() {
 		Newspack_Newsletters_Logger::log( 'Mailchimp cache: Handling cron request to refresh cache' );
-		delete_option( self::get_lists_cache_key() );
-		delete_option( self::get_cache_date_key() );
-
 		try {
 			$lists = self::fetch_lists(); // Force a cache refresh.
 		} catch ( Exception $e ) {
 			Newspack_Newsletters_Logger::log( 'Mailchimp cache: Error refreshing lists cache: ' . $e->getMessage() );
-			return;
-		}
-
-		if ( is_wp_error( $lists ) ) {
-			Newspack_Newsletters_Logger::log( 'Mailchimp cache: Error refreshing lists cache: ' . $lists->get_error_message() );
 			return;
 		}
 
@@ -557,7 +561,7 @@ final class Newspack_Newsletters_Mailchimp_Cached_Data {
 	public static function fetch_lists( $limit = null ) {
 		$mc = self::get_mc_api();
 		if ( \is_wp_error( $mc ) ) {
-			return $mc;
+			return [];
 		}
 		$lists_response = ( self::get_mc_instance() )->validate(
 			$mc->get(

--- a/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp-cached-data.php
+++ b/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp-cached-data.php
@@ -317,6 +317,9 @@ final class Newspack_Newsletters_Mailchimp_Cached_Data {
 				$list_id ? 'list ' . $list_id : 'all lists'
 			)
 		);
+		if ( ! $list_id ) {
+			$list_id = 'lists';
+		}
 		$cache_date = get_option( self::get_cache_date_key( $list_id ) );
 		if ( $cache_date && ( time() - $cache_date ) > self::SURFACE_ERRORS_AFTER ) {
 			$errors             = get_option( self::ERRORS_OPTION, [] );

--- a/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp.php
+++ b/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp.php
@@ -1426,7 +1426,7 @@ final class Newspack_Newsletters_Mailchimp extends \Newspack_Newsletters_Service
 				throw new Exception( esc_html__( 'A Mailchimp error has occurred.', 'newspack-newsletters' ) );
 			}
 		}
-		if ( ! empty( $result['status'] ) && 400 < (int) $result['status'] ) {
+		if ( ! empty( $result['status'] ) && 400 <= (int) $result['status'] ) {
 			if ( $preferred_error && ! Newspack_Newsletters::debug_mode() ) {
 				if ( ! empty( $result['detail'] ) ) {
 					$preferred_error .= ' ' . $result['detail'];

--- a/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp.php
+++ b/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp.php
@@ -1426,7 +1426,7 @@ final class Newspack_Newsletters_Mailchimp extends \Newspack_Newsletters_Service
 				throw new Exception( esc_html__( 'A Mailchimp error has occurred.', 'newspack-newsletters' ) );
 			}
 		}
-		if ( ! empty( $result['status'] ) && in_array( $result['status'], [ 400, 404 ] ) ) {
+		if ( ! empty( $result['status'] ) && 400 < (int) $result['status'] ) {
 			if ( $preferred_error && ! Newspack_Newsletters::debug_mode() ) {
 				if ( ! empty( $result['detail'] ) ) {
 					$preferred_error .= ' ' . $result['detail'];

--- a/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp.php
+++ b/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp.php
@@ -1426,7 +1426,7 @@ final class Newspack_Newsletters_Mailchimp extends \Newspack_Newsletters_Service
 				throw new Exception( esc_html__( 'A Mailchimp error has occurred.', 'newspack-newsletters' ) );
 			}
 		}
-		if ( ! empty( $result['status'] ) && 400 <= (int) $result['status'] ) {
+		if ( ! empty( $result['status'] ) && (int) $result['status'] >= 400  ) {
 			if ( $preferred_error && ! Newspack_Newsletters::debug_mode() ) {
 				if ( ! empty( $result['detail'] ) ) {
 					$preferred_error .= ' ' . $result['detail'];

--- a/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp.php
+++ b/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp.php
@@ -1426,7 +1426,7 @@ final class Newspack_Newsletters_Mailchimp extends \Newspack_Newsletters_Service
 				throw new Exception( esc_html__( 'A Mailchimp error has occurred.', 'newspack-newsletters' ) );
 			}
 		}
-		if ( ! empty( $result['status'] ) && (int) $result['status'] >= 400  ) {
+		if ( ! empty( $result['status'] ) && (int) $result['status'] >= 400 ) {
 			if ( $preferred_error && ! Newspack_Newsletters::debug_mode() ) {
 				if ( ! empty( $result['detail'] ) ) {
 					$preferred_error .= ' ' . $result['detail'];


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes a fatal error when trying to fetch audience/list data using an invalid Mailchimp API key. The fatal was happening because our Mailchimp integration's API response validation logic only considered status codes of `400` or `404` to be errors, but an invalid API key error is returned with a status code of `401`, and unhandled WP errors are returned with status codes of `500`. So this PR will handle any response with a status code of `400` or greater as an error.

### How to test the changes in this Pull Request:

1. On `trunk`, connect your site to Mailchimp using a valid API key.
2. In the Mailchimp dashboard, revoke that API key.
3. Using WP CLI, trigger the cron job to refresh the Mailchimp cache (or just wait >20 minutes): `wp cron event run newspack_nl_mailchimp_refresh_cache`
4. Visit **Newspack > Engagement** and **Newsletters > Settings** admin pages and observe fatal errors in each.
5. Check out this branch and refresh both admin pages, and confirm no fatal error and a more helpful error message shown in both places:

<img width="1041" alt="Screenshot 2024-10-31 at 3 15 38 PM" src="https://github.com/user-attachments/assets/9847eb4b-4421-44eb-839e-022b55ea9280">
<img width="418" alt="Screenshot 2024-10-31 at 3 16 25 PM" src="https://github.com/user-attachments/assets/ce6900a8-e981-4cb5-8fb4-62e1174a8037">

6. Confirm that you can update the API key to a new valid key and that saving persists the key and restores the connection to the ESP.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1208644983311128