### PR TITLE
fix(send-lists): temporary fix for searching many mailchimp audiences

### DIFF
--- a/src/newsletter-editor/store.js
+++ b/src/newsletter-editor/store.js
@@ -158,7 +158,6 @@ export const fetchSendLists = debounce( async ( opts, replace = false ) => {
 		const { name } = getServiceProvider();
 		const args = {
 			type: 'list',
-			limit: 10,
 			provider: name,
 			...opts,
 		};


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes an issue we've seen in the wild with searching for send sublists when connected to a Mailchimp account with more than 10 audiences. By default the Send List autocomplete UI for sublists will limit results to the first 10 audiences in the account, so if a publisher has more than that, sublists will not be returned for audience 11 and up. This temporary fix removes the limit param so that the `/send-lists` API request will always return all matching send lists, and the autocomplete component itself will limit the suggestions it shows to 10 max. This may have negative performance repercussions for ESP accounts containing many, many lists and/or sublist entities (as it will increase the size of the payload returned by the `/send-lists` REST API endpoint), so we may want to revisit this with some smarter optimizations in the future if it proves to be a major bottleneck, but for now this will allow all publishers to select all of their lists and sublists.

### How to test the changes in this Pull Request:

1. To test this, you need to connect your site to a Mailchimp account that has more than 10 audiences.
2. Create or edit a newsletter. On `release`, in the Send List sidebar panel, select an audience that would be beyond the first 10 audiences in the account, then observe that the sublist autocomplete always returns 0 results.
3. Check out this branch and confirm that the sublist autocomplete is able to fetch results for any audience.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1208699686650755