### PR TITLE
fix: correct button stacking on sent newsletters

### DIFF
--- a/src/components/send-button/index.js
+++ b/src/components/send-button/index.js
@@ -245,7 +245,7 @@ export default compose( [
 		// For sent newsletters, display the generic button text.
 		if ( isPublished || sent ) {
 			return (
-				<Fragment>
+				<div style={{ display: 'flex' }}>
 					<PreviewHTMLButton />
 					<Button
 						className="editor-post-publish-button"
@@ -294,7 +294,7 @@ export default compose( [
 							</div>
 						</Modal>
 					) }
-				</Fragment>
+				</div>
 			);
 		}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR is a near-twin of https://github.com/Automattic/newspack-newsletters/pull/1681, and fixes the button stacking issue that also happens after the newsletter is sent in WP 6.7.

See 1208604228632024-as-1208716676665710

### How to test the changes in this Pull Request:

1. Start with a test site running the latest WordPress 6.7 RC.
2. Send a newsletter, or open an already-send newsletter in the editor.
3. Note the button appearance (you may need to shrink your browser window down to less than 1400px wide to recreate):

![CleanShot 2024-11-07 at 17 46 20](https://github.com/user-attachments/assets/9198ab1e-b6e6-41e6-bd98-3de86c08d4b3)

4. Apply this PR and run `npm run build`.
5. Repeat steps 2-3 and confirm that the buttons look okay now:

![CleanShot 2024-11-07 at 17 44 48](https://github.com/user-attachments/assets/7a433879-e9f2-4c85-8f69-3b24481b5f3d)


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
