### PR TITLE
fix: let the exceptions be thrown

### DIFF
--- a/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp-cached-data.php
+++ b/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp-cached-data.php
@@ -570,6 +570,7 @@ final class Newspack_Newsletters_Mailchimp_Cached_Data {
 		if ( ! $limit ) {
 			update_option( self::get_lists_cache_key(), $lists_response['lists'], false ); // auto-load false.
 			update_option( self::get_cache_date_key(), time(), false ); // auto-load false.
+			self::clear_errors();
 		}
 
 		return $lists_response['lists'];

--- a/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp-cached-data.php
+++ b/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp-cached-data.php
@@ -108,29 +108,6 @@ final class Newspack_Newsletters_Mailchimp_Cached_Data {
 	}
 
 	/**
-	 * Retrieves an instance of the Mailchimp api
-	 *
-	 * @return DrewM\MailChimp\MailChimp|WP_Error
-	 */
-	private static function get_mc_api() {
-		$api_key = self::get_mc_instance()->api_key();
-		if ( empty( $api_key ) ) {
-			return new WP_Error(
-				'newspack_newsletters_mailchimp_error',
-				__( 'Missing Mailchimp API key.', 'newspack-newsletters' )
-			);
-		}
-		try {
-			return new Mailchimp( $api_key );
-		} catch ( Exception $e ) {
-			return new WP_Error(
-				'newspack_newsletters_mailchimp_error',
-				$e->getMessage()
-			);
-		}
-	}
-
-	/**
 	 * Get audiences (lists).
 	 *
 	 * @param int|null $limit (Optional) The maximum number of items to return. If not given, will get all items.
@@ -547,10 +524,8 @@ final class Newspack_Newsletters_Mailchimp_Cached_Data {
 	 * @return array|WP_Error The audiences, or WP_Error if there was an error.
 	 */
 	public static function fetch_lists( $limit = null ) {
-		$mc = self::get_mc_api();
-		if ( \is_wp_error( $mc ) ) {
-			return [];
-		}
+		$mc = new Mailchimp( ( self::get_mc_instance() )->api_key() );
+
 		$lists_response = ( self::get_mc_instance() )->validate(
 			$mc->get(
 				'lists',
@@ -581,10 +556,7 @@ final class Newspack_Newsletters_Mailchimp_Cached_Data {
 	 * @return array The audience segment
 	 */
 	public static function fetch_segment( $segment_id, $list_id ) {
-		$mc = self::get_mc_api();
-		if ( \is_wp_error( $mc ) ) {
-			return $mc;
-		}
+		$mc = new Mailchimp( ( self::get_mc_instance() )->api_key() );
 		$response = ( self::get_mc_instance() )->validate(
 			$mc->get(
 				"lists/$list_id/segments/$segment_id",
@@ -611,10 +583,7 @@ final class Newspack_Newsletters_Mailchimp_Cached_Data {
 	public static function fetch_segments( $list_id, $limit = null ) {
 		$segments = [];
 
-		$mc = self::get_mc_api();
-		if ( \is_wp_error( $mc ) ) {
-			return $segments;
-		}
+		$mc = new Mailchimp( ( self::get_mc_instance() )->api_key() );
 
 		$saved_segments_response  = ( self::get_mc_instance() )->validate(
 			$mc->get(
@@ -642,10 +611,7 @@ final class Newspack_Newsletters_Mailchimp_Cached_Data {
 	 * @return array The audience interest_categories
 	 */
 	private static function fetch_interest_categories( $list_id, $limit = null ) {
-		$mc = self::get_mc_api();
-		if ( \is_wp_error( $mc ) ) {
-			return [];
-		}
+		$mc = new Mailchimp( ( self::get_mc_instance() )->api_key() );
 		$interest_categories = $list_id ? ( self::get_mc_instance() )->validate(
 			$mc->get( "lists/$list_id/interest-categories", [ 'count' => $limit ?? 1000 ], 60 ),
 			__( 'Error retrieving Mailchimp groups.', 'newspack_newsletters' )
@@ -674,10 +640,7 @@ final class Newspack_Newsletters_Mailchimp_Cached_Data {
 	 * @return array The audience tags
 	 */
 	public static function fetch_tags( $list_id, $limit = null ) {
-		$mc = self::get_mc_api();
-		if ( \is_wp_error( $mc ) ) {
-			return [];
-		}
+		$mc = new Mailchimp( ( self::get_mc_instance() )->api_key() );
 		$tags = $list_id ? ( self::get_mc_instance() )->validate(
 			$mc->get(
 				"lists/$list_id/segments",
@@ -704,10 +667,7 @@ final class Newspack_Newsletters_Mailchimp_Cached_Data {
 	 * @return array The list folders
 	 */
 	private static function fetch_folders() {
-		$mc = self::get_mc_api();
-		if ( \is_wp_error( $mc ) ) {
-			return [];
-		}
+		$mc = new Mailchimp( ( self::get_mc_instance() )->api_key() );
 		$response = ( self::get_mc_instance() )->validate(
 			$mc->get( 'campaign-folders', [ 'count' => 1000 ], 60 ),
 			__( 'Error retrieving Mailchimp folders.', 'newspack_newsletters' )
@@ -723,10 +683,7 @@ final class Newspack_Newsletters_Mailchimp_Cached_Data {
 	 * @return array The list interest_categories
 	 */
 	private static function fetch_merge_fields( $list_id ) {
-		$mc = self::get_mc_api();
-		if ( \is_wp_error( $mc ) ) {
-			return [];
-		}
+		$mc = new Mailchimp( ( self::get_mc_instance() )->api_key() );
 		$response = ( self::get_mc_instance() )->validate(
 			$mc->get(
 				"lists/$list_id/merge-fields",

--- a/tests/test-mailchimp-cached-data.php
+++ b/tests/test-mailchimp-cached-data.php
@@ -21,8 +21,8 @@ class Newsletters_Mailchimp_Cached_Data_Test extends WP_UnitTestCase {
 	 * Test the API setup.
 	 */
 	public function test_mailchimp_cached_data_api_setup() {
-		// This tests if an empty API key won't cause the code to error out.
+		// Makes sure cached data fetch_methods throw an exception in case of error.
+		$this->expectException( Exception::class );
 		$segments = Newspack_Newsletters_Mailchimp_Cached_Data::fetch_segments( 'list1' );
-		$this->assertEquals( [], $segments );
 	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

See https://github.com/Automattic/newspack-newsletters/pull/1690#pullrequestreview-2424810964

This PR reverts https://github.com/Automattic/newspack-newsletters/pull/1636

The pattern we use in Newsletters is not something we use in other plugins and we keep forgetting about it.

The pattern is that instead of returning errors, the methods will throw exceptions that we need to catch. This is the basis of the `validate` method so I followed the same thing for the whole Mailchimp Cache class.

In #1636, we are supressing this errors, and the result is that they are not being surfaced when they should.

The thing that we were solving in #1636 was not an issue, it was expected behavior, you can see by the methods doc blocks that they are expected to throw.

### How to test the changes in this Pull Request:

Smoke test

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
