### PR TITLE
fix: remove behavior to hide post title in newsletter editor

### DIFF
--- a/src/newsletter-editor/editor/index.js
+++ b/src/newsletter-editor/editor/index.js
@@ -49,7 +49,6 @@ const Editor = compose( [
 			),
 			meta,
 			sent,
-			isPublic: meta.is_public,
 			newsletterSendErrors: meta.newsletter_send_errors,
 			isCustomFieldsMetaBoxActive: getAllMetaBoxes().some( box => box.id === 'postcustom' ),
 		};
@@ -82,7 +81,6 @@ const Editor = compose( [
 		createNotice,
 		html,
 		isCustomFieldsMetaBoxActive,
-		isPublic,
 		lockPostAutosaving,
 		lockPostSaving,
 		meta,
@@ -197,16 +195,6 @@ const Editor = compose( [
 				removeNotice( noticeId );
 			}
 		}, [ html ] );
-
-		useEffect( () => {
-			// Hide post title if the newsletter is a not a public post.
-			const editorTitleEl = document.querySelector( '.editor-post-title' );
-			if ( editorTitleEl ) {
-				editorTitleEl.classList[ isPublic ? 'remove' : 'add' ](
-					'newspack-newsletters-post-title-hidden'
-				);
-			}
-		}, [ isPublic ] );
 
 		return createPortal( <SendButton />, publishEl );
 	}

--- a/src/newsletter-editor/editor/style.scss
+++ b/src/newsletter-editor/editor/style.scss
@@ -1,15 +1,4 @@
 .post-type-newspack_nl_cpt {
-	.editor-post-title {
-		&.newspack-newsletters-post-title-hidden {
-			font-size: 1em;
-			height: 0;
-			margin: -4rem 0 calc(-1 * var(--wp--style--block-gap));
-			opacity: 0;
-			padding: 0;
-			pointer-events: none;
-		}
-	}
-
 	.components-button.editor-post-publish-button__button.is-primary {
 		display: none;
 	}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

This removes the behavior which attempts to hide the editor post title element in newsletter CPTs when the newsletter is NOT marked to be a "public post" after sending. The hiding behavior is inconsistent between WP 6.6 vs. WP 6.7 (it's actually been broken for while and few people noticed), and after some internal discussion we decided that the intended behavior that hides the core editor's title element in favor of the "Subject" field in the sidebar was potentially more confusing than helpful. This PR retains both the core post title element (keeping the UX more consistent with all other WP post editor screens) and sidebar subject field, which may be a little redundant but the most cautious approach to avoid disrupting editorial workflows.

Tagging @thomasguillot on this because I see some activity on this in some [past](https://github.com/Automattic/newspack-newsletters/pull/773) [threads](https://github.com/Automattic/newspack-newsletters/pull/735), in case you want to revisit this UX.

### How to test the changes in this Pull Request:

1. Edit a newsletter post and confirm that the post title is always visible at the top of the post editor screen, as with all other WP post editor screens. There should be no other functional changes.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
