### PR TITLE
fix: avoid double notice components

### DIFF
--- a/src/newsletter-editor/editor/index.js
+++ b/src/newsletter-editor/editor/index.js
@@ -134,6 +134,7 @@ const Editor = compose( [
 
 				// Show an editor notice if the newsletter has been sent.
 				createNotice( 'success', successNote + dateTime, {
+					id: 'newspack-newsletters-campaign-sent-notice',
 					isDismissible: false,
 				} );
 
@@ -151,6 +152,7 @@ const Editor = compose( [
 						'newspack-newsletters'
 					),
 					{
+						id: 'newspack-newsletters-custom-fields-warning',
 						isDismissible: false,
 						actions: [
 							{


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

In WP 6.7 some `Notice` components are rendering twice if created via `createNotice` but without an `id` prop. This adds the `id` prop to all `createNotice` calls to avoid the duplicate renders.

<img width="326" alt="Screenshot 2024-11-11 at 10 16 01 AM" src="https://github.com/user-attachments/assets/244c4909-9f56-46d1-903f-38c975249240">

### How to test the changes in this Pull Request:

1. On `trunk`, using WP 6.7, edit a newsletter that's been sent already and observe that the `Campaign sent on...` message appears at the top of the editor screen twice.
2. Check out this branch, refresh, and confirm it appears just once.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
