### PR TITLE
chore: update 'tested up to' WP version number

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -1,7 +1,7 @@
 === Newspack Newsletters ===
 Contributors: automattic, rabberson, adamboro, thomasguillot, dkoo, laurelfulford, claudiulodro, iuravic, jboydston
 Requires at least: 6.6
-Tested up to: 6.4.3
+Tested up to: 6.7
 Requires PHP: 7.4
 Stable tag: trunk
 Tags: newsletters, Newspack, Mailchimp, Active Campaign, Constant Contact


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR bumps our WordPress "tested up to" version to 6.7; I noticed by hapenstance it was still at 6.4.3. This is especially funny since we've been requiring WP 6.6 to run it 😂 

![CleanShot 2024-11-14 at 14 42 45](https://github.com/user-attachments/assets/7a37efd4-9bdd-45f0-9cba-1cfc91c22ebc)

### How to test the changes in this Pull Request:

1. Confirm the tested up to version in the readme is now up-to-date!

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
