### PR TITLE
Feat/esp report error handling

### DIFF
--- a/includes/service-providers/class-newspack-newsletters-service-provider.php
+++ b/includes/service-providers/class-newspack-newsletters-service-provider.php
@@ -940,10 +940,10 @@ Error message(s) received:
 	/**
 	 * Get usage data for yesterday.
 	 *
-	 * @return Newspack_Newsletters_Service_Provider_Usage_Report|WP_Error
+	 * @return Newspack_Newsletters_Service_Provider_Usage_Report|WP_Error|null Usage report, error or Null in case there's no need to check for a report.
 	 */
 	public function get_usage_report() {
-		return new WP_Error( 'newspack_newsletters_not_implemented', __( 'Not implemented', 'newspack-newsletters' ), [ 'status' => 400 ] );
+		return null; // Not implemented for the provider.
 	}
 
 	/**

--- a/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp-usage-reports.php
+++ b/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp-usage-reports.php
@@ -52,7 +52,9 @@ class Newspack_Newsletters_Mailchimp_Usage_Reports {
 		}
 
 		$reports = [];
-		$lists  = $mc_api->get( 'lists', [ 'count' => 1000 ] );
+		$lists   = Newspack_Newsletters_Mailchimp::instance()->validate(
+			$mc_api->get( 'lists', [ 'count' => 1000 ] )
+		);
 		if ( ! isset( $lists['lists'] ) ) {
 			return $reports;
 		}
@@ -112,7 +114,16 @@ class Newspack_Newsletters_Mailchimp_Usage_Reports {
 		// sent/opens/clicks data, the campaign reports have to be used.
 		// It appears that the sent/opens/clicks data in the lists activity are only added after a
 		// delay of 2-3 days.
-		$reports = self::get_list_activity_reports( $days_in_past );
+
+		try {
+			// Get the list activity reports.
+			$reports = self::get_list_activity_reports( $days_in_past );
+		} catch ( Exception $e ) {
+			return new WP_Error(
+				'newspack_newsletters_mailchimp_error',
+				$e->getMessage()
+			);
+		}
 
 		$campaign_reports = [];
 		// Look at reports for campaigns sent at most two weeks ago, unless $days_in_past is larger.

--- a/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp-usage-reports.php
+++ b/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp-usage-reports.php
@@ -21,8 +21,15 @@ class Newspack_Newsletters_Mailchimp_Usage_Reports {
 	 * @return DrewM\MailChimp\MailChimp|WP_Error
 	 */
 	private static function get_mc_api() {
+		$api_key = Newspack_Newsletters_Mailchimp::instance()->api_key();
+		if ( empty( $api_key ) ) {
+			return new WP_Error(
+				'newspack_newsletters_mailchimp_empty_api_key',
+				__( 'Mailchimp API key is not set.', 'newspack-newsletters' )
+			);
+		}
 		try {
-			return new Mailchimp( Newspack_Newsletters_Mailchimp::instance()->api_key() );
+			return new Mailchimp( $api_key );
 		} catch ( Exception $e ) {
 			return new WP_Error(
 				'newspack_newsletters_mailchimp_error',
@@ -170,11 +177,17 @@ class Newspack_Newsletters_Mailchimp_Usage_Reports {
 	/**
 	 * Creates a usage report.
 	 *
-	 * @return Newspack_Newsletters_Service_Provider_Usage_Report|WP_Error Usage report or error.
+	 * @return Newspack_Newsletters_Service_Provider_Usage_Report|WP_Error|null Usage report, error or Null in case there's no need to check for a report.
 	 */
 	public static function get_usage_report() {
 		$reports = self::get_usage_reports( 1 );
 		if ( \is_wp_error( $reports ) ) {
+
+			// if the api key is not set, Mailchimp is not in use, we shouldn't even try to get the usage report.
+			if ( $reports->get_error_code() === 'newspack_newsletters_mailchimp_empty_api_key' ) {
+				return null;
+			}
+
 			return $reports;
 		}
 		return reset( $reports );

--- a/tests/test-usage-reports.php
+++ b/tests/test-usage-reports.php
@@ -12,12 +12,42 @@ class Usage_Reports_Test extends WP_UnitTestCase {
 	/**
 	 * Test usage report.
 	 */
-	public function test_usage_report_basic() {
-		// Ensure the API key is not set (might be set by a different test).
+	public function test_usage_report_no_api_key() {
+
 		delete_option( 'newspack_mailchimp_api_key' );
 
+		self::assertSame(
+			Newspack_Newsletters_Mailchimp_Usage_Reports::get_usage_report(),
+			null
+		);
+	}
+
+	/**
+	 * Test usage report with invalid API key.
+	 */
+	public function test_usage_report_invalid_api_key() {
+
+		update_option( 'newspack_mailchimp_api_key', 'asd123' );
+
+		self::assertSame(
+			Newspack_Newsletters_Mailchimp_Usage_Reports::get_usage_report()->get_error_code(),
+			'newspack_newsletters_mailchimp_error'
+		);
+	}
+
+	/**
+	 * Test usage report with basic data.
+	 */
+	public function test_usage_report_basic() {
+
+		update_option( 'newspack_mailchimp_api_key', 'asd123' );
+
+		add_filter( 'mailchimp_mock_get', [ __CLASS__, 'mock_get_response' ], 10, 3 );
+		$report = Newspack_Newsletters_Mailchimp_Usage_Reports::get_usage_report();
+		remove_filter( 'mailchimp_mock_get', [ __CLASS__, 'mock_get_response' ] );
+
 		self::assertEquals(
-			Newspack_Newsletters_Mailchimp_Usage_Reports::get_usage_report()->to_array(),
+			$report->to_array(),
 			[
 				'date'           => gmdate( 'Y-m-d', strtotime( '-1 day' ) ),
 				'emails_sent'    => 0,
@@ -29,5 +59,18 @@ class Usage_Reports_Test extends WP_UnitTestCase {
 				'growth_rate'    => 0,
 			]
 		);
+	}
+
+	/**
+	 * Mock get response.
+	 *
+	 * @param string $method Request method.
+	 * @param string $path   Request path.
+	 * @param array  $options Request options.
+	 *
+	 * @return array Mock response.
+	 */
+	public static function mock_get_response( $method, $path, $options ) {
+		return [ 'lists' => [] ];
 	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

* Do not trigger errors when Mailchimp is NOT configured 991df5ebc0469e613f41a123c9da5f46938372f7
* Trigger errors when Mailchimp is MISconfigured b8c253db696e3693916dabb395c741f3627849ad

### How to test the changes in this Pull Request:

1. Set mailchimp as provider
2. Leave the API key empty
3. Run `Newspack_Newsletters_Mailchimp_Usage_Reports::get_usage_report();`
4. Confirm it return NULL
5. Now enter an invalid API key
6. Run `Newspack_Newsletters_Mailchimp_Usage_Reports::get_usage_report();`
7.Confirm it returns a WP_Error object


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
