### PR TITLE
fix: add check to see if color is populated before adding to CSS

### DIFF
--- a/includes/class-newspack-newsletters-editor.php
+++ b/includes/class-newspack-newsletters-editor.php
@@ -115,6 +115,9 @@ final class Newspack_Newsletters_Editor {
 		$color_palette = json_decode( get_option( Newspack_Newsletters::NEWSPACK_NEWSLETTERS_PALETTE_META, false ), true );
 		if ( ! empty( $color_palette ) ) {
 			foreach ( $color_palette as $color_name => $color_value ) {
+				if ( '' === $color_name || '' === $color_value ) {
+					continue;
+				}
 				$rules[] = '.has-' . esc_html( $color_name ) . '-color { color: ' . esc_html( $color_value ) . '; }';
 			}
 		}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR adds a check for empty colour name and values before adding them to the newsletter styles, to rule out an edge case where an empty colour is being passed.

See: 1200550061930446-as-1208643535764387

### How to test the changes in this Pull Request:

We have [one test site](https://latinfinance-newsletter-testing.newspackstaging.com/) where this issue can be replicated, but unfortunately it's hard to replicate independently! 

1. On the test site, try sending yourself a test newsletter to a Gmail account.
2. In your inbox, note that the email has a lot of spacing, and seems to be missing other styles (like the links are blue).
3. Upload a version of the plugin with this PR to the test site.
4. Repeat steps 1-2 and confirm the newsletters look okay.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
