### PR TITLE
fix(ras-acc): revert RAS-ACC release

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   labeler:
-    if: github.event.pull_request.merged == true && github.event.pull_request.base.ref == 'trunk' && github.event.pull_request.user.login != 'dependabot[bot]'
+    if: github.event.pull_request.merged == true && github.event.pull_request.base.ref == 'trunk'
     permissions:
       contents: read
       pull-requests: write
@@ -14,7 +14,7 @@ jobs:
     - uses: actions/labeler@v5
 
   comment_pr:
-    if: github.event.pull_request.merged == true && github.event.pull_request.base.ref == 'trunk' && github.event.pull_request.user.login != 'dependabot[bot]'
+    if: github.event.pull_request.merged == true && github.event.pull_request.base.ref == 'trunk'
     permissions:
       contents: read
       pull-requests: write
@@ -25,7 +25,7 @@ jobs:
         uses: thollander/actions-comment-pull-request@v3
         with:
           message: |
-            Hey @${{ github.event.pull_request.user.login }}, good job getting this PR merged! :tada:
+            Hey @${{ github.event.pull_request.assignee.login }}, good job getting this PR merged! :tada:
 
             Now, the `needs-changelog` label has been added to it.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,16 +1,3 @@
-# [3.6.0](https://github.com/Automattic/newspack-newsletters/compare/v3.5.0...v3.6.0) (2024-12-09)
-
-
-### Bug Fixes
-
-* let the exceptions be thrown ([#1698](https://github.com/Automattic/newspack-newsletters/issues/1698)) ([85746b8](https://github.com/Automattic/newspack-newsletters/commit/85746b87de538ceccbc5141c0d6869b6071cad83))
-
-
-### Features
-
-* **ras-acc:** add reader account creation and login improvements ([#1716](https://github.com/Automattic/newspack-newsletters/issues/1716)) ([4640cae](https://github.com/Automattic/newspack-newsletters/commit/4640cae18706102bafaf2553df9eae93eddc20b9))
-* rate limit requests for CC ([#1714](https://github.com/Automattic/newspack-newsletters/issues/1714)) ([ad092ca](https://github.com/Automattic/newspack-newsletters/commit/ad092cab16714da143c604615c4af328d3847535))
-
 # [3.5.0](https://github.com/Automattic/newspack-newsletters/compare/v3.4.0...v3.5.0) (2024-11-25)
 
 

--- a/includes/class-newspack-newsletters-renderer.php
+++ b/includes/class-newspack-newsletters-renderer.php
@@ -852,18 +852,17 @@ final class Newspack_Newsletters_Renderer {
 				$social_wrapper_attrs = array(
 					'icon-size'     => '24px',
 					'mode'          => 'horizontal',
-					'border-radius' => '999px',
-					'icon-padding'  => isset( $attrs['className'] ) && 'is-style-filled-primary-text' === $attrs['className'] ? '0px' : '7px',
 					'padding'       => '0',
+					'border-radius' => '999px',
+					'icon-padding'  => '7px',
 				);
 				if ( isset( $attrs['align'] ) ) {
 					$social_wrapper_attrs['align'] = $attrs['align'];
 				} else {
 					$social_wrapper_attrs['align'] = 'left';
 				}
-
 				$markup = '<mj-social ' . self::array_to_attributes( $social_wrapper_attrs ) . '>';
-				foreach ( $inner_blocks as $index => $link_block ) {
+				foreach ( $inner_blocks as $link_block ) {
 					if ( isset( $link_block['attrs']['url'] ) ) {
 						$url = $link_block['attrs']['url'];
 						// Handle older version of the block, where innner blocks we named `core/social-link-<service>`.
@@ -876,13 +875,7 @@ final class Newspack_Newsletters_Renderer {
 								'src'              => plugins_url( 'assets/' . $social_icon['icon'], __DIR__ ),
 								'background-color' => $social_icon['color'],
 								'css-class'        => 'social-element',
-								'padding'          => '8px',
 							);
-
-							if ( $index === 0 || $index === count( $inner_blocks ) - 1 ) {
-								$img_attrs['padding-left']  = $index === 0 ? '0' : '8px';
-								$img_attrs['padding-right'] = $index === 0 ? '8px' : '0';
-							}
 
 							$markup .= '<mj-social-element ' . self::array_to_attributes( $img_attrs ) . '/>';
 						}

--- a/includes/service-providers/class-newspack-newsletters-service-provider.php
+++ b/includes/service-providers/class-newspack-newsletters-service-provider.php
@@ -940,10 +940,10 @@ Error message(s) received:
 	/**
 	 * Get usage data for yesterday.
 	 *
-	 * @return Newspack_Newsletters_Service_Provider_Usage_Report|WP_Error|null Usage report, error or Null in case there's no need to check for a report.
+	 * @return Newspack_Newsletters_Service_Provider_Usage_Report|WP_Error
 	 */
 	public function get_usage_report() {
-		return null; // Not implemented for the provider.
+		return new WP_Error( 'newspack_newsletters_not_implemented', __( 'Not implemented', 'newspack-newsletters' ), [ 'status' => 400 ] );
 	}
 
 	/**

--- a/includes/service-providers/constant_contact/class-newspack-newsletters-constant-contact-sdk.php
+++ b/includes/service-providers/constant_contact/class-newspack-newsletters-constant-contact-sdk.php
@@ -69,27 +69,6 @@ final class Newspack_Newsletters_Constant_Contact_SDK {
 	private $custom_fields;
 
 	/**
-	 * Request counter for rate limiting
-	 *
-	 * @var int
-	 */
-	private static $request_count = 0;
-
-	/**
-	 * Last request timestamp
-	 *
-	 * @var float
-	 */
-	private static $last_request_time = 0;
-
-	/**
-	 * Maximum requests per second
-	 *
-	 * @var int
-	 */
-	private static $max_requests_per_second = 4;
-
-	/**
 	 * Perform API requests.
 	 *
 	 * @param string $method  Request method.
@@ -101,22 +80,6 @@ final class Newspack_Newsletters_Constant_Contact_SDK {
 	 * @throws Exception Error message.
 	 */
 	private function request( $method, $path, $options = [] ) {
-		// Rate limiting logic.
-		$current_time = microtime( true );
-		if ( self::$request_count >= self::$max_requests_per_second ) {
-			$time_since_last_request = $current_time - self::$last_request_time;
-			if ( $time_since_last_request < 1 ) {
-				// Sleep for the remaining time in the 1-second window.
-				usleep( ( 1 - $time_since_last_request ) * 1000000 );
-				self::$request_count = 0;
-			}
-		}
-
-		// Reset counter if more than 1 second has passed.
-		if ( $current_time - self::$last_request_time >= 1 ) {
-			self::$request_count = 0;
-		}
-
 		/** Remove "/v3/" coming from paging cursors. */
 		if ( 0 === strpos( $path, '/v3' ) ) {
 			$path = substr( $path, 4 );
@@ -138,10 +101,6 @@ final class Newspack_Newsletters_Constant_Contact_SDK {
 			],
 		];
 		try {
-			// Update request counter and timestamp before making request.
-			self::$request_count++;
-			self::$last_request_time = microtime( true );
-
 			$response = wp_safe_remote_request( $url, $args + $options );
 			if ( is_wp_error( $response ) ) {
 				throw new Exception( $response->get_error_message() );

--- a/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp-cached-data.php
+++ b/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp-cached-data.php
@@ -111,6 +111,29 @@ final class Newspack_Newsletters_Mailchimp_Cached_Data {
 	}
 
 	/**
+	 * Retrieves an instance of the Mailchimp api
+	 *
+	 * @return DrewM\MailChimp\MailChimp|WP_Error
+	 */
+	private static function get_mc_api() {
+		$api_key = self::get_mc_instance()->api_key();
+		if ( empty( $api_key ) ) {
+			return new WP_Error(
+				'newspack_newsletters_mailchimp_error',
+				__( 'Missing Mailchimp API key.', 'newspack-newsletters' )
+			);
+		}
+		try {
+			return new Mailchimp( $api_key );
+		} catch ( Exception $e ) {
+			return new WP_Error(
+				'newspack_newsletters_mailchimp_error',
+				$e->getMessage()
+			);
+		}
+	}
+
+	/**
 	 * Get audiences (lists).
 	 *
 	 * @param int|null $limit (Optional) The maximum number of items to return. If not given, will get all items.
@@ -553,8 +576,10 @@ final class Newspack_Newsletters_Mailchimp_Cached_Data {
 	 * @return array|WP_Error The audiences, or WP_Error if there was an error.
 	 */
 	public static function fetch_lists( $limit = null ) {
-		$mc = new Mailchimp( ( self::get_mc_instance() )->api_key() );
-
+		$mc = self::get_mc_api();
+		if ( \is_wp_error( $mc ) ) {
+			return [];
+		}
 		$lists_response = ( self::get_mc_instance() )->validate(
 			$mc->get(
 				'lists',
@@ -570,7 +595,6 @@ final class Newspack_Newsletters_Mailchimp_Cached_Data {
 		if ( ! $limit ) {
 			update_option( self::get_lists_cache_key(), $lists_response['lists'], false ); // auto-load false.
 			update_option( self::get_cache_date_key(), time(), false ); // auto-load false.
-			self::clear_errors();
 		}
 
 		return $lists_response['lists'];
@@ -586,7 +610,10 @@ final class Newspack_Newsletters_Mailchimp_Cached_Data {
 	 * @return array The audience segment
 	 */
 	public static function fetch_segment( $segment_id, $list_id ) {
-		$mc = new Mailchimp( ( self::get_mc_instance() )->api_key() );
+		$mc = self::get_mc_api();
+		if ( \is_wp_error( $mc ) ) {
+			return $mc;
+		}
 		$response = ( self::get_mc_instance() )->validate(
 			$mc->get(
 				"lists/$list_id/segments/$segment_id",
@@ -613,7 +640,10 @@ final class Newspack_Newsletters_Mailchimp_Cached_Data {
 	public static function fetch_segments( $list_id, $limit = null ) {
 		$segments = [];
 
-		$mc = new Mailchimp( ( self::get_mc_instance() )->api_key() );
+		$mc = self::get_mc_api();
+		if ( \is_wp_error( $mc ) ) {
+			return $segments;
+		}
 
 		$saved_segments_response  = ( self::get_mc_instance() )->validate(
 			$mc->get(
@@ -641,7 +671,10 @@ final class Newspack_Newsletters_Mailchimp_Cached_Data {
 	 * @return array The audience interest_categories
 	 */
 	private static function fetch_interest_categories( $list_id, $limit = null ) {
-		$mc = new Mailchimp( ( self::get_mc_instance() )->api_key() );
+		$mc = self::get_mc_api();
+		if ( \is_wp_error( $mc ) ) {
+			return [];
+		}
 		$interest_categories = $list_id ? ( self::get_mc_instance() )->validate(
 			$mc->get( "lists/$list_id/interest-categories", [ 'count' => $limit ?? 1000 ], 60 ),
 			__( 'Error retrieving Mailchimp groups.', 'newspack_newsletters' )
@@ -670,7 +703,10 @@ final class Newspack_Newsletters_Mailchimp_Cached_Data {
 	 * @return array The audience tags
 	 */
 	public static function fetch_tags( $list_id, $limit = null ) {
-		$mc = new Mailchimp( ( self::get_mc_instance() )->api_key() );
+		$mc = self::get_mc_api();
+		if ( \is_wp_error( $mc ) ) {
+			return [];
+		}
 		$tags = $list_id ? ( self::get_mc_instance() )->validate(
 			$mc->get(
 				"lists/$list_id/segments",
@@ -697,7 +733,10 @@ final class Newspack_Newsletters_Mailchimp_Cached_Data {
 	 * @return array The list folders
 	 */
 	private static function fetch_folders() {
-		$mc = new Mailchimp( ( self::get_mc_instance() )->api_key() );
+		$mc = self::get_mc_api();
+		if ( \is_wp_error( $mc ) ) {
+			return [];
+		}
 		$response = ( self::get_mc_instance() )->validate(
 			$mc->get( 'campaign-folders', [ 'count' => 1000 ], 60 ),
 			__( 'Error retrieving Mailchimp folders.', 'newspack_newsletters' )
@@ -713,7 +752,10 @@ final class Newspack_Newsletters_Mailchimp_Cached_Data {
 	 * @return array The list interest_categories
 	 */
 	private static function fetch_merge_fields( $list_id ) {
-		$mc = new Mailchimp( ( self::get_mc_instance() )->api_key() );
+		$mc = self::get_mc_api();
+		if ( \is_wp_error( $mc ) ) {
+			return [];
+		}
 		$response = ( self::get_mc_instance() )->validate(
 			$mc->get(
 				"lists/$list_id/merge-fields",

--- a/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp-usage-reports.php
+++ b/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp-usage-reports.php
@@ -21,15 +21,8 @@ class Newspack_Newsletters_Mailchimp_Usage_Reports {
 	 * @return DrewM\MailChimp\MailChimp|WP_Error
 	 */
 	private static function get_mc_api() {
-		$api_key = Newspack_Newsletters_Mailchimp::instance()->api_key();
-		if ( empty( $api_key ) ) {
-			return new WP_Error(
-				'newspack_newsletters_mailchimp_empty_api_key',
-				__( 'Mailchimp API key is not set.', 'newspack-newsletters' )
-			);
-		}
 		try {
-			return new Mailchimp( $api_key );
+			return new Mailchimp( Newspack_Newsletters_Mailchimp::instance()->api_key() );
 		} catch ( Exception $e ) {
 			return new WP_Error(
 				'newspack_newsletters_mailchimp_error',
@@ -52,9 +45,7 @@ class Newspack_Newsletters_Mailchimp_Usage_Reports {
 		}
 
 		$reports = [];
-		$lists   = Newspack_Newsletters_Mailchimp::instance()->validate(
-			$mc_api->get( 'lists', [ 'count' => 1000 ] )
-		);
+		$lists  = $mc_api->get( 'lists', [ 'count' => 1000 ] );
 		if ( ! isset( $lists['lists'] ) ) {
 			return $reports;
 		}
@@ -114,16 +105,7 @@ class Newspack_Newsletters_Mailchimp_Usage_Reports {
 		// sent/opens/clicks data, the campaign reports have to be used.
 		// It appears that the sent/opens/clicks data in the lists activity are only added after a
 		// delay of 2-3 days.
-
-		try {
-			// Get the list activity reports.
-			$reports = self::get_list_activity_reports( $days_in_past );
-		} catch ( Exception $e ) {
-			return new WP_Error(
-				'newspack_newsletters_mailchimp_error',
-				$e->getMessage()
-			);
-		}
+		$reports = self::get_list_activity_reports( $days_in_past );
 
 		$campaign_reports = [];
 		// Look at reports for campaigns sent at most two weeks ago, unless $days_in_past is larger.
@@ -188,17 +170,11 @@ class Newspack_Newsletters_Mailchimp_Usage_Reports {
 	/**
 	 * Creates a usage report.
 	 *
-	 * @return Newspack_Newsletters_Service_Provider_Usage_Report|WP_Error|null Usage report, error or Null in case there's no need to check for a report.
+	 * @return Newspack_Newsletters_Service_Provider_Usage_Report|WP_Error Usage report or error.
 	 */
 	public static function get_usage_report() {
 		$reports = self::get_usage_reports( 1 );
 		if ( \is_wp_error( $reports ) ) {
-
-			// if the api key is not set, Mailchimp is not in use, we shouldn't even try to get the usage report.
-			if ( $reports->get_error_code() === 'newspack_newsletters_mailchimp_empty_api_key' ) {
-				return null;
-			}
-
 			return $reports;
 		}
 		return reset( $reports );

--- a/newspack-newsletters.php
+++ b/newspack-newsletters.php
@@ -8,7 +8,7 @@
  * License: GPL2
  * Text Domain:     newspack-newsletters
  * Domain Path:     /languages
- * Version:         3.6.0
+ * Version:         3.6.0-alpha.1
  *
  * @package         Newspack_Newsletters
  */

--- a/newspack-newsletters.php
+++ b/newspack-newsletters.php
@@ -8,7 +8,7 @@
  * License: GPL2
  * Text Domain:     newspack-newsletters
  * Domain Path:     /languages
- * Version:         3.6.0-alpha.1
+ * Version:         3.5.0
  *
  * @package         Newspack_Newsletters
  */

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,11 +12,11 @@
 				"classnames": "^2.5.1",
 				"mjml-browser": "^4.15.3",
 				"newspack-components": "^3.1.0",
-				"qs": "^6.13.1"
+				"qs": "^6.13.0"
 			},
 			"devDependencies": {
 				"@rushstack/eslint-patch": "^1.10.4",
-				"@wordpress/browserslist-config": "^6.12.0",
+				"@wordpress/browserslist-config": "^6.11.0",
 				"eslint": "^8.57.0",
 				"lint-staged": "^15.2.10",
 				"newspack-scripts": "^5.5.2",
@@ -6197,9 +6197,9 @@
 			}
 		},
 		"node_modules/@wordpress/browserslist-config": {
-			"version": "6.12.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/browserslist-config/-/browserslist-config-6.12.0.tgz",
-			"integrity": "sha512-rFsMgWpJSu6I4rgqIGr/+ofVC4hsGIpJCXorNpRX8Zdo6wZvo/jHCZfOHq1RQ0dw9kNM2Q5UE5Sve1XpsDWPXA==",
+			"version": "6.11.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/browserslist-config/-/browserslist-config-6.11.0.tgz",
+			"integrity": "sha512-wUDbJ3x7c8iMZLtwo+7VlWZ/vDc47PDW2eSAKW18RrQBSTdaNmWi4qiyFYi7Ye2XkyfUd2gp71MTJjZi6n/V2A==",
 			"dev": true,
 			"engines": {
 				"node": ">=18.12.0",
@@ -8456,21 +8456,6 @@
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
 			"integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
 			"dev": true
-		},
-		"node_modules/body-parser/node_modules/qs": {
-			"version": "6.13.0",
-			"resolved": "https://registry.npmjs.org/qs/-/qs-6.13.0.tgz",
-			"integrity": "sha512-+38qI9SOr8tfZ4QmJNplMUxqjbe7LKvvZgWdExBOmd+egZTtjLB67Gu0HRX3u/XOq7UU2Nx6nsjvS16Z9uwfpg==",
-			"dev": true,
-			"dependencies": {
-				"side-channel": "^1.0.6"
-			},
-			"engines": {
-				"node": ">=0.6"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
 		},
 		"node_modules/bonjour-service": {
 			"version": "1.2.1",
@@ -12070,21 +12055,6 @@
 			"resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.10.tgz",
 			"integrity": "sha512-7lf7qcQidTku0Gu3YDPc8DJ1q7OOucfa/BSsIwjuh56VU7katFvuM8hULfkwB3Fns/rsVF7PwPKVw1sl5KQS9w==",
 			"dev": true
-		},
-		"node_modules/express/node_modules/qs": {
-			"version": "6.13.0",
-			"resolved": "https://registry.npmjs.org/qs/-/qs-6.13.0.tgz",
-			"integrity": "sha512-+38qI9SOr8tfZ4QmJNplMUxqjbe7LKvvZgWdExBOmd+egZTtjLB67Gu0HRX3u/XOq7UU2Nx6nsjvS16Z9uwfpg==",
-			"dev": true,
-			"dependencies": {
-				"side-channel": "^1.0.6"
-			},
-			"engines": {
-				"node": ">=0.6"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
 		},
 		"node_modules/ext": {
 			"version": "1.7.0",
@@ -22176,9 +22146,9 @@
 			}
 		},
 		"node_modules/qs": {
-			"version": "6.13.1",
-			"resolved": "https://registry.npmjs.org/qs/-/qs-6.13.1.tgz",
-			"integrity": "sha512-EJPeIn0CYrGu+hli1xilKAPXODtJ12T0sP63Ijx2/khC2JtuaN3JyNIpvmnkmaEtha9ocbG4A4cMcr+TvqvwQg==",
+			"version": "6.13.0",
+			"resolved": "https://registry.npmjs.org/qs/-/qs-6.13.0.tgz",
+			"integrity": "sha512-+38qI9SOr8tfZ4QmJNplMUxqjbe7LKvvZgWdExBOmd+egZTtjLB67Gu0HRX3u/XOq7UU2Nx6nsjvS16Z9uwfpg==",
 			"dependencies": {
 				"side-channel": "^1.0.6"
 			},

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "newspack-newsletters",
-	"version": "3.6.0",
+	"version": "3.5.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "newspack-newsletters",
-			"version": "3.6.0",
+			"version": "3.5.0",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"classnames": "^2.5.1",

--- a/package.json
+++ b/package.json
@@ -42,11 +42,11 @@
 		"classnames": "^2.5.1",
 		"mjml-browser": "^4.15.3",
 		"newspack-components": "^3.1.0",
-		"qs": "^6.13.1"
+		"qs": "^6.13.0"
 	},
 	"devDependencies": {
 		"@rushstack/eslint-patch": "^1.10.4",
-		"@wordpress/browserslist-config": "^6.12.0",
+		"@wordpress/browserslist-config": "^6.11.0",
 		"eslint": "^8.57.0",
 		"lint-staged": "^15.2.10",
 		"newspack-scripts": "^5.5.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "newspack-newsletters",
-	"version": "3.6.0",
+	"version": "3.5.0",
 	"description": "",
 	"scripts": {
 		"cm": "newspack-scripts commit",

--- a/src/blocks/subscribe/index.php
+++ b/src/blocks/subscribe/index.php
@@ -179,7 +179,7 @@ function render_block( $attrs ) {
 		<?php echo $subscribed ? 'data-status="200"' : ''; ?>
 	>
 		<?php if ( ! $subscribed ) : ?>
-			<form id="<?php echo esc_attr( get_form_id() ); ?>" data-newspack-recaptcha="newspack_newsletter_signup">
+			<form id="<?php echo esc_attr( get_form_id() ); ?>">
 				<input type="hidden" name="<?php echo esc_attr( FORM_ACTION ); ?>" value="1" />
 				<?php
 				/**

--- a/src/blocks/subscribe/view.js
+++ b/src/blocks/subscribe/view.js
@@ -29,7 +29,6 @@ function domReady( callback ) {
 }
 
 domReady( function () {
-	const successEvent = new Event( 'newspack-newsletters-subscribe-success' );
 	document.querySelectorAll( '.newspack-newsletters-subscribe' ).forEach( container => {
 		const form = container.querySelector( 'form' );
 		if ( ! form ) {
@@ -58,7 +57,6 @@ domReady( function () {
 			messageNode.className = `message status-${ status }`;
 			if ( status === 200 ) {
 				container.replaceChild( responseContainer, form );
-				form.dispatchEvent( successEvent );
 			}
 		};
 		form.addEventListener( 'submit', ev => {
@@ -72,36 +70,62 @@ domReady( function () {
 				return form.endFlow( newspack_newsletters_subscribe_block.invalid_email, 400 );
 			}
 
-			const body = new FormData( form );
-			if ( ! body.has( 'npe' ) || ! body.get( 'npe' ) ) {
-				return form.endFlow( newspack_newsletters_subscribe_block.invalid_email, 400 );
-			}
-			if ( nonce ) {
-				body.set( 'newspack_newsletters_subscribe', nonce );
-			}
-			emailInput.setAttribute( 'disabled', 'true' );
-			submit.setAttribute( 'disabled', 'true' );
+			const newspack_grecaptcha = window.newspack_grecaptcha || null;
+			const getCaptchaV3Token = newspack_grecaptcha
+				? newspack_grecaptcha?.getCaptchaV3Token
+				: () => new Promise( res => res( '' ) ); // Empty promise.
 
-			fetch( form.getAttribute( 'action' ) || window.location.pathname, {
-				method: 'POST',
-				headers: {
-					Accept: 'application/json',
-				},
-				body,
-			} ).then( res => {
-				res
-					.json()
-					.then(
-						( {
-							message,
-							newspack_newsletters_subscribed: wasSubscribed,
-							newspack_newsletters_subscribe,
-						} ) => {
-							nonce = newspack_newsletters_subscribe;
-							form.endFlow( message, res.status, wasSubscribed );
-						}
-					);
-			} );
+			getCaptchaV3Token() // Get a token for reCAPTCHA v3, if needed.
+				.then( captchaToken => {
+					// If there's no token, we don't need to do anything.
+					if ( ! captchaToken ) {
+						return;
+					}
+					let tokenField = form[ 'g-recaptcha-response' ];
+					if ( ! tokenField ) {
+						tokenField = document.createElement( 'input' );
+						tokenField.setAttribute( 'type', 'hidden' );
+						tokenField.setAttribute( 'name', 'g-recaptcha-response' );
+						tokenField.setAttribute( 'autocomplete', 'off' );
+						form.appendChild( tokenField );
+					}
+					tokenField.value = captchaToken;
+				} )
+				.catch( e => {
+					form.endFlow( e, 400 );
+				} )
+				.finally( () => {
+					const body = new FormData( form );
+					if ( ! body.has( 'npe' ) || ! body.get( 'npe' ) ) {
+						return form.endFlow( newspack_newsletters_subscribe_block.invalid_email, 400 );
+					}
+					if ( nonce ) {
+						body.set( 'newspack_newsletters_subscribe', nonce );
+					}
+					emailInput.setAttribute( 'disabled', 'true' );
+					submit.setAttribute( 'disabled', 'true' );
+
+					fetch( form.getAttribute( 'action' ) || window.location.pathname, {
+						method: 'POST',
+						headers: {
+							Accept: 'application/json',
+						},
+						body,
+					} ).then( res => {
+						res
+							.json()
+							.then(
+								( {
+									message,
+									newspack_newsletters_subscribed: wasSubscribed,
+									newspack_newsletters_subscribe,
+								} ) => {
+									nonce = newspack_newsletters_subscribe;
+									form.endFlow( message, res.status, wasSubscribed );
+								}
+							);
+					} );
+				} );
 		} );
 	} );
 } );

--- a/tests/test-mailchimp-cached-data.php
+++ b/tests/test-mailchimp-cached-data.php
@@ -21,8 +21,8 @@ class Newsletters_Mailchimp_Cached_Data_Test extends WP_UnitTestCase {
 	 * Test the API setup.
 	 */
 	public function test_mailchimp_cached_data_api_setup() {
-		// Makes sure cached data fetch_methods throw an exception in case of error.
-		$this->expectException( Exception::class );
+		// This tests if an empty API key won't cause the code to error out.
 		$segments = Newspack_Newsletters_Mailchimp_Cached_Data::fetch_segments( 'list1' );
+		$this->assertEquals( [], $segments );
 	}
 }

--- a/tests/test-renderer.php
+++ b/tests/test-renderer.php
@@ -345,7 +345,7 @@ class Newsletters_Renderer_Test extends WP_UnitTestCase {
 					'innerHTML'    => '<div></div>',
 				]
 			),
-			'<mj-section padding="0"><mj-column padding="12px" width="100%"><mj-social icon-size="24px" mode="horizontal" border-radius="999px" icon-padding="7px" padding="0" align="left"><mj-social-element href="https://x.com/hi" src="' . $plugin_path . 'assets/white-x.png" background-color="#000000" css-class="social-element" padding="8px" padding-left="0" padding-right="8px"/></mj-social></mj-column></mj-section>',
+			'<mj-section padding="0"><mj-column padding="12px" width="100%"><mj-social icon-size="24px" mode="horizontal" padding="0" border-radius="999px" icon-padding="7px" align="left"><mj-social-element href="https://x.com/hi" src="' . $plugin_path . 'assets/white-x.png" background-color="#000000" css-class="social-element"/></mj-social></mj-column></mj-section>',
 			'Renders social icons'
 		);
 	}

--- a/tests/test-usage-reports.php
+++ b/tests/test-usage-reports.php
@@ -12,42 +12,12 @@ class Usage_Reports_Test extends WP_UnitTestCase {
 	/**
 	 * Test usage report.
 	 */
-	public function test_usage_report_no_api_key() {
-
+	public function test_usage_report_basic() {
+		// Ensure the API key is not set (might be set by a different test).
 		delete_option( 'newspack_mailchimp_api_key' );
 
-		self::assertSame(
-			Newspack_Newsletters_Mailchimp_Usage_Reports::get_usage_report(),
-			null
-		);
-	}
-
-	/**
-	 * Test usage report with invalid API key.
-	 */
-	public function test_usage_report_invalid_api_key() {
-
-		update_option( 'newspack_mailchimp_api_key', 'asd123' );
-
-		self::assertSame(
-			Newspack_Newsletters_Mailchimp_Usage_Reports::get_usage_report()->get_error_code(),
-			'newspack_newsletters_mailchimp_error'
-		);
-	}
-
-	/**
-	 * Test usage report with basic data.
-	 */
-	public function test_usage_report_basic() {
-
-		update_option( 'newspack_mailchimp_api_key', 'asd123' );
-
-		add_filter( 'mailchimp_mock_get', [ __CLASS__, 'mock_get_response' ], 10, 3 );
-		$report = Newspack_Newsletters_Mailchimp_Usage_Reports::get_usage_report();
-		remove_filter( 'mailchimp_mock_get', [ __CLASS__, 'mock_get_response' ] );
-
 		self::assertEquals(
-			$report->to_array(),
+			Newspack_Newsletters_Mailchimp_Usage_Reports::get_usage_report()->to_array(),
 			[
 				'date'           => gmdate( 'Y-m-d', strtotime( '-1 day' ) ),
 				'emails_sent'    => 0,
@@ -59,18 +29,5 @@ class Usage_Reports_Test extends WP_UnitTestCase {
 				'growth_rate'    => 0,
 			]
 		);
-	}
-
-	/**
-	 * Mock get response.
-	 *
-	 * @param string $method Request method.
-	 * @param string $path   Request path.
-	 * @param array  $options Request options.
-	 *
-	 * @return array Mock response.
-	 */
-	public static function mock_get_response( $method, $path, $options ) {
-		return [ 'lists' => [] ];
 	}
 }


### PR DESCRIPTION
This reverts commit 39a94e9a5fd33dfa9e2e04315985b3e339ed7f73, reversing changes made to 1acd7cdce479453e0596cee74d59f27883fc96a1.

### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

This is a "just in case" PR, to be used only if we need to revert the RAS-ACC release in #1720.

### How to test the changes in this Pull Request:

1. Confirm that the changeset is identical to (but opposite of) that from #1720.
2. Confirm that the plugin runs and is functionally identical to [v3.5.0](https://github.com/Automattic/newspack-newsletters/releases/tag/v3.5.0).

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->