### PR TITLE
fix: avoid creating merge fields if we can't get merge fields

### DIFF
--- a/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp.php
+++ b/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp.php
@@ -1574,13 +1574,7 @@ final class Newspack_Newsletters_Mailchimp extends \Newspack_Newsletters_Service
 
 		// Get and match existing merge fields.
 		try {
-			$existing_fields = $mc->get(
-				"lists/$audience_id/merge-fields",
-				[
-					'count' => 1000,
-				],
-				60
-			)['merge_fields'];
+			$existing_fields = Newspack_Newsletters_Mailchimp_Cached_Data::get_merge_fields( $audience_id );
 		} catch ( \Exception $e ) {
 			do_action(
 				'newspack_log',

--- a/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp.php
+++ b/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp.php
@@ -1587,14 +1587,14 @@ final class Newspack_Newsletters_Mailchimp extends \Newspack_Newsletters_Service
 
 			// If we didn't get ANY merge fields in the response, something is wrong. Bail to avoid creating duplicate fields.
 			if ( empty( $response['merge_fields'] ) ) {
-				throw new Exception( esc_html__( 'Could not fetch merge fields', 'newspack-newsletters' ) );
+				throw new Exception( esc_html__( 'Response returned no merge_fields', 'newspack-newsletters' ) );
 			}
 			$existing_fields = $response['merge_fields'];
 		} catch ( \Exception $e ) {
 			do_action(
 				'newspack_log',
 				'newspack_mailchimp_prepare_merge_fields',
-				__( 'Error getting merge fields', 'newspack-newsletters' ),
+				'Error getting merge fields',
 				[
 					'type'       => 'error',
 					'data'       => [

--- a/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp.php
+++ b/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp.php
@@ -1791,6 +1791,13 @@ final class Newspack_Newsletters_Mailchimp extends \Newspack_Newsletters_Service
 
 			if ( isset( $contact['metadata'] ) && is_array( $contact['metadata'] ) && ! empty( $contact['metadata'] ) ) {
 				$merge_fields = $this->prepare_merge_fields( $list_id, $contact );
+
+				/**
+				 * Filter the merge fields payload.
+				 *
+				 * @param array $merge_fields The merge fields payload to pass to the Mailchimp API.
+				 */
+				$merge_fields = apply_filters( 'newspack_mailchimp_merge_fields', $merge_fields );
 				if ( empty( $merge_fields ) ) {
 					return new WP_Error(
 						'newspack_newsletters_mailchimp_fetch_merge_fields_failed',

--- a/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp.php
+++ b/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp.php
@@ -1426,6 +1426,7 @@ final class Newspack_Newsletters_Mailchimp extends \Newspack_Newsletters_Service
 				throw new Exception( esc_html__( 'A Mailchimp error has occurred.', 'newspack-newsletters' ) );
 			}
 		}
+		// See Mailchimp error code glossary: https://mailchimp.com/developer/marketing/docs/errors/#error-glossary.
 		if ( ! empty( $result['status'] ) && (int) $result['status'] >= 400 ) {
 			if ( $preferred_error && ! Newspack_Newsletters::debug_mode() ) {
 				if ( ! empty( $result['detail'] ) ) {
@@ -1614,7 +1615,10 @@ final class Newspack_Newsletters_Mailchimp extends \Newspack_Newsletters_Service
 					);
 				}
 			}
-			return [];
+			return new \WP_Error(
+				'newspack_mailchimp_prepare_merge_fields',
+				$e->getMessage()
+			);
 		}
 
 		usort(
@@ -1755,6 +1759,8 @@ final class Newspack_Newsletters_Mailchimp extends \Newspack_Newsletters_Service
 	 * @param array  $interests An array of interests as expected by the API, where the key is the interest ID and the value is a bool (add or remove).
 	 *
 	 * @return array|WP_Error Contact data if it was added, or error otherwise.
+	 *
+	 * @throws Exception Error message.
 	 */
 	public function add_contact( $contact, $list_id = false, $tags = [], $interests = [] ) {
 		if ( false === $list_id ) {
@@ -1790,19 +1796,15 @@ final class Newspack_Newsletters_Mailchimp extends \Newspack_Newsletters_Service
 			$mc = new Mailchimp( $this->api_key() );
 
 			if ( isset( $contact['metadata'] ) && is_array( $contact['metadata'] ) && ! empty( $contact['metadata'] ) ) {
-				$merge_fields = $this->prepare_merge_fields( $list_id, $contact );
 
 				/**
 				 * Filter the merge fields payload.
 				 *
 				 * @param array $merge_fields The merge fields payload to pass to the Mailchimp API.
 				 */
-				$merge_fields = apply_filters( 'newspack_mailchimp_merge_fields', $merge_fields );
-				if ( empty( $merge_fields ) ) {
-					return new WP_Error(
-						'newspack_newsletters_mailchimp_fetch_merge_fields_failed',
-						__( 'Failed get fetch merge fields from list.', 'newspack-newsletters' )
-					);
+				$merge_fields = apply_filters( 'newspack_mailchimp_merge_fields', $this->prepare_merge_fields( $list_id, $contact ) );
+				if ( is_wp_error( $merge_fields ) ) {
+					throw new Exception( $merge_fields->get_error_message() );
 				}
 				$update_payload['merge_fields'] = $merge_fields;
 			}
@@ -1819,24 +1821,7 @@ final class Newspack_Newsletters_Mailchimp extends \Newspack_Newsletters_Service
 
 			// Create or update a list member.
 			$member_hash = Mailchimp::subscriberHash( $email_address );
-			$result = $mc->put( "lists/$list_id/members/$member_hash", $update_payload );
-
-			if (
-				! $result ||
-				! isset( $result['status'] ) ||
-				// See Mailchimp error code glossary: https://mailchimp.com/developer/marketing/docs/errors/#error-glossary.
-				(int) $result['status'] >= 400 ||
-				( isset( $result['errors'] ) && count( $result['errors'] ) )
-			) {
-				return new WP_Error(
-					'newspack_newsletters_mailchimp_add_contact_failed',
-					sprintf(
-						/* translators: %s: Mailchimp error message */
-						__( 'Failed to add contact to list. %s', 'newspack-newsletters' ),
-						isset( $result['detail'] ) ? $result['detail'] : ''
-					)
-				);
-			}
+			$result      = $this->validate( $mc->put( "lists/$list_id/members/$member_hash", $update_payload ) );
 		} catch ( \Exception $e ) {
 			return new \WP_Error(
 				'newspack_newsletters_mailchimp_add_contact_failed',

--- a/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp.php
+++ b/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp.php
@@ -1605,20 +1605,6 @@ final class Newspack_Newsletters_Mailchimp extends \Newspack_Newsletters_Service
 					'file'       => 'newspack_mailchimp',
 				]
 			);
-			if ( method_exists( 'Newspack\Reader_Activation\ESP_Sync', 'schedule_sync' ) ) {
-				$user = get_user_by( 'email', $contact['email'] );
-				if ( $user ) {
-					\Newspack\Reader_Activation\ESP_Sync::schedule_sync(
-						$user->ID,
-						__( 'Scheduling retry sync after failing to fetch merge field data.', 'newspack-newsletters' ),
-						300 // Try again in 5 minutes.
-					);
-				}
-			}
-			return new \WP_Error(
-				'newspack_mailchimp_prepare_merge_fields',
-				$e->getMessage()
-			);
 		}
 
 		usort(
@@ -1803,10 +1789,9 @@ final class Newspack_Newsletters_Mailchimp extends \Newspack_Newsletters_Service
 				 * @param array $merge_fields The merge fields payload to pass to the Mailchimp API.
 				 */
 				$merge_fields = apply_filters( 'newspack_mailchimp_merge_fields', $this->prepare_merge_fields( $list_id, $contact ) );
-				if ( is_wp_error( $merge_fields ) ) {
-					throw new Exception( $merge_fields->get_error_message() );
+				if ( ! empty( $merge_fields ) ) {
+					$update_payload['merge_fields'] = $merge_fields;
 				}
-				$update_payload['merge_fields'] = $merge_fields;
 			}
 
 			// Add groups and tags, if any.

--- a/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp.php
+++ b/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp.php
@@ -1607,6 +1607,10 @@ final class Newspack_Newsletters_Mailchimp extends \Newspack_Newsletters_Service
 			);
 		}
 
+		if ( empty( $existing_fields ) ) {
+			$existing_fields = [];
+		}
+
 		usort(
 			$existing_fields,
 			function( $a, $b ) {

--- a/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp.php
+++ b/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp.php
@@ -1557,6 +1557,8 @@ final class Newspack_Newsletters_Mailchimp extends \Newspack_Newsletters_Service
 	 * @param array  $contact     The contact.
 	 *
 	 * @return array Merge fields.
+	 *
+	 * @throws Exception Error message.
 	 */
 	private function prepare_merge_fields( $audience_id, $contact ) {
 		$mc           = new Mailchimp( $this->api_key() );
@@ -1572,14 +1574,26 @@ final class Newspack_Newsletters_Mailchimp extends \Newspack_Newsletters_Service
 			ARRAY_FILTER_USE_BOTH
 		);
 
-		// Get and match existing merge fields.
+		// Get and match existing merge fields. Merge fields must always be fetched from the API to ensure we have the latest data.
 		try {
-			$existing_fields = Newspack_Newsletters_Mailchimp_Cached_Data::get_merge_fields( $audience_id );
+			$response = $this->validate(
+				$mc->get(
+					"lists/$audience_id/merge-fields",
+					[ 'count' => 1000 ],
+					60
+				)
+			);
+
+			// If we didn't get ANY merge fields in the response, something is wrong. Bail to avoid creating duplicate fields.
+			if ( empty( $response['merge_fields'] ) ) {
+				throw new Exception( esc_html__( 'Could not fetch merge fields', 'newspack-newsletters' ) );
+			}
+			$existing_fields = $response['merge_fields'];
 		} catch ( \Exception $e ) {
 			do_action(
 				'newspack_log',
 				'newspack_mailchimp_prepare_merge_fields',
-				sprintf( 'Error getting merge fields: %s', $e->getMessage() ),
+				__( 'Error getting merge fields', 'newspack-newsletters' ),
 				[
 					'type'       => 'error',
 					'data'       => [
@@ -1590,10 +1604,17 @@ final class Newspack_Newsletters_Mailchimp extends \Newspack_Newsletters_Service
 					'file'       => 'newspack_mailchimp',
 				]
 			);
+			if ( method_exists( 'Newspack\Reader_Activation\ESP_Sync', 'schedule_sync' ) ) {
+				$user = get_user_by( 'email', $contact['email'] );
+				if ( $user ) {
+					\Newspack\Reader_Activation\ESP_Sync::schedule_sync(
+						$user->ID,
+						__( 'Scheduling retry sync after failing to fetch merge field data.', 'newspack-newsletters' ),
+						300 // Try again in 5 minutes.
+					);
+				}
+			}
 			return [];
-		}
-		if ( empty( $existing_fields ) ) {
-			$existing_fields = [];
 		}
 
 		usort(
@@ -1770,9 +1791,13 @@ final class Newspack_Newsletters_Mailchimp extends \Newspack_Newsletters_Service
 
 			if ( isset( $contact['metadata'] ) && is_array( $contact['metadata'] ) && ! empty( $contact['metadata'] ) ) {
 				$merge_fields = $this->prepare_merge_fields( $list_id, $contact );
-				if ( ! empty( $merge_fields ) ) {
-					$update_payload['merge_fields'] = $merge_fields;
+				if ( empty( $merge_fields ) ) {
+					return new WP_Error(
+						'newspack_newsletters_mailchimp_fetch_merge_fields_failed',
+						__( 'Failed get fetch merge fields from list.', 'newspack-newsletters' )
+					);
 				}
+				$update_payload['merge_fields'] = $merge_fields;
 			}
 
 			// Add groups and tags, if any.

--- a/tests/mocks/class-mailchimp-mock.php
+++ b/tests/mocks/class-mailchimp-mock.php
@@ -6,6 +6,30 @@ namespace DrewM\MailChimp;
  * Mocks the MailChimp class.
  */
 class MailChimp {
+	/**
+	 * Init.
+	 */
+	public static function init() {
+		add_filter( 'newspack_mailchimp_merge_fields', [ __CLASS__, 'mock_merge_fields' ] );
+	}
+
+	/**
+	 * Remove mock filters.
+	 */
+	public static function remove_filters() {
+		echo 'removing filter';
+		remove_filter( 'newspack_mailchimp_merge_fields', [ __CLASS__, 'mock_merge_fields' ] );
+	}
+
+	/**
+	 * Mock merge fields payload so that we can test the MailChimp API.
+	 */
+	public static function mock_merge_fields() {
+		return [
+			'FNAME' => 'Contact First Name',
+			'LNAME' => 'Contact Last Name',
+		];
+	}
 
 	/**
 	 * Can use the mock API?
@@ -48,3 +72,5 @@ class MailChimp {
 		return md5( strtolower( $email ) );
 	}
 }
+
+Mailchimp::init();

--- a/tests/mocks/class-mailchimp-mock.php
+++ b/tests/mocks/class-mailchimp-mock.php
@@ -6,30 +6,6 @@ namespace DrewM\MailChimp;
  * Mocks the MailChimp class.
  */
 class MailChimp {
-	/**
-	 * Init.
-	 */
-	public static function init() {
-		add_filter( 'newspack_mailchimp_merge_fields', [ __CLASS__, 'mock_merge_fields' ] );
-	}
-
-	/**
-	 * Remove mock filters.
-	 */
-	public static function remove_filters() {
-		echo 'removing filter';
-		remove_filter( 'newspack_mailchimp_merge_fields', [ __CLASS__, 'mock_merge_fields' ] );
-	}
-
-	/**
-	 * Mock merge fields payload so that we can test the MailChimp API.
-	 */
-	public static function mock_merge_fields() {
-		return [
-			'FNAME' => 'Contact First Name',
-			'LNAME' => 'Contact Last Name',
-		];
-	}
 
 	/**
 	 * Can use the mock API?
@@ -72,5 +48,3 @@ class MailChimp {
 		return md5( strtolower( $email ) );
 	}
 }
-
-Mailchimp::init();


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

When preparing a contact's data sync, we compare the contact's meta fields with the existing merge fields in the audience so that we can use the fields that exist and create the ones that don't yet exist. However, if we can't get info about the existing merge fields via the Mailchimp API for any reason, we should stop the sync to avoid potentially creating duplicate merge fields.

This PR also uses the `validate` method to catch any potential error-like responses from the Mailchimp API.

Coupled with https://github.com/Automattic/newspack-plugin/pull/3639, this PR will also schedule a retry sync after five minutes if we fail to fetch merge fields, up to a maximum of five times.

Addresses: `1200550061930446-as-1208959720314117`

### How to test the changes in this Pull Request:

1. Smoke test syncing new and existing contacts with Mailchimp and confirm that contact metadata gets synced correctly to existing merge fields, and that merge fields that don't yet exist get created.

NOTE: leaving the below in place for the record, but it's no longer part of this PR.

<details>
<summary>Click to see additional testing steps (no longer part of this PR)</summary>

2. Temporarily add a line `$response = [];` [here](https://github.com/Automattic/newspack-newsletters/pull/1729/files#diff-961258e170b9bfe6e81621bab727a9a65947cd67cc016bf5ce1926dd8c78d77cR1586) to simulate a non-error response from the Mailchimp API that nonetheless fails to return merge field data.
3. Trigger a contact sync to Mailchimp via any means.
4. Confirm that the sync now fails with an error, without creating any new merge fields.
5. Using WP CLI, run `wp cron event list` and confirm there's a non-recurring `newspack_scheduled_esp_sync` job scheduled for 5 minutes in the future.
6. Wait 5 minutes or run `wp cron event run newspack_scheduled_esp_sync` to trigger the job immediately. Repeat this 5 times.
7. After 5 failed syncs, confirm that a `Failed to sync contact <email address> after 5 retries` is logged, and that there's no more `newspack_scheduled_esp_sync` job scheduled.
8. Remove the temporary error line added in step 2 and resync the contact.
9. Using WP CLI, run `Newspack\Reader_Activation\Sync::schedule_sync( $user_id, 'Testing scheduled sync', 30 );` and confirm that the scheduled sync happens successfully after 30 seconds.

</details>

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
