### PR TITLE
fix: throw error if we fail to fetch merge fields

### DIFF
--- a/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp.php
+++ b/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp.php
@@ -1605,6 +1605,10 @@ final class Newspack_Newsletters_Mailchimp extends \Newspack_Newsletters_Service
 					'file'       => 'newspack_mailchimp',
 				]
 			);
+			return new \WP_Error(
+				'newspack_mailchimp_prepare_merge_fields',
+				$e->getMessage()
+			);
 		}
 
 		if ( empty( $existing_fields ) ) {
@@ -1793,8 +1797,8 @@ final class Newspack_Newsletters_Mailchimp extends \Newspack_Newsletters_Service
 				 * @param array $merge_fields The merge fields payload to pass to the Mailchimp API.
 				 */
 				$merge_fields = apply_filters( 'newspack_mailchimp_merge_fields', $this->prepare_merge_fields( $list_id, $contact ) );
-				if ( ! empty( $merge_fields ) ) {
-					$update_payload['merge_fields'] = $merge_fields;
+				if ( is_wp_error( $merge_fields ) ) {
+					throw new Exception( $merge_fields->get_error_message() );
 				}
 			}
 

--- a/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp.php
+++ b/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp.php
@@ -1800,6 +1800,7 @@ final class Newspack_Newsletters_Mailchimp extends \Newspack_Newsletters_Service
 				if ( is_wp_error( $merge_fields ) ) {
 					throw new Exception( $merge_fields->get_error_message() );
 				}
+				$update_payload['merge_fields'] = $merge_fields;
 			}
 
 			// Add groups and tags, if any.

--- a/tests/mocks/class-mailchimp-mock.php
+++ b/tests/mocks/class-mailchimp-mock.php
@@ -6,6 +6,30 @@ namespace DrewM\MailChimp;
  * Mocks the MailChimp class.
  */
 class MailChimp {
+	/**
+	 * Init.
+	 */
+	public static function init() {
+		add_filter( 'newspack_mailchimp_merge_fields', [ __CLASS__, 'mock_merge_fields' ] );
+	}
+
+	/**
+	 * Remove mock filters.
+	 */
+	public static function remove_filters() {
+		echo 'removing filter';
+		remove_filter( 'newspack_mailchimp_merge_fields', [ __CLASS__, 'mock_merge_fields' ] );
+	}
+
+	/**
+	 * Mock merge fields payload so that we can test the MailChimp API.
+	 */
+	public static function mock_merge_fields() {
+		return [
+			'FNAME' => 'Contact First Name',
+			'LNAME' => 'Contact Last Name',
+		];
+	}
 
 	/**
 	 * Can use the mock API?
@@ -48,3 +72,5 @@ class MailChimp {
 		return md5( strtolower( $email ) );
 	}
 }
+
+Mailchimp::init();


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Reinstates a reverted change from #1729. Throws an error if the request to fetch existing merge fields from Mailchimp fails for any reason. This should help prevent duplicate merge fields being created in this scenario.

### How to test the changes in this Pull Request:

1. Temporarily add a line `$response = [];` [here](https://github.com/Automattic/newspack-newsletters/pull/1732/files#diff-961258e170b9bfe6e81621bab727a9a65947cd67cc016bf5ce1926dd8c78d77cR1587) to simulate a non-error response from the Mailchimp API that nonetheless fails to return merge field data.
2. Trigger a contact sync to Mailchimp via any means.
3. Confirm that the sync now fails with an error, without creating any new merge fields.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
