### PR TITLE
fix: always allow tracking redirects to site url

### DIFF
--- a/includes/tracking/class-click.php
+++ b/includes/tracking/class-click.php
@@ -153,18 +153,19 @@ final class Click {
 		$url = html_entity_decode( esc_url_raw( \wp_unslash( $_GET['url'] ?? '' ) ) );
 		// phpcs:enable
 
-		// Double-check and make sure the URL is actually a URL within the email.
+		$is_admin_user = current_user_can( 'edit_others_posts' );
+		// If the redirect URL does not point to the site, double-check it is actually a URL within the email.
 		$url_without_query_args = untrailingslashit( strtok( $url, '?' ) );
-		$newsletter_content     = (string) get_post_meta( $newsletter_id, 'newspack_email_html', true );
-		$is_admin_user          = current_user_can( 'edit_others_posts' );
-		if (
-			false === stripos( $newsletter_content, $url_without_query_args ) &&
-			false === stripos( $newsletter_content, urlencode( $url_without_query_args ) ) && // URL might be encoded via a block pattern.
-			\get_site_url() !== $url_without_query_args && // ESP might have replaced all links, so always allow redirects to the site URL.
-			! $is_admin_user // Allow redirect for logged-in editor or admin users.
-		) {
-			\wp_die( 'Invalid URL', '', 400 );
-			exit;
+		if ( false === strpos( $url_without_query_args, \get_site_url() ) ) {
+			$newsletter_content = (string) get_post_meta( $newsletter_id, 'newspack_email_html', true );
+			if (
+				false === stripos( $newsletter_content, $url_without_query_args ) &&
+				false === stripos( $newsletter_content, urlencode( $url_without_query_args ) ) && // URL might be encoded via a block pattern.
+				! $is_admin_user // Allow redirect for logged-in editor or admin users.
+			) {
+				\wp_die( 'Invalid URL', '', 400 );
+				exit;
+			}
 		}
 
 		/**

--- a/includes/tracking/class-click.php
+++ b/includes/tracking/class-click.php
@@ -160,6 +160,7 @@ final class Click {
 		if (
 			false === stripos( $newsletter_content, $url_without_query_args ) &&
 			false === stripos( $newsletter_content, urlencode( $url_without_query_args ) ) && // URL might be encoded via a block pattern.
+			\get_site_url() !== $url_without_query_args && // ESP might have replaced all links, so always allow redirects to the site URL.
 			! $is_admin_user // Allow redirect for logged-in editor or admin users.
 		) {
 			\wp_die( 'Invalid URL', '', 400 );


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes https://app.asana.com/0/1200550061930446/1209150484237807/f

Ensures redirects to the site always work.

### How to test the changes in this Pull Request:

1. Create a newspack ad with a link to a page on your site
2. Create a new newsletter with no other links to your site, insert the ad, then send
3. In the mailchimp email, clicking the ad link should work.
4. Now update the newspack ad link in wp-admin to point something like newspack.com
5. Go back to the email. On `release`, clicking the ad link will lead to the invalid url notice. On this branch, it will work.

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
