### PR TITLE
fix(MC): only remove sender email on successful response

### DIFF
--- a/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp.php
+++ b/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp.php
@@ -1017,7 +1017,7 @@ final class Newspack_Newsletters_Mailchimp extends \Newspack_Newsletters_Service
 		}
 		if ( ! empty( $sender_email ) ) {
 			$is_valid_email = $this->validate_sender_email( $sender_email );
-			if ( is_wp_error( $is_valid_email ) ) {
+			if ( is_wp_error( $is_valid_email ) && $is_valid_email->get_error_code() === 'newspack_newsletters_unverified_sender_domain' ) {
 				delete_post_meta( $post->ID, 'senderEmail' ); // Delete invalid email so we can't accidentally attempt to send with it.
 				return $is_valid_email;
 			}


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Part of https://app.asana.com/0/inbox/1206274567818680/1209110002658535/1209173334757411/f

This PR ensures we only remove a sender email when Mailchimp has confirmed the email is unverified. Previously, if the MC connection failed for any reason during this check we would also remove the sender email, which could result in a scheduled email saving without the from email, and a doomed newsletter send failure.

### How to test the changes in this Pull Request:

1. As admin, create a new scheduled newsletter, and set the sender email to something invalid like `test@invalid.com`
2. Schedule the newsletter and confirm you see an error when scheduling:
![Screenshot 2025-01-17 at 10 17 52](https://github.com/user-attachments/assets/81a42c69-614d-4245-85b9-dc4827e68966)
3. Repeat step one but this time, in another window just before sending, go to ESP settings and add jargon to the API key
4. Schedule the newsletter and confirm you see a generic connection error:
![Screenshot 2025-01-17 at 10 25 31](https://github.com/user-attachments/assets/6fc93ec1-160c-43ce-a5c9-7ee3ebc278e5)
5. Fix the API key and reload the newsletter editor.
6. On this branch the sender email will still be populated. On `trunk` it will not.

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
