### PR TITLE
feat: better reader-facing error messages

### DIFF
--- a/includes/service-providers/active_campaign/class-newspack-newsletters-active-campaign.php
+++ b/includes/service-providers/active_campaign/class-newspack-newsletters-active-campaign.php
@@ -1401,20 +1401,17 @@ final class Newspack_Newsletters_Active_Campaign extends \Newspack_Newsletters_S
 				]
 			);
 
-			/**
-			 * A default error message to show to readers if their signup request results in an error.
-			 *
-			 * @param string $reader_error The default error message.
-			 * @param string $email_address The email address that was attempted to be subscribed.
-			 * @param string $list_id The ActiveCampaign list ID that the email address was attempted to be subscribed to.
-			 */
-			$reader_error = apply_filters(
-				'newspack_newsletters_add_contact_reader_error_message',
-				__( "Sorry, this email cannot be subscribed to this newsletter. Please contact support with the email list you were trying to subscribe to and we'll add you to the list.", 'newspack-newsletters' ),
-				$contact['email'],
-				$list_id
+			if ( Newspack_Newsletters::debug_mode() ) {
+				return $result;
+			}
+
+			$reader_error = $this->get_add_contact_reader_error_message(
+				[
+					'email'   => $contact['email'],
+					'list_id' => $list_id,
+				]
 			);
-			return Newspack_Newsletters::debug_mode() ? $result : new \WP_Error( 'newspack_active_campaign_add_contact_failed', $reader_error );
+			return new \WP_Error( 'newspack_active_campaign_add_contact_failed', $reader_error );
 		}
 
 		// On success, clear cached contact data to make sure we get updated data next time we need.

--- a/includes/service-providers/active_campaign/class-newspack-newsletters-active-campaign.php
+++ b/includes/service-providers/active_campaign/class-newspack-newsletters-active-campaign.php
@@ -1385,7 +1385,36 @@ final class Newspack_Newsletters_Active_Campaign extends \Newspack_Newsletters_S
 		);
 
 		if ( is_wp_error( $result ) ) {
-			return $result;
+			// Log the error with any details returned from the API.
+			do_action(
+				'newspack_log',
+				'newspack_active_campaign_add_contact_failed',
+				'Error adding contact to ActiveCampaign.',
+				[
+					'type'       => 'error',
+					'data'       => [
+						'messages' => $result->get_error_messages(),
+						'status'   => $result->get_error_code(),
+					],
+					'user_email' => $contact['email'],
+					'file'       => 'newspack_active_campaign',
+				]
+			);
+
+			/**
+			 * A default error message to show to readers if their signup request results in an error.
+			 *
+			 * @param string $reader_error The default error message.
+			 * @param string $email_address The email address that was attempted to be subscribed.
+			 * @param string $list_id The ActiveCampaign list ID that the email address was attempted to be subscribed to.
+			 */
+			$reader_error = apply_filters(
+				'newspack_newsletters_add_contact_reader_error_message',
+				__( "Sorry, this email cannot be subscribed to this newsletter. Please contact support with the email list you were trying to subscribe to and we'll add you to the list.", 'newspack-newsletters' ),
+				$contact['email'],
+				$list_id
+			);
+			return Newspack_Newsletters::debug_mode() ? $result : new \WP_Error( 'newspack_active_campaign_add_contact_failed', $reader_error );
 		}
 
 		// On success, clear cached contact data to make sure we get updated data next time we need.

--- a/includes/service-providers/campaign_monitor/class-newspack-newsletters-campaign-monitor.php
+++ b/includes/service-providers/campaign_monitor/class-newspack-newsletters-campaign-monitor.php
@@ -851,9 +851,38 @@ final class Newspack_Newsletters_Campaign_Monitor extends \Newspack_Newsletters_
 				return $result;
 			}
 		} catch ( \Exception $e ) {
+			// Log the error with any details returned from the API.
+			do_action(
+				'newspack_log',
+				'newspack_campaign_monitor_add_contact_failed',
+				'Error adding contact to Campaign Monitor.',
+				[
+					'type'       => 'error',
+					'data'       => [
+						'messages' => $e->getMessage(),
+						'status'   => $e->getCode(),
+					],
+					'user_email' => $contact['email'],
+					'file'       => 'newspack_campaign_monitor',
+				]
+			);
+
+			/**
+			 * A default error message to show to readers if their signup request results in an error.
+			 *
+			 * @param string $reader_error The default error message.
+			 * @param string $email_address The email address that was attempted to be subscribed.
+			 * @param string $list_id The Campaign Monitor list ID that the email address was attempted to be subscribed to.
+			 */
+			$reader_error = apply_filters(
+				'newspack_newsletters_add_contact_reader_error_message',
+				__( "Sorry, this email cannot be subscribed to this newsletter. Please contact support with the email list you were trying to subscribe to and we'll add you to the list.", 'newspack-newsletters' ),
+				$contact['email'],
+				$list_id
+			);
 			return new \WP_Error(
-				'newspack_add_contact',
-				$e->getMessage()
+				'newspack_campaign_monitor_add_contact_failed',
+				Newspack_Newsletters::debug_mode() ? $e->getMessage() : $reader_error
 			);
 		}
 	}

--- a/includes/service-providers/campaign_monitor/class-newspack-newsletters-campaign-monitor.php
+++ b/includes/service-providers/campaign_monitor/class-newspack-newsletters-campaign-monitor.php
@@ -867,19 +867,13 @@ final class Newspack_Newsletters_Campaign_Monitor extends \Newspack_Newsletters_
 				]
 			);
 
-			/**
-			 * A default error message to show to readers if their signup request results in an error.
-			 *
-			 * @param string $reader_error The default error message.
-			 * @param string $email_address The email address that was attempted to be subscribed.
-			 * @param string $list_id The Campaign Monitor list ID that the email address was attempted to be subscribed to.
-			 */
-			$reader_error = apply_filters(
-				'newspack_newsletters_add_contact_reader_error_message',
-				__( "Sorry, this email cannot be subscribed to this newsletter. Please contact support with the email list you were trying to subscribe to and we'll add you to the list.", 'newspack-newsletters' ),
-				$contact['email'],
-				$list_id
+			$reader_error = $this->get_add_contact_reader_error_message(
+				[
+					'email'   => $contact['email'],
+					'list_id' => $list_id,
+				]
 			);
+
 			return new \WP_Error(
 				'newspack_campaign_monitor_add_contact_failed',
 				Newspack_Newsletters::debug_mode() ? $e->getMessage() : $reader_error

--- a/includes/service-providers/class-newspack-newsletters-service-provider.php
+++ b/includes/service-providers/class-newspack-newsletters-service-provider.php
@@ -594,6 +594,28 @@ Error message(s) received:
 	}
 
 	/**
+	 * Get a reader-facing error message to be shown when the add_contact method fails.
+	 *
+	 * @param array $params Additional information about the request that triggered the error.
+	 *
+	 * @return string
+	 */
+	public function get_add_contact_reader_error_message( $params = [] ) {
+		/**
+		 * A default error message to show to readers if their signup request results in an error.
+		 *
+		 * @param string $reader_error The default error message.
+		 * @param array  $params Additional information about the request that triggered the error.
+		 */
+		$reader_error = apply_filters(
+			'newspack_newsletters_add_contact_reader_error_message',
+			__( "Sorry, this email cannot be subscribed to this newsletter. Please contact support with the email list you were trying to subscribe to and we'll add you to the list.", 'newspack-newsletters' ),
+			$params
+		);
+		return $reader_error;
+	}
+
+	/**
 	 * Handle adding to local lists.
 	 * If the $list_id is a local list, a tag will be added to the contact.
 	 *

--- a/includes/service-providers/constant_contact/class-newspack-newsletters-constant-contact.php
+++ b/includes/service-providers/constant_contact/class-newspack-newsletters-constant-contact.php
@@ -1200,21 +1200,9 @@ final class Newspack_Newsletters_Constant_Contact extends \Newspack_Newsletters_
 			}
 		}
 
-		/**
-		 * A default error message to show to readers if their signup request results in an error.
-		 *
-		 * @param string $reader_error The default error message.
-		 * @param string $email_address The email address that was attempted to be subscribed.
-		 * @param string $list_id The Constant Contact list ID that the email address was attempted to be subscribed to.
-		 */
-		$reader_error = apply_filters(
-			'newspack_newsletters_add_contact_reader_error_message',
-			__( "Sorry, this email cannot be subscribed to this newsletter. Please contact support with the email list you were trying to subscribe to and we'll add you to the list.", 'newspack-newsletters' ),
-			$contact['email'],
-			$list_id
-		);
 		$result = $cc->upsert_contact( $contact['email'], $data );
-		if ( is_wp_error( $result ) ) {
+		if ( is_wp_error( $result ) || empty( $result ) ) {
+
 			// Log the error with any details returned from the API.
 			do_action(
 				'newspack_log',
@@ -1223,20 +1211,22 @@ final class Newspack_Newsletters_Constant_Contact extends \Newspack_Newsletters_
 				[
 					'type'       => 'error',
 					'data'       => [
-						'messages' => $result->get_error_messages(),
-						'status'   => $result->get_error_code(),
+						'messages' => empty( $result ) ? 'Unknown error' : $result->get_error_messages(),
+						'status'   => empty( $result ) ? 'Unknown error' : $result->get_error_code(),
 					],
 					'user_email' => $contact['email'],
 					'file'       => 'newspack_constant_contact',
 				]
 			);
-			return Newspack_Newsletters::debug_mode() ? $result : new \WP_Error( 'newspack_constant_contact_add_contact_failed', $reader_error );
-		}
-		if ( ! $result ) {
-			return new WP_Error(
-				'newspack_constant_contact_add_contact_unknown_error',
-				$reader_error
+
+			$reader_error = $this->get_add_contact_reader_error_message(
+				[
+					'email'   => $contact['email'],
+					'list_id' => $list_id,
+				]
 			);
+
+			return Newspack_Newsletters::debug_mode() ? $result : new \WP_Error( 'newspack_constant_contact_add_contact_failed', $reader_error );
 		}
 
 		return get_object_vars( $result );

--- a/includes/service-providers/constant_contact/class-newspack-newsletters-constant-contact.php
+++ b/includes/service-providers/constant_contact/class-newspack-newsletters-constant-contact.php
@@ -1200,14 +1200,42 @@ final class Newspack_Newsletters_Constant_Contact extends \Newspack_Newsletters_
 			}
 		}
 
+		/**
+		 * A default error message to show to readers if their signup request results in an error.
+		 *
+		 * @param string $reader_error The default error message.
+		 * @param string $email_address The email address that was attempted to be subscribed.
+		 * @param string $list_id The Constant Contact list ID that the email address was attempted to be subscribed to.
+		 */
+		$reader_error = apply_filters(
+			'newspack_newsletters_add_contact_reader_error_message',
+			__( "Sorry, this email cannot be subscribed to this newsletter. Please contact support with the email list you were trying to subscribe to and we'll add you to the list.", 'newspack-newsletters' ),
+			$contact['email'],
+			$list_id
+		);
 		$result = $cc->upsert_contact( $contact['email'], $data );
 		if ( is_wp_error( $result ) ) {
-			return $result;
+			// Log the error with any details returned from the API.
+			do_action(
+				'newspack_log',
+				'newspack_constant_contact_add_contact_failed',
+				'Error adding contact to Constant Contact.',
+				[
+					'type'       => 'error',
+					'data'       => [
+						'messages' => $result->get_error_messages(),
+						'status'   => $result->get_error_code(),
+					],
+					'user_email' => $contact['email'],
+					'file'       => 'newspack_constant_contact',
+				]
+			);
+			return Newspack_Newsletters::debug_mode() ? $result : new \WP_Error( 'newspack_constant_contact_add_contact_failed', $reader_error );
 		}
 		if ( ! $result ) {
 			return new WP_Error(
-				'newspack_newsletters_error',
-				__( 'Failed to add contact.', 'newspack-newsletters' )
+				'newspack_constant_contact_add_contact_unknown_error',
+				$reader_error
 			);
 		}
 

--- a/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp.php
+++ b/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp.php
@@ -1840,16 +1840,12 @@ final class Newspack_Newsletters_Mailchimp extends \Newspack_Newsletters_Service
 			 * @param string $reader_error The default error message.
 			 * @param string $email_address The email address that was attempted to be subscribed.
 			 * @param string $list_id The Mailchimp list ID that the email address was attempted to be subscribed to.
-			 * @param array $tags The tags that were attempted to be added to the email address.
-			 * @param array $interests The interests that were attempted to be added to the email address.
 			 */
 			$reader_error = apply_filters(
-				'newspack_newsletters_mailchimp_add_contact_reader_error_message',
+				'newspack_newsletters_add_contact_reader_error_message',
 				__( "Sorry, this email cannot be subscribed to this newsletter. Please contact support with the email list you were trying to subscribe to and we'll add you to the list.", 'newspack-newsletters' ),
 				$email_address,
-				$list_id,
-				$tags,
-				$interests
+				$list_id
 			);
 			$result      = $this->validate( $mc->put( "lists/$list_id/members/$member_hash", $update_payload ), $reader_error, $email_address );
 		} catch ( \Exception $e ) {

--- a/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp.php
+++ b/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp.php
@@ -1414,26 +1414,21 @@ final class Newspack_Newsletters_Mailchimp extends \Newspack_Newsletters_Service
 	 * Throw an Exception if Mailchimp response indicates an error.
 	 *
 	 * @param Object $result Result of the Mailchimp operation.
-	 * @param String $preferred_error Preset error to use instead of Mailchimp errors.
+	 * @param String $preferred_error Error message to show to readers instead of showing Mailchimp API errors.
+	 * @param String $email_address Email address, for debugging purposes.
 	 * @throws Exception Error message.
 	 * @return The results of the API call.
 	 */
-	public function validate( $result, $preferred_error = null ) {
+	public function validate( $result, $preferred_error = null, $email_address = '' ) {
+		$default_error = __( 'Sorry, a Mailchimp error has occurred. Please try again later or contact us for support.', 'newspack-newsletters' );
+		if ( ! $preferred_error ) {
+			$preferred_error = $default_error;
+		}
 		if ( ! $result ) {
-			if ( $preferred_error ) {
-				throw new Exception( esc_html( $preferred_error ) );
-			} else {
-				throw new Exception( esc_html__( 'A Mailchimp error has occurred.', 'newspack-newsletters' ) );
-			}
+			throw new Exception( esc_html( $preferred_error ) );
 		}
 		// See Mailchimp error code glossary: https://mailchimp.com/developer/marketing/docs/errors/#error-glossary.
 		if ( ! empty( $result['status'] ) && (int) $result['status'] >= 400 ) {
-			if ( $preferred_error && ! Newspack_Newsletters::debug_mode() ) {
-				if ( ! empty( $result['detail'] ) ) {
-					$preferred_error .= ' ' . $result['detail'];
-				}
-				throw new Exception( esc_html( $preferred_error ) );
-			}
 			$messages = [];
 			if ( ! empty( $result['errors'] ) ) {
 				foreach ( $result['errors'] as $error ) {
@@ -1442,13 +1437,36 @@ final class Newspack_Newsletters_Mailchimp extends \Newspack_Newsletters_Service
 					}
 				}
 			}
-			if ( ! count( $messages ) && ! empty( $result['detail'] ) ) {
+			if ( ! empty( $result['detail'] ) ) {
 				$messages[] = $result['detail'];
 			}
 			if ( ! count( $messages ) ) {
-				$message[] = __( 'A Mailchimp error has occurred.', 'newspack-newsletters' );
+				$message[] = $preferred_error;
 			}
-			throw new Exception( esc_html( implode( ' ', $messages ) ) );
+
+			// Log the error with any details returned from the API.
+			do_action(
+				'newspack_log',
+				'newspack_mailchimp_api_error',
+				'Error adding contact to Mailchimp.',
+				[
+					'type'       => 'error',
+					'data'       => [
+						'messages' => $messages,
+						'status'   => $result['status'],
+						'title'    => ! empty( $result['title'] ) ? $result['title'] : '',
+					],
+					'user_email' => $email_address,
+					'file'       => 'newspack_mailchimp',
+				]
+			);
+
+			if ( Newspack_Newsletters::debug_mode() ) {
+				// Show the "real" error message(s) if in debug mode.
+				throw new Exception( esc_html( implode( ' ', $messages ) ) );
+			} else {
+				throw new Exception( esc_html( $preferred_error ) );
+			}
 		}
 		return $result;
 	}
@@ -1815,7 +1833,25 @@ final class Newspack_Newsletters_Mailchimp extends \Newspack_Newsletters_Service
 
 			// Create or update a list member.
 			$member_hash = Mailchimp::subscriberHash( $email_address );
-			$result      = $this->validate( $mc->put( "lists/$list_id/members/$member_hash", $update_payload ) );
+
+			/**
+			 * A default error message to show to readers if their signup request results in an error.
+			 *
+			 * @param string $reader_error The default error message.
+			 * @param string $email_address The email address that was attempted to be subscribed.
+			 * @param string $list_id The Mailchimp list ID that the email address was attempted to be subscribed to.
+			 * @param array $tags The tags that were attempted to be added to the email address.
+			 * @param array $interests The interests that were attempted to be added to the email address.
+			 */
+			$reader_error = apply_filters(
+				'newspack_newsletters_mailchimp_add_contact_reader_error_message',
+				__( "Sorry, this email cannot be subscribed to this newsletter. Please contact support with the email list you were trying to subscribe to and we'll add you to the list.", 'newspack-newsletters' ),
+				$email_address,
+				$list_id,
+				$tags,
+				$interests
+			);
+			$result      = $this->validate( $mc->put( "lists/$list_id/members/$member_hash", $update_payload ), $reader_error, $email_address );
 		} catch ( \Exception $e ) {
 			return new \WP_Error(
 				'newspack_newsletters_mailchimp_add_contact_failed',

--- a/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp.php
+++ b/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp.php
@@ -1832,22 +1832,16 @@ final class Newspack_Newsletters_Mailchimp extends \Newspack_Newsletters_Service
 			Newspack_Newsletters_Logger::log( 'Mailchimp add_contact PUT payload: ' . wp_json_encode( $update_payload ) );
 
 			// Create or update a list member.
-			$member_hash = Mailchimp::subscriberHash( $email_address );
-
-			/**
-			 * A default error message to show to readers if their signup request results in an error.
-			 *
-			 * @param string $reader_error The default error message.
-			 * @param string $email_address The email address that was attempted to be subscribed.
-			 * @param string $list_id The Mailchimp list ID that the email address was attempted to be subscribed to.
-			 */
-			$reader_error = apply_filters(
-				'newspack_newsletters_add_contact_reader_error_message',
-				__( "Sorry, this email cannot be subscribed to this newsletter. Please contact support with the email list you were trying to subscribe to and we'll add you to the list.", 'newspack-newsletters' ),
-				$email_address,
-				$list_id
+			$member_hash  = Mailchimp::subscriberHash( $email_address );
+			$reader_error = $this->get_add_contact_reader_error_message(
+				[
+					'email'     => $contact['email'],
+					'list_id'   => $list_id,
+					'tags'      => $tags,
+					'interests' => $interests,
+				]
 			);
-			$result      = $this->validate( $mc->put( "lists/$list_id/members/$member_hash", $update_payload ), $reader_error, $email_address );
+			$result       = $this->validate( $mc->put( "lists/$list_id/members/$member_hash", $update_payload ), $reader_error, $email_address );
 		} catch ( \Exception $e ) {
 			return new \WP_Error(
 				'newspack_newsletters_mailchimp_add_contact_failed',


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Implements a filterable generic reader-facing error message to show to readers in favor of just passing on the raw errors from the ESP's API. The raw errors and any details we can glean from them are logged for debugging purposes using `newspack_log`.

Only affects the `add_contact` methods for each ESP for now, which is the main context in which readers might encounter API errors when signing up.

### How to test the changes in this Pull Request:

1. Check out this PR.
2. Using the Newsletter Subscription Form block, the Reader Registration block, ~the auth modal, and a post-checkout newsletter signup modal~ (EDIT: apparently these don't currently handle errors, so let's skip for now), sign up an email address for a newsletter list and ensure it will result in an error. You can force an error by :
  - Using an email you know can't be subscribed to the list—for example, for Mailchimp, signing up using an email address that has previously unsubscribed from the same audience
  - Or, by throwing an exception or WP_Error in the active ESP's `add_contact` method (whether to throw an exception or an error depends on the specific ESP you're using).

3. Confirm that in the reader-facing front-end, you see the generic error message:

<img width="798" alt="Screenshot 2025-01-22 at 4 57 06 PM" src="https://github.com/user-attachments/assets/e8062372-db43-4161-802b-fc18360daae4" />

4. Also confirm that the "real" error message is logged via `newspack_log`.
5. Define `NEWSPACK_NEWSLETTERS_DEBUG_MODE` as true in wp-config.php and repeat the signup attempt, but this time confirm that the "real" error message is shown instead of the generic one.
6. Optionally, test the new `newspack_newsletters_add_contact_reader_error_message` filter by adding your own custom error message via `add_filter()`.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1208879786064023