### PR TITLE
fix: avoid moving cursor when editing Subject input field

### DIFF
--- a/src/newsletter-editor/sidebar/index.js
+++ b/src/newsletter-editor/sidebar/index.js
@@ -40,7 +40,7 @@ const Sidebar = ( {
 	stringifiedCampaignDefaults,
 	postId,
 } ) => {
-	const [ plainTextTitle, setPlainTextTitle ] = useState( title );
+	const [ plainTextTitle, setPlainTextTitle ] = useState( null );
 	const isRetrieving = useIsRetrieving();
 	const newsletterData = useNewsletterData();
 	const newsletterDataError = useNewsletterDataError();
@@ -48,16 +48,28 @@ const Sidebar = ( {
 	const updateMeta = ( toUpdate ) => editPost( { meta: toUpdate } );
 	const entityConverter = useRef( null );
 
+	// Create a temp textarea element that we can use to convert HTML entities like &amp; to unicode characters.
 	useEffect( () => {
-		// Create a temp textarea element that we can use to convert HTML entities like &amp; to unicode characters.
 		if ( entityConverter.current ) {
 		} else {
 			entityConverter.current = document.createElement( 'textarea' );
 		}
+		return () => entityConverter?.current?.remove && entityConverter.current.remove(); // Clean up temp element from DOM on unmount.
+	}, [] );
+
+	// Decode HTML entities in title.
+	useEffect( () => {
 		entityConverter.current.innerHTML = title;
 		setPlainTextTitle( entityConverter.current.value );
-		return () => entityConverter?.current?.remove && entityConverter.current.remove(); // Clean up temp element from DOM on unmount.
 	}, [ title ] );
+
+	// Encode HTML entities in title.
+	useEffect( () => {
+		if ( null !== plainTextTitle ) {
+			entityConverter.current.innerText = plainTextTitle;
+			editPost( { title: entityConverter.current.innerHTML } );
+		}
+	}, [ plainTextTitle ] );
 
 	// Reconcile stored campaign data with data fetched from ESP.
 	useEffect( () => {
@@ -199,8 +211,7 @@ const Sidebar = ( {
 				className="newspack-newsletters__subject-textcontrol"
 				value={ plainTextTitle }
 				disabled={ inFlight }
-				onChange={ value => setPlainTextTitle( value ) }
-				onBlur={ () => editPost( { title: plainTextTitle } ) }
+				onChange={ setPlainTextTitle }
 			/>
 			<TextareaControl
 				label={ __( 'Preview text', 'newspack-newsletters' ) }

--- a/src/newsletter-editor/sidebar/index.js
+++ b/src/newsletter-editor/sidebar/index.js
@@ -48,14 +48,14 @@ const Sidebar = ( {
 	const updateMeta = ( toUpdate ) => editPost( { meta: toUpdate } );
 	const entityConverter = useRef( null );
 
-	// Create a temp textarea element that we can use to convert HTML entities like &amp; to unicode characters.
 	useEffect( () => {
+		// Create a temp textarea element that we can use to convert HTML entities like &amp; to unicode characters.
 		if ( entityConverter.current ) {
-			entityConverter.current.innerHTML = title;
-			setPlainTextTitle( entityConverter.current.value );
 		} else {
 			entityConverter.current = document.createElement( 'textarea' );
 		}
+		entityConverter.current.innerHTML = title;
+		setPlainTextTitle( entityConverter.current.value );
 		return () => entityConverter?.current?.remove && entityConverter.current.remove(); // Clean up temp element from DOM on unmount.
 	}, [ title ] );
 
@@ -199,7 +199,8 @@ const Sidebar = ( {
 				className="newspack-newsletters__subject-textcontrol"
 				value={ plainTextTitle }
 				disabled={ inFlight }
-				onChange={ value => editPost( { title: value } ) }
+				onChange={ value => setPlainTextTitle( value ) }
+				onBlur={ () => editPost( { title: plainTextTitle } ) }
 			/>
 			<TextareaControl
 				label={ __( 'Preview text', 'newspack-newsletters' ) }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes a small bug with the Subject input field from #1686. Because WP HTML-encodes the title string, we need to convert the encoded string back to plain text before setting the value of the subject field, to avoid double-encoding the title. But because the input value directly changes the title, which triggers the conversion back to plain text, this results in the entire string being replaced in the component state upon every keypress. This PR fixes this issue by only updating the actual post title when the input field is blurred (unfocused).

### How to test the changes in this Pull Request:

1. On `trunk`, edit a newsletter and edit the Subject field in the newsletter sidebar. Place your cursor in the middle of the string and edit, and observe that upon every keypress the cursor jumps to the end of the string.
2. Check out this branch and repeat. This time, confirm that the cursor does not reposition itself while typing in the input field, and that after you click or tab out of the input field, the post title is updated to match the input.
3. Smoke test editing the subject by changing the title in the block editor content area (the subject field should still update automatically to match).
4. Smoke test saving the post with HTML characters (such as ampersands) in the title and refresh the editor. Confirm that the title saved to the DB is HTML-encoded (use WP CLI: `wp post get <post ID> --fields=post_title`, but that it still renders as plain text in both the big content-area title and in the Subject input field.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1209079466938940