### PR TITLE
fix: allow for context-specific reader-facing error messsages

### DIFF
--- a/includes/class-newspack-newsletters-contacts.php
+++ b/includes/class-newspack-newsletters-contacts.php
@@ -223,6 +223,8 @@ class Newspack_Newsletters_Contacts {
 		 */
 		do_action( 'newspack_newsletters_upsert', $provider->service, $contact, $lists, $result, $is_updating, $context );
 
+		// Logs the success or error resulting from the upsert request.
+		// To see errors returned by the ESP's API, look for the `newspack_{esp}_api_error` error code.
 		do_action(
 			'newspack_log',
 			'newspack_esp_sync_upsert_contact',

--- a/includes/class-newspack-newsletters-contacts.php
+++ b/includes/class-newspack-newsletters-contacts.php
@@ -236,6 +236,7 @@ class Newspack_Newsletters_Contacts {
 					'lists'    => $lists,
 					'contact'  => $contact,
 					'errors'   => $errors->get_error_messages(),
+					'status'   => $errors->get_error_codes(),
 				],
 				'user_email' => $contact['email'],
 				'file'       => 'newspack_esp_sync',
@@ -243,7 +244,15 @@ class Newspack_Newsletters_Contacts {
 		);
 
 		if ( $errors->has_errors() ) {
-			return $errors;
+			// Get a reader-friendly error message to show to the user.
+			$reader_error = $provider->get_reader_error_message(
+				[
+					'email' => $contact['email'],
+					'lists' => $lists,
+				],
+				is_wp_error( $result ) ? $result : $errors
+			);
+			return Newspack_Newsletters::debug_mode() ? $errors : new \WP_Error( 'newspack_newsletters_upsert_contact_error', $reader_error );
 		}
 
 		return $result;

--- a/includes/service-providers/active_campaign/class-newspack-newsletters-active-campaign.php
+++ b/includes/service-providers/active_campaign/class-newspack-newsletters-active-campaign.php
@@ -1388,7 +1388,7 @@ final class Newspack_Newsletters_Active_Campaign extends \Newspack_Newsletters_S
 			// Log the error with any details returned from the API.
 			do_action(
 				'newspack_log',
-				'newspack_active_campaign_add_contact_failed',
+				'newspack_' . $this->service . '_api_error',
 				'Error adding contact to ActiveCampaign.',
 				[
 					'type'       => 'error',
@@ -1405,11 +1405,12 @@ final class Newspack_Newsletters_Active_Campaign extends \Newspack_Newsletters_S
 				return $result;
 			}
 
-			$reader_error = $this->get_add_contact_reader_error_message(
+			$reader_error = $this->get_reader_error_message(
 				[
 					'email'   => $contact['email'],
 					'list_id' => $list_id,
-				]
+				],
+				$result
 			);
 			return new \WP_Error( 'newspack_active_campaign_add_contact_failed', $reader_error );
 		}

--- a/includes/service-providers/active_campaign/class-newspack-newsletters-active-campaign.php
+++ b/includes/service-providers/active_campaign/class-newspack-newsletters-active-campaign.php
@@ -1385,34 +1385,7 @@ final class Newspack_Newsletters_Active_Campaign extends \Newspack_Newsletters_S
 		);
 
 		if ( is_wp_error( $result ) ) {
-			// Log the error with any details returned from the API.
-			do_action(
-				'newspack_log',
-				'newspack_' . $this->service . '_api_error',
-				'Error adding contact to ActiveCampaign.',
-				[
-					'type'       => 'error',
-					'data'       => [
-						'messages' => $result->get_error_messages(),
-						'status'   => $result->get_error_code(),
-					],
-					'user_email' => $contact['email'],
-					'file'       => 'newspack_active_campaign',
-				]
-			);
-
-			if ( Newspack_Newsletters::debug_mode() ) {
-				return $result;
-			}
-
-			$reader_error = $this->get_reader_error_message(
-				[
-					'email'   => $contact['email'],
-					'list_id' => $list_id,
-				],
-				$result
-			);
-			return new \WP_Error( 'newspack_active_campaign_add_contact_failed', $reader_error );
+			return $result;
 		}
 
 		// On success, clear cached contact data to make sure we get updated data next time we need.

--- a/includes/service-providers/campaign_monitor/class-newspack-newsletters-campaign-monitor.php
+++ b/includes/service-providers/campaign_monitor/class-newspack-newsletters-campaign-monitor.php
@@ -854,7 +854,7 @@ final class Newspack_Newsletters_Campaign_Monitor extends \Newspack_Newsletters_
 			// Log the error with any details returned from the API.
 			do_action(
 				'newspack_log',
-				'newspack_campaign_monitor_add_contact_failed',
+				'newspack_' . $this->service . '_api_error',
 				'Error adding contact to Campaign Monitor.',
 				[
 					'type'       => 'error',
@@ -867,11 +867,12 @@ final class Newspack_Newsletters_Campaign_Monitor extends \Newspack_Newsletters_
 				]
 			);
 
-			$reader_error = $this->get_add_contact_reader_error_message(
+			$reader_error = $this->get_reader_error_message(
 				[
 					'email'   => $contact['email'],
 					'list_id' => $list_id,
-				]
+				],
+				$e
 			);
 
 			return new \WP_Error(

--- a/includes/service-providers/campaign_monitor/class-newspack-newsletters-campaign-monitor.php
+++ b/includes/service-providers/campaign_monitor/class-newspack-newsletters-campaign-monitor.php
@@ -851,33 +851,9 @@ final class Newspack_Newsletters_Campaign_Monitor extends \Newspack_Newsletters_
 				return $result;
 			}
 		} catch ( \Exception $e ) {
-			// Log the error with any details returned from the API.
-			do_action(
-				'newspack_log',
-				'newspack_' . $this->service . '_api_error',
-				'Error adding contact to Campaign Monitor.',
-				[
-					'type'       => 'error',
-					'data'       => [
-						'messages' => $e->getMessage(),
-						'status'   => $e->getCode(),
-					],
-					'user_email' => $contact['email'],
-					'file'       => 'newspack_campaign_monitor',
-				]
-			);
-
-			$reader_error = $this->get_reader_error_message(
-				[
-					'email'   => $contact['email'],
-					'list_id' => $list_id,
-				],
-				$e
-			);
-
 			return new \WP_Error(
-				'newspack_campaign_monitor_add_contact_failed',
-				Newspack_Newsletters::debug_mode() ? $e->getMessage() : $reader_error
+				'newspack_newsletters_campaign_monitor_api_error',
+				$e->getMessage()
 			);
 		}
 	}

--- a/includes/service-providers/class-newspack-newsletters-service-provider.php
+++ b/includes/service-providers/class-newspack-newsletters-service-provider.php
@@ -601,7 +601,7 @@ Error message(s) received:
 	 *
 	 * @return string
 	 */
-	public function get_reader_error_message( $params = [], $raw_error ) {
+	public function get_reader_error_message( $params = [], $raw_error = null ) {
 		/**
 		 * A default error message to show to readers if their signup request results in an error.
 		 *

--- a/includes/service-providers/class-newspack-newsletters-service-provider.php
+++ b/includes/service-providers/class-newspack-newsletters-service-provider.php
@@ -597,20 +597,23 @@ Error message(s) received:
 	 * Get a reader-facing error message to be shown when the add_contact method fails.
 	 *
 	 * @param array $params Additional information about the request that triggered the error.
+	 * @param mixed $raw_error Raw error data from the ESP's API. This can vary depending on the provider.
 	 *
 	 * @return string
 	 */
-	public function get_add_contact_reader_error_message( $params = [] ) {
+	public function get_reader_error_message( $params = [], $raw_error ) {
 		/**
 		 * A default error message to show to readers if their signup request results in an error.
 		 *
 		 * @param string $reader_error The default error message.
 		 * @param array  $params Additional information about the request that triggered the error.
+		 * @param mixed $raw_error Raw error data from the ESP's API. This can vary depending on the provider.
 		 */
 		$reader_error = apply_filters(
 			'newspack_newsletters_add_contact_reader_error_message',
-			__( "Sorry, this email cannot be subscribed to this newsletter. Please contact support with the email list you were trying to subscribe to and we'll add you to the list.", 'newspack-newsletters' ),
-			$params
+			__( 'Sorry, a Mailchimp error has occurred. Please try again later or contact us for support.', 'newspack-newsletters' ),
+			$params,
+			$raw_error
 		);
 		return $reader_error;
 	}

--- a/includes/service-providers/class-newspack-newsletters-service-provider.php
+++ b/includes/service-providers/class-newspack-newsletters-service-provider.php
@@ -611,7 +611,7 @@ Error message(s) received:
 		 */
 		$reader_error = apply_filters(
 			'newspack_newsletters_add_contact_reader_error_message',
-			__( 'Sorry, a Mailchimp error has occurred. Please try again later or contact us for support.', 'newspack-newsletters' ),
+			__( 'Sorry, an error has occurred. Please try again later or contact us for support.', 'newspack-newsletters' ),
 			$params,
 			$raw_error
 		);

--- a/includes/service-providers/constant_contact/class-newspack-newsletters-constant-contact-sdk.php
+++ b/includes/service-providers/constant_contact/class-newspack-newsletters-constant-contact-sdk.php
@@ -794,7 +794,7 @@ final class Newspack_Newsletters_Constant_Contact_SDK {
 				[ 'body' => wp_json_encode( $body ) ]
 			);
 		} catch ( Exception $e ) {
-			return new WP_Error( 'newspack_newsletter_error_upserting_contact', $e->getMessage() );
+			return new WP_Error( 'newspack_newsletters_constant_contact_api_error', $e->getMessage() );
 		}
 
 		return $this->get_contact( $email_address );

--- a/includes/service-providers/constant_contact/class-newspack-newsletters-constant-contact.php
+++ b/includes/service-providers/constant_contact/class-newspack-newsletters-constant-contact.php
@@ -1206,7 +1206,7 @@ final class Newspack_Newsletters_Constant_Contact extends \Newspack_Newsletters_
 			// Log the error with any details returned from the API.
 			do_action(
 				'newspack_log',
-				'newspack_constant_contact_add_contact_failed',
+				'newspack_' . $this->service . '_api_error',
 				'Error adding contact to Constant Contact.',
 				[
 					'type'       => 'error',
@@ -1219,11 +1219,12 @@ final class Newspack_Newsletters_Constant_Contact extends \Newspack_Newsletters_
 				]
 			);
 
-			$reader_error = $this->get_add_contact_reader_error_message(
+			$reader_error = $this->get_reader_error_message(
 				[
 					'email'   => $contact['email'],
 					'list_id' => $list_id,
-				]
+				],
+				$result
 			);
 
 			return Newspack_Newsletters::debug_mode() ? $result : new \WP_Error( 'newspack_constant_contact_add_contact_failed', $reader_error );

--- a/includes/service-providers/constant_contact/class-newspack-newsletters-constant-contact.php
+++ b/includes/service-providers/constant_contact/class-newspack-newsletters-constant-contact.php
@@ -1201,33 +1201,8 @@ final class Newspack_Newsletters_Constant_Contact extends \Newspack_Newsletters_
 		}
 
 		$result = $cc->upsert_contact( $contact['email'], $data );
-		if ( is_wp_error( $result ) || empty( $result ) ) {
-
-			// Log the error with any details returned from the API.
-			do_action(
-				'newspack_log',
-				'newspack_' . $this->service . '_api_error',
-				'Error adding contact to Constant Contact.',
-				[
-					'type'       => 'error',
-					'data'       => [
-						'messages' => empty( $result ) ? 'Unknown error' : $result->get_error_messages(),
-						'status'   => empty( $result ) ? 'Unknown error' : $result->get_error_code(),
-					],
-					'user_email' => $contact['email'],
-					'file'       => 'newspack_constant_contact',
-				]
-			);
-
-			$reader_error = $this->get_reader_error_message(
-				[
-					'email'   => $contact['email'],
-					'list_id' => $list_id,
-				],
-				$result
-			);
-
-			return Newspack_Newsletters::debug_mode() ? $result : new \WP_Error( 'newspack_constant_contact_add_contact_failed', $reader_error );
+		if ( is_wp_error( $result ) ) {
+			return $result;
 		}
 
 		return get_object_vars( $result );

--- a/includes/service-providers/interface-newspack-newsletters-esp-service.php
+++ b/includes/service-providers/interface-newspack-newsletters-esp-service.php
@@ -9,7 +9,6 @@
  * ESP API.
  */
 interface Newspack_Newsletters_ESP_API_Interface {
-
 	/**
 	 * Get API credentials for service provider.
 	 *

--- a/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp.php
+++ b/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp.php
@@ -1422,7 +1422,7 @@ final class Newspack_Newsletters_Mailchimp extends \Newspack_Newsletters_Service
 	public function reader_error_message( $reader_error, $params, $raw_error ) {
 		// Handle special case where a user is in compliance state.
 		if ( is_wp_error( $raw_error ) && false !== strpos( $raw_error->get_error_message(), 'Member In Compliance State' ) ) {
-			$reader_error = __( "Sorry, this email cannot be subscribed to this newsletter. Please contact support with the email list you were trying to subscribe to and we'll add you to the list.", 'newspack-newsletters' );
+			$reader_error = __( "We'll need to subscribe this email address manually. Please contact our support team.", 'newspack-newsletters' );
 		}
 		return $reader_error;
 	}

--- a/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp.php
+++ b/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp.php
@@ -1478,7 +1478,7 @@ final class Newspack_Newsletters_Mailchimp extends \Newspack_Newsletters_Service
 						'status'   => $result['status'],
 						'title'    => ! empty( $result['title'] ) ? $result['title'] : '',
 					],
-					'user_email' => $email_address,
+					'user_email' => $payload['email'] ?? '',
 					'file'       => 'newspack_mailchimp',
 				]
 			);

--- a/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp.php
+++ b/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp.php
@@ -62,7 +62,7 @@ final class Newspack_Newsletters_Mailchimp extends \Newspack_Newsletters_Service
 		add_action( 'updated_post_meta', [ $this, 'save' ], 10, 4 );
 		add_action( 'wp_trash_post', [ $this, 'trash' ], 10, 1 );
 		add_filter( 'newspack_newsletters_process_link', [ $this, 'process_link' ], 10, 2 );
-
+		add_filter( 'newspack_newsletters_add_contact_reader_error_message', [ $this, 'reader_error_message' ], 10, 3 );
 		add_action( 'newspack_newsletters_subscription_lists_metabox_after_tag', [ $this, 'lists_metabox_notice' ] );
 
 		parent::__construct( $this );
@@ -1411,16 +1411,38 @@ final class Newspack_Newsletters_Mailchimp extends \Newspack_Newsletters_Service
 	}
 
 	/**
+	 * Filters the error message shown to readers when an error occurs.
+	 *
+	 * @param string $reader_error The default error message.
+	 * @param array  $params Additional information about the request that triggered the error.
+	 * @param mixed  $raw_error Raw error data from the ESP's API. This can vary depending on the provider.
+	 *
+	 * @return string The filtered error message.
+	 */
+	public function reader_error_message( $reader_error, $params, $raw_error ) {
+		// Handle special case where a user is in compliance state.
+		if (
+			! empty( $raw_error['status'] ) &&
+			(int) $raw_error['status'] >= 400 &&
+			! empty( $raw_error['title'] ) &&
+			$raw_error['title'] === 'Member In Compliance State'
+		) {
+			$reader_error = __( "Sorry, this email cannot be subscribed to this newsletter. Please contact support with the email list you were trying to subscribe to and we'll add you to the list.", 'newspack-newsletters' );
+		}
+		return $reader_error;
+	}
+
+	/**
 	 * Throw an Exception if Mailchimp response indicates an error.
 	 *
 	 * @param Object $result Result of the Mailchimp operation.
 	 * @param String $preferred_error Error message to show to readers instead of showing Mailchimp API errors.
-	 * @param String $email_address Email address, for debugging purposes.
+	 * @param Array  $payload Payload data, for debugging purposes.
 	 * @throws Exception Error message.
 	 * @return The results of the API call.
 	 */
-	public function validate( $result, $preferred_error = null, $email_address = '' ) {
-		$default_error = __( 'Sorry, a Mailchimp error has occurred. Please try again later or contact us for support.', 'newspack-newsletters' );
+	public function validate( $result, $preferred_error = null, $payload = [] ) {
+		$default_error = $this->get_reader_error_message( $payload, $result );
 		if ( ! $preferred_error ) {
 			$preferred_error = $default_error;
 		}
@@ -1447,7 +1469,7 @@ final class Newspack_Newsletters_Mailchimp extends \Newspack_Newsletters_Service
 			// Log the error with any details returned from the API.
 			do_action(
 				'newspack_log',
-				'newspack_mailchimp_api_error',
+				'newspack_' . $this->service . '_api_error',
 				'Error adding contact to Mailchimp.',
 				[
 					'type'       => 'error',
@@ -1833,15 +1855,16 @@ final class Newspack_Newsletters_Mailchimp extends \Newspack_Newsletters_Service
 
 			// Create or update a list member.
 			$member_hash  = Mailchimp::subscriberHash( $email_address );
-			$reader_error = $this->get_add_contact_reader_error_message(
+			$result       = $this->validate(
+				$mc->put( "lists/$list_id/members/$member_hash", $update_payload ),
+				null,
 				[
-					'email'     => $contact['email'],
+					'email'     => $email_address,
 					'list_id'   => $list_id,
 					'tags'      => $tags,
 					'interests' => $interests,
 				]
 			);
-			$result       = $this->validate( $mc->put( "lists/$list_id/members/$member_hash", $update_payload ), $reader_error, $email_address );
 		} catch ( \Exception $e ) {
 			return new \WP_Error(
 				'newspack_newsletters_mailchimp_add_contact_failed',

--- a/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp.php
+++ b/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp.php
@@ -1421,12 +1421,7 @@ final class Newspack_Newsletters_Mailchimp extends \Newspack_Newsletters_Service
 	 */
 	public function reader_error_message( $reader_error, $params, $raw_error ) {
 		// Handle special case where a user is in compliance state.
-		if (
-			! empty( $raw_error['status'] ) &&
-			(int) $raw_error['status'] >= 400 &&
-			! empty( $raw_error['title'] ) &&
-			$raw_error['title'] === 'Member In Compliance State'
-		) {
+		if ( is_wp_error( $raw_error ) && false !== strpos( $raw_error->get_error_message(), 'Member In Compliance State' ) ) {
 			$reader_error = __( "Sorry, this email cannot be subscribed to this newsletter. Please contact support with the email list you were trying to subscribe to and we'll add you to the list.", 'newspack-newsletters' );
 		}
 		return $reader_error;
@@ -1437,12 +1432,11 @@ final class Newspack_Newsletters_Mailchimp extends \Newspack_Newsletters_Service
 	 *
 	 * @param Object $result Result of the Mailchimp operation.
 	 * @param String $preferred_error Error message to show to readers instead of showing Mailchimp API errors.
-	 * @param Array  $payload Payload data, for debugging purposes.
 	 * @throws Exception Error message.
 	 * @return The results of the API call.
 	 */
-	public function validate( $result, $preferred_error = null, $payload = [] ) {
-		$default_error = $this->get_reader_error_message( $payload, $result );
+	public function validate( $result, $preferred_error = null ) {
+		$default_error = __( 'An unknown Mailchimp error occurred.', 'newspack-newsletters' );
 		if ( ! $preferred_error ) {
 			$preferred_error = $default_error;
 		}
@@ -1452,6 +1446,9 @@ final class Newspack_Newsletters_Mailchimp extends \Newspack_Newsletters_Service
 		// See Mailchimp error code glossary: https://mailchimp.com/developer/marketing/docs/errors/#error-glossary.
 		if ( ! empty( $result['status'] ) && (int) $result['status'] >= 400 ) {
 			$messages = [];
+			if ( ! empty( $result['title'] ) ) {
+				$messages[] = $result['title'] . ':';
+			}
 			if ( ! empty( $result['errors'] ) ) {
 				foreach ( $result['errors'] as $error ) {
 					if ( ! empty( $error['message'] ) ) {
@@ -1463,32 +1460,10 @@ final class Newspack_Newsletters_Mailchimp extends \Newspack_Newsletters_Service
 				$messages[] = $result['detail'];
 			}
 			if ( ! count( $messages ) ) {
-				$message[] = $preferred_error;
+				$messages[] = $preferred_error;
 			}
 
-			// Log the error with any details returned from the API.
-			do_action(
-				'newspack_log',
-				'newspack_' . $this->service . '_api_error',
-				'Error adding contact to Mailchimp.',
-				[
-					'type'       => 'error',
-					'data'       => [
-						'messages' => $messages,
-						'status'   => $result['status'],
-						'title'    => ! empty( $result['title'] ) ? $result['title'] : '',
-					],
-					'user_email' => $payload['email'] ?? '',
-					'file'       => 'newspack_mailchimp',
-				]
-			);
-
-			if ( Newspack_Newsletters::debug_mode() ) {
-				// Show the "real" error message(s) if in debug mode.
-				throw new Exception( esc_html( implode( ' ', $messages ) ) );
-			} else {
-				throw new Exception( esc_html( $preferred_error ) );
-			}
+			throw new Exception( esc_html( implode( ' ', $messages ) ), ! empty( $result['status'] ) ? intval( $result['status'] ) : 400 );
 		}
 		return $result;
 	}
@@ -1867,7 +1842,7 @@ final class Newspack_Newsletters_Mailchimp extends \Newspack_Newsletters_Service
 			);
 		} catch ( \Exception $e ) {
 			return new \WP_Error(
-				'newspack_newsletters_mailchimp_add_contact_failed',
+				'newspack_newsletters_mailchimp_api_error',
 				$e->getMessage()
 			);
 		}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Builds on filters added in #1745 by allowing reader-facing error messages to be altered depending on the context of the original error thrown by the ESP's API. 

This PR adds a special error message for the Mailchimp error that occurs when a contact attempts to resubscribe to a list they've previously unsubscribed from. In all other cases, the error shown will be a generic error: `Sorry, an error has occurred. Please try again later or contact us for support.`

Also standardizes the error code used across all ESP's when `add_contact` results in an error to: `newspack_{esp}_api_error`

### How to test the changes in this Pull Request:

#### set up a contact for the compliance state

1. Check out this branch.
2. With Mailchimp enabled, sign up as a reader with a real email address for a test newsletter list/group/tag via any means on the site.
3. Send a live newsletter campaign to the list/group/tag that the reader will receive.
4. Once you receive the email in the reader's inbox, click the "Unsubscribe" link at the bottom and confirm.
5. In a new session, attempt to resubscribe to the same newsletter lists using the same reader email.
6. Confirm the following error is shown:

<img width="822" alt="Screenshot 2025-02-11 at 4 49 10 PM" src="https://github.com/user-attachments/assets/b788a809-7e9a-4932-b274-7543c6ea8a1c" />

7. Temporarily force an error to occur in the first line of the Mailchimp class `validate()` method:

```diff
	public function validate( $result, $preferred_error = null, $payload = [] ) {
+		$result['status'] = 400;
+		$result['title']  = 'Test error';
+		$result['detail'] = 'Test error message';
		$default_error = $this->get_reader_error_message( $payload, $result );
```

8. In a new session, subscribe to a newsletter list with a fresh email address and confirm you get the generic error message:

<img width="828" alt="Screenshot 2025-02-11 at 4 55 17 PM" src="https://github.com/user-attachments/assets/9a2add74-b465-454e-a1e0-36a4ac43bf37" />

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
