### PR TITLE
feat: add global control for text color and support link color in paragraph block

### DIFF
--- a/includes/class-newspack-newsletters-layouts.php
+++ b/includes/class-newspack-newsletters-layouts.php
@@ -77,7 +77,6 @@ final class Newspack_Newsletters_Layouts {
 		\register_meta( 'post', 'font_body', $meta_default_params );
 		\register_meta( 'post', 'background_color', $meta_default_params );
 		\register_meta( 'post', 'text_color', $meta_default_params );
-		\register_meta( 'post', 'link_color', $meta_default_params );
 		\register_meta( 'post', 'custom_css', $meta_default_params );
 		\register_meta( 'post', 'campaign_defaults', $meta_default_params );
 	}
@@ -93,7 +92,6 @@ final class Newspack_Newsletters_Layouts {
 		$date               = gmdate( get_option( 'date_format' ) );
 		$bg_color           = '#ffffff';
 		$text_color         = '#000000';
-		$link_color         = '#0000ff';
 		$social_links_color = 'black';
 
 		// Check if service provider is Mailchimp.
@@ -210,7 +208,6 @@ final class Newspack_Newsletters_Layouts {
 				$post->meta = [
 					'background_color'  => get_post_meta( $post->ID, 'background_color', true ),
 					'text_color'        => get_post_meta( $post->ID, 'text_color', true ),
-					'link_color'        => get_post_meta( $post->ID, 'link_color', true ),
 					'font_body'         => get_post_meta( $post->ID, 'font_body', true ),
 					'font_header'       => get_post_meta( $post->ID, 'font_header', true ),
 					'custom_css'        => get_post_meta( $post->ID, 'custom_css', true ),

--- a/includes/class-newspack-newsletters-layouts.php
+++ b/includes/class-newspack-newsletters-layouts.php
@@ -76,6 +76,8 @@ final class Newspack_Newsletters_Layouts {
 		\register_meta( 'post', 'font_header', $meta_default_params );
 		\register_meta( 'post', 'font_body', $meta_default_params );
 		\register_meta( 'post', 'background_color', $meta_default_params );
+		\register_meta( 'post', 'text_color', $meta_default_params );
+		\register_meta( 'post', 'link_color', $meta_default_params );
 		\register_meta( 'post', 'custom_css', $meta_default_params );
 		\register_meta( 'post', 'campaign_defaults', $meta_default_params );
 	}
@@ -91,6 +93,7 @@ final class Newspack_Newsletters_Layouts {
 		$date               = gmdate( get_option( 'date_format' ) );
 		$bg_color           = '#ffffff';
 		$text_color         = '#000000';
+		$link_color         = '#0000ff';
 		$social_links_color = 'black';
 
 		// Check if service provider is Mailchimp.
@@ -206,6 +209,8 @@ final class Newspack_Newsletters_Layouts {
 			function ( $post ) {
 				$post->meta = [
 					'background_color'  => get_post_meta( $post->ID, 'background_color', true ),
+					'text_color'        => get_post_meta( $post->ID, 'text_color', true ),
+					'link_color'        => get_post_meta( $post->ID, 'link_color', true ),
 					'font_body'         => get_post_meta( $post->ID, 'font_body', true ),
 					'font_header'       => get_post_meta( $post->ID, 'font_header', true ),
 					'custom_css'        => get_post_meta( $post->ID, 'custom_css', true ),

--- a/includes/class-newspack-newsletters-renderer.php
+++ b/includes/class-newspack-newsletters-renderer.php
@@ -263,12 +263,39 @@ final class Newspack_Newsletters_Renderer {
 			}
 		}
 
+		// Link color handling.
+		if ( isset( $block_attrs['style']['elements']['link']['color']['text'] ) ) {
+			$link_color = $block_attrs['style']['elements']['link']['color']['text'];
+			// Check if the color is a preset.
+			if ( strpos( $link_color, 'var:preset|color|' ) === 0 ) {
+				// Extract the color name and retrieve it in theme.json.
+				$color_name    = str_replace( 'var:preset|color|', '', $link_color );
+				$theme_json    = WP_Theme_JSON_Resolver::get_theme_data();
+				$color_palette = $theme_json->get_settings()['color']['palette']['theme'] ?? [];
+				$hex_color     = '#000000'; // Fallback color.
+				if ( ! empty( $color_palette ) && is_array( $color_palette ) ) {
+					foreach ( $color_palette as $color ) {
+						if ( isset( $color['slug'] ) && $color['slug'] === $color_name ) {
+							$hex_color = $color['color']; // Get the Hex value.
+							break;
+						}
+					}
+				}
+				$colors['link'] = $hex_color; // Set the Hex color.
+			} else {
+				$colors['link'] = $link_color;
+			}
+		}
+
 		// Add !important to all colors.
 		if ( isset( $colors['color'] ) ) {
 			$colors['color'] .= ' !important';
 		}
 		if ( isset( $colors['background-color'] ) ) {
 			$colors['background-color'] .= ' !important';
+		}
+		if ( isset( $colors['link'] ) ) {
+			$colors['link'] .= ' !important';
 		}
 
 		return $colors;
@@ -558,14 +585,27 @@ final class Newspack_Newsletters_Renderer {
 					$inner_html = sprintf( '<%1$s>%2$s</%1$s>', $tag_name, $inner_html );
 				}
 
+				// Initialize the MJML markup.
+				$block_mjml_markup = '';
+
 				// Only mj-text has to use container-background-color attr for background color.
 				if ( isset( $text_attrs['background-color'] ) ) {
 					$text_attrs['container-background-color'] = $text_attrs['background-color'];
 					unset( $text_attrs['background-color'] );
 				}
 
+				// Handle link colors.
+				if ( isset( $attrs['link'] ) ) {
+					// Apply inline style to links.
+					$inner_html = preg_replace(
+						'/<a([^>]*?)>/i',
+						'<a$1 style="color: ' . esc_attr( $attrs['link'] ) . ';">',
+						$inner_html
+					);
+				}
+
 				// Avoid wrapping markup in `mj-text` if the block is an inner block.
-				$block_mjml_markup = $is_in_list_or_quote ? $inner_html : '<mj-text ' . self::array_to_attributes( $text_attrs ) . '>' . $inner_html . '</mj-text>';
+				$block_mjml_markup .= $is_in_list_or_quote ? $inner_html : '<mj-text ' . self::array_to_attributes( $text_attrs ) . '>' . $inner_html . '</mj-text>';
 				break;
 
 			/**
@@ -1009,6 +1049,7 @@ final class Newspack_Newsletters_Renderer {
 				if ( isset( $attrs['color'] ) ) {
 					$default_attrs['color'] = $attrs['color'];
 				}
+
 				$markup = '<mj-wrapper ' . self::array_to_attributes( $attrs ) . '>';
 				foreach ( $inner_blocks as $block ) {
 					$markup .= self::render_mjml_component( $block, false, true, $default_attrs );
@@ -1278,7 +1319,6 @@ final class Newspack_Newsletters_Renderer {
 		$body             = self::post_to_mjml_components( $post ); // phpcs:ignore WordPressVIPMinimum.Variables.VariableAnalysis.UnusedVariable
 		$background_color = get_post_meta( $post->ID, 'background_color', true );
 		$text_color       = get_post_meta( $post->ID, 'text_color', true );
-		$link_color       = get_post_meta( $post->ID, 'link_color', true );
 		$preview_text     = self::get_preview_text( $post );
 		$custom_css       = get_post_meta( $post->ID, 'custom_css', true );
 		if ( ! $background_color ) {
@@ -1286,9 +1326,6 @@ final class Newspack_Newsletters_Renderer {
 		}
 		if ( ! $text_color ) {
 			$text_color = '#000000';
-		}
-		if ( ! $link_color ) {
-			$link_color = '#0000ff';
 		}
 
 		ob_start();

--- a/includes/class-newspack-newsletters-renderer.php
+++ b/includes/class-newspack-newsletters-renderer.php
@@ -1277,10 +1277,18 @@ final class Newspack_Newsletters_Renderer {
 		 */
 		$body             = self::post_to_mjml_components( $post ); // phpcs:ignore WordPressVIPMinimum.Variables.VariableAnalysis.UnusedVariable
 		$background_color = get_post_meta( $post->ID, 'background_color', true );
+		$text_color       = get_post_meta( $post->ID, 'text_color', true );
+		$link_color       = get_post_meta( $post->ID, 'link_color', true );
 		$preview_text     = self::get_preview_text( $post );
 		$custom_css       = get_post_meta( $post->ID, 'custom_css', true );
 		if ( ! $background_color ) {
 			$background_color = '#ffffff';
+		}
+		if ( ! $text_color ) {
+			$text_color = '#000000';
+		}
+		if ( ! $link_color ) {
+			$link_color = '#0000ff';
 		}
 
 		ob_start();

--- a/includes/class-newspack-newsletters.php
+++ b/includes/class-newspack-newsletters.php
@@ -394,6 +394,38 @@ final class Newspack_Newsletters {
 		);
 		\register_meta(
 			'post',
+			'text_color',
+			[
+				'object_subtype' => self::NEWSPACK_NEWSLETTERS_CPT,
+				'show_in_rest'   => [
+					'schema' => [
+						'context' => [ 'edit' ],
+					],
+				],
+				'type'           => 'string',
+				'single'         => true,
+				'auth_callback'  => '__return_true',
+				'default'        => '',
+			]
+		);
+		\register_meta(
+			'post',
+			'link_color',
+			[
+				'object_subtype' => self::NEWSPACK_NEWSLETTERS_CPT,
+				'show_in_rest'   => [
+					'schema' => [
+						'context' => [ 'edit' ],
+					],
+				],
+				'type'           => 'string',
+				'single'         => true,
+				'auth_callback'  => '__return_true',
+				'default'        => '',
+			]
+		);
+		\register_meta(
+			'post',
 			'preview_text',
 			[
 				'object_subtype' => self::NEWSPACK_NEWSLETTERS_CPT,
@@ -973,11 +1005,14 @@ final class Newspack_Newsletters {
 			$font_header      = get_post_meta( $post->ID, 'font_header', true );
 			$font_body        = get_post_meta( $post->ID, 'font_body', true );
 			$background_color = get_post_meta( $post->ID, 'background_color', true );
+			$text_color       = get_post_meta( $post->ID, 'text_color', true );
+			$link_color       = get_post_meta( $post->ID, 'link_color', true );
 			?>
 				<style>
 					.main-content {
 						background-color: <?php echo esc_attr( $background_color ); ?>;
 						font-family: <?php echo esc_attr( $font_body ); ?>;
+						color: <?php echo esc_attr( $text_color ); ?>;
 					}
 					.main-content h1,
 					.main-content h2,
@@ -986,6 +1021,9 @@ final class Newspack_Newsletters {
 					.main-content h5,
 					.main-content h6 {
 						font-family: <?php echo esc_attr( $font_header ); ?>;
+					}
+					.main-content a {
+						color: <?php echo esc_attr( $link_color ); ?>;
 					}
 					<?php if ( $background_color ) : ?>
 						.entry-content {

--- a/includes/class-newspack-newsletters.php
+++ b/includes/class-newspack-newsletters.php
@@ -410,22 +410,6 @@ final class Newspack_Newsletters {
 		);
 		\register_meta(
 			'post',
-			'link_color',
-			[
-				'object_subtype' => self::NEWSPACK_NEWSLETTERS_CPT,
-				'show_in_rest'   => [
-					'schema' => [
-						'context' => [ 'edit' ],
-					],
-				],
-				'type'           => 'string',
-				'single'         => true,
-				'auth_callback'  => '__return_true',
-				'default'        => '',
-			]
-		);
-		\register_meta(
-			'post',
 			'preview_text',
 			[
 				'object_subtype' => self::NEWSPACK_NEWSLETTERS_CPT,
@@ -1006,7 +990,6 @@ final class Newspack_Newsletters {
 			$font_body        = get_post_meta( $post->ID, 'font_body', true );
 			$background_color = get_post_meta( $post->ID, 'background_color', true );
 			$text_color       = get_post_meta( $post->ID, 'text_color', true );
-			$link_color       = get_post_meta( $post->ID, 'link_color', true );
 			?>
 				<style>
 					.main-content {
@@ -1021,9 +1004,6 @@ final class Newspack_Newsletters {
 					.main-content h5,
 					.main-content h6 {
 						font-family: <?php echo esc_attr( $font_header ); ?>;
-					}
-					.main-content a {
-						color: <?php echo esc_attr( $link_color ); ?>;
 					}
 					<?php if ( $background_color ) : ?>
 						.entry-content {

--- a/includes/email-template-mjml.css
+++ b/includes/email-template-mjml.css
@@ -6,7 +6,6 @@ p {
 
 /* Link */
 a {
-	color: inherit !important;
 	text-decoration: underline;
 }
 a:active, a:focus, a:hover {

--- a/includes/email-template-mjml.css
+++ b/includes/email-template-mjml.css
@@ -6,6 +6,7 @@ p {
 
 /* Link */
 a {
+	color: inherit !important;
 	text-decoration: underline;
 }
 a:active, a:focus, a:hover {

--- a/includes/email-template.mjml.php
+++ b/includes/email-template.mjml.php
@@ -14,7 +14,9 @@
 		<mj-style>
 		<?php
 			$default_css = file_get_contents( dirname( __FILE__ ) . '/email-template-mjml.css' );
-			$css         = $default_css . "\n" . $custom_css;
+			// Add global link color styling
+			$link_color_css = "a { color: " . ($link_color ?? '#0000ff') . "; }";
+			$css         = $default_css . "\n" . $link_color_css . "\n" . $custom_css;
 
 			echo esc_html( $css );
 			echo Newspack_Newsletters_Editor::get_color_palette_css();
@@ -24,6 +26,10 @@
 		<?php if ( isset( $preview_text ) ): ?>
 			<mj-preview><?php echo $preview_text; ?></mj-preview>
 		<?php endif; ?>
+		<mj-attributes>
+			<mj-all color="<?php echo $text_color ?? '#000000'; ?>" />
+			<mj-text color="<?php echo $text_color ?? '#000000'; ?>" />
+		</mj-attributes>
 	</mj-head>
 	<mj-body background-color="<?php echo $background_color; ?>" css-class="updated-<?php echo $updated; ?>">
 		<?php echo $body; ?>

--- a/includes/email-template.mjml.php
+++ b/includes/email-template.mjml.php
@@ -14,9 +14,7 @@
 		<mj-style>
 		<?php
 			$default_css = file_get_contents( dirname( __FILE__ ) . '/email-template-mjml.css' );
-			// Add global link color styling
-			$link_color_css = "a { color: " . ($link_color ?? '#0000ff') . "; }";
-			$css         = $default_css . "\n" . $link_color_css . "\n" . $custom_css;
+			$css         = $default_css . "\n" . $custom_css;
 
 			echo esc_html( $css );
 			echo Newspack_Newsletters_Editor::get_color_palette_css();

--- a/src/components/init-modal/style.scss
+++ b/src/components/init-modal/style.scss
@@ -80,6 +80,10 @@
 				line-height: 1;
 			}
 		}
+
+		.components-modal__header + div:not([class]) {
+			height: 100%;
+		}
 	}
 
 	&__content {

--- a/src/components/newsletter-preview/index.js
+++ b/src/components/newsletter-preview/index.js
@@ -69,6 +69,8 @@ const NewsletterPreview = ( { layoutId = null, meta = {}, ...props } ) => {
 				className="newspack-newsletters__layout-preview"
 				style={ {
 					backgroundColor: meta.background_color,
+					textColor: meta.text_color,
+					linkColor: meta.link_color,
 				} }
 			>
 				<BlockPreview { ...props } />

--- a/src/components/newsletter-preview/index.js
+++ b/src/components/newsletter-preview/index.js
@@ -70,7 +70,6 @@ const NewsletterPreview = ( { layoutId = null, meta = {}, ...props } ) => {
 				style={ {
 					backgroundColor: meta.background_color,
 					textColor: meta.text_color,
-					linkColor: meta.link_color,
 				} }
 			>
 				<BlockPreview { ...props } />

--- a/src/editor/style.scss
+++ b/src/editor/style.scss
@@ -90,6 +90,11 @@
 
 		a {
 			font-family: inherit;
+			text-decoration: underline;
+		}
+
+		a:not(:is(.wp-block-paragraph.has-link-color a, .wp-block-paragraph.has-link-color * a)) {
+			color: inherit;
 		}
 
 		code {

--- a/src/newsletter-editor/layout/index.js
+++ b/src/newsletter-editor/layout/index.js
@@ -30,6 +30,8 @@ export default compose( [
 		const meta = getEditedPostAttribute( 'meta' );
 		const {
 			background_color,
+			text_color,
+			link_color,
 			font_body,
 			font_header,
 			custom_css,
@@ -40,6 +42,8 @@ export default compose( [
 		} = meta;
 		const layoutMeta = {
 			background_color,
+			text_color,
+			link_color,
 			font_body,
 			font_header,
 			custom_css,

--- a/src/newsletter-editor/layout/index.js
+++ b/src/newsletter-editor/layout/index.js
@@ -31,7 +31,6 @@ export default compose( [
 		const {
 			background_color,
 			text_color,
-			link_color,
 			font_body,
 			font_header,
 			custom_css,
@@ -43,7 +42,6 @@ export default compose( [
 		const layoutMeta = {
 			background_color,
 			text_color,
-			link_color,
 			font_body,
 			font_header,
 			custom_css,

--- a/src/newsletter-editor/styling/index.js
+++ b/src/newsletter-editor/styling/index.js
@@ -75,6 +75,8 @@ const customStylesSelector = select => {
 		fontBody: meta.font_body || fontOptgroups[ 1 ].options[ 0 ].value,
 		fontHeader: meta.font_header || fontOptgroups[ 0 ].options[ 0 ].value,
 		backgroundColor: meta.background_color || '#ffffff',
+		textColor: meta.text_color || '#000000',
+		linkColor: meta.link_color || '#0000ff',
 		customCss: meta.custom_css || '',
 	};
 };
@@ -148,7 +150,7 @@ export const useCustomFontsInIframe = () => {
 };
 
 export const ApplyStyling = withSelect( customStylesSelector )(
-	( { fontBody, fontHeader, backgroundColor, customCss } ) => {
+	( { fontBody, fontHeader, backgroundColor, textColor, linkColor, customCss } ) => {
 		useEffect( () => {
 			document.documentElement.style.setProperty( '--newspack-body-font', fontBody );
 		}, [ fontBody ] );
@@ -159,8 +161,18 @@ export const ApplyStyling = withSelect( customStylesSelector )(
 			const editorElement = document.querySelector( '.editor-styles-wrapper' );
 			if ( editorElement ) {
 				editorElement.style.backgroundColor = backgroundColor;
+				editorElement.style.color = textColor;
 			}
-		}, [ backgroundColor ] );
+		}, [ backgroundColor, textColor ] );
+		useEffect( () => {
+			const editorElement = document.querySelector( '.editor-styles-wrapper' );
+			if ( editorElement ) {
+				const links = editorElement.getElementsByTagName('a');
+				Array.from(links).forEach(link => {
+					link.style.color = linkColor;
+				});
+			}
+		}, [ linkColor ] );
 		useEffect( () => {
 			const editorElement = document.querySelector( '.edit-post-visual-editor' );
 			if ( editorElement ) {
@@ -188,7 +200,7 @@ export const Styling = compose( [
 		return { editPost };
 	} ),
 	withSelect( customStylesSelector ),
-] )( ( { editPost, fontBody, fontHeader, customCss, backgroundColor } ) => {
+] )( ( { editPost, fontBody, fontHeader, customCss, backgroundColor, textColor, linkColor } ) => {
 	const updateStyleValue = ( key, value ) => {
 		editPost( { meta: { [ key ]: value } } );
 	};
@@ -221,11 +233,31 @@ export const Styling = compose( [
 			</PanelBody>
 			<PanelBody name="newsletters-color-panel" title={ __( 'Color', 'newspack-newsletters' ) }>
 				<PanelRow className="newspack-newsletters__color-panel">
-					<BaseControl label={ __( 'Background color', 'newspack-newsletters' ) } id={ id }>
+					<BaseControl label={ __( 'Background color', 'newspack-newsletters' ) } id={ `${ id }-bg` }>
 						<ColorPicker
-							id={ id }
+							id={ `${ id }-bg` }
 							color={ backgroundColor }
 							onChangeComplete={ value => updateStyleValue( 'background_color', value.hex ) }
+							disableAlpha
+						/>
+					</BaseControl>
+				</PanelRow>
+				<PanelRow className="newspack-newsletters__color-panel">
+					<BaseControl label={ __( 'Text color', 'newspack-newsletters' ) } id={ `${ id }-text` }>
+						<ColorPicker
+							id={ `${ id }-text` }
+							color={ textColor }
+							onChangeComplete={ value => updateStyleValue( 'text_color', value.hex ) }
+							disableAlpha
+						/>
+					</BaseControl>
+				</PanelRow>
+				<PanelRow className="newspack-newsletters__color-panel">
+					<BaseControl label={ __( 'Link color', 'newspack-newsletters' ) } id={ `${ id }-link` }>
+						<ColorPicker
+							id={ `${ id }-link` }
+							color={ linkColor }
+							onChangeComplete={ value => updateStyleValue( 'link_color', value.hex ) }
 							disableAlpha
 						/>
 					</BaseControl>

--- a/src/newsletter-editor/styling/index.js
+++ b/src/newsletter-editor/styling/index.js
@@ -76,7 +76,6 @@ const customStylesSelector = select => {
 		fontHeader: meta.font_header || fontOptgroups[ 0 ].options[ 0 ].value,
 		backgroundColor: meta.background_color || '#ffffff',
 		textColor: meta.text_color || '#000000',
-		linkColor: meta.link_color || '#0000ff',
 		customCss: meta.custom_css || '',
 	};
 };
@@ -150,7 +149,7 @@ export const useCustomFontsInIframe = () => {
 };
 
 export const ApplyStyling = withSelect( customStylesSelector )(
-	( { fontBody, fontHeader, backgroundColor, textColor, linkColor, customCss } ) => {
+	( { fontBody, fontHeader, backgroundColor, textColor, customCss } ) => {
 		useEffect( () => {
 			document.documentElement.style.setProperty( '--newspack-body-font', fontBody );
 		}, [ fontBody ] );
@@ -164,15 +163,6 @@ export const ApplyStyling = withSelect( customStylesSelector )(
 				editorElement.style.color = textColor;
 			}
 		}, [ backgroundColor, textColor ] );
-		useEffect( () => {
-			const editorElement = document.querySelector( '.editor-styles-wrapper' );
-			if ( editorElement ) {
-				const links = editorElement.getElementsByTagName('a');
-				Array.from(links).forEach(link => {
-					link.style.color = linkColor;
-				});
-			}
-		}, [ linkColor ] );
 		useEffect( () => {
 			const editorElement = document.querySelector( '.edit-post-visual-editor' );
 			if ( editorElement ) {
@@ -200,7 +190,7 @@ export const Styling = compose( [
 		return { editPost };
 	} ),
 	withSelect( customStylesSelector ),
-] )( ( { editPost, fontBody, fontHeader, customCss, backgroundColor, textColor, linkColor } ) => {
+] )( ( { editPost, fontBody, fontHeader, customCss, backgroundColor, textColor } ) => {
 	const updateStyleValue = ( key, value ) => {
 		editPost( { meta: { [ key ]: value } } );
 	};
@@ -248,16 +238,6 @@ export const Styling = compose( [
 							id={ `${ id }-text` }
 							color={ textColor }
 							onChangeComplete={ value => updateStyleValue( 'text_color', value.hex ) }
-							disableAlpha
-						/>
-					</BaseControl>
-				</PanelRow>
-				<PanelRow className="newspack-newsletters__color-panel">
-					<BaseControl label={ __( 'Link color', 'newspack-newsletters' ) } id={ `${ id }-link` }>
-						<ColorPicker
-							id={ `${ id }-link` }
-							color={ linkColor }
-							onChangeComplete={ value => updateStyleValue( 'link_color', value.hex ) }
 							disableAlpha
 						/>
 					</BaseControl>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR adds a global text colour control to the newsletter styles panel. It also adds support for link colour, specifically the Paragraph block. The reason is by default a link will inherit the text colour but in some cases, the user might want a different colour for a specific paragraph.

Note: The link colour settings is only available on block themes so to test this functionality you will need to activate Newspack Block Theme.

https://github.com/user-attachments/assets/aad4d6df-8d60-4bf6-b2be-ea8a9f5e32d4

### How to test the changes in this Pull Request:

1. Switch to this branch
2. Create a new newsletter
3. Change the global text colour
4. Edit a paragraph block and add an inline link.
5. Customise the color of the links in your paragraph block (note: for this step you need the Block Theme).
6. Send a test email.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
