### PR TITLE
feat(embed): update preview icons

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
 			"version": "3.8.0",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
+				"@wordpress/icons": "^10.18.0",
 				"classnames": "^2.5.1",
 				"mjml-browser": "^4.15.3",
 				"newspack-components": "^3.1.0",
@@ -1914,8 +1915,9 @@
 			"license": "MIT"
 		},
 		"node_modules/@babel/runtime": {
-			"version": "7.24.7",
-			"license": "MIT",
+			"version": "7.25.7",
+			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.25.7.tgz",
+			"integrity": "sha512-FjoyLe754PMiYsFaN5C94ttGiOmBNYTf6pLr4xXHAT5uctHb092PBszndLDR5XA/jghQvn4n7JMHl7dmTgbm9w==",
 			"dependencies": {
 				"regenerator-runtime": "^0.14.0"
 			},
@@ -6627,14 +6629,14 @@
 			}
 		},
 		"node_modules/@wordpress/element": {
-			"version": "6.5.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-6.5.0.tgz",
-			"integrity": "sha512-N9w3jfceltdDEN71jpaMCXU+jbvec9kredvQIn/6YNiUMarPXWth7DJYU3+mDtbYawnTIvytzGjbj/J+bqqdHg==",
+			"version": "6.18.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-6.18.0.tgz",
+			"integrity": "sha512-38wA2ta4GGOxuKofmyNP+EWA03bqBwUufQNQNd8GgcaKo4N/j+0wQMouLC/2g6n9MU5B0DH4tIv9uP9qR1miYg==",
 			"dependencies": {
-				"@babel/runtime": "^7.16.0",
+				"@babel/runtime": "7.25.7",
 				"@types/react": "^18.2.79",
 				"@types/react-dom": "^18.2.25",
-				"@wordpress/escape-html": "^3.5.0",
+				"@wordpress/escape-html": "^3.18.0",
 				"change-case": "^4.1.2",
 				"is-plain-object": "^5.0.0",
 				"react": "^18.3.0",
@@ -6646,11 +6648,11 @@
 			}
 		},
 		"node_modules/@wordpress/escape-html": {
-			"version": "3.5.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-3.5.0.tgz",
-			"integrity": "sha512-8dUWTmsDZuqAmBtRgk0JpiIafRKPM4n8tqCr147AugTbP/vyQ7rIzG3M/YCtVSmDr6f/qZ32YU8J7c34RhZ/9g==",
+			"version": "3.18.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-3.18.0.tgz",
+			"integrity": "sha512-5hcsoIin5IYAEejuRJqnFQB5q5C0q8VII/H7wWOWoe8IXiRQCiju/DWRC25AL2xWdUdaqiG84JuiPq+7Npb8gw==",
 			"dependencies": {
-				"@babel/runtime": "^7.16.0"
+				"@babel/runtime": "7.25.7"
 			},
 			"engines": {
 				"node": ">=18.12.0",
@@ -6741,13 +6743,13 @@
 			}
 		},
 		"node_modules/@wordpress/icons": {
-			"version": "10.5.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-10.5.0.tgz",
-			"integrity": "sha512-BZwKBRKoTef9uW73T+FwK6d4JlcvgdVAaz3LB5dCluXg5PLV5ufMdumAaMxKWq/Ffl92/ddt8CKIdHjxfAZF4A==",
+			"version": "10.18.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-10.18.0.tgz",
+			"integrity": "sha512-stWW0msTspv6wCB3Pcu7PtVoFQBRr4R+oOvXlxVnpsUKuUz+mIAS08Sme9bTkHiVtHBZRK6YGpt4wYK6W0FXcw==",
 			"dependencies": {
-				"@babel/runtime": "^7.16.0",
-				"@wordpress/element": "^6.5.0",
-				"@wordpress/primitives": "^4.5.0"
+				"@babel/runtime": "7.25.7",
+				"@wordpress/element": "^6.18.0",
+				"@wordpress/primitives": "^4.18.0"
 			},
 			"engines": {
 				"node": ">=18.12.0",
@@ -7036,12 +7038,12 @@
 			}
 		},
 		"node_modules/@wordpress/primitives": {
-			"version": "4.5.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/primitives/-/primitives-4.5.0.tgz",
-			"integrity": "sha512-1TYCpCAr2BmYJESlD8v325GgYXSgUbrFtebwgvpMN/28CEwmPN+ORRECV41nPX4yVJ2k0kYzYxzQUGp/78xWsw==",
+			"version": "4.18.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/primitives/-/primitives-4.18.0.tgz",
+			"integrity": "sha512-c/8wC1MgbiQc/8kQlxuNuzeDeEW65jHSK0/qZ/afvHL1T4AmYmyC791nabpyGM+Le1kwe1LCDbPo/x2Oig0nbA==",
 			"dependencies": {
-				"@babel/runtime": "^7.16.0",
-				"@wordpress/element": "^6.5.0",
+				"@babel/runtime": "7.25.7",
+				"@wordpress/element": "^6.18.0",
 				"clsx": "^2.1.1"
 			},
 			"engines": {

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
 		"url": "https://github.com/Automattic/newspack-newsletters/issues"
 	},
 	"dependencies": {
+		"@wordpress/icons": "^10.18.0",
 		"classnames": "^2.5.1",
 		"mjml-browser": "^4.15.3",
 		"newspack-components": "^3.1.0",

--- a/src/editor/blocks/embed/index.js
+++ b/src/editor/blocks/embed/index.js
@@ -12,7 +12,7 @@ import { select } from '@wordpress/data';
 import { ToolbarButton, ToolbarGroup, Placeholder } from '@wordpress/components';
 import { BlockControls, useBlockProps, RichText } from '@wordpress/block-editor';
 import { createBlock } from '@wordpress/blocks';
-import { globe } from '@wordpress/icons';
+import { envelope, layout } from '@wordpress/icons';
 
 /**
  * Internal dependencies
@@ -113,7 +113,7 @@ export default () => {
 						<BlockControls>
 							<ToolbarGroup>
 								<ToolbarButton
-									icon="email"
+									icon={ envelope }
 									label={ __( 'Preview email format', 'newspack-newsletters' ) }
 									isActive={ isViewingEmail }
 									onClick={ () => {
@@ -121,7 +121,7 @@ export default () => {
 									} }
 								/>
 								<ToolbarButton
-									icon={ globe }
+									icon={ layout }
 									label={ __( 'Preview web format', 'newspack-newsletters' ) }
 									isActive={ ! isViewingEmail }
 									onClick={ () => {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This is a tiny PR that:

* Add the latest npm package for `@wordpress/icons`
* Updates the preview embed icons

### How to test the changes in this Pull Request:

1. Add an embed block (e.g. youtube) to your newsletter
2. Notice the icons
3. Switch to this branch
4. Refresh newsletter
5. Notice new icons

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
