### PR TITLE
fix(editor): allow newsletter editor JS to run for manual ESP

### DIFF
--- a/src/newsletter-editor/index.js
+++ b/src/newsletter-editor/index.js
@@ -9,7 +9,7 @@ import {
 	PluginSidebar,
 	PluginSidebarMoreMenuItem,
 	PluginPostStatusInfo,
-} from '@wordpress/edit-post';
+} from '@wordpress/editor';
 import { registerPlugin } from '@wordpress/plugins';
 import { styles } from '@wordpress/icons';
 
@@ -26,7 +26,7 @@ import { PublicSettings } from './public';
 import registerEditorPlugin from './editor/';
 import withApiHandler from '../components/with-api-handler';
 import { registerStore, fetchNewsletterData, useNewsletterDataError } from './store';
-import { isSupportedESP } from './utils';
+import { isManualESP, isSupportedESP } from './utils';
 import CampaignLink from './campaign-link';
 import './debug-send';
 
@@ -125,19 +125,22 @@ function NewsletterEdit( { apiFetchWithErrorHandling, setInFlightForAsync, inFli
 				{ isConnected && <PublicSettings /> }
 			</PluginPostStatusInfo>
 
-			<PluginDocumentSettingPanel
-				name="newsletters-settings-panel"
-				title={ __( 'Newsletter Campaign', 'newspack-newsletters' ) }
-			>
-				<CampaignLink />
-				<Sidebar
-					inFlight={ inFlight }
-					isConnected={ isConnected }
-					oauthUrl={ oauthUrl }
-					onAuthorize={ verifyToken }
-				/>
-			</PluginDocumentSettingPanel>
-			{ isSupportedESP() && (
+			{ isSupportedESP() && ! isManualESP() && (
+				<PluginDocumentSettingPanel
+					name="newsletters-settings-panel"
+					title={ __( 'Newsletter Campaign', 'newspack-newsletters' ) }
+				>
+					<CampaignLink />
+					<Sidebar
+						inFlight={ inFlight }
+						isConnected={ isConnected }
+						oauthUrl={ oauthUrl }
+						onAuthorize={ verifyToken }
+					/>
+				</PluginDocumentSettingPanel>
+			) }
+
+			{ isSupportedESP() && ! isManualESP() && (
 				<PluginDocumentSettingPanel
 					name="newsletters-testing-panel"
 					title={ __( 'Testing', 'newspack-newsletters' ) }

--- a/src/newsletter-editor/store.js
+++ b/src/newsletter-editor/store.js
@@ -17,6 +17,7 @@ import { addQueryArgs } from '@wordpress/url';
 /**
  * Internal dependencies
  */
+import { isManualESP, isSupportedESP } from './utils';
 import { getServiceProvider } from '../service-providers';
 
 /**
@@ -117,6 +118,10 @@ export const updateNewsletterDataError = error =>
 
 // Dispatcher to fetch newsletter data from the server.
 export const fetchNewsletterData = async postId => {
+	if ( ! isSupportedESP() || isManualESP() ) {
+		return;
+	}
+
 	const isRetrieving = coreSelect( STORE_NAMESPACE ).getIsRetrieving();
 	if ( isRetrieving ) {
 		return;
@@ -148,6 +153,10 @@ export const fetchNewsletterData = async postId => {
 
 // Dispatcher to fetch any errors from the most recent sync attempt.
 export const fetchSyncErrors = async postId => {
+	if ( ! isSupportedESP() || isManualESP() ) {
+		return;
+	}
+
 	const isRetrieving = coreSelect( STORE_NAMESPACE ).getIsRetrieving();
 	if ( isRetrieving ) {
 		return;
@@ -170,6 +179,10 @@ export const fetchSyncErrors = async postId => {
 
 // Dispatcher to fetch send lists and sublists from the connected ESP and update the newsletterData in store.
 export const fetchSendLists = debounce( async ( opts, replace = false ) => {
+	if ( ! isSupportedESP() || isManualESP() ) {
+		return [];
+	}
+
 	updateNewsletterDataError( null );
 	try {
 		const { name } = getServiceProvider();

--- a/src/newsletter-editor/utils.js
+++ b/src/newsletter-editor/utils.js
@@ -12,15 +12,25 @@ import { __ } from '@wordpress/i18n';
 import { getServiceProvider } from '../service-providers';
 
 /**
- * Is the current ESP a supported, connected ESP?
+ * Is the current ESP a supported ESP?
+ *
+ * @return {boolean} True if the ESP is supported.
+ */
+export const isSupportedESP = () => {
+	const { supported_esps: supportedESPs } = newspack_email_editor_data || {};
+	const { name: serviceProviderName } = getServiceProvider();
+	return serviceProviderName && supportedESPs?.includes( serviceProviderName );
+};
+
+/**
+ * Is the current ESP "manual"?
  *
  * @return {boolean} True if the ESP is supported and connected.
  */
-export const isSupportedESP = () => {
-	const { supported_esps: suppportedESPs } = newspack_email_editor_data || {};
+export const isManualESP = () => {
 	const { name: serviceProviderName } = getServiceProvider();
-	return serviceProviderName && 'manual' !== serviceProviderName && suppportedESPs?.includes( serviceProviderName );
-};
+	return 'manual' === serviceProviderName;
+}
 
 /**
  * Validation utility.


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

#1658 accidentally broke the layout editor and other Newsletter CPT-specific editor sidebars for the "manual" ESP. This restores those items without also trying to fetch data from a nonexistent ESP API.

Closes `1200550061930446/1209518851763061`

### How to test the changes in this Pull Request:

1. In Newsletters > Settings, set your Service Provider to "Manual / Other"
2. On `release`, create a new newsletter. Observe that the layout selection modal is not displayed, and that no newsletter-specific sidebars are shown in the editor (Ads Settings, Layout, Advertisers).
3. Check out this branch and create a new newsletter again. This time, confirm that the layout selection modal is displayed, that the editor populates its content after selecting a layout, and that the newsletter-specific sidebars are shown in the editor (all except for Newsletter Campaign, which is only relevant for connected ESPs).
4. Smoke test previewing and sending the newsletter and confirm that all works as expected. Note that for the "manual" ESP sending the newsletter means showing the pre-send modal with an option to mark the post as sent as well as copy the HTML to manually paste into an external ESP.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1209518851763061