### PR TITLE
feat: update buttons style in editor

### DIFF
--- a/src/ads/newsletter-editor/disable-auto-ads.js
+++ b/src/ads/newsletter-editor/disable-auto-ads.js
@@ -93,6 +93,8 @@ export default function DisableAutoAds( { saveOnToggle = false } ) {
 						rel={ adsConfig.manageUrlRel }
 						target={ adsConfig.manageUrlTarget }
 						variant="secondary"
+						className="newspack-newsletters-button--full-width"
+						__next40pxDefaultSize
 					>
 						{
 							// Translators: "manage ad" message.

--- a/src/ads/newsletter-editor/index.js
+++ b/src/ads/newsletter-editor/index.js
@@ -10,7 +10,7 @@ function NewslettersAdsSettings() {
 	return (
 		<PluginDocumentSettingPanel
 			name="newsletters-ads-settings-panel"
-			title={ __( 'Ads Settings', 'newspack-newsletters' ) }
+			title={ __( 'Advertising', 'newspack-newsletters' ) }
 		>
 			<DisableAutoAds />
 		</PluginDocumentSettingPanel>

--- a/src/components/init-modal/screens/layout-picker/index.js
+++ b/src/components/init-modal/screens/layout-picker/index.js
@@ -23,11 +23,11 @@ import SingleLayoutPreview from './SingleLayoutPreview';
 
 const LAYOUTS_TABS = [
 	{
-		title: __( 'Prebuilt Layouts', 'newspack-newsletters' ),
+		title: __( 'Prebuilt layouts', 'newspack-newsletters' ),
 		filter: layout => layout.post_author === undefined,
 	},
 	{
-		title: __( 'Saved Layouts', 'newspack-newsletters' ),
+		title: __( 'Saved layouts', 'newspack-newsletters' ),
 		filter: isUserDefinedLayout,
 		isEditable: true,
 	},
@@ -125,15 +125,15 @@ export default function LayoutPicker() {
 				</div>
 			</div>
 			<div className="newspack-newsletters-modal__action-buttons">
-				<Button isSecondary onClick={ () => insertLayout( BLANK_LAYOUT_ID ) }>
-					{ __( 'Blank Newsletter', 'newspack-newsletters' ) }
+				<Button variant="secondary" onClick={ () => insertLayout( BLANK_LAYOUT_ID ) }>
+					{ __( 'Blank newsletter', 'newspack-newsletters' ) }
 				</Button>
 				<Button
-					isPrimary
+					variant="primary"
 					disabled={ isFetchingLayouts || ! selectedLayoutId }
 					onClick={ () => insertLayout( selectedLayoutId ) }
 				>
-					{ __( 'Use Selected Layout', 'newspack-newsletters' ) }
+					{ __( 'Use selected layout', 'newspack-newsletters' ) }
 				</Button>
 			</div>
 		</>

--- a/src/editor/style.scss
+++ b/src/editor/style.scss
@@ -399,14 +399,16 @@
 
 .newspack-newsletters {
 	&__modal {
-		max-width: 360px;
-
-		.components-button + .components-button {
-			margin-left: 12px;
-		}
-
+		p,
 		.components-notice {
 			margin: 0;
+		}
+
+		.newspack-newsletters__modal-buttons {
+			display: flex;
+			flex-direction: row-reverse;
+			gap: 12px;
+			margin-top: 24px;
 		}
 	}
 }

--- a/src/newsletter-editor/editor/style.scss
+++ b/src/newsletter-editor/editor/style.scss
@@ -11,5 +11,10 @@
 		display: flex;
 		flex-wrap: wrap;
 		gap: 12px;
+
+		.components-button {
+			flex: 1 1 100%;
+			justify-content: center;
+		}
 	}
 }

--- a/src/newsletter-editor/layout/index.js
+++ b/src/newsletter-editor/layout/index.js
@@ -190,26 +190,31 @@ export default compose( [
 						variant="secondary"
 						disabled={ isEditedPostEmpty || isSavingLayout }
 						onClick={ () => setIsManageModalVisible( true ) }
+						__next40pxDefaultSize
 					>
-						{ __( 'Save New Layout', 'newspack-newsletters' ) }
+						{ __( 'Save new layout', 'newspack-newsletters' ) }
 					</Button>
 
 					{ isUsingCustomLayout && (
 						<Button
-							variant="tertiary"
-							disabled={ isPostContentSameAsLayout || isSavingLayout }
+							variant="secondary"
+							disabled={ isPostContentSameAsLayout || ( isSavingLayout && isManageModalVisible ) }
+							isBusy={ isSavingLayout && ! isManageModalVisible }
 							onClick={ handeLayoutUpdate }
+							__next40pxDefaultSize
 						>
-							{ __( 'Update Layout', 'newspack-newsletters' ) }
+							{ __( 'Update layout', 'newspack-newsletters' ) }
 						</Button>
 					) }
 
 					<Button
 						variant="secondary"
 						isDestructive
+						disabled={ isEditedPostEmpty || isSavingLayout }
 						onClick={ () => setWarningModalVisible( true ) }
+						__next40pxDefaultSize
 					>
-						{ __( 'Reset Layout', 'newspack-newsletters' ) }
+						{ __( 'Reset layout', 'newspack-newsletters' ) }
 					</Button>
 				</div>
 
@@ -218,6 +223,7 @@ export default compose( [
 						className="newspack-newsletters__modal"
 						title={ __( 'Save newsletter as a layout', 'newspack-newsletters' ) }
 						onRequestClose={ () => setIsManageModalVisible( null ) }
+						size="small"
 					>
 						<TextControl
 							label={ __( 'Title', 'newspack-newsletters' ) }
@@ -225,43 +231,50 @@ export default compose( [
 							value={ newLayoutName }
 							onChange={ setNewLayoutName }
 						/>
-						<Button
-							isPrimary
-							disabled={ isSavingLayout || newLayoutName.length === 0 }
-							onClick={ handleSaveAsLayout }
-						>
-							{ __( 'Save', 'newspack-newsletters' ) }
-						</Button>
-						<Button isSecondary onClick={ () => setIsManageModalVisible( null ) }>
-							{ __( 'Cancel', 'newspack-newsletters' ) }
-						</Button>
+						<div className="newspack-newsletters__modal-buttons">
+							<Button
+								variant="primary"
+								disabled={ newLayoutName.length === 0 }
+								isBusy={ isSavingLayout }
+								onClick={ handleSaveAsLayout }
+							>
+								{ __( 'Save', 'newspack-newsletters' ) }
+							</Button>
+							<Button variant="tertiary" onClick={ () => setIsManageModalVisible( null ) }>
+								{ __( 'Cancel', 'newspack-newsletters' ) }
+							</Button>
+						</div>
 					</Modal>
 				) }
 
 				{ warningModalVisible && (
 					<Modal
 						className="newspack-newsletters__modal"
-						title={ __( 'Overwrite newsletter content?', 'newspack-newsletters' ) }
+						title={ __( 'Reset newsletter layout?', 'newspack-newsletters' ) }
 						onRequestClose={ () => setWarningModalVisible( false ) }
+						size="small"
 					>
 						<p>
 							{ __(
-								"Changing the newsletter's layout will remove any customizations or edits you have already made.",
+								"Resetting the layout will remove all customizations and edits you’ve made. This action cannot be undone.",
 								'newspack-newsletters'
 							) }
 						</p>
-						<Button
-							isPrimary
-							onClick={ () => {
-								editPost( { content: '', meta: { template_id: -1 } } );
-								setWarningModalVisible( false );
-							} }
-						>
-							{ __( 'Reset layout', 'newspack-newsletters' ) }
-						</Button>
-						<Button isSecondary onClick={ () => setWarningModalVisible( false ) }>
-							{ __( 'Cancel', 'newspack-newsletters' ) }
-						</Button>
+						<div className="newspack-newsletters__modal-buttons">
+							<Button
+								variant="primary"
+								isDestructive
+								onClick={ () => {
+									editPost( { content: '', meta: { template_id: -1 } } );
+									setWarningModalVisible( false );
+								} }
+							>
+								{ __( 'Reset layout', 'newspack-newsletters' ) }
+							</Button>
+							<Button variant="tertiary" onClick={ () => setWarningModalVisible( false ) }>
+								{ __( 'Cancel', 'newspack-newsletters' ) }
+							</Button>
+						</div>
 					</Modal>
 				) }
 			</Fragment>

--- a/src/newsletter-editor/testing/index.js
+++ b/src/newsletter-editor/testing/index.js
@@ -6,7 +6,7 @@ import { __ } from '@wordpress/i18n';
 import { withSelect, withDispatch } from '@wordpress/data';
 import { compose } from '@wordpress/compose';
 import { useEffect, useState, Fragment } from '@wordpress/element';
-import { Button, Spinner, TextControl } from '@wordpress/components';
+import { Button, TextControl } from '@wordpress/components';
 import { hasValidEmail , usePrevious } from '../utils';
 
 /**
@@ -113,13 +113,14 @@ export default compose( [
 					<Button
 						variant="secondary"
 						onClick={ triggerSave }
-						disabled={ disabled || localInFlight || inFlight || ! hasValidEmail( testEmail ) }
+						isBusy={ inFlight || localInFlight }
+						disabled={ disabled || ! hasValidEmail( testEmail ) }
+						__next40pxDefaultSize
 					>
 						{ inFlight || localInFlight
-							? __( 'Sending Test Email…', 'newspack-newsletters' )
-							: __( 'Send a Test Email', 'newspack-newsletters' ) }
+							? __( 'Sending test email…', 'newspack-newsletters' )
+							: __( 'Send a test email', 'newspack-newsletters' ) }
 					</Button>
-					{ ( inFlight || localInFlight ) && <Spinner /> }
 				</div>
 				{ localMessage ? (
 					<p className="newspack-newsletters__testing-message">{ localMessage }</p>

--- a/src/newsletter-editor/testing/style.scss
+++ b/src/newsletter-editor/testing/style.scss
@@ -1,7 +1,16 @@
 .newspack-newsletters {
 	&__testing-controls {
-		align-items: center;
 		display: flex;
-		justify-content: flex-start;
+
+		.components-button {
+			flex: 1 1 100%;
+			justify-content: center;
+		}
+	}
+
+	&-button--full-width {
+		display: flex;
+		flex: 1 1 100%;
+		justify-content: center;
 	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR does not change any functionalities but improves consistency across buttons in terms of size and labeling (following WP’s no-capitalisation principle). Additionally, it adds `isBusy` to some layout actions and removes the `Spinner`.

### How to test the changes in this Pull Request:

1. Switch to this branch
2. Make sure the actions (Layout, Test email, Manage ads) are still working

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
