### PR TITLE
fix: add UTM parameters to link URLs inside newsletter content

### DIFF
--- a/includes/class-newspack-newsletters-renderer.php
+++ b/includes/class-newspack-newsletters-renderer.php
@@ -407,10 +407,10 @@ final class Newspack_Newsletters_Renderer {
 			'utm_medium' => 'email',
 		];
 		if ( $campaign_name ) {
-			$utm_params['utm_campaign'] = $campaign_name;
+			$utm_params['utm_campaign'] = rawurlencode( $campaign_name );
 		}
 		if ( $send_list_id ) {
-			$utm_params['utm_source'] = $send_list_id;
+			$utm_params['utm_source'] = rawurlencode( $send_list_id );
 		}
 		foreach ( $urls as $index => $url ) {
 			/** Skip if link was already processed. */

--- a/includes/class-newspack-newsletters-renderer.php
+++ b/includes/class-newspack-newsletters-renderer.php
@@ -398,8 +398,20 @@ final class Newspack_Newsletters_Renderer {
 	 */
 	public static function process_links( $html, $post = null ) {
 		preg_match_all( '/href="([^"]*)"/', $html, $matches );
-		$href_params = $matches[0];
-		$urls        = $matches[1];
+		$href_params   = $matches[0];
+		$urls          = $matches[1];
+		$provider      = Newspack_Newsletters::get_service_provider();
+		$campaign_name = $post ? $provider->get_campaign_name( $post ) : false;
+		$send_list_id  = $post ? get_post_meta( $post->ID, 'send_list_id', true ) : false;
+		$utm_params    = [
+			'utm_medium' => 'email',
+		];
+		if ( $campaign_name ) {
+			$utm_params['utm_campaign'] = $campaign_name;
+		}
+		if ( $send_list_id ) {
+			$utm_params['utm_source'] = $send_list_id;
+		}
 		foreach ( $urls as $index => $url ) {
 			/** Skip if link was already processed. */
 			if ( ! empty( self::$processed_links[ $url ] ) ) {
@@ -412,9 +424,7 @@ final class Newspack_Newsletters_Renderer {
 			$url_with_params = apply_filters(
 				'newspack_newsletters_process_link',
 				add_query_arg(
-					[
-						'utm_medium' => 'email',
-					],
+					$utm_params,
 					$url
 				),
 				$url,

--- a/includes/class-newspack-newsletters-renderer.php
+++ b/includes/class-newspack-newsletters-renderer.php
@@ -401,11 +401,14 @@ final class Newspack_Newsletters_Renderer {
 		$href_params   = $matches[0];
 		$urls          = $matches[1];
 		$provider      = Newspack_Newsletters::get_service_provider();
-		$campaign_name = $post ? $provider->get_campaign_name( $post ) : false;
+		$campaign_name = $post && $provider ? $provider->get_campaign_name( $post ) : false;
 		$send_list_id  = $post ? get_post_meta( $post->ID, 'send_list_id', true ) : false;
 		$utm_params    = [
 			'utm_medium' => 'email',
 		];
+		if ( ! $campaign_name && $post ) {
+			$campaign_name = get_the_title( $post );
+		}
 		if ( $campaign_name ) {
 			$utm_params['utm_campaign'] = rawurlencode( $campaign_name );
 		}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

We currently add `utm_medium=email` to all link URLs inside newsletter content, but no other params. This PR adds the following UTM params as well:

- `utm_campaign` - Should match the value of the Campaign Name field (but URL-encoded)
- `utm_source` - The ID of the top-level send list the newsletter is being sent to (but URL-encoded)

Note that the connected ESP or other third-party integrations may overwrite some or all of these parameters with its own. For example, if using Mailchimp with the [Google Analytics extension](https://mailchimp.com/help/integrate-google-analytics-with-mailchimp/), the GA extension will set its own `utm_campaign` and `utm_source` values, overwriting our defaults.

### How to test the changes in this Pull Request:

1. Create a new newsletter and make sure its content contains some links.
2. Save the newsletter to trigger a sync to the connected ESP.
3. In the connected ESP, view the synced campaign's HTML and confirm that all links in the content have `utm_medium`, `utm_campaign`, and `utm_source` parameters as defined above
4. Send the campaign to a test list at which you can receive the live email. Click through the links in the email content and confirm that `utm_medium`, `utm_campaign`, and `utm_source` parameters are passed through to the ultimate destination. (This last step is necessary because most ESPs filter in-content URLs through their own tracking redirects.)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1209564094585411