### PR TITLE
fix: registration page event meta

### DIFF
--- a/src/blocks/subscribe/index.php
+++ b/src/blocks/subscribe/index.php
@@ -474,8 +474,12 @@ function process_form() {
 	$email     = \sanitize_email( $_REQUEST['npe'] ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 	$lists     = array_map( 'sanitize_text_field', $_REQUEST['lists'] ); // phpcs:ignore
 	$popup_id  = isset( $_REQUEST['newspack_popup_id'] ) ? (int) $_REQUEST['newspack_popup_id'] : false; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
-	$metadata  = [
-		'current_page_url'                => home_url( add_query_arg( array(), \wp_get_referer() ) ),
+	$current_page_url = \wp_get_raw_referer();
+	if ( strpos( $current_page_url, 'http' ) !== 0 ) {
+		$current_page_url = \home_url( $current_page_url );
+	}
+	$metadata = [
+		'current_page_url'                => $current_page_url,
 		'newspack_popup_id'               => $popup_id,
 		'newsletters_subscription_method' => 'newsletters-subscription-block',
 	];


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

This fixes an issue identified while testing https://github.com/Automattic/newspack-plugin/pull/3779#issuecomment-2715251472 

The Registration page is getting a broken URL, where the site base URL shows up twice. Ex: 

```
"NP_Registration Page": "https:\/\/leogermani.sa.ngrok.io\/https:\/\/leogermani.sa.ngrok.io\/buy-news\/?utm_medium=test&utm_campaign=NRH&utm_content=NRH+content"
```

Note: Also removed the call for `add_query_arg()` because:
1. It was having no effect. Passing an empty array will not do anything
2. We can't strip the query string out of the URL because it's used later in the sync process to extract the UTM data

### How to test the changes in this Pull Request:

1. Set up a site with RAS
3. Add a newsletter registration block to a page
4. on trunk or release, subscribe to a newsletter
5. Inspect the ESP sync data and look at the value on "Registration page". You should see the duplicate URL
6. Checkout this branch and confirm it fixes it.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
