### PR TITLE
fix(editor): fix multiple-emails notice for AC and MC ESPs

### DIFF
--- a/includes/service-providers/active_campaign/class-newspack-newsletters-active-campaign.php
+++ b/includes/service-providers/active_campaign/class-newspack-newsletters-active-campaign.php
@@ -799,9 +799,8 @@ final class Newspack_Newsletters_Active_Campaign extends \Newspack_Newsletters_S
 			$send_list_id    = get_post_meta( $post_id, 'send_list_id', true );
 			$send_sublist_id = get_post_meta( $post_id, 'send_sublist_id', true );
 			$newsletter_data = [
-				'campaign'                          => true, // Satisfy the JS API.
-				'campaign_id'                       => $campaign_id,
-				'supports_multiple_test_recipients' => true,
+				'campaign'    => true, // Satisfy the JS API.
+				'campaign_id' => $campaign_id,
 			];
 
 			// Handle legacy send-to meta.

--- a/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp.php
+++ b/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp.php
@@ -546,12 +546,13 @@ final class Newspack_Newsletters_Mailchimp extends \Newspack_Newsletters_Service
 			$send_list_id    = get_post_meta( $post_id, 'send_list_id', true );
 			$send_sublist_id = get_post_meta( $post_id, 'send_sublist_id', true );
 			$newsletter_data = [
-				'campaign'               => $campaign,
-				'campaign_id'            => $mc_campaign_id,
-				'folders'                => Newspack_Newsletters_Mailchimp_Cached_Data::get_folders(),
-				'allowed_sender_domains' => $this->get_verified_domains(),
-				'merge_fields'           => $list_id ? Newspack_Newsletters_Mailchimp_Cached_Data::get_merge_fields( $list_id ) : [],
-				'link'                   => sprintf( 'https://%s.admin.mailchimp.com/campaigns/edit?id=%d', explode( '-', $this->api_key() )[1], $campaign['web_id'] ),
+				'campaign'                          => $campaign,
+				'campaign_id'                       => $mc_campaign_id,
+				'folders'                           => Newspack_Newsletters_Mailchimp_Cached_Data::get_folders(),
+				'allowed_sender_domains'            => $this->get_verified_domains(),
+				'merge_fields'                      => $list_id ? Newspack_Newsletters_Mailchimp_Cached_Data::get_merge_fields( $list_id ) : [],
+				'link'                              => sprintf( 'https://%s.admin.mailchimp.com/campaigns/edit?id=%d', explode( '-', $this->api_key() )[1], $campaign['web_id'] ),
+				'supports_multiple_test_recipients' => true,
 			];
 
 			// Reconcile campaign settings with info fetched from the ESP for a true two-way sync.


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

ActiveCampaign does not handle multiple test email addresses, while Mailchimp does. This was already introduced in #1515 but must've gotten mixed up during the recent big refactor.  

The `supports_multiple_test_recipients` remains true for CampaignMonitor, since it [does support](https://www.campaignmonitor.com/api/v3-3/campaigns/#sending-campaign-preview) multiple test email recipients. 

### How to test the changes in this Pull Request:

1. Set AC as the ESP, edit or create a newsletter
2. Observe the "Testing" sidebar panel does not mention "Use commas to separate multiple emails." in the input help text
3. Set MC as the ESP, observe the panel does mention it

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1209680651926639