### PR TITLE
fix: mailchimp email change sync strategy

### DIFF
--- a/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp.php
+++ b/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp.php
@@ -1807,7 +1807,6 @@ final class Newspack_Newsletters_Mailchimp extends \Newspack_Newsletters_Service
 			$mc = new Mailchimp( $this->api_key() );
 
 			if ( isset( $contact['metadata'] ) && is_array( $contact['metadata'] ) && ! empty( $contact['metadata'] ) ) {
-
 				/**
 				 * Filter the merge fields payload.
 				 *
@@ -1828,11 +1827,58 @@ final class Newspack_Newsletters_Mailchimp extends \Newspack_Newsletters_Service
 				$update_payload['interests'] = $interests;
 			}
 
+			// Create or update a list member.
+			$member_hash = Mailchimp::subscriberHash( $email_address );
+
+			// Mailchimp will only allow subscribed contacts to update the email address field.
+			// To work around this for unsubscribed accounts, we archive the old contact, then creating notes linking old and new contacts.
+			$existing_email_address = isset( $contact['existing_contact_data']['email_address'] ) ? $contact['existing_contact_data']['email_address'] : null;
+			if ( $existing_email_address && $existing_email_address !== $email_address ) {
+				$existing_member_hash = Mailchimp::subscriberHash( $existing_email_address );
+				if ( isset( $update_payload['status'] ) && 'subscribed' !== $update_payload['status'] ) {
+					$this->validate(
+						$mc->post(
+							"lists/$list_id/members/$existing_member_hash/notes",
+							[
+								'note' => sprintf(
+									// Translators: 1 is a hash value representing the contact's new ID. 2 is the contact's new email address.
+									__( 'Contact requested email change. Migrated to %1$s (%2$s).', 'newspack-newsletters' ),
+									$member_hash,
+									$email_address
+								),
+							]
+						),
+						$reader_error,
+						$existing_email_address
+					);
+					$this->validate(
+						$mc->post(
+							"lists/$list_id/members/$member_hash/notes",
+							[
+								'note' => sprintf(
+									// Translators: 1 is a hash value representing the contact's previous ID. 2 is the contact's previous email address.
+									__( 'Contact requested email change. Migrated from %1$s (%2$s).', 'newspack-newsletters' ),
+									$existing_member_hash,
+									$existing_email_address
+								),
+							]
+						),
+						$reader_error,
+						$existing_email_address
+					);
+					$this->validate(
+						$mc->delete( "lists/$list_id/members/$existing_member_hash" ),
+						$reader_error,
+						$existing_email_address
+					);
+				} else {
+					$member_hash = $existing_member_hash;
+				}
+			}
+
 			Newspack_Newsletters_Logger::log( 'Mailchimp add_contact PUT payload: ' . wp_json_encode( $update_payload ) );
 
-			// Create or update a list member.
-			$member_hash  = Mailchimp::subscriberHash( $email_address );
-			$result       = $this->validate(
+			$result = $this->validate(
 				$mc->put( "lists/$list_id/members/$member_hash", $update_payload ),
 				null,
 				[
@@ -1842,48 +1888,6 @@ final class Newspack_Newsletters_Mailchimp extends \Newspack_Newsletters_Service
 					'interests' => $interests,
 				]
 			);
-
-			// Mailchimp will only allow subscribed contacts to update the email address field, so to work around this for unsubscribed accounts
-			// we are instead creating a new contact (via the request above), archiving the old one, then creating notes linking both contacts.
-			$existing_email_address = isset( $contact['existing_contact_data']['email_address'] ) ? $contact['existing_contact_data']['email_address'] : null;
-			if ( $existing_email_address && $existing_email_address !== $email_address ) {
-				$existing_member_hash = Mailchimp::subscriberHash( $existing_email_address );
-				$this->validate(
-					$mc->post(
-						"lists/$list_id/members/$existing_member_hash/notes",
-						[
-							'note' => sprintf(
-								// Translators: 1 is a hash value representing the contact's new ID. 2 is the contact's new email address.
-								__( 'Contact requested email change. Migrated to %1$s (%2$s).', 'newspack-newsletters' ),
-								$member_hash,
-								$email_address
-							),
-						]
-					),
-					$reader_error,
-					$existing_email_address
-				);
-				$this->validate(
-					$mc->post(
-						"lists/$list_id/members/$member_hash/notes",
-						[
-							'note' => sprintf(
-								// Translators: 1 is a hash value representing the contact's previous ID. 2 is the contact's previous email address.
-								__( 'Contact requested email change. Migrated from %1$s (%2$s).', 'newspack-newsletters' ),
-								$existing_member_hash,
-								$existing_email_address
-							),
-						]
-					),
-					$reader_error,
-					$existing_email_address
-				);
-				$this->validate(
-					$mc->delete( "lists/$list_id/members/$existing_member_hash" ),
-					$reader_error,
-					$existing_email_address
-				);
-			}
 		} catch ( \Exception $e ) {
 			return new \WP_Error(
 				'newspack_newsletters_mailchimp_api_error',

--- a/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp.php
+++ b/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp.php
@@ -1826,68 +1826,58 @@ final class Newspack_Newsletters_Mailchimp extends \Newspack_Newsletters_Service
 			if ( ! empty( $interests ) ) {
 				$update_payload['interests'] = $interests;
 			}
-
-			// Create or update a list member.
-			$member_hash = Mailchimp::subscriberHash( $email_address );
-
-			// Mailchimp will only allow subscribed contacts to update the email address field.
-			// To work around this for unsubscribed accounts, we archive the old contact, then creating notes linking old and new contacts.
+			$member_hash            = Mailchimp::subscriberHash( $email_address );
 			$existing_email_address = isset( $contact['existing_contact_data']['email_address'] ) ? $contact['existing_contact_data']['email_address'] : null;
-			if ( $existing_email_address && $existing_email_address !== $email_address ) {
-				$existing_member_hash = Mailchimp::subscriberHash( $existing_email_address );
-				if ( isset( $update_payload['status'] ) && 'subscribed' !== $update_payload['status'] ) {
-					$this->validate(
-						$mc->post(
-							"lists/$list_id/members/$existing_member_hash/notes",
-							[
-								'note' => sprintf(
-									// Translators: 1 is a hash value representing the contact's new ID. 2 is the contact's new email address.
-									__( 'Contact requested email change. Migrated to %1$s (%2$s).', 'newspack-newsletters' ),
-									$member_hash,
-									$email_address
-								),
-							]
-						),
-						$reader_error,
-						$existing_email_address
-					);
-					$this->validate(
-						$mc->post(
-							"lists/$list_id/members/$member_hash/notes",
-							[
-								'note' => sprintf(
-									// Translators: 1 is a hash value representing the contact's previous ID. 2 is the contact's previous email address.
-									__( 'Contact requested email change. Migrated from %1$s (%2$s).', 'newspack-newsletters' ),
-									$existing_member_hash,
-									$existing_email_address
-								),
-							]
-						),
-						$reader_error,
-						$existing_email_address
-					);
-					$this->validate(
-						$mc->delete( "lists/$list_id/members/$existing_member_hash" ),
-						$reader_error,
-						$existing_email_address
-					);
-				} else {
-					$member_hash = $existing_member_hash;
-				}
-			}
+			$existing_member_hash   = $existing_email_address ? Mailchimp::subscriberHash( $existing_email_address ) : null;
+			$is_email_update        = $existing_email_address && $existing_email_address !== $email_address;
+			$is_subscribed          = isset( $update_payload['status'] ) && 'subscribed' === $update_payload['status'];
 
 			Newspack_Newsletters_Logger::log( 'Mailchimp add_contact PUT payload: ' . wp_json_encode( $update_payload ) );
 
+			$hash = $member_hash;
+			if ( $is_email_update && $is_subscribed ) {
+				$hash = $existing_member_hash;
+			}
 			$result = $this->validate(
-				$mc->put( "lists/$list_id/members/$member_hash", $update_payload ),
-				null,
-				[
-					'email'     => $email_address,
-					'list_id'   => $list_id,
-					'tags'      => $tags,
-					'interests' => $interests,
-				]
+				$mc->put( "lists/$list_id/members/$hash", $update_payload ),
+				__( 'Error upserting contact to Mailchimp.', 'newspack-newsletters' )
 			);
+			if ( $is_email_update && ! $is_subscribed ) {
+				// Mailchimp will only allow subscribed contacts to update the email address field.
+				// To work around this for unsubscribed accounts, we archive the old contact, then create notes linking old and new contacts.
+				$this->validate(
+					$mc->post(
+						"lists/$list_id/members/$existing_member_hash/notes",
+						[
+							'note' => sprintf(
+								// Translators: 1 is a hash value representing the contact's new ID. 2 is the contact's new email address.
+								__( 'Contact requested email change. Migrated to %1$s (%2$s).', 'newspack-newsletters' ),
+								$member_hash,
+								$email_address
+							),
+						]
+					),
+					__( 'Error adding migration note to existing contact.', 'newspack-newsletters' )
+				);
+				$this->validate(
+					$mc->post(
+						"lists/$list_id/members/$member_hash/notes",
+						[
+							'note' => sprintf(
+								// Translators: 1 is a hash value representing the contact's previous ID. 2 is the contact's previous email address.
+								__( 'Contact requested email change. Migrated from %1$s (%2$s).', 'newspack-newsletters' ),
+								$existing_member_hash,
+								$existing_email_address
+							),
+						]
+					),
+					__( 'Error adding migration note to new contact.', 'newspack-newsletters' )
+				);
+				$this->validate(
+					$mc->delete( "lists/$list_id/members/$existing_member_hash" ),
+					__( 'Error deleting existing contact.', 'newspack-newsletters' )
+				);
+			}
 		} catch ( \Exception $e ) {
 			return new \WP_Error(
 				'newspack_newsletters_mailchimp_api_error',

--- a/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp.php
+++ b/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp.php
@@ -1832,19 +1832,29 @@ final class Newspack_Newsletters_Mailchimp extends \Newspack_Newsletters_Service
 			$is_email_update        = $existing_email_address && $existing_email_address !== $email_address;
 			$is_subscribed          = isset( $update_payload['status'] ) && 'subscribed' === $update_payload['status'];
 
+			// Mailchimp only allows subscribed contacts to update the email address field
+			// so if the contact is not subscribed, we need to migrate existing merge fields.
+			if ( $is_email_update && ! $is_subscribed ) {
+				$existing_contact = $this->get_contact_data( $existing_email_address, true );
+				try {
+					if ( is_wp_error( $existing_contact ) ) {
+						throw new Exception( $existing_contact->get_error_message() );
+					}
+					$update_payload = array_merge( $update_payload, [ 'merge_fields' => $existing_contact['merge_fields'] ] );
+				} catch ( \Exception $e ) {
+					Newspack_Newsletters_Logger::log( 'Failed to migrate merge fields: ' . $e->getMessage() );
+				}
+			}
+
 			Newspack_Newsletters_Logger::log( 'Mailchimp add_contact PUT payload: ' . wp_json_encode( $update_payload ) );
 
-			$hash = $member_hash;
-			if ( $is_email_update && $is_subscribed ) {
-				$hash = $existing_member_hash;
-			}
+			$hash   = $is_email_update && $is_subscribed ? $existing_member_hash : $member_hash;
 			$result = $this->validate(
 				$mc->put( "lists/$list_id/members/$hash", $update_payload ),
 				__( 'Error upserting contact to Mailchimp.', 'newspack-newsletters' )
 			);
 			if ( $is_email_update && ! $is_subscribed ) {
-				// Mailchimp will only allow subscribed contacts to update the email address field.
-				// To work around this for unsubscribed accounts, we archive the old contact, then create notes linking old and new contacts.
+				// For non-subscribed accounts, we create notes linking old and new contacts and archive the old contact.
 				$this->validate(
 					$mc->post(
 						"lists/$list_id/members/$existing_member_hash/notes",
@@ -2017,11 +2027,10 @@ final class Newspack_Newsletters_Mailchimp extends \Newspack_Newsletters_Service
 	 * Get contact data by email.
 	 *
 	 * @param string $email          Email address.
-	 * @param bool   $return_details Fetch full contact data.
 	 *
 	 * @return array|WP_Error Response or error if contact was not found.
 	 */
-	public function get_contact_data( $email, $return_details = false ) {
+	public function get_contact_data( $email ) {
 		try {
 			$mc    = new Mailchimp( $this->api_key() );
 			$result  = $mc->get(
@@ -2042,9 +2051,10 @@ final class Newspack_Newsletters_Mailchimp extends \Newspack_Newsletters_Service
 
 			$keys = [ 'full_name', 'email_address', 'id' ];
 			$data = [
-				'lists'     => [],
-				'tags'      => [],
-				'interests' => [],
+				'lists'        => [],
+				'tags'         => [],
+				'interests'    => [],
+				'merge_fields' => [],
 			];
 			foreach ( $found as $contact ) {
 				foreach ( $keys as $key ) {
@@ -2063,6 +2073,9 @@ final class Newspack_Newsletters_Mailchimp extends \Newspack_Newsletters_Service
 					'contact_id' => $contact['contact_id'],
 					'status'     => $contact['status'],
 				];
+				if ( isset( $contact['merge_fields'] ) ) {
+					$data['merge_fields'] = $contact['merge_fields'];
+				}
 			}
 			return $data;
 		} catch ( \Exception $e ) {

--- a/tests/test-mailchimp-contact-methods.php
+++ b/tests/test-mailchimp-contact-methods.php
@@ -504,6 +504,7 @@ class MailchimpContactMethodsTest extends WP_UnitTestCase {
 							'status'     => 'subscribed',
 						],
 					],
+					'merge_fields'  => [],
 				],
 			],
 			[
@@ -533,6 +534,7 @@ class MailchimpContactMethodsTest extends WP_UnitTestCase {
 							'status'     => 'subscribed',
 						],
 					],
+					'merge_fields'  => [],
 				],
 			],
 			[


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes https://app.asana.com/0/1208993180326452/1209773985622233

This PR adjusts the strategy we use to update email addresses for mailchimp. Previously we always created a new contact, then archived the previous to account for a limitation with Mailchimp where non-subscribed contacts can't update email address.

These changes adjust the strategy to:
- Update email address for subscribed contacts (rather than migrate to a new contact)
- Migrate non-subscribed contacts, also migrating all prior merge fields

### How to test the changes in this Pull Request:

Before testing, ensure the `NEWSPACK_EMAIL_CHANGE_ENABLED` is defined and true in wp-config.

1. Make sure your connected ESP is mailchimp
2. As a subscribed reader, go to My Account > Account details in WP Admin and update the email address
3. Confirm the contact is updated in Mailchimp with the new email address
4. Now find a non-subscribed reader IN MAILCHIMP, and manually edit a non-newspack merge field
5. As the non-subscribed reader, repeat step 2 in WP Admin
6. Confirm the "old" contact associated with the previous email address is now archived in Mailchimp and a note has been added pointing to the new contact.
7. Confirm a new contact is created in Mailchimp with the new email address, all merge fields have been migrated (including any non-newspack ones), and a note has been added pointing to the old contact

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
