### PR TITLE
fix: migrate tags and groups on email change

### DIFF
--- a/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp.php
+++ b/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp.php
@@ -1833,14 +1833,26 @@ final class Newspack_Newsletters_Mailchimp extends \Newspack_Newsletters_Service
 			$is_subscribed          = isset( $update_payload['status'] ) && 'subscribed' === $update_payload['status'];
 
 			// Mailchimp only allows subscribed contacts to update the email address field
-			// so if the contact is not subscribed, we need to migrate existing merge fields.
+			// so if the contact is not subscribed, we need to migrate existing data.
 			if ( $is_email_update && ! $is_subscribed ) {
 				$existing_contact = $this->get_contact_data( $existing_email_address, true );
 				try {
 					if ( is_wp_error( $existing_contact ) ) {
 						throw new Exception( $existing_contact->get_error_message() );
 					}
-					$update_payload = array_merge( $update_payload, [ 'merge_fields' => $existing_contact['merge_fields'] ] );
+					$update_payload = array_merge(
+						$update_payload,
+						[
+							'interests'    => $existing_contact['interests'][ $list_id ] ?? [],
+							'merge_fields' => $existing_contact['merge_fields'],
+							'tags'         => array_map(
+								function ( $tag ) {
+									return $tag['name'];
+								},
+								$existing_contact['tags'][ $list_id ] ?? []
+							),
+						]
+					);
 				} catch ( \Exception $e ) {
 					Newspack_Newsletters_Logger::log( 'Failed to migrate merge fields: ' . $e->getMessage() );
 				}


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes https://app.asana.com/0/1208993180326452/1209801509781960

This PR ensures we are also migrating tags and groups when an email change for a non-subscribed reader occurs.

![Screenshot 2025-03-27 at 11 30 57](https://github.com/user-attachments/assets/937bda94-ac5e-4576-845b-5c82b7039209)

### How to test the changes in this Pull Request:

Ensure the `NEWSPACK_EMAIL_CHANGE_ENABLED` FF is defined and true in `wp-config` before testing.

1. In mailchimp, find a reader that is not subscribed and ensure the contact has at least one tag and group.
2. As the reader, visit the site and go to my account 
3. Update the email address and submit then verify
4. In mailchimp again, confirm the old contact is archived, and a new contact is created for the new email address with the merge fields, tags, and groups all migrated.

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
