### PR TITLE
fix: update social icon editor CSS selector for WP 6.8

### DIFF
--- a/src/editor/style.scss
+++ b/src/editor/style.scss
@@ -305,16 +305,6 @@
 					padding: 0 7px;
 				}
 			}
-			&[data-type="core/social-link"] {
-				align-items: center;
-				display: flex;
-				justify-content: center;
-				padding: 0;
-
-				&:not([contenteditable]):focus::after {
-					right: 0;
-				}
-			}
 
 			&[data-type="core/separator"],
 			.wp-block-separator {
@@ -368,6 +358,17 @@
 			&[data-align="right"] {
 				.wp-block-social-links {
 					margin-right: 0;
+				}
+			}
+
+			.wp-social-link {
+				align-items: center;
+				display: flex;
+				justify-content: center;
+				padding: 0;
+
+				&:not([contenteditable]):focus::after {
+					right: 0;
 				}
 			}
 		}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

In WP 6.8 RC, the social icon markup for newsletters has changed, meaning the `[data-type="core/social-link"]` selector we use no longer works for applying some styles.

This PR updates the selector and reorganized them a bit (so the non-`&` selector isn't mixed in with the `&` selectors).

See 1209694846565575-as-1209804816680570

### How to test the changes in this Pull Request:

1. On a site running the WP 6.8 RC, create a new newsletter draft from a template; note how the social icons look in the editor:

![CleanShot 2025-03-28 at 11 24 40](https://github.com/user-attachments/assets/00bb8f65-1f89-4b37-8f22-a089c05bf4dc)

2. Apply this PR and run `npm run build`
3. Refresh the editor and confirm the buttons look as expected:

![CleanShot 2025-03-28 at 11 23 00](https://github.com/user-attachments/assets/05946fbd-1ad6-48ba-9ca6-c0371da385f0)

4. On a site running the current WP release (6.7.2), repeat the testing steps and confirm this change doesn't break things in the WP 6.7.2 version.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
