### PR TITLE
fix(ads): prevent ads with same position from replacing each other

### DIFF
--- a/includes/class-newspack-newsletters-ads.php
+++ b/includes/class-newspack-newsletters-ads.php
@@ -473,10 +473,22 @@ final class Newspack_Newsletters_Ads {
 			} else {
 				$position = intval( get_post_meta( $ad->ID, 'position_block_count', true ) );
 			}
-			$ads[ $position ] = $ad;
+
+			if ( ! isset( $ads[ $position ] ) ) {
+				$ads[ $position ] = [];
+			}
+			$ads[ $position ][] = $ad;
 		}
-		sort( $ads );
-		return array_values( $ads );
+
+		$flattened_ads = [];
+		foreach ( $ads as $position_ads ) {
+			foreach ( $position_ads as $ad ) {
+				$flattened_ads[] = $ad;
+			}
+		}
+
+		sort( $flattened_ads );
+		return $flattened_ads;
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

When calculating the ads positioning for a newsletter, ads with the same position replace each other, resulting in missing ads. This PR fixes the issue.

### How to test the changes in this Pull Request:

1. While on `release`, create 2 newsletter ads with % position at 0
2. Draft a newsletter and add 2 newsletter ad blocks with automatic ad selectin
3. Preview the newsletter and confirm only 1 ad render
4. Check out this branch, save the newsletter again and preview
5. Confirm both ads render

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1209838494028101