### PR TITLE
fix(CC): update existing contact when changing email address

### DIFF
--- a/includes/service-providers/constant_contact/class-newspack-newsletters-constant-contact.php
+++ b/includes/service-providers/constant_contact/class-newspack-newsletters-constant-contact.php
@@ -1205,8 +1205,8 @@ final class Newspack_Newsletters_Constant_Contact extends \Newspack_Newsletters_
 		if ( isset( $contact['existing_contact_data']['email_address'] ) ) {
 			$existing_email = $contact['existing_contact_data']['email_address'];
 			if ( $existing_email->address !== $email ) {
-				$data['email'] = $email;
-				$email         = $existing_email->address;
+				$data['email_address'] = $email;
+				$email                 = $existing_email->address;
 			}
 		}
 		$result = $cc->upsert_contact( $email, $data );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

When updating a reader account's email address via My Account, the updated email address should be synced to the existing contact in Constant Contact (if any), instead of creating a new contact and deleting the old one. This matches the behavior for both ActiveCampaign and Mailchimp APIs when updating the email address for an existing contact.

### How to test the changes in this Pull Request:

1. Check out this branch and https://github.com/Automattic/newspack-plugin/pull/3832 if not yet merged
2. On a site connected to Constant Contact, register a reader account and verify the email address
3. In Constant Contact, find the contact that has been created and note the email address
4. Change the reader's email address in My Account and confirm the update
5. In Constant Contact, confirm that the existing contact has been updated with the new email address, but that all other info is otherwise unchanged

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
