### PR TITLE
fix: tweak sorting logic to prevent issue with manual insertion

### DIFF
--- a/includes/class-newspack-newsletters-ads.php
+++ b/includes/class-newspack-newsletters-ads.php
@@ -480,6 +480,20 @@ final class Newspack_Newsletters_Ads {
 			$ads[ $position ][] = $ad;
 		}
 
+		sort( $ads );
+		return array_values( $ads );
+	}
+
+	/**
+	 * Get a flattened array of ads for automatic insertion.
+	 *
+	 * @param int $newsletter_id   Newsletter post ID.
+	 *
+	 * @return WP_Post[] Array of ad posts.
+	 */
+	public static function get_newsletter_ads_flat( $newsletter_id ) {
+		$ads = self::get_newsletter_ads( $newsletter_id );
+
 		$flattened_ads = [];
 		foreach ( $ads as $position_ads ) {
 			foreach ( $position_ads as $ad ) {

--- a/includes/class-newspack-newsletters-renderer.php
+++ b/includes/class-newspack-newsletters-renderer.php
@@ -1174,7 +1174,7 @@ final class Newspack_Newsletters_Renderer {
 				if ( ! empty( $attrs['adId'] ) ) {
 					$ad_post = get_post( $attrs['adId'] );
 				} elseif ( ! empty( self::$newsletter_id ) ) {
-					$ads = Newspack_Newsletters_Ads::get_newsletter_ads( self::$newsletter_id );
+					$ads = Newspack_Newsletters_Ads::get_newsletter_ads_flat( self::$newsletter_id );
 					foreach ( $ads as $ad ) {
 						if ( ! Newspack_Newsletters_Ads::is_ad_inserted( self::$newsletter_id, $ad->ID ) ) {
 							$ad_post = $ad;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR separates out the flattening logic added in https://github.com/Automattic/newspack-newsletters/pull/1794 so the original array format can also be used where needed. 

I'm open to feedback if there's a better approach to fix this!

### How to test the changes in this Pull Request:

1. On the `release` branch, add two newsletter ads with a 0% position.
2. Edit a newsletter and add two ad blocks.
3. Try to manually assign a specific ad to one of the blocks, and note the funky dropdown:

![CleanShot 2025-04-07 at 15 37 05](https://github.com/user-attachments/assets/737be886-df7d-40e5-9552-93258dd83b26)

4. Apply this PR; repeat steps 2 and 3 and confirm the dropdown works, and you can now pick an ad:

![CleanShot 2025-04-07 at 15 36 22](https://github.com/user-attachments/assets/6e659263-ff3f-47e1-82a7-dd0eb599fcdc)

5. Try assigning ads manually and previewing them, making sure they're inserted as expected.
6. Try running the testing steps from https://github.com/Automattic/newspack-newsletters/pull/1794 and make sure these changes don't reintroduce that issue.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
