### PR TITLE
fix(ads): separate sort by position logic

### DIFF
--- a/includes/class-newspack-newsletters-ads.php
+++ b/includes/class-newspack-newsletters-ads.php
@@ -455,7 +455,17 @@ final class Newspack_Newsletters_Ads {
 					continue;
 				}
 			}
+			$ads[] = $ad;
+		}
 
+		// Return early if there's only one ad. No need to sort.
+		if ( count( $ads ) <= 1 ) {
+			return $ads;
+		}
+
+		// Sort ads by position.
+		$ads_by_position = [];
+		foreach ( $ads as $ad ) {
 			$insertion_strategy = get_post_meta( $ad->ID, 'insertion_strategy', true );
 			if ( empty( $insertion_strategy ) ) {
 				$insertion_strategy = 'percentage';
@@ -474,14 +484,14 @@ final class Newspack_Newsletters_Ads {
 				$position = intval( get_post_meta( $ad->ID, 'position_block_count', true ) );
 			}
 
-			if ( ! isset( $ads[ $position ] ) ) {
-				$ads[ $position ] = [];
+			if ( ! isset( $ads_by_position[ $position ] ) ) {
+				$ads_by_position[ $position ] = [];
 			}
-			$ads[ $position ][] = $ad;
+			$ads_by_position[ $position ][] = $ad;
 		}
 
 		$flattened_ads = [];
-		foreach ( $ads as $position_ads ) {
+		foreach ( $ads_by_position as $position_ads ) {
 			foreach ( $position_ads as $ad ) {
 				$flattened_ads[] = $ad;
 			}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Alternative to #1797.

The hotfix from #1794 introduced a bug when `Newspack_Newsletters_Ads::get_newsletter_ads()` is called with `$skip_validation = true`.

The position map logic is skipped and the array breaks when flattening before return.

This PR fixes the issue by separating the ads array creation from the sorting logic.

### How to test the changes in this Pull Request:

1. While on the release branch confirm you're unable to select specific ads in Newsletter Ad block
2. Checkout this branch and confirm you are able to select ads and they render as expected in preview
3. Confirm the steps from #1794 are also reproducible

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
