### PR TITLE
fix: subscribe to local list methods

### DIFF
--- a/includes/service-providers/active_campaign/class-newspack-newsletters-active-campaign.php
+++ b/includes/service-providers/active_campaign/class-newspack-newsletters-active-campaign.php
@@ -390,15 +390,17 @@ final class Newspack_Newsletters_Active_Campaign extends \Newspack_Newsletters_S
 	/**
 	 * Add a tag to a contact
 	 *
-	 * @param string     $email The contact email.
-	 * @param string|int $tag The tag ID.
-	 * @param string     $list_id The List ID. Not needed for Active Campaign.
+	 * @param string|array $contact Either the contact email or the contact array with email, name and metadata.
+	 * @param string|int   $tag The tag name.
+	 * @param string       $list_id The List ID. Not needed for Active Campaign.
 	 * @return true|WP_Error
 	 */
-	public function add_tag_to_contact( $email, $tag, $list_id = null ) {
+	public function add_tag_to_contact( $contact, $tag, $list_id = null ) {
+		$email = is_string( $contact ) ? $contact : $contact['email'];
 		$existing_contact = $this->get_contact_data( $email );
 		if ( is_wp_error( $existing_contact ) ) {
-			return $existing_contact;
+			$contact['tags'] = $tag;
+			return $this->add_contact( $contact, $list_id );
 		}
 
 		$contact_tag = [
@@ -1319,6 +1321,16 @@ final class Newspack_Newsletters_Active_Campaign extends \Newspack_Newsletters_S
 				]
 			);
 		}
+
+		if ( ! empty( $contact['tags'] ) ) {
+			if ( is_string( $contact['tags'] ) || is_int( $contact['tags'] ) ) {
+				$contact['tags'] = [ $contact['tags'] ];
+			}
+			if ( is_array( $contact['tags'] ) ) {
+				$payload['tags'] = implode( ',', $contact['tags'] );
+			}
+		}
+
 		/** Register metadata fields. */
 		if ( ! empty( $contact['metadata'] ) ) {
 			$existing_fields = $this->get_all_contact_fields();

--- a/includes/service-providers/class-newspack-newsletters-service-provider.php
+++ b/includes/service-providers/class-newspack-newsletters-service-provider.php
@@ -647,7 +647,7 @@ Error message(s) received:
 		}
 
 		$list_settings = $list->get_provider_settings( $this->service );
-		return $this->add_esp_local_list_to_contact( $contact['email'], $list_settings['tag_id'], $list_settings['list'] );
+		return $this->add_esp_local_list_to_contact( $contact, $list_settings['tag_name'], $list_settings['list'] );
 	}
 
 	/**
@@ -837,12 +837,12 @@ Error message(s) received:
 	/**
 	 * Add a tag to a contact
 	 *
-	 * @param string     $email The contact email.
-	 * @param string|int $tag The tag ID.
-	 * @param string     $list_id The List ID.
+	 * @param string|array $contact Either the contact email or the contact array with email, name and metadata.
+	 * @param string|int   $tag The tag name.
+	 * @param string       $list_id The List ID.
 	 * @return true|WP_Error
 	 */
-	public function add_tag_to_contact( $email, $tag, $list_id = null ) {
+	public function add_tag_to_contact( $contact, $tag, $list_id = null ) {
 		return new WP_Error( 'newspack_newsletters_not_implemented', __( 'Not implemented', 'newspack-newsletters' ), [ 'status' => 400 ] );
 	}
 
@@ -927,13 +927,13 @@ Error message(s) received:
 	 *
 	 * By default it will use Tags, but the provider can override this method to use something else
 	 *
-	 * @param string     $email The contact email.
-	 * @param string|int $esp_local_list The esp_local_list ID retrieved with get_esp_local_list_id() or the the esp_local_list string.
-	 * @param string     $list_id The List ID.
+	 * @param string|array $contact Either the contact email or the contact array with email, name and metadata.
+	 * @param string|int   $esp_local_list The esp_local_list ID retrieved with get_esp_local_list_id() or the the esp_local_list string.
+	 * @param string       $list_id The List ID.
 	 * @return true|WP_Error
 	 */
-	public function add_esp_local_list_to_contact( $email, $esp_local_list, $list_id = null ) {
-		return $this->add_tag_to_contact( $email, $esp_local_list, $list_id );
+	public function add_esp_local_list_to_contact( $contact, $esp_local_list, $list_id = null ) {
+		return $this->add_tag_to_contact( $contact, $esp_local_list, $list_id );
 	}
 
 	/**

--- a/includes/service-providers/constant_contact/class-newspack-newsletters-constant-contact.php
+++ b/includes/service-providers/constant_contact/class-newspack-newsletters-constant-contact.php
@@ -1406,12 +1406,13 @@ final class Newspack_Newsletters_Constant_Contact extends \Newspack_Newsletters_
 	/**
 	 * Add a tag to a contact
 	 *
-	 * @param string     $email The contact email.
-	 * @param string|int $tag The tag ID.
-	 * @param string     $list_id The List ID.
+	 * @param string|array $contact Either the contact email or the contact array with email, name and metadata.
+	 * @param string|int   $tag The tag name.
+	 * @param string       $list_id The List ID.
 	 * @return true|WP_Error
 	 */
-	public function add_tag_to_contact( $email, $tag, $list_id = null ) {
+	public function add_tag_to_contact( $contact, $tag, $list_id = null ) {
+		$email = is_string( $contact ) ? $contact : $contact['email'];
 		$tags = $this->get_contact_tags_ids( $email );
 		if ( is_wp_error( $tags ) ) {
 			$tags = [];

--- a/includes/service-providers/interface-newspack-newsletters-esp-service.php
+++ b/includes/service-providers/interface-newspack-newsletters-esp-service.php
@@ -153,12 +153,12 @@ interface Newspack_Newsletters_ESP_API_Interface {
 	/**
 	 * Add a tag to a contact
 	 *
-	 * @param string     $email The contact email.
-	 * @param string|int $tag The tag ID.
-	 * @param string     $list_id The List ID.
+	 * @param string|array $contact Either the contact email or the contact array with email, name and metadata.
+	 * @param string|int   $tag The tag name.
+	 * @param string       $list_id The List ID.
 	 * @return true|WP_Error
 	 */
-	public function add_tag_to_contact( $email, $tag, $list_id = null );
+	public function add_tag_to_contact( $contact, $tag, $list_id = null );
 
 	/**
 	 * Remove a tag from a contact

--- a/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp-groups.php
+++ b/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp-groups.php
@@ -81,13 +81,13 @@ trait Newspack_Newsletters_Mailchimp_Groups {
 	 *
 	 * Mailchimp overrides it to use Groups instead of Tags
 	 *
-	 * @param string     $email The contact email.
-	 * @param string|int $esp_local_list The esp_local_list ID retrieved with get_esp_local_list_id() or the the esp_local_list string.
-	 * @param string     $list_id The List ID.
+	 * @param string|array $contact Either the contact email or the contact array with email, name and metadata.
+	 * @param string|int   $esp_local_list The esp_local_list ID retrieved with get_esp_local_list_id() or the the esp_local_list string.
+	 * @param string       $list_id The List ID.
 	 * @return true|WP_Error
 	 */
-	public function add_esp_local_list_to_contact( $email, $esp_local_list, $list_id = null ) {
-		return $this->add_group_to_contact( $email, $esp_local_list, $list_id );
+	public function add_esp_local_list_to_contact( $contact, $esp_local_list, $list_id = null ) {
+		return $this->add_group_to_contact( $contact, $esp_local_list, $list_id );
 	}
 
 	/**
@@ -296,15 +296,16 @@ trait Newspack_Newsletters_Mailchimp_Groups {
 	/**
 	 * Add a group to a contact
 	 *
-	 * @param string $email The contact email.
-	 * @param string $group_id The group ID.
-	 * @param string $list_id The List ID.
+	 * @param string|array $contact Either the contact email or the contact array with email, name and metadata.
+	 * @param string       $group_id The group ID.
+	 * @param string       $list_id The List ID.
 	 * @return true|WP_Error
 	 */
-	public function add_group_to_contact( $email, $group_id, $list_id = null ) {
+	public function add_group_to_contact( $contact, $group_id, $list_id = null ) {
+		$email = is_string( $contact ) ? $contact : $contact['email'];
 		$existing_contact = $this->get_contact_data( $email );
 		if ( is_wp_error( $existing_contact ) ) {
-			return $existing_contact;
+			return $this->add_contact( $contact, $list_id, [], [ $group_id => true ] );
 		}
 
 		$mc    = new Mailchimp( $this->api_key() );

--- a/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp.php
+++ b/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp.php
@@ -274,15 +274,16 @@ final class Newspack_Newsletters_Mailchimp extends \Newspack_Newsletters_Service
 	/**
 	 * Add a tag to a contact
 	 *
-	 * @param string     $email The contact email.
-	 * @param string|int $tag The tag ID.
-	 * @param string     $list_id The List ID.
+	 * @param string|array $contact Either the contact email or the contact array with email, name and metadata.
+	 * @param string|int   $tag The tag name.
+	 * @param string       $list_id The List ID.
 	 * @return true|WP_Error
 	 */
-	public function add_tag_to_contact( $email, $tag, $list_id = null ) {
+	public function add_tag_to_contact( $contact, $tag, $list_id = null ) {
+		$email = is_string( $contact ) ? $contact : $contact['email'];
 		$existing_contact = $this->get_contact_data( $email );
 		if ( is_wp_error( $existing_contact ) ) {
-			return $existing_contact;
+			return $this->add_contact( $contact, $list_id, [ $tag ] );
 		}
 		$mc      = new Mailchimp( $this->api_key() );
 		$created = $mc->post(


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes an issue where a contact would not be subscribed if subscribing only to a local list.

In the `add_tag_to_contact` and `add_group_to_contact` methods, there was a check for an existing contact. If the contact didn't exist, we were not adding it.

This PR fixes it.

ATTENTION: THIS IS NOT READY. It's probably breaking Mailchimp, because we are passing the label instead of the ID. But for groups, we want the ID, while for tags we want the label. Need to figure this out yet.

### How to test the changes in this Pull Request:

Repeat this with all ESPs

1. Set up a new local list
2. Add a subscription block to a page
3. as a visitor, subscribe via block, entering a name and making sure to select ONLY the local list
4. Go to the ESP and confirm the contact was added in the correct list/audience with the correct group/tag

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
