### PR TITLE
feat(reader-data): dispatch reader data activity when reader registered

### DIFF
--- a/src/blocks/subscribe/index.php
+++ b/src/blocks/subscribe/index.php
@@ -490,12 +490,13 @@ function process_form() {
 		$metadata['status'] = 'pending';
 	}
 
+	$registered_user = false;
 	if ( ! \is_user_logged_in() && \class_exists( '\Newspack\Reader_Activation' ) && \Newspack\Reader_Activation::is_enabled() ) {
 		$metadata = array_merge( $metadata, [ 'registration_method' => 'newsletters-subscription' ] );
 		if ( $popup_id ) {
 			$metadata['registration_method'] = 'newsletters-subscription-popup';
 		}
-		\Newspack\Reader_Activation::register_reader( $email, $name, true, $metadata );
+		$registered_user = \Newspack\Reader_Activation::register_reader( $email, $name, true, $metadata );
 	}
 
 	$result = \Newspack_Newsletters_Contacts::subscribe(
@@ -529,6 +530,12 @@ function process_form() {
 
 	// Propagate the form action for subsequent form submissions.
 	$result[ FORM_ACTION ] = '1';
+
+	// Whether the user was newly registered.
+	$result['registered'] = $registered_user && ! \is_wp_error( $registered_user );
+	if ( $result['registered'] ) {
+		$result['registration_method'] = $metadata['registration_method'];
+	}
 
 	return send_form_response( $result );
 }

--- a/src/blocks/subscribe/index.php
+++ b/src/blocks/subscribe/index.php
@@ -497,6 +497,9 @@ function process_form() {
 			$metadata['registration_method'] = 'newsletters-subscription-popup';
 		}
 		$registered_user = \Newspack\Reader_Activation::register_reader( $email, $name, true, $metadata );
+		if ( $registered_user ) {
+			$metadata['registered'] = '1';
+		}
 	}
 
 	$result = \Newspack_Newsletters_Contacts::subscribe(
@@ -531,11 +534,8 @@ function process_form() {
 	// Propagate the form action for subsequent form submissions.
 	$result[ FORM_ACTION ] = '1';
 
-	// Whether the user was newly registered.
-	$result['registered'] = $registered_user && ! \is_wp_error( $registered_user );
-	if ( $result['registered'] ) {
-		$result['registration_method'] = $metadata['registration_method'];
-	}
+	// Append additional metadata to the result.
+	$result['metadata'] = $metadata;
 
 	return send_form_response( $result );
 }

--- a/src/blocks/subscribe/view.js
+++ b/src/blocks/subscribe/view.js
@@ -44,7 +44,7 @@ domReady( function () {
 		const spinner = document.createElement( 'span' );
 		spinner.classList.add( 'spinner' );
 
-		form.endFlow = ( message, status = 500, wasSubscribed = false ) => {
+		form.endFlow = ( message, status = 500, wasSubscribed = false, wasRegistered = false, registrationMethod = 'newsletters-subscription' ) => {
 			container.setAttribute( 'data-status', status );
 			const messageNode = document.createElement( 'p' );
 			emailInput.removeAttribute( 'disabled' );
@@ -59,6 +59,17 @@ domReady( function () {
 			if ( status === 200 ) {
 				container.replaceChild( responseContainer, form );
 				form.dispatchEvent( successEvent );
+				if ( wasRegistered ) {
+					window.newspackRAS = window.newspackRAS || [];
+					window.newspackRAS.push( function( ras ) {
+						const activity = { email: emailInput.value, registration_method: registrationMethod };
+						const promptContainer = container.closest( '.newspack-popup-container' );
+						if ( promptContainer && promptContainer.id ) {
+							activity.popup_id = promptContainer.getAttribute( 'id' ).replace( 'id_', '' );
+						}
+						ras.dispatchActivity( 'reader_registered', activity );
+					} );
+				}
 			}
 		};
 		form.addEventListener( 'submit', ev => {
@@ -96,9 +107,11 @@ domReady( function () {
 							message,
 							newspack_newsletters_subscribed: wasSubscribed,
 							newspack_newsletters_subscribe,
+							registered: wasRegistered,
+							registration_method: registrationMethod,
 						} ) => {
 							nonce = newspack_newsletters_subscribe;
-							form.endFlow( message, res.status, wasSubscribed );
+							form.endFlow( message, res.status, wasSubscribed, wasRegistered, registrationMethod );
 						}
 					);
 			} );

--- a/src/blocks/subscribe/view.js
+++ b/src/blocks/subscribe/view.js
@@ -44,7 +44,7 @@ domReady( function () {
 		const spinner = document.createElement( 'span' );
 		spinner.classList.add( 'spinner' );
 
-		form.endFlow = ( message, status = 500, wasSubscribed = false, wasRegistered = false, registrationMethod = 'newsletters-subscription' ) => {
+		form.endFlow = ( message, status = 500, wasSubscribed = false, metadata = {} ) => {
 			container.setAttribute( 'data-status', status );
 			const messageNode = document.createElement( 'p' );
 			emailInput.removeAttribute( 'disabled' );
@@ -59,13 +59,15 @@ domReady( function () {
 			if ( status === 200 ) {
 				container.replaceChild( responseContainer, form );
 				form.dispatchEvent( successEvent );
-				if ( wasRegistered ) {
+				if ( metadata?.registered ) {
 					window.newspackRAS = window.newspackRAS || [];
 					window.newspackRAS.push( function( ras ) {
-						const activity = { email: emailInput.value, registration_method: registrationMethod };
-						const promptContainer = container.closest( '.newspack-popup-container' );
-						if ( promptContainer && promptContainer.id ) {
-							activity.popup_id = promptContainer.getAttribute( 'id' ).replace( 'id_', '' );
+						const activity = { email: emailInput.value, registration_method: metadata?.registration_method };
+						if ( metadata?.newspack_popup_id ) {
+							activity.newspack_popup_id = metadata?.newspack_popup_id;
+						}
+						if ( metadata?.gate_post_id ) {
+							activity.gate_post_id = metadata?.gate_post_id;
 						}
 						ras.dispatchActivity( 'reader_registered', activity );
 					} );
@@ -107,11 +109,10 @@ domReady( function () {
 							message,
 							newspack_newsletters_subscribed: wasSubscribed,
 							newspack_newsletters_subscribe,
-							registered: wasRegistered,
-							registration_method: registrationMethod,
+							metadata,
 						} ) => {
 							nonce = newspack_newsletters_subscribe;
-							form.endFlow( message, res.status, wasSubscribed, wasRegistered, registrationMethod );
+							form.endFlow( message, res.status, wasSubscribed, metadata );
 						}
 					);
 			} );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

This PR dispatches a `reader_registered` reader data activity when a new reader account is registered as a result of signing up for newsletters via the Newsletters Subscription Form block. This is used by https://github.com/Automattic/newspack-plugin/pull/3895 to fire an analytics event on reader registration.

### How to test the changes in this Pull Request:

See https://github.com/Automattic/newspack-plugin/pull/3895.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
