### PR TITLE
fix(local-lists): create contact first, if adding to local lists only

### DIFF
--- a/includes/service-providers/class-newspack-newsletters-service-provider.php
+++ b/includes/service-providers/class-newspack-newsletters-service-provider.php
@@ -677,6 +677,8 @@ Error message(s) received:
 			return new WP_Error( 'newspack_newsletters_list_not_configured_for_provider', "List $list_id not properly configured for the provider" );
 		}
 
+		$list_settings = $list->get_provider_settings( $this->service );
+
 		// If the contact doesn't exist, create it.
 		if ( ! $this->contact_exists( $contact['email'] ) ) {
 			$result = $this->add_contact( $contact, $list_settings['list'] );
@@ -685,7 +687,6 @@ Error message(s) received:
 			}
 		}
 
-		$list_settings = $list->get_provider_settings( $this->service );
 		return $this->add_esp_local_list_to_contact( $contact['email'], $list_settings['tag_id'], $list_settings['list'] );
 	}
 

--- a/includes/service-providers/class-newspack-newsletters-service-provider.php
+++ b/includes/service-providers/class-newspack-newsletters-service-provider.php
@@ -55,6 +55,13 @@ abstract class Newspack_Newsletters_Service_Provider implements Newspack_Newslet
 	public static $support_local_lists = false;
 
 	/**
+	 * Memoization of existing contacts.
+	 *
+	 * @var array
+	 */
+	private $existing_contacts = [];
+
+	/**
 	 * Class constructor.
 	 */
 	public function __construct() {
@@ -578,21 +585,6 @@ Error message(s) received:
 			return $this->add_contact( $contact );
 		}
 
-		// If subscribing to local lists only, the contact has to be created first.
-		// Local lists are tags/groups in ESP, so the contact has to exist first, in
-		// order to be added.
-		$only_local = array_reduce(
-			$lists,
-			fn( $carry, $list ) => $carry && $list->is_local(),
-			true
-		);
-		if ( $only_local ) {
-			$result = $this->add_contact( $contact );
-			if ( is_wp_error( $result ) ) {
-				return $result;
-			}
-		}
-
 		foreach ( $lists as $list ) {
 			if ( $list->is_local() ) {
 				$result = $this->add_contact_to_local_list( $contact, $list );
@@ -634,6 +626,30 @@ Error message(s) received:
 	}
 
 	/**
+	 * Check if a contact exists in the ESP.
+	 *
+	 * @param string $email The contact email address.
+	 *
+	 * @return bool True if the contact exists, false otherwise.
+	 */
+	public function contact_exists( $email ) {
+		if ( in_array( $email, $this->existing_contacts, true ) ) {
+			return true;
+		}
+
+		$contact = $this->get_contact_data( $email );
+		if ( is_wp_error( $contact ) ) {
+			// Don't memoize missing contacts.
+			return false;
+		}
+
+		// Memoize existing contacts.
+		$this->existing_contacts[] = $email;
+
+		return true;
+	}
+
+	/**
 	 * Handle adding to local lists.
 	 * If the $list_id is a local list, a tag will be added to the contact.
 	 *
@@ -659,6 +675,14 @@ Error message(s) received:
 
 		if ( ! $list->is_configured_for_provider( $this->service ) ) {
 			return new WP_Error( 'newspack_newsletters_list_not_configured_for_provider', "List $list_id not properly configured for the provider" );
+		}
+
+		// If the contact doesn't exist, create it.
+		if ( ! $this->contact_exists( $contact['email'] ) ) {
+			$result = $this->add_contact( $contact, $list_settings['list'] );
+			if ( is_wp_error( $result ) ) {
+				return $result;
+			}
 		}
 
 		$list_settings = $list->get_provider_settings( $this->service );

--- a/includes/service-providers/class-newspack-newsletters-service-provider.php
+++ b/includes/service-providers/class-newspack-newsletters-service-provider.php
@@ -578,6 +578,21 @@ Error message(s) received:
 			return $this->add_contact( $contact );
 		}
 
+		// If subscribing to local lists only, the contact has to be created first.
+		// Local lists are tags/groups in ESP, so the contact has to exist first, in
+		// order to be added.
+		$only_local = array_reduce(
+			$lists,
+			fn( $carry, $list ) => $carry && $list->is_local(),
+			true
+		);
+		if ( $only_local ) {
+			$result = $this->add_contact( $contact );
+			if ( is_wp_error( $result ) ) {
+				return $result;
+			}
+		}
+
 		foreach ( $lists as $list ) {
 			if ( $list->is_local() ) {
 				$result = $this->add_contact_to_local_list( $contact, $list );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

When a reader is subscribing to a "local list", they are only tagged in the ESP (there is no corresponding _list_ in the ESP). The logic was assuming that the contact would already exist in the ESP, when the tagging occurred. This PR fixes it, so that the contact is first upserted (the `add_contact` method is an upsertion, not creation). 

This won't affect Mailchimp, since it overrides the `upsert_contact` method. I could not reproduce the issue on Mailchimp, so a similar fix is not needed.

Alternative to #1799.

### How to test the changes in this Pull Request:

1. Set ActiveCamapaign as the ESP
1. Set up a new local list 
2. Add a newsletter subscription block and set it to subscribe to the new list only
3. On the frontend, subscribe
4. Observe the contact was added and tagged in AC

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->