### PR TITLE
fix(posts-inserter-block): sponsorship scope handling

### DIFF
--- a/src/editor/blocks/posts-inserter/utils.js
+++ b/src/editor/blocks/posts-inserter/utils.js
@@ -183,18 +183,14 @@ const createBlockTemplatesForSinglePost = ( post, attributes ) => {
 		postContentBlocks.push( getSubtitleBlockTemplate( post, attributes ) );
 	}
 
-	if ( hasSponsors && 'underwritten' !== post.meta.newspack_sponsor_sponsorship_scope ) {
+	// If the meta is set, use it. Otherwise, if any sponsor is 'native', use 'native'. Otherwise, default to 'underwritten'.
+	const sponsorshipScope = post.meta.newspack_sponsor_sponsorship_scope 
+		|| ( ( post.newspack_sponsors_info || [] ).some( sponsor => sponsor.sponsor_scope ==='native' ) ? 'native' : 'underwritten' );
+	if ( hasSponsors && 'underwritten' !== sponsorshipScope ) {
 		// If the post is set to show only sponsor, OR set to inherit and all sponsors are set to show only sponsor, hide the byline.
 		if (
 			'sponsor' === post.meta.newspack_sponsor_native_byline_display ||
-			( 'inherit' === post.meta.newspack_sponsor_native_byline_display &&
-				false ===
-					post.newspack_sponsors_info.reduce( ( acc, sponsor ) => {
-						if ( 'author' === sponsor.sponsor_byline_display ) {
-							return true;
-						}
-						return acc;
-					}, false ) )
+			( 'inherit' === post.meta.newspack_sponsor_native_byline_display && sponsorshipScope !== 'underwritten' )
 		) {
 			displayAuthor = false;
 		}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes logic to display byline in the Posts Inserter block.

### How to test the changes in this Pull Request:

1. On `trunk`
1. Create an "underwritten" type sponsor (Advertising → Sponsors)
2. Edit the most recent post and set the new sponsor there (sidebar → Sponsors)
3. In a newsletter, insert the Posts Inserter block – observe the post with the sponsor does not have a byline
4. Switch to this branch, reload editor, observe the byline as expected
5. Switch the sponsor to "native"
6. In the newsletter editor, observe that instead of an author byline, there's the sponsor

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1209894180116263