### PR TITLE
fix(posts-inserter): use post date in TZ (instead of GMT)

### DIFF
--- a/src/editor/blocks/posts-inserter/utils.js
+++ b/src/editor/blocks/posts-inserter/utils.js
@@ -40,7 +40,7 @@ const getDateBlockTemplate = ( post, { textFontSize, textColor } ) => {
 	return [
 		'core/paragraph',
 		assignFontSize( textFontSize, {
-			content: dateI18n( dateFormat, post.date_gmt ),
+			content: dateI18n( dateFormat, post.date ),
 			fontSize: 'normal',
 			style: { color: { text: textColor } },
 		} ),
@@ -215,7 +215,7 @@ const createBlockTemplatesForSinglePost = ( post, attributes ) => {
 			postContentBlocks.push( author );
 		}
 	}
-	if ( attributes.displayPostDate && post.date_gmt ) {
+	if ( attributes.displayPostDate && post.date ) {
 		postContentBlocks.push( getDateBlockTemplate( post, attributes ) );
 	}
 	if ( attributes.displayPostExcerpt ) {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Switches the date used by the Posts Inserter block to the date in site's TZ, instead of using GMT. 

### How to test the changes in this Pull Request:

1. Switch site TZ to something way off GMT
2. Publish a new post
3. Edit a newsletter, insert a Posts Inserter block, toggle "Date" in the sidebar block settings
4. Hopefully, observe a wrong date – because that date is GMT
5. Otherwise, just smoke test, and confirm you see the correct date

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1209779163284606