### PR TITLE
fix(email-html): sanity check for img alt attr

### DIFF
--- a/includes/class-newspack-newsletters-renderer.php
+++ b/includes/class-newspack-newsletters-renderer.php
@@ -114,8 +114,13 @@ final class Newspack_Newsletters_Renderer {
 			return '';
 		}
 
-		$alt        = get_post_meta( $attachment_id, '_wp_attachment_image_alt', true );
 		$attachment = get_post( $attachment_id );
+		// Sanity check.
+		if ( $attachment->post_type !== 'attachment' ) {
+			return '';
+		}
+
+		$alt = get_post_meta( $attachment_id, '_wp_attachment_image_alt', true );
 
 		if ( empty( $alt ) ) {
 			$alt = $attachment->post_content;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

If email post content was copied from a different site, the `img` `alt` attribute might cause trouble. This PR adds a sanity check to see if the source for the `alt` attribute is an attachment.

### How to test the changes in this Pull Request:

1. On `trunk`
1. Edit a newsletter and insert and image
2. Switch to code view, and replace the `id` with a regular post id 

<img width="331" alt="image" src="https://github.com/user-attachments/assets/ec14474f-5a44-4cdf-b5f0-74c5b27e7913" />

4. Save draft and save a test email
5. Observe the post with the post id set in `id` is now a part of the HTML payload
6. Switch to this branch, observe the issue is not reproducible anymore

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1209238604046667