### PR TITLE
feat(admin-menu): remove non-applicable admin menu items

### DIFF
--- a/includes/class-newspack-newsletters-ads.php
+++ b/includes/class-newspack-newsletters-ads.php
@@ -173,6 +173,21 @@ final class Newspack_Newsletters_Ads {
 	}
 
 	/**
+	 * Display Newsletter Ads as a separate menu item, if the user can't edit Newsletters but can edit Newsletter Ads.
+	 * Otherwise, the Newsletter Ads will be a submenu item under Newsletters.
+	 */
+	public static function display_ads_menu_item_separately() {
+		$newsletters_post_type_object = get_post_type_object( Newspack_Newsletters::NEWSPACK_NEWSLETTERS_CPT );
+		$newsletter_ad_post_type_object = get_post_type_object( self::CPT );
+		if ( $newsletter_ad_post_type_object ) {
+			$can_edit_newsletter_ads = current_user_can( $newsletter_ad_post_type_object->cap->edit_posts );
+		} else {
+			$can_edit_newsletter_ads = false;
+		}
+		return ! current_user_can( $newsletters_post_type_object->cap->edit_posts ) && $can_edit_newsletter_ads;
+	}
+
+	/**
 	 * Add ads page link.
 	 */
 	public static function add_ads_page() {
@@ -182,15 +197,27 @@ final class Newspack_Newsletters_Ads {
 		$page_title = apply_filters( 'newspack_newsletters_ads_page_title', __( 'Newsletters Ads', 'newspack-newsletters' ) );
 		$menu_title = apply_filters( 'newspack_newsletters_ads_menu_title', __( 'Ads', 'newspack-newsletters' ) );
 
-		add_submenu_page(
-			'edit.php?post_type=' . Newspack_Newsletters::NEWSPACK_NEWSLETTERS_CPT,
-			$page_title,
-			$menu_title,
-			$newsletter_ad_post_type_object->cap->edit_posts,
-			'edit.php?post_type=' . self::CPT,
-			null,
-			2
-		);
+		if ( self::display_ads_menu_item_separately() ) {
+			add_menu_page(
+				$page_title,
+				$page_title,
+				$newsletter_ad_post_type_object->cap->edit_posts,
+				'edit.php?post_type=' . self::CPT,
+				null,
+				'data:image/svg+xml;base64,' . base64_encode( '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" aria-hidden="true" focusable="false" fill="none"><path fill-rule="evenodd" clip-rule="evenodd" d="M3 7c0-1.1.9-2 2-2h14a2 2 0 0 1 2 2v10a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V7Zm2-.5h14c.3 0 .5.2.5.5v1L12 13.5 4.5 7.9V7c0-.3.2-.5.5-.5Zm-.5 3.3V17c0 .3.2.5.5.5h14c.3 0 .5-.2.5-.5V9.8L12 15.4 4.5 9.8Z"></path></svg>' )
+			);
+
+		} else {
+			add_submenu_page(
+				'edit.php?post_type=' . Newspack_Newsletters::NEWSPACK_NEWSLETTERS_CPT,
+				$page_title,
+				$menu_title,
+				$newsletter_ad_post_type_object->cap->edit_posts,
+				'edit.php?post_type=' . self::CPT,
+				null,
+				2
+			);
+		}
 	}
 
 	/**

--- a/includes/class-newspack-newsletters-ads.php
+++ b/includes/class-newspack-newsletters-ads.php
@@ -176,46 +176,30 @@ final class Newspack_Newsletters_Ads {
 	 * Add ads page link.
 	 */
 	public static function add_ads_page() {
-		// Check if user can access the newsletters CPT.
-		$newsletters_post_type_object = get_post_type_object( Newspack_Newsletters::NEWSPACK_NEWSLETTERS_CPT );
-		$can_edit_newsletters = current_user_can( $newsletters_post_type_object->cap->edit_posts );
+		$newsletter_ad_post_type_object = get_post_type_object( self::CPT );
+		$can_edit_newsletter_ads = current_user_can( $newsletter_ad_post_type_object->cap->edit_posts );
 
-		if ( $can_edit_newsletters ) {
-			// Add as submenu under newsletters if user has access.
-			$page_title = apply_filters( 'newspack_newsletters_ads_page_title', __( 'Newsletters Ads', 'newspack-newsletters' ) );
-			$menu_title = apply_filters( 'newspack_newsletters_ads_menu_title', __( 'Ads', 'newspack-newsletters' ) );
+		$page_title = apply_filters( 'newspack_newsletters_ads_page_title', __( 'Newsletters Ads', 'newspack-newsletters' ) );
+		$menu_title = apply_filters( 'newspack_newsletters_ads_menu_title', __( 'Ads', 'newspack-newsletters' ) );
 
-			add_submenu_page(
-				'edit.php?post_type=' . Newspack_Newsletters::NEWSPACK_NEWSLETTERS_CPT,
-				$page_title,
-				$menu_title,
-				'edit_others_posts',
-				'edit.php?post_type=' . self::CPT,
-				null,
-				2
-			);
-		} elseif ( current_user_can( 'edit_others_posts' ) ) {
-			// Add as top-level menu if user can't access newsletters but can edit ads.
-			$page_title = apply_filters( 'newspack_newsletters_ads_page_title_toplevel', __( 'Newsletter Ads', 'newspack-newsletters' ) );
-			$menu_title = apply_filters( 'newspack_newsletters_ads_menu_title_toplevel', __( 'Newsletter Ads', 'newspack-newsletters' ) );
-
-			add_menu_page(
-				$page_title,
-				$menu_title,
-				'edit_others_posts',
-				'edit.php?post_type=' . self::CPT,
-				'',
-				'dashicons-megaphone',
-				30
-			);
-		}
+		add_submenu_page(
+			'edit.php?post_type=' . Newspack_Newsletters::NEWSPACK_NEWSLETTERS_CPT,
+			$page_title,
+			$menu_title,
+			$newsletter_ad_post_type_object->cap->edit_posts,
+			'edit.php?post_type=' . self::CPT,
+			null,
+			2
+		);
 	}
 
 	/**
 	 * Register the custom post type for layouts.
 	 */
 	public static function register_ads_cpt() {
-		if ( ! current_user_can( 'edit_others_posts' ) ) {
+		$newsletters_post_type_object = get_post_type_object( Newspack_Newsletters::NEWSPACK_NEWSLETTERS_CPT );
+		$can_edit_newsletters = current_user_can( $newsletters_post_type_object->cap->edit_posts );
+		if ( ! $can_edit_newsletters ) {
 			return;
 		}
 

--- a/includes/class-newspack-newsletters-ads.php
+++ b/includes/class-newspack-newsletters-ads.php
@@ -176,15 +176,39 @@ final class Newspack_Newsletters_Ads {
 	 * Add ads page link.
 	 */
 	public static function add_ads_page() {
-		add_submenu_page(
-			'edit.php?post_type=' . Newspack_Newsletters::NEWSPACK_NEWSLETTERS_CPT,
-			__( 'Newsletters Ads', 'newspack-newsletters' ),
-			__( 'Ads', 'newspack-newsletters' ),
-			'edit_others_posts',
-			'/edit.php?post_type=' . self::CPT,
-			null,
-			2
-		);
+		// Check if user can access the newsletters CPT.
+		$newsletters_post_type_object = get_post_type_object( Newspack_Newsletters::NEWSPACK_NEWSLETTERS_CPT );
+		$can_edit_newsletters = current_user_can( $newsletters_post_type_object->cap->edit_posts );
+
+		if ( $can_edit_newsletters ) {
+			// Add as submenu under newsletters if user has access.
+			$page_title = apply_filters( 'newspack_newsletters_ads_page_title', __( 'Newsletters Ads', 'newspack-newsletters' ) );
+			$menu_title = apply_filters( 'newspack_newsletters_ads_menu_title', __( 'Ads', 'newspack-newsletters' ) );
+
+			add_submenu_page(
+				'edit.php?post_type=' . Newspack_Newsletters::NEWSPACK_NEWSLETTERS_CPT,
+				$page_title,
+				$menu_title,
+				'edit_others_posts',
+				'edit.php?post_type=' . self::CPT,
+				null,
+				2
+			);
+		} elseif ( current_user_can( 'edit_others_posts' ) ) {
+			// Add as top-level menu if user can't access newsletters but can edit ads.
+			$page_title = apply_filters( 'newspack_newsletters_ads_page_title_toplevel', __( 'Newsletter Ads', 'newspack-newsletters' ) );
+			$menu_title = apply_filters( 'newspack_newsletters_ads_menu_title_toplevel', __( 'Newsletter Ads', 'newspack-newsletters' ) );
+
+			add_menu_page(
+				$page_title,
+				$menu_title,
+				'edit_others_posts',
+				'edit.php?post_type=' . self::CPT,
+				'',
+				'dashicons-megaphone',
+				30
+			);
+		}
 	}
 
 	/**

--- a/includes/class-newspack-newsletters.php
+++ b/includes/class-newspack-newsletters.php
@@ -543,25 +543,26 @@ final class Newspack_Newsletters {
 	 */
 	public static function remove_admin_menu_items() {
 		$newsletter_post_type_object = get_post_type_object( self::NEWSPACK_NEWSLETTERS_CPT );
+		$newsletter_ad_post_type_object = get_post_type_object( Newspack_Newsletters_Ads::CPT );
 
-		if ( current_user_can( $newsletter_post_type_object->cap->edit_posts ) ) {
-			// Handle Newsletter Ads when the user can't edit newsletters.
-			$newsletter_ad_post_type_object = get_post_type_object( Newspack_Newsletters_Ads::CPT );
-			$can_edit_newsletter_ads = $newsletter_ad_post_type_object !== null && current_user_can( $newsletter_ad_post_type_object->cap->edit_posts );
-			if ( ! $can_edit_newsletter_ads ) {
-				// If the user can edit newsletters, the Newsletter Ads menu item will be in a submenu.
-				remove_submenu_page( 'edit.php?post_type=' . self::NEWSPACK_NEWSLETTERS_CPT, 'edit.php?post_type=' . Newspack_Newsletters_Ads::CPT );
-			}
-		} else {
-			// If the user can't edit newsletters, the "Category" will be the top-level menu item.
-			$category_page_slug = 'edit-tags.php?taxonomy=category&amp;post_type=' . self::NEWSPACK_NEWSLETTERS_CPT;
-			// If they user can't edit newsletters, the Newsletter Ads menu item will be visible but unusable (it's a taxonomy on Newsletters).
-			remove_submenu_page( $category_page_slug, 'edit.php?post_type=' . Newspack_Newsletters_Ads::CPT );
+		if ( $newsletter_post_type_object === null || $newsletter_ad_post_type_object === null ) {
+			return;
+		}
 
+		// If the user can't edit newsletters, the "Category" will be the top-level menu item.
+		$category_page_slug = 'edit-tags.php?taxonomy=category&amp;post_type=' . self::NEWSPACK_NEWSLETTERS_CPT;
+
+		$can_edit_newsletters = current_user_can( $newsletter_post_type_object->cap->edit_posts );
+		$can_edit_newsletter_ads = current_user_can( $newsletter_ad_post_type_object->cap->edit_posts );
+
+		if ( ! $can_edit_newsletters && ! $can_edit_newsletter_ads ) {
 			// If they user can't edit newsletters, the taxonomy menu items will still be visible. Let's remove them.
 			remove_submenu_page( $category_page_slug, $category_page_slug );
 			remove_submenu_page( $category_page_slug, 'edit-tags.php?taxonomy=post_tag&amp;post_type=' . self::NEWSPACK_NEWSLETTERS_CPT );
 		}
+
+		// Note: Newsletter Ads menu handling is done in Newspack_Newsletters_Ads::add_ads_page()
+		// which dynamically places the menu based on user capabilities.
 	}
 
 	/**

--- a/includes/class-newspack-newsletters.php
+++ b/includes/class-newspack-newsletters.php
@@ -85,6 +85,7 @@ final class Newspack_Newsletters {
 		add_action( 'init', [ __CLASS__, 'register_blocks' ] );
 		add_action( 'init', [ __CLASS__, 'load_textdomain' ] );
 		add_action( 'rest_api_init', [ __CLASS__, 'rest_api_init' ] );
+		add_action( 'admin_menu', [ __CLASS__, 'remove_admin_menu_items' ], 99 );
 		add_action( 'default_title', [ __CLASS__, 'default_title' ], 10, 2 );
 		add_action( 'wp_head', [ __CLASS__, 'public_newsletter_custom_style' ], 10, 2 );
 		add_filter( 'display_post_states', [ __CLASS__, 'display_post_states' ], 10, 2 );
@@ -535,6 +536,32 @@ final class Newspack_Newsletters {
 			'menu_icon'        => 'data:image/svg+xml;base64,' . base64_encode( '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" aria-hidden="true" focusable="false" fill="none"><path fill-rule="evenodd" clip-rule="evenodd" d="M3 7c0-1.1.9-2 2-2h14a2 2 0 0 1 2 2v10a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V7Zm2-.5h14c.3 0 .5.2.5.5v1L12 13.5 4.5 7.9V7c0-.3.2-.5.5-.5Zm-.5 3.3V17c0 .3.2.5.5.5h14c.3 0 .5-.2.5-.5V9.8L12 15.4 4.5 9.8Z"></path></svg>' ),
 		];
 		\register_post_type( self::NEWSPACK_NEWSLETTERS_CPT, $cpt_args );
+	}
+
+	/**
+	 * Remove some admin menu items, if the user has no matching capability.
+	 */
+	public static function remove_admin_menu_items() {
+		$newsletter_post_type_object = get_post_type_object( self::NEWSPACK_NEWSLETTERS_CPT );
+
+		if ( current_user_can( $newsletter_post_type_object->cap->edit_posts ) ) {
+			// Handle Newsletter Ads when the user can't edit newsletters.
+			$newsletter_ad_post_type_object = get_post_type_object( Newspack_Newsletters_Ads::CPT );
+			$can_edit_newsletter_ads = $newsletter_ad_post_type_object !== null && current_user_can( $newsletter_ad_post_type_object->cap->edit_posts );
+			if ( ! $can_edit_newsletter_ads ) {
+				// If the user can edit newsletters, the Newsletter Ads menu item will be in a submenu.
+				remove_submenu_page( 'edit.php?post_type=' . self::NEWSPACK_NEWSLETTERS_CPT, 'edit.php?post_type=' . Newspack_Newsletters_Ads::CPT );
+			}
+		} else {
+			// If the user can't edit newsletters, the "Category" will be the top-level menu item.
+			$category_page_slug = 'edit-tags.php?taxonomy=category&amp;post_type=' . self::NEWSPACK_NEWSLETTERS_CPT;
+			// If they user can't edit newsletters, the Newsletter Ads menu item will be visible but unusable (it's a taxonomy on Newsletters).
+			remove_submenu_page( $category_page_slug, 'edit.php?post_type=' . Newspack_Newsletters_Ads::CPT );
+
+			// If they user can't edit newsletters, the taxonomy menu items will still be visible. Let's remove them.
+			remove_submenu_page( $category_page_slug, $category_page_slug );
+			remove_submenu_page( $category_page_slug, 'edit-tags.php?taxonomy=post_tag&amp;post_type=' . self::NEWSPACK_NEWSLETTERS_CPT );
+		}
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Adjusts admin menu items to align with capabilities.

Part of NPPM-336

### How to test the changes in this Pull Request:

1. On `trunk`,
2. Activate `capability-manager-enhanced` plugin and edit the Editor role 
3. In the "Unique Post Type Capabilities" choose "Newsletters" and "Newsletter Ads" and click "Update"
4. Deselect all capabilities in "Newsletters" and "Newsletter Ads" rows:

<img width="713" alt="image" src="https://github.com/user-attachments/assets/636ca3ce-12c2-487a-aac8-1d8de03e9fb6" />

5. Log in as the editor, observe Newsletters menu item with Categories, Tags, Advertising submenu items
6. Switch to this branch, observe no Newsletter menu item
7. Adjust editor permissions to all all of Newsletters, but not Newsletters Ads → observe the menu item displayed accordingly
8. Adjust permissions to all of Newsletters and Newsletter Ads → observe the menu item displayed accordingly
9 Adjust permissions to all of Newsletter Ads, but not Newsletters → observe the menu item displayed accordingly

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->