### PR TITLE
fix(email-html): button rendering

### DIFF
--- a/includes/class-newspack-newsletters-renderer.php
+++ b/includes/class-newspack-newsletters-renderer.php
@@ -735,7 +735,7 @@ final class Newspack_Newsletters_Renderer {
 					$inner_blocks,
 					function ( $acc, $block ) {
 						if ( isset( $block['attrs']['width'] ) ) {
-							$acc .= intval( $block['attrs']['width'] );
+							$acc += intval( $block['attrs']['width'] );
 						}
 						return $acc;
 					},
@@ -766,7 +766,6 @@ final class Newspack_Newsletters_Renderer {
 					$is_multi_row  = true;
 				}
 
-				$remaining_width  = 100;
 				$block_mjml_array = [];
 
 				foreach ( $inner_blocks as $button_block ) {
@@ -832,46 +831,20 @@ final class Newspack_Newsletters_Renderer {
 						$column_width                  = $attrs['width'];
 						$default_button_attrs['width'] = '100%'; // Buttons with defined width should fill their column.
 					}
-
 					$column_attrs['width'] = $column_width . '%';
-					$remaining_width      -= $column_width;
-
 					$block_mjml_array[] = [
 						'<mj-column ' . self::array_to_attributes( $column_attrs ) . '>',
 						'<mj-button ' . self::array_to_attributes( $default_button_attrs ) . ">$text</mj-button>",
 						'</mj-column>',
 					];
-
-					if ( $remaining_width < $default_width ) {
-						$remaining_width    = 100;
-						$block_mjml_array[] = [
-							'<mj-section ' . self::array_to_attributes( $wrapper_attrs ) . '>',
-							null,
-							'</mj-section>',
-						];
-					}
 				}
 
-				if ( $is_multi_row && $remaining_width < 100 ) {
-					$block_mjml_array[] = [
-						'<mj-section ' . self::array_to_attributes( $wrapper_attrs ) . '>',
-						null,
-						'</mj-section>',
-					];
-				}
-
-				$markup     = '';
-				$button_row = '';
+				$markup = '<mj-section ' . self::array_to_attributes( $wrapper_attrs ) . '>';
 				foreach ( $block_mjml_array as $block_mjml ) {
-					if ( isset( $block_mjml[1] ) ) {
-						// Add a button to the button row markup.
-						$button_row .= $block_mjml[0] . $block_mjml[1] . $block_mjml[2];
-					} else {
-						// Wrap button row in a section, then reset button row markup.
-						$markup    .= $block_mjml[0] . $button_row . $block_mjml[2];
-						$button_row = '';
-					}
+					$markup .= implode( $block_mjml );
 				}
+				$markup .= '</mj-section>';
+
 				$block_mjml_markup = '<mj-wrapper ' . self::array_to_attributes( $wrapper_attrs ) . '>' . $markup . '</mj-wrapper>';
 				break;
 

--- a/tests/test-renderer.php
+++ b/tests/test-renderer.php
@@ -279,7 +279,6 @@ class Newsletters_Renderer_Test extends WP_UnitTestCase {
 			'Renders right aligned button'
 		);
 
-
 		// Multiple buttons.
 		$this->assertEquals(
 			Newspack_Newsletters_Renderer::render_mjml_component(
@@ -311,6 +310,40 @@ class Newsletters_Renderer_Test extends WP_UnitTestCase {
 				]
 			),
 			'<mj-section padding="0"><mj-wrapper padding="0" text-align="left"><mj-section padding="0" text-align="left"><mj-column padding="12px" css-class="mj-column-has-width" width="50%"><mj-button align="left" padding="0" inner-padding="12px 24px" line-height="1.5" href="" border-radius="999px" font-size="16px"  font-weight="bold" color="#fff !important" background-color="#32373c">Test Button</mj-button></mj-column><mj-column padding="12px" css-class="mj-column-has-width" width="50%"><mj-button align="left" padding="0" inner-padding="12px 24px" line-height="1.5" href="" border-radius="999px" font-size="16px"  font-weight="bold" color="#fff !important" background-color="#32373c">Test Button</mj-button></mj-column></mj-section></mj-wrapper></mj-section>',
+			'Renders multiple buttons'
+		);
+
+		// Multiple buttons, with widths.
+		$this->assertEquals(
+			Newspack_Newsletters_Renderer::render_mjml_component(
+				[
+					'blockName'    => 'core/buttons',
+					'attrs'        => [],
+					'innerBlocks'  => [
+						[
+							'blockName'    => 'core/button',
+							'attrs'        => [ 'width' => '25' ],
+							'innerBlocks'  => [],
+							'innerContent' => [ $inner_html ],
+							'innerHTML'    => $inner_html,
+						],
+						[
+							'blockName'    => 'core/button',
+							'attrs'        => [],
+							'innerBlocks'  => [],
+							'innerContent' => [ $inner_html ],
+							'innerHTML'    => $inner_html,
+						],
+					],
+					'innerContent' => [
+						'<div>',
+						null,
+						'</div>',
+					],
+					'innerHTML'    => '<div></div>',
+				]
+			),
+			'<mj-section padding="0"><mj-wrapper padding="0" text-align="left"><mj-section padding="0" text-align="left"><mj-column padding="12px" css-class="mj-column-has-width" width="25%"><mj-button align="left" padding="0" inner-padding="12px 24px" line-height="1.5" href="" border-radius="999px" font-size="16px"  font-weight="bold" color="#fff !important" background-color="#32373c" width="100%">Test Button</mj-button></mj-column><mj-column padding="12px" css-class="mj-column-has-width" width="75%"><mj-button align="left" padding="0" inner-padding="12px 24px" line-height="1.5" href="" border-radius="999px" font-size="16px"  font-weight="bold" color="#fff !important" background-color="#32373c">Test Button</mj-button></mj-column></mj-section></mj-wrapper></mj-section>',
 			'Renders multiple buttons'
 		);
 	}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes an issue with button rendering. 

### How to test the changes in this Pull Request:

1. On `trunk`, create a newsletter and insert a button with a defined width (e.g. 25%)
2. Click "Preview email", observe no button rendered
3. Switch to this branch, observe the buttons are rendered with proper widths

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1209952801077368