### PR TITLE
fix(editor): ads config call

### DIFF
--- a/includes/class-newspack-newsletters-ads.php
+++ b/includes/class-newspack-newsletters-ads.php
@@ -345,7 +345,7 @@ final class Newspack_Newsletters_Ads {
 	public static function get_ads_config( $request ) {
 		$letterhead                 = new Newspack_Newsletters_Letterhead();
 		$has_letterhead_credentials = $letterhead->has_api_credentials();
-		$post_id                    = $request->get_param( 'id' );
+		$post_id                    = $request->get_param( 'postId' );
 		$newspack_ad_type           = self::CPT;
 
 		$url_to_manage_promotions   = 'https://app.tryletterhead.com/promotions';

--- a/src/editor/blocks/ad/edit.js
+++ b/src/editor/blocks/ad/edit.js
@@ -27,7 +27,7 @@ export default function SubscribeEdit( { setAttributes, attributes: { adId } } )
 	useEffect( () => {
 		setInFlight( true );
 		apiFetch( {
-			path: `/wp/v2/${ NEWSLETTER_AD_CPT_SLUG }/config/?post_id=${ postId }`,
+			path: `/wp/v2/${ NEWSLETTER_AD_CPT_SLUG }/config/?postId=${ postId }`,
 		} )
 			.then( response => {
 				setAdsConfig( response );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes the calls to ads configuration endpoint. The param name was `id`/`post_id`/`postId`. This PR unifies that. The param is not actually used in the context in which it's broken, so there's no user-facing fix here.

### How to test the changes in this Pull Request:

1. On `trunk`, ensure you have some newsletters ads published
2. Edit a newsletter, observe `PHP Warning:  Attempt to read property "post_content" on null` logged
3. Switch to this branch, reload, observe no warnings logged

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->