### PR TITLE
fix: ignore sticky posts in the post inserter query when not otherwise manipulated

### DIFF
--- a/includes/class-newspack-newsletters-editor.php
+++ b/includes/class-newspack-newsletters-editor.php
@@ -52,8 +52,7 @@ final class Newspack_Newsletters_Editor {
 		add_filter( 'block_categories_all', [ __CLASS__, 'add_custom_block_category' ] );
 		add_filter( 'allowed_block_types_all', [ __CLASS__, 'newsletters_allowed_block_types' ], 10, 2 );
 		add_action( 'rest_post_query', [ __CLASS__, 'maybe_filter_excerpt_length' ], 10, 2 );
-		add_action( 'rest_post_query', [ __CLASS__, 'maybe_exclude_sponsored_posts' ], 10, 2 );
-		add_action( 'rest_post_query', [ __CLASS__, 'rest_post_query_filter' ] );
+		add_action( 'rest_post_query', [ __CLASS__, 'rest_post_query_filter' ], 10, 2 );
 		add_action( 'rest_api_init', [ __CLASS__, 'add_newspack_author_info' ] );
 		add_filter( 'the_posts', [ __CLASS__, 'maybe_reset_excerpt_length' ] );
 		add_filter( 'should_load_remote_block_patterns', [ __CLASS__, 'strip_block_patterns' ] );
@@ -450,19 +449,6 @@ final class Newspack_Newsletters_Editor {
 	}
 
 	/**
-	 * Default settings for the rest post query.
-	 *
-	 * @param array $args Request arguments.
-	 *
-	 * @return array Modified request args.
-	 */
-	public static function rest_post_query_filter( $args ) {
-		// Ignore sticky posts in query.
-		$args['ignore_sticky_posts'] = true;
-		return $args;
-	}
-
-	/**
 	 * If excerpt length is set in Post Inserter block attributes, override the site's excerpt length using the setting.
 	 *
 	 * @param array           $args Request arguments.
@@ -481,16 +467,20 @@ final class Newspack_Newsletters_Editor {
 	}
 
 	/**
-	 * If Posts Inserter is set to hide sponsored content, add a tax query to exclude sponsored posts.
+	 * Update the Post Inserter query.
 	 *
 	 * @param array           $args Request arguments.
 	 * @param WP_REST_Request $request The original REST request params.
 	 *
 	 * @return array Filtered request args.
 	 */
-	public static function maybe_exclude_sponsored_posts( $args, $request ) {
+	public static function rest_post_query_filter( $args, $request ) {
 		$params = $request->get_params();
 
+		// Ignore sticky posts in query.
+		$args['ignore_sticky_posts'] = true;
+
+		// If Posts Inserter is set to hide sponsored content, add a tax query to exclude sponsored posts.
 		if ( ! empty( $params['exclude_sponsors'] ) && class_exists( '\Newspack_Sponsors\Core' ) ) {
 			if ( empty( $args['tax_query'] ) ) {
 				$args['tax_query'] = []; // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_tax_query

--- a/includes/class-newspack-newsletters-editor.php
+++ b/includes/class-newspack-newsletters-editor.php
@@ -500,6 +500,9 @@ final class Newspack_Newsletters_Editor {
 					];
 				}
 			}
+		} else {
+			// If we're not removing sponsors by modifying the query, make sure to ignore sticky posts.
+			$args['ignore_sticky_posts'] = true;
 		}
 
 		return $args;

--- a/includes/class-newspack-newsletters-editor.php
+++ b/includes/class-newspack-newsletters-editor.php
@@ -53,6 +53,7 @@ final class Newspack_Newsletters_Editor {
 		add_filter( 'allowed_block_types_all', [ __CLASS__, 'newsletters_allowed_block_types' ], 10, 2 );
 		add_action( 'rest_post_query', [ __CLASS__, 'maybe_filter_excerpt_length' ], 10, 2 );
 		add_action( 'rest_post_query', [ __CLASS__, 'maybe_exclude_sponsored_posts' ], 10, 2 );
+		add_action( 'rest_post_query', [ __CLASS__, 'rest_post_query_filter' ] );
 		add_action( 'rest_api_init', [ __CLASS__, 'add_newspack_author_info' ] );
 		add_filter( 'the_posts', [ __CLASS__, 'maybe_reset_excerpt_length' ] );
 		add_filter( 'should_load_remote_block_patterns', [ __CLASS__, 'strip_block_patterns' ] );
@@ -449,6 +450,19 @@ final class Newspack_Newsletters_Editor {
 	}
 
 	/**
+	 * Default settings for the rest post query.
+	 *
+	 * @param array $args Request arguments.
+	 *
+	 * @return array Modified request args.
+	 */
+	public static function rest_post_query_filter( $args ) {
+		// Ignore sticky posts in query.
+		$args['ignore_sticky_posts'] = true;
+		return $args;
+	}
+
+	/**
 	 * If excerpt length is set in Post Inserter block attributes, override the site's excerpt length using the setting.
 	 *
 	 * @param array           $args Request arguments.
@@ -500,9 +514,6 @@ final class Newspack_Newsletters_Editor {
 					];
 				}
 			}
-		} else {
-			// If we're not removing sponsors by modifying the query, make sure to ignore sticky posts.
-			$args['ignore_sticky_posts'] = true;
 		}
 
 		return $args;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This is an odd edge case, but when you have some posts marked as 'Sticky' and 'Display sponsored posts' turned on, the sticky posts will show at the top of the Post Inserter block. When you disable 'Display sponsored posts', the plugin manipulates the post query so sticky posts aren't at the top by default.

### How to test the changes in this Pull Request:

1. Mark 2-3 older posts as Sticky. You can do this from the Quick Edit view under Posts, or by clicking "Published" in the sidebar on a single post (that opens a model with "Sticky" at the bottom).
2. Make a new newsletter, and add the Post Inserter block.
3. Note your sticky post(s) are at the top, ahead of newer posts. 
4. Turn off "Display sponsored posts" and note your newer posts are now at the top.
5. Apply this PR.
6. Refresh the editor, and toggle on and off "Display sponsored posts"; confirm that the sticky posts don't appear at the top in either case. 

See p1744750283207519-slack-newspack-support

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
