### PR TITLE
fix: fix error handling for active campaign add tag

### DIFF
--- a/includes/service-providers/active_campaign/class-newspack-newsletters-active-campaign.php
+++ b/includes/service-providers/active_campaign/class-newspack-newsletters-active-campaign.php
@@ -416,7 +416,11 @@ final class Newspack_Newsletters_Active_Campaign extends \Newspack_Newsletters_S
 			]
 		);
 
-		if ( is_array( $created ) && ! empty( $created['contacts'] ) ) {
+		if ( is_wp_error( $created ) ) {
+			$created = [ 'message' => $created->get_error_message() ];
+		}
+
+		if ( is_array( $created ) && ! empty( $created['contactTag'] ) ) {
 			return true;
 		}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes two issues:

1. The add_tag to contact method will return an Error if you try to add a tag that the contact already has
2. The application will crash if you try to add a tag that doesn't exist

### How to test the changes in this Pull Request:

1. On `trunk` add a tag to a contact via wp shell doing this:

```
$ac = Newspack_Newsletters_Active_Campaign::instance();
$ac->add_tag_to_contact( 'email@leo.com', 27 );
```

Where `email@leo.com` is an email already registered in Active Campaign and `27` is the ID of an existing tag.

4. Confirm the method returns `true` and the tag is added to the contact.
5. Now run the same command again and confirm the method returns a `WP_Error` object.
6. Now run the command again trying to add a tag that doesn't exist: `$ac->add_tag_to_contact( 'email@leo.com', 9999 );`
7. Confirm the application crashes with an Uncaught error
8. Apply this branch
9. Repeat the steps above and confirm that:
10. When you try to add a tag that the contact already has, you still get `true' as a result
11. When you try to add a tag that doesn't exist you get a WP_Error as a return and no crashes

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
