### PR TITLE
feat(ga4): dispatch newsletter_signup activity upon signup via block

### DIFF
--- a/src/blocks/subscribe/view.js
+++ b/src/blocks/subscribe/view.js
@@ -59,17 +59,24 @@ domReady( function () {
 			if ( status === 200 ) {
 				container.replaceChild( responseContainer, form );
 				form.dispatchEvent( successEvent );
-				if ( metadata?.registered ) {
-					window.newspackRAS = window.newspackRAS || [];
+				window.newspackRAS = window.newspackRAS || [];
+				const formData = new FormData( form );
+				const lists = formData.getAll( 'lists[]' );
+				const baseActivity = { email: emailInput.value };
+				if ( metadata?.newspack_popup_id ) {
+					baseActivity.newspack_popup_id = metadata.newspack_popup_id;
+				}
+				if ( metadata?.gate_post_id ) {
+					baseActivity.gate_post_id = metadata.gate_post_id;
+				}
+				if ( lists.length && wasSubscribed ) {
 					window.newspackRAS.push( function( ras ) {
-						const activity = { email: emailInput.value, registration_method: metadata?.registration_method };
-						if ( metadata?.newspack_popup_id ) {
-							activity.newspack_popup_id = metadata?.newspack_popup_id;
-						}
-						if ( metadata?.gate_post_id ) {
-							activity.gate_post_id = metadata?.gate_post_id;
-						}
-						ras.dispatchActivity( 'reader_registered', activity );
+						ras.dispatchActivity( 'newsletter_signup', { ...baseActivity, lists, newsletters_subscription_method: metadata?.newsletters_subscription_method || 'newsletters-subscription-block' } );
+					} );
+				}
+				if ( metadata?.registered ) {
+					window.newspackRAS.push( function( ras ) {
+						ras.dispatchActivity( 'reader_registered', { ...baseActivity, registration_method: metadata?.registration_method || 'newsletters-subscription' } );
 					} );
 				}
 			}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Dispatch `newsletter_signup` activity after successful signup via block.

### How to test the changes in this Pull Request:

See https://github.com/Automattic/newspack-plugin/pull/3938 for testing instructions.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
