### PR TITLE
fix(admin-menu): hide advertisers menu from admin dashboard

### DIFF
--- a/includes/class-newspack-newsletters-ads.php
+++ b/includes/class-newspack-newsletters-ads.php
@@ -258,6 +258,7 @@ final class Newspack_Newsletters_Ads {
 				'public'            => true,
 				'hierarchical'      => true,
 				'show_in_rest'      => true,
+				'show_in_menu'      => false,
 				'show_admin_column' => true,
 			]
 		);


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes https://app.asana.com/1/26890605006346/project/1208970929679778/task/1209931109967257?focus=true.

Streamline the Newsletters section navigation by addressing a confusing menu structure. Previously, both "Advertiser" and "Advertising" links appeared in the secondary menu:
- Clicking "Advertisers" opened the correct Advertisers tab, but "Advertising" remained highlighted.
- Clicking "Advertising" opened the Ads tab, also with "Advertising" highlighted.

This caused inconsistency in navigation. This removes the redundant "Advertisers" link, leaving only "Advertising" link in the secondary menu, as per the original mockups. This link correctly opens the first tab under the Advertising section.

### How to test the changes in this Pull Request:

1. Navigate to the Newsletters section in the WordPress admin.
2. Confirm that only one "Advertising" link appears in the secondary menu.
3. Clicking this "Advertising" link should open the first tab (e.g. Ads) under the tertiary menu, with correct menu highlighting.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
