### PR TITLE
fix: advertisers menu

### DIFF
--- a/includes/class-newspack-newsletters-ads.php
+++ b/includes/class-newspack-newsletters-ads.php
@@ -52,7 +52,10 @@ final class Newspack_Newsletters_Ads {
 		add_action( 'init', [ __CLASS__, 'register_newsletter_meta' ] );
 		add_action( 'save_post_' . self::CPT, [ __CLASS__, 'ad_default_fields' ], 10, 3 );
 		add_action( 'rest_api_init', [ __CLASS__, 'rest_api_init' ] );
+
+		// Menus are manually registered so the main Newspack plugin can deregister them.
 		add_action( 'admin_menu', [ __CLASS__, 'add_ads_page' ] );
+
 		add_filter( 'get_post_metadata', [ __CLASS__, 'migrate_diable_ads' ], 10, 4 );
 		add_action( 'newspack_newsletters_tracking_pixel_seen', [ __CLASS__, 'track_ad_impression' ], 10, 2 );
 		add_filter( 'newspack_newsletters_newsletter_content', [ __CLASS__, 'filter_newsletter_content' ], 10, 2 );
@@ -184,6 +187,16 @@ final class Newspack_Newsletters_Ads {
 			'/edit.php?post_type=' . self::CPT,
 			null,
 			2
+		);
+
+		add_submenu_page(
+			'edit.php?post_type=' . Newspack_Newsletters::NEWSPACK_NEWSLETTERS_CPT,
+			__( 'Advertisers', 'newspack-newsletters' ),
+			__( 'Advertisers', 'newspack-newsletters' ),
+			'edit_others_posts',
+			'edit-tags.php?taxonomy=' . self::ADVERTISER_TAX . '&post_type=' . Newspack_Newsletters::NEWSPACK_NEWSLETTERS_CPT,
+			null,
+			3
 		);
 	}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

https://github.com/Automattic/newspack-newsletters/pull/1820 removed the Advertisers menu item, but what we really want is to register it in a different way so the main plugin [removes it](https://github.com/Automattic/newspack-plugin/blob/1c8c7d7fd1ea2e62e4947c2a52ef0df02d284c0c/includes/wizards/class-newsletters-wizard.php#L82-L85) when enabled.

### How to test the changes in this Pull Request:

1. Deactivate the main plugin and confirm the Advertisers menu item is visible and it points to the taxonomy
2. Activate the main Newspack plugin and confirm the menu entry is gone


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
