### PR TITLE
feat: allow ESP provider extension

### DIFF
--- a/includes/class-newspack-newsletters-settings.php
+++ b/includes/class-newspack-newsletters-settings.php
@@ -178,6 +178,13 @@ class Newspack_Newsletters_Settings {
 			);
 		}
 
+		/**
+		 * Filters the settings list.
+		 *
+		 * @param array $settings_list The settings list.
+		 */
+		$settings_list = apply_filters( 'newspack_newsletters_settings_list', $settings_list );
+
 		// Filter out options related to unsupported providers.
 		$supported_providers = Newspack_Newsletters::get_supported_providers();
 		$settings_list       = array_reduce(
@@ -204,12 +211,7 @@ class Newspack_Newsletters_Settings {
 			[]
 		);
 
-		/**
-		 * Filters the settings list.
-		 *
-		 * @param array $settings_list The settings list.
-		 */
-		return apply_filters( 'newspack_newsletters_settings_list', $settings_list );
+		return $settings_list;
 	}
 
 	/**

--- a/includes/class-newspack-newsletters-settings.php
+++ b/includes/class-newspack-newsletters-settings.php
@@ -101,20 +101,6 @@ class Newspack_Newsletters_Settings {
 				'onboarding'  => true,
 			),
 			array(
-				'description' => esc_html__( 'Campaign Monitor API Key', 'newspack-newsletters' ),
-				'key'         => 'newspack_newsletters_campaign_monitor_api_key',
-				'type'        => 'text',
-				'provider'    => 'campaign_monitor',
-				'onboarding'  => true,
-			),
-			array(
-				'description' => esc_html__( 'Campaign Monitor Client ID', 'newspack-newsletters' ),
-				'key'         => 'newspack_newsletters_campaign_monitor_client_id',
-				'type'        => 'text',
-				'provider'    => 'campaign_monitor',
-				'onboarding'  => true,
-			),
-			array(
 				'description' => esc_html__( 'ActiveCampaign API URL', 'newspack-newsletters' ),
 				'key'         => 'newspack_newsletters_active_campaign_url',
 				'type'        => 'text',

--- a/includes/class-newspack-newsletters-settings.php
+++ b/includes/class-newspack-newsletters-settings.php
@@ -79,7 +79,7 @@ class Newspack_Newsletters_Settings {
 				'description' => esc_html__( 'Mailchimp API Key', 'newspack-newsletters' ),
 				'key'         => 'newspack_mailchimp_api_key',
 				'type'        => 'text',
-				'default'     => get_option( 'newspack_newsletters_mailchimp_api_key', '' ),
+				'default'     => get_option( 'newspack_mailchimp_api_key', get_option( 'newspack_newsletters_mailchimp_api_key' ) ),
 				'provider'    => 'mailchimp',
 				'placeholder' => esc_attr( '123457103961b1f4dc0b2b2fd59c137b-us1' ),
 				'help'        => esc_html__( 'Find or generate your API key', 'newspack-newsletter' ),

--- a/includes/class-newspack-newsletters-settings.php
+++ b/includes/class-newspack-newsletters-settings.php
@@ -47,36 +47,31 @@ class Newspack_Newsletters_Settings {
 	 * @return array Settings list.
 	 */
 	public static function get_settings_list() {
+
+		$esp_list = [
+			[
+				'name'  => esc_html__( 'Select service provider', 'newspack-newsletter' ),
+				'value' => '',
+			],
+		];
+
+		foreach ( Newspack_Newsletters::get_registered_providers() as $provider_slug => $provider ) {
+			$esp_list[] = [
+				'name'  => $provider['name'],
+				'value' => $provider_slug,
+			];
+		}
+
+		$esp_list[] = [
+			'name'  => esc_html__( 'Manual / Other', 'newspack-newsletters' ),
+			'value' => 'manual',
+		];
+
 		$settings_list = array(
 			array(
 				'description' => esc_html__( 'Service Provider', 'newspack-newsletters' ),
 				'key'         => 'newspack_newsletters_service_provider',
-				'options'     => array(
-					array(
-						'name'  => esc_html__( 'Select service provider', 'newspack-newsletter' ),
-						'value' => '',
-					),
-					array(
-						'name'  => esc_html__( 'Mailchimp', 'newspack-newsletters' ),
-						'value' => 'mailchimp',
-					),
-					array(
-						'name'  => esc_html__( 'Constant Contact', 'newspack-newsletters' ),
-						'value' => 'constant_contact',
-					),
-					array(
-						'name'  => esc_html__( 'Campaign Monitor', 'newspack-newsletters' ),
-						'value' => 'campaign_monitor',
-					),
-					array(
-						'name'  => esc_html__( 'ActiveCampaign', 'newspack-newsletters' ),
-						'value' => 'active_campaign',
-					),
-					array(
-						'name'  => esc_html__( 'Manual / Other', 'newspack-newsletters' ),
-						'value' => 'manual',
-					),
-				),
+				'options'     => $esp_list,
 				'type'        => 'select',
 				'onboarding'  => true,
 			),
@@ -209,7 +204,12 @@ class Newspack_Newsletters_Settings {
 			[]
 		);
 
-		return $settings_list;
+		/**
+		 * Filters the settings list.
+		 *
+		 * @param array $settings_list The settings list.
+		 */
+		return apply_filters( 'newspack_newsletters_settings_list', $settings_list );
 	}
 
 	/**

--- a/includes/class-newspack-newsletters.php
+++ b/includes/class-newspack-newsletters.php
@@ -126,9 +126,27 @@ final class Newspack_Newsletters {
 		/**
 		 * Filter the registered providers.
 		 *
-		 * @param array $providers The registered providers. Keys are providers slugs and values the providers class names
+		 * In order to register a new provider, create a new class that extends Newspack_Newsletters_Service_Provider
+		 * and add it to the $providers array.
+		 *
+		 * Do not directly load the class file in your plugin/theme, instead, inform the class name and the file path
+		 * to the filter.
+		 *
+		 * @param array $providers The registered providers. The keys are the provider slugs and the values are arrays with the following structure: {
+		 *     @type string $name The provider name.
+		 *     @type string $class The provider class name.
+		 *     @type string $class_file The provider class file path.
+		 * }
 		 */
-		return apply_filters( 'newspack_newsletters_registered_providers', $providers );
+		$providers = apply_filters( 'newspack_newsletters_registered_providers', $providers );
+
+		foreach ( $providers as $provider_slug => $provider ) {
+			if ( ! class_exists( $provider['class'] ) && isset( $provider['class_file'] ) && file_exists( $provider['class_file'] ) ) {
+				require_once $provider['class_file'];
+			}
+		}
+
+		return $providers;
 	}
 
 	/**

--- a/includes/class-newspack-newsletters.php
+++ b/includes/class-newspack-newsletters.php
@@ -113,10 +113,6 @@ final class Newspack_Newsletters {
 				'name'  => 'Constant Contact',
 				'class' => 'Newspack_Newsletters_Constant_Contact',
 			],
-			'campaign_monitor' => [
-				'name'  => 'Campaign Monitor',
-				'class' => 'Newspack_Newsletters_Campaign_Monitor',
-			],
 			'active_campaign'  => [
 				'name'  => 'Active Campaign',
 				'class' => 'Newspack_Newsletters_Active_Campaign',
@@ -173,11 +169,6 @@ final class Newspack_Newsletters {
 
 		// Add support for manual/other.
 		$supported_providers[] = 'manual';
-
-		// Remove support for Campaign Monitor if we don't have the required environment flag.
-		if ( 'campaign_monitor' !== self::service_provider() && ( ! defined( 'NEWSPACK_NEWSLETTERS_SUPPORT_DEPRECATED_CAMPAIGN_MONITOR' ) || ! NEWSPACK_NEWSLETTERS_SUPPORT_DEPRECATED_CAMPAIGN_MONITOR ) ) {
-			$supported_providers = array_values( array_diff( $supported_providers, [ 'campaign_monitor' ] ) );
-		}
 
 		return $supported_providers;
 	}

--- a/includes/class-newspack-newsletters.php
+++ b/includes/class-newspack-newsletters.php
@@ -37,18 +37,6 @@ final class Newspack_Newsletters {
 	];
 
 	/**
-	 * List of the implemented Servide providers. Keys are providers slugs and values the providers class names
-	 *
-	 * @var array
-	 */
-	const REGISTERED_PROVIDERS = [
-		'mailchimp'        => 'Newspack_Newsletters_Mailchimp',
-		'constant_contact' => 'Newspack_Newsletters_Constant_Contact',
-		'campaign_monitor' => 'Newspack_Newsletters_Campaign_Monitor',
-		'active_campaign'  => 'Newspack_Newsletters_Active_Campaign',
-	];
-
-	/**
 	 * The single instance of the class.
 	 *
 	 * @var Newspack_Newsletters
@@ -110,12 +98,60 @@ final class Newspack_Newsletters {
 	}
 
 	/**
+	 * Get the registered providers.
+	 *
+	 * @return array
+	 */
+	public static function get_registered_providers() {
+
+		$providers = [
+			'mailchimp'        => [
+				'name'  => 'Mailchimp',
+				'class' => 'Newspack_Newsletters_Mailchimp',
+			],
+			'constant_contact' => [
+				'name'  => 'Constant Contact',
+				'class' => 'Newspack_Newsletters_Constant_Contact',
+			],
+			'campaign_monitor' => [
+				'name'  => 'Campaign Monitor',
+				'class' => 'Newspack_Newsletters_Campaign_Monitor',
+			],
+			'active_campaign'  => [
+				'name'  => 'Active Campaign',
+				'class' => 'Newspack_Newsletters_Active_Campaign',
+			],
+		];
+
+		/**
+		 * Filter the registered providers.
+		 *
+		 * @param array $providers The registered providers. Keys are providers slugs and values the providers class names
+		 */
+		return apply_filters( 'newspack_newsletters_registered_providers', $providers );
+	}
+
+	/**
+	 * Get the provider class for a given provider slug.
+	 *
+	 * @param string $provider_slug The provider slug.
+	 * @return string|null The provider class or null if not found.
+	 */
+	public static function get_provider_class( $provider_slug ) {
+		$providers = self::get_registered_providers();
+		if ( isset( $providers[ $provider_slug ] ) ) {
+			return $providers[ $provider_slug ]['class'];
+		}
+		return null;
+	}
+
+	/**
 	 * In preparation for deprecating support for Campaign Monitor, locks support behind an environment flag.
 	 *
 	 * @return array
 	 */
 	public static function get_supported_providers() {
-		$supported_providers = array_keys( self::REGISTERED_PROVIDERS );
+		$supported_providers = array_keys( self::get_registered_providers() );
 
 		// Add support for manual/other.
 		$supported_providers[] = 'manual';
@@ -154,10 +190,10 @@ final class Newspack_Newsletters {
 	 * @return ?Newspack_Newsletters_Service_Provider
 	 */
 	public static function get_service_provider_instance( $provider_slug ) {
-		if ( empty( self::REGISTERED_PROVIDERS[ $provider_slug ] ) ) {
+		if ( empty( self::get_provider_class( $provider_slug ) ) ) {
 			return null;
 		}
-		return self::REGISTERED_PROVIDERS[ $provider_slug ]::instance();
+		return self::get_provider_class( $provider_slug )::instance();
 	}
 
 	/**

--- a/includes/class-newspack-newsletters.php
+++ b/includes/class-newspack-newsletters.php
@@ -7,8 +7,6 @@
 
 defined( 'ABSPATH' ) || exit;
 
-use Newspack_Newsletters_Mailchimp_Api as Mailchimp;
-
 /**
  * Main Newspack Newsletters Class.
  */
@@ -67,6 +65,7 @@ final class Newspack_Newsletters {
 	 * Constructor.
 	 */
 	public function __construct() {
+		add_action( 'init', [ __CLASS__, 'memoize_service_provider' ] );
 		add_action( 'init', [ __CLASS__, 'register_cpt' ] );
 		add_action( 'init', [ __CLASS__, 'register_meta' ] );
 		add_action( 'init', [ __CLASS__, 'register_editor_only_meta' ] );
@@ -87,7 +86,6 @@ final class Newspack_Newsletters {
 		add_filter( 'render_block', [ __CLASS__, 'remove_email_only_block' ], 10, 2 );
 		add_action( 'pre_get_posts', [ __CLASS__, 'display_newsletters_in_archives' ] );
 		add_action( 'the_post', [ __CLASS__, 'fix_public_status' ] );
-		self::set_service_provider( self::service_provider() );
 
 		$needs_nag = is_admin() && ! self::is_service_provider_configured() && ! get_option( 'newspack_newsletters_activation_nag_viewed', false );
 		if ( $needs_nag ) {
@@ -95,6 +93,22 @@ final class Newspack_Newsletters {
 			add_action( 'admin_enqueue_scripts', [ __CLASS__, 'activation_nag_dismissal_script' ] );
 			add_action( 'wp_ajax_newspack_newsletters_activation_nag_dismissal', [ __CLASS__, 'activation_nag_dismissal_ajax' ] );
 		}
+	}
+
+	/**
+	 * Store the service provider instance in a static property.
+	 */
+	public static function memoize_service_provider() {
+		$service_provider = self::service_provider();
+		$is_esp_manual    = 'manual' === $service_provider;
+
+		// 'newspack_mailchimp_api_key' is a newer option introduced to manage MC API key accross Newspack plugins.
+		// Keeping the old option for backwards compatibility.
+		if ( ! $is_esp_manual && ! $service_provider && get_option( 'newspack_mailchimp_api_key', get_option( 'newspack_newsletters_mailchimp_api_key' ) ) ) {
+			// Legacy – Mailchimp provider set before multi-provider handling was set up.
+			self::set_service_provider( 'mailchimp' );
+		}
+		self::$provider = self::get_service_provider_instance( $service_provider );
 	}
 
 	/**
@@ -121,6 +135,9 @@ final class Newspack_Newsletters {
 
 		/**
 		 * Filter the registered providers.
+		 *
+		 * To register a new provider, create a class that extends Newspack_Newsletters_Service_Provider
+		 * and add it to the $providers array. Include or require it on the 'init' action hook.
 		 *
 		 * In order to register a new provider, create a new class that extends Newspack_Newsletters_Service_Provider
 		 * and add it to the $providers array.
@@ -933,27 +950,15 @@ final class Newspack_Newsletters {
 	 */
 	public static function api_settings() {
 		$service_provider = self::service_provider();
+		$is_esp_manual    = 'manual' === $service_provider;
 		$response         = [
 			'service_provider' => $service_provider ? $service_provider : '',
 			'status'           => false,
 		];
-		$is_esp_manual    = 'manual' === $service_provider;
-
-		// 'newspack_mailchimp_api_key' is a new option introduced to manage MC API key accross Newspack plugins.
-		// Keeping the old option for backwards compatibility.
-		if ( ! $is_esp_manual && ! self::$provider && get_option( 'newspack_mailchimp_api_key', get_option( 'newspack_newsletters_mailchimp_api_key' ) ) ) {
-			// Legacy – Mailchimp provider set before multi-provider handling was set up.
-			self::set_service_provider( 'mailchimp' );
-		}
-
 		if ( self::$provider ) {
 			$response['credentials'] = self::$provider->api_credentials();
 		}
-
-		if (
-			$is_esp_manual ||
-			( self::$provider && self::$provider->has_api_credentials() )
-		) {
+		if ( $is_esp_manual || ( self::$provider && self::$provider->has_api_credentials() ) ) {
 			$response['status'] = true;
 		}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Add filters to make it possible for a plugin to register a new ESP.

### How to test the changes in this Pull Request:

1. Smoke test and make sure things are still working
2. Use the code provided below ("Sample Custom plugin") as a custom plugin that registers a new ESP
3. Confirm that the Settings page shows the new ESP options and saves them properly
4. Check it on both plugin's native settings page and the React Settings page on Newspack plugin

<details>

<summary>Sample Custom plugin</summary>

```
<?php

add_filter(
	'newspack_newsletters_settings_list',
	function( $settings_list ) {
		$new_items = [
			[
				'description' => esc_html__( 'Beehiiv API Key', 'newspack-newsletters' ),
				'key'         => 'newspack_newsletters_beehiiv_api_key',
				'type'        => 'text',
				'provider'    => 'beehiiv',
				'onboarding'  => true,
			],
			[
				'description' => esc_html__( 'Beehiiv Publication ID', 'newspack-newsletters' ),
				'key'         => 'newspack_newsletters_beehiiv_api_publication_id',
				'type'        => 'text',
				'provider'    => 'beehiiv',
				'onboarding'  => true,
			],
		];

		// add it to the second and third positions.
		array_splice( $settings_list, 1, 0, $new_items );

		return $settings_list;
	}
);

add_filter(
	'newspack_newsletters_registered_providers',
	function( $providers ) {
		$providers['beehiiv'] = [
			'name'  => 'Beehiiv',
			'class' => 'Newspack_Newsletters_Beehiiv',
		];
		return $providers;
	}
);

final class Newspack_Newsletters_Beehiiv extends \Newspack_Newsletters_Service_Provider {

	/**
	 * Get API credentials for service provider.
	 *
	 * @return Object Stored API credentials for the service provider.
	 */
	public function api_credentials() {
		return [
			'api_key'            => get_option( 'newspack_newsletters_beehiiv_api_key', '' ),
			'api_publication_id' => get_option( 'newspack_newsletters_beehiiv_api_publication_id', '' ),
		];
	}

	/**
	 * Set the API credentials for the service provider.
	 *
	 * @param object $credentials API credentials.
	 *
	 * @return Boolean Whether any API credential was updated.
	 */
	public function set_api_credentials( $credentials ) {
		if ( empty( $credentials['api_key'] ) || empty( $credentials['api_publication_id'] ) ) {
			return new WP_Error(
				'newspack_newsletters_invalid_keys',
				__( 'Please input Beehiiv API key and publication ID.', 'newspack-newsletters' )
			);
		} else {
			$update_api_key    = update_option( 'newspack_newsletters_beehiiv_api_key', $credentials['api_key'] );
			$update_api_publication_id = update_option( 'newspack_newsletters_beehiiv_api_publication_id', $credentials['api_publication_id'] );
			return $update_api_key || $update_api_publication_id;
		}
	}

	/**
	 * Get API key for service provider.
	 *
	 * @return String Stored API key for the service provider.
	 */
	public function api_key() {
		$credentials = $this->api_credentials();
		return $credentials['api_key'];
	}

	/**
	 * Get API publication ID for service provider.
	 *
	 * @return String Stored API publication ID for the service provider.
	 */
	public function api_publication_id() {
		$credentials = $this->api_credentials();
		return $credentials['api_publication_id'];
	}

	/**
	 * Check if provider has all necessary credentials set.
	 *
	 * @return Boolean Result.
	 */
	public function has_api_credentials() {
		return ! empty( $this->api_key() ) && ! empty( $this->api_publication_id() );
	}

	/**
	 * Get configuration for conditional tag support.
	 *
	 * @return array
	 */
	public static function get_conditional_tag_support() {
		return [
			'support_url' => '',
			'example'     => [
				'before' => '',
				'after'  => '',
			],
		];
	}

	/**
	 * Set list for a campaign.
	 *
	 * A campaign can not use segments and lists at the same time, so we also unset all segments.
	 *
	 * @param string $post_id Campaign Id.
	 * @param string $list_id ID of the list.
	 * @return object|WP_Error API API Response or error.
	 */
	public function list( $post_id, $list_id ) {
		return new WP_Error( 'newspack_newsletters_error', 'Beehiiv is not supported yet.' );
	}

	/**
	 * Retrieve a campaign.
	 *
	 * @param integer $post_id Numeric ID of the Newsletter post.
	 * @return object|WP_Error API Response or error.
	 * @throws Exception Error message.
	 */
	public function retrieve( $post_id ) {
		return new WP_Error( 'newspack_newsletters_error', 'Beehiiv is not supported yet.' );
	}

	/**
	 * Send test email or emails.
	 *
	 * @param integer $post_id Numeric ID of the Newsletter post.
	 * @param array   $emails Array of email addresses to send to.
	 * @return object|WP_Error API Response or error.
	 */
	public function test( $post_id, $emails ) {
		return new WP_Error( 'newspack_newsletters_error', 'Beehiiv is not supported yet.' );
	}

	/**
	 * Synchronize post with corresponding ESP campaign.
	 *
	 * @param WP_Post $post Post to synchronize.
	 *
	 * @return object|WP_Error API Response or error.
	 *
	 * @throws Exception Error message.
	 */
	public function sync( $post ) {
		return new WP_Error( 'newspack_newsletters_error', 'Beehiiv is not supported yet.' );
	}

	/**
	 * Get lists.
	 *
	 * @return array|WP_Error List of existing lists or error.
	 */
	public function get_lists() {
		return new WP_Error( 'newspack_newsletters_error', 'Beehiiv is not supported yet.' );
	}

	/**
	 * Get all applicable lists and segments as Send_List objects.
	 * Note that in CC, campaigns can be sent to either lists or segments, not both,
	 * so both entity types should be treated as top-level send lists.
	 *
	 * @param array   $args Array of search args. See Send_Lists::get_default_args() for supported params and default values.
	 * @param boolean $to_array If true, convert Send_List objects to arrays before returning.
	 *
	 * @return Send_List[]|array|WP_Error Array of Send_List objects or arrays on success, or WP_Error object on failure.
	 */
	public function get_send_lists( $args = [], $to_array = false ) {
		return new WP_Error( 'newspack_newsletters_error', 'Beehiiv is not supported yet.' );
	}

	/**
	 * Add contact to a list or update an existing contact.
	 *
	 * @param array        $contact      {
	 *      Contact data.
	 *
	 *    @type string   $email    Contact email address.
	 *    @type string   $name     Contact name. Optional.
	 *    @type string[] $metadata Contact additional metadata. Optional.
	 * }
	 * @param string|false $list_id      List to add the contact to.
	 *
	 * @return array|WP_Error Contact data if the contact was added or error if failed.
	 */
	public function add_contact( $contact, $list_id = false ) {
		return new WP_Error( 'newspack_newsletters_error', 'Beehiiv is not supported yet.' );
	}

	/**
	 * Get contact data by email.
	 *
	 * @param string $email Email address.
	 * @param bool   $return_details Fetch full contact data.
	 *
	 * @return array|WP_Error Response or error if contact was not found.
	 */
	public function get_contact_data( $email, $return_details = false ) {
		return new WP_Error( 'newspack_newsletters_error', 'Beehiiv is not supported yet.' );
	}

	/**
	 * Get the lists a contact is subscribed to.
	 *
	 * @param string $email The contact email.
	 *
	 * @return string[] Contact subscribed lists IDs.
	 */
	public function get_contact_lists( $email ) {
		return new WP_Error( 'newspack_newsletters_error', 'Beehiiv is not supported yet.' );
	}

	/**
	 * Retrieve the ESP's tag ID from its name
	 *
	 * @param string  $tag_name The tag.
	 * @param boolean $create_if_not_found Whether to create a new tag if not found. Default to true.
	 * @param string  $list_id The List ID.
	 * @return int|WP_Error The tag ID on success. WP_Error on failure.
	 */
	public function get_tag_id( $tag_name, $create_if_not_found = true, $list_id = null ) {
		return new WP_Error( 'newspack_newsletters_error', 'Beehiiv is not supported yet.' );
	}

	/**
	 * Retrieve the ESP's tag name from its ID
	 *
	 * @param int    $tag_id The tag ID.
	 * @param string $list_id The List ID.
	 * @return string|WP_Error The tag name on success. WP_Error on failure.
	 */
	public function get_tag_by_id( $tag_id, $list_id = null ) {
		return new WP_Error( 'newspack_newsletters_error', 'Beehiiv is not supported yet.' );
	}

	/**
	 * Create a Tag on the provider
	 *
	 * @param string $tag The Tag name.
	 * @param string $list_id The List ID.
	 * @return array|WP_Error The tag representation with at least 'id' and 'name' keys on succes. WP_Error on failure.
	 */
	public function create_tag( $tag, $list_id = null ) {
		return new WP_Error( 'newspack_newsletters_error', 'Beehiiv is not supported yet.' );
	}

	/**
	 * Updates a Tag name on the provider
	 *
	 * @param string|int $tag_id The tag ID.
	 * @param string     $tag The Tag new name.
	 * @param string     $list_id The List ID.
	 * @return array|WP_Error The tag representation with at least 'id' and 'name' keys on succes. WP_Error on failure.
	 */
	public function update_tag( $tag_id, $tag, $list_id = null ) {
		return new WP_Error( 'newspack_newsletters_error', 'Beehiiv is not supported yet.' );
	}

	/**
	 * Add a tag to a contact
	 *
	 * @param string     $email The contact email.
	 * @param string|int $tag The tag ID.
	 * @param string     $list_id The List ID.
	 * @return true|WP_Error
	 */
	public function add_tag_to_contact( $email, $tag, $list_id = null ) {
		return new WP_Error( 'newspack_newsletters_error', 'Beehiiv is not supported yet.' );
	}

	/**
	 * Remove a tag from a contact
	 *
	 * @param string     $email The contact email.
	 * @param string|int $tag The tag ID.
	 * @param string     $list_id The List ID.
	 * @return true|WP_Error
	 */
	public function remove_tag_from_contact( $email, $tag, $list_id = null ) {
		return new WP_Error( 'newspack_newsletters_error', 'Beehiiv is not supported yet.' );
	}

	/**
	 * Get the IDs of the tags associated with a contact.
	 *
	 * @param string $email The contact email.
	 * @return array|WP_Error The tag IDs on success. WP_Error on failure.
	 */
	public function get_contact_tags_ids( $email ) {
		return new WP_Error( 'newspack_newsletters_error', 'Beehiiv is not supported yet.' );
	}

	/**
	 * Update a contact lists subscription.
	 *
	 * @param string   $email           Contact email address.
	 * @param string[] $lists_to_add    Array of list IDs to subscribe the contact to.
	 * @param string[] $lists_to_remove Array of list IDs to remove the contact from.
	 *
	 * @return true|WP_Error True if the contact was updated or error.
	 */
	public function update_contact_lists( $email, $lists_to_add = [], $lists_to_remove = [] ) {
		return new WP_Error( 'newspack_newsletters_error', 'Beehiiv is not supported yet.' );
	}

	/**
	 * Update ESP campaign after refreshing the email HTML, which is triggered by post save.
	 *
	 * @param int   $meta_id Numeric ID of the meta field being updated.
	 * @param int   $post_id The post ID for the meta field being updated.
	 * @param mixed $meta_key The meta key being updated.
	 */
	public function save( $meta_id, $post_id, $meta_key ) {
		return new WP_Error( 'newspack_newsletters_error', 'Beehiiv is not supported yet.' );
	}

	/**
	 * Send a campaign.
	 *
	 * @param WP_Post $post Post to send.
	 *
	 * @return true|WP_Error True if the campaign was sent or error if failed.
	 */
	public function send( $post ) {
		return new WP_Error( 'newspack_newsletters_error', 'Beehiiv is not supported yet.' );
	}

	/**
	 * After Newsletter post is deleted, clean up by deleting corresponding ESP campaign.
	 *
	 * @param string $post_id Numeric ID of the campaign.
	 */
	public function trash( $post_id ) {
	}

	/**
	 * Get usage report for yesterday.
	 *
	 * @return Newspack_Newsletters_Service_Provider_Usage_Report|WP_Error
	 */
	public function get_usage_report() {
		return new WP_Error( 'newspack_newsletters_error', 'Beehiiv is not supported yet.' );
	}
}

```
</details>
### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1210267463874056