### PR TITLE
fix(settings): separate memoizing service provider and fallback to Mailchimp

### DIFF
--- a/includes/class-newspack-newsletters-settings.php
+++ b/includes/class-newspack-newsletters-settings.php
@@ -79,7 +79,7 @@ class Newspack_Newsletters_Settings {
 				'description' => esc_html__( 'Mailchimp API Key', 'newspack-newsletters' ),
 				'key'         => 'newspack_mailchimp_api_key',
 				'type'        => 'text',
-				'default'     => get_option( 'newspack_mailchimp_api_key', '' ),
+				'default'     => get_option( 'newspack_mailchimp_api_key', get_option( 'newspack_newsletters_mailchimp_api_key' ) ),
 				'provider'    => 'mailchimp',
 				'placeholder' => esc_attr( '123457103961b1f4dc0b2b2fd59c137b-us1' ),
 				'help'        => esc_html__( 'Find or generate your API key', 'newspack-newsletter' ),

--- a/includes/class-newspack-newsletters-settings.php
+++ b/includes/class-newspack-newsletters-settings.php
@@ -79,7 +79,7 @@ class Newspack_Newsletters_Settings {
 				'description' => esc_html__( 'Mailchimp API Key', 'newspack-newsletters' ),
 				'key'         => 'newspack_mailchimp_api_key',
 				'type'        => 'text',
-				'default'     => get_option( 'newspack_newsletters_mailchimp_api_key', '' ),
+				'default'     => get_option( 'newspack_mailchimp_api_key', '' ),
 				'provider'    => 'mailchimp',
 				'placeholder' => esc_attr( '123457103961b1f4dc0b2b2fd59c137b-us1' ),
 				'help'        => esc_html__( 'Find or generate your API key', 'newspack-newsletter' ),

--- a/includes/class-newspack-newsletters.php
+++ b/includes/class-newspack-newsletters.php
@@ -139,12 +139,25 @@ final class Newspack_Newsletters {
 		 * To register a new provider, create a class that extends Newspack_Newsletters_Service_Provider
 		 * and add it to the $providers array. Include or require it on the 'init' action hook.
 		 *
+		 * In order to register a new provider, create a new class that extends Newspack_Newsletters_Service_Provider
+		 * and add it to the $providers array.
+		 *
+		 * Do not directly load the class file in your plugin/theme, instead, inform the class name and the file path
+		 * to the filter.
+		 *
 		 * @param array $providers The registered providers. The keys are the provider slugs and the values are arrays with the following structure: {
 		 *     @type string $name The provider name.
 		 *     @type string $class The provider class name.
+		 *     @type string $class_file The provider class file path.
 		 * }
 		 */
 		$providers = apply_filters( 'newspack_newsletters_registered_providers', $providers );
+
+		foreach ( $providers as $provider_slug => $provider ) {
+			if ( ! class_exists( $provider['class'] ) && isset( $provider['class_file'] ) && file_exists( $provider['class_file'] ) ) {
+				require_once $provider['class_file'];
+			}
+		}
 
 		return $providers;
 	}

--- a/includes/class-newspack-newsletters.php
+++ b/includes/class-newspack-newsletters.php
@@ -7,8 +7,6 @@
 
 defined( 'ABSPATH' ) || exit;
 
-use Newspack_Newsletters_Mailchimp_Api as Mailchimp;
-
 /**
  * Main Newspack Newsletters Class.
  */
@@ -67,6 +65,7 @@ final class Newspack_Newsletters {
 	 * Constructor.
 	 */
 	public function __construct() {
+		add_action( 'init', [ __CLASS__, 'memoize_service_provider' ] );
 		add_action( 'init', [ __CLASS__, 'register_cpt' ] );
 		add_action( 'init', [ __CLASS__, 'register_meta' ] );
 		add_action( 'init', [ __CLASS__, 'register_editor_only_meta' ] );
@@ -87,7 +86,6 @@ final class Newspack_Newsletters {
 		add_filter( 'render_block', [ __CLASS__, 'remove_email_only_block' ], 10, 2 );
 		add_action( 'pre_get_posts', [ __CLASS__, 'display_newsletters_in_archives' ] );
 		add_action( 'the_post', [ __CLASS__, 'fix_public_status' ] );
-		self::set_service_provider( self::service_provider() );
 
 		$needs_nag = is_admin() && ! self::is_service_provider_configured() && ! get_option( 'newspack_newsletters_activation_nag_viewed', false );
 		if ( $needs_nag ) {
@@ -95,6 +93,22 @@ final class Newspack_Newsletters {
 			add_action( 'admin_enqueue_scripts', [ __CLASS__, 'activation_nag_dismissal_script' ] );
 			add_action( 'wp_ajax_newspack_newsletters_activation_nag_dismissal', [ __CLASS__, 'activation_nag_dismissal_ajax' ] );
 		}
+	}
+
+	/**
+	 * Store the service provider instance in a static property.
+	 */
+	public static function memoize_service_provider() {
+		$service_provider = self::service_provider();
+		$is_esp_manual    = 'manual' === $service_provider;
+
+		// 'newspack_mailchimp_api_key' is a newer option introduced to manage MC API key accross Newspack plugins.
+		// Keeping the old option for backwards compatibility.
+		if ( ! $is_esp_manual && ! $service_provider && get_option( 'newspack_mailchimp_api_key', get_option( 'newspack_newsletters_mailchimp_api_key' ) ) ) {
+			// Legacy – Mailchimp provider set before multi-provider handling was set up.
+			self::set_service_provider( 'mailchimp' );
+		}
+		self::$provider = self::get_service_provider_instance( $service_provider );
 	}
 
 	/**
@@ -122,25 +136,15 @@ final class Newspack_Newsletters {
 		/**
 		 * Filter the registered providers.
 		 *
-		 * In order to register a new provider, create a new class that extends Newspack_Newsletters_Service_Provider
-		 * and add it to the $providers array.
-		 *
-		 * Do not directly load the class file in your plugin/theme, instead, inform the class name and the file path
-		 * to the filter.
+		 * To register a new provider, create a class that extends Newspack_Newsletters_Service_Provider
+		 * and add it to the $providers array. Include or require it on the 'init' action hook.
 		 *
 		 * @param array $providers The registered providers. The keys are the provider slugs and the values are arrays with the following structure: {
 		 *     @type string $name The provider name.
 		 *     @type string $class The provider class name.
-		 *     @type string $class_file The provider class file path.
 		 * }
 		 */
 		$providers = apply_filters( 'newspack_newsletters_registered_providers', $providers );
-
-		foreach ( $providers as $provider_slug => $provider ) {
-			if ( ! class_exists( $provider['class'] ) && isset( $provider['class_file'] ) && file_exists( $provider['class_file'] ) ) {
-				require_once $provider['class_file'];
-			}
-		}
 
 		return $providers;
 	}
@@ -933,27 +937,15 @@ final class Newspack_Newsletters {
 	 */
 	public static function api_settings() {
 		$service_provider = self::service_provider();
+		$is_esp_manual    = 'manual' === $service_provider;
 		$response         = [
 			'service_provider' => $service_provider ? $service_provider : '',
 			'status'           => false,
 		];
-		$is_esp_manual    = 'manual' === $service_provider;
-
-		// 'newspack_mailchimp_api_key' is a new option introduced to manage MC API key accross Newspack plugins.
-		// Keeping the old option for backwards compatibility.
-		if ( ! $is_esp_manual && ! self::$provider && get_option( 'newspack_mailchimp_api_key', get_option( 'newspack_newsletters_mailchimp_api_key' ) ) ) {
-			// Legacy – Mailchimp provider set before multi-provider handling was set up.
-			self::set_service_provider( 'mailchimp' );
-		}
-
 		if ( self::$provider ) {
 			$response['credentials'] = self::$provider->api_credentials();
 		}
-
-		if (
-			$is_esp_manual ||
-			( self::$provider && self::$provider->has_api_credentials() )
-		) {
+		if ( $is_esp_manual || ( self::$provider && self::$provider->has_api_credentials() ) ) {
 			$response['status'] = true;
 		}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Fixes some issues surfaced when registering a new service provider via the `newspack_newsletters_registered_providers` filter hook:

- Separates memoization of the service provider instance from updating the option. This avoids calling `update_option` every time the `Newspack_Newsletters` class is constructed.
- Delays memoization until the `init` action hook. This is so that external plugins that register their own provider classes on the `newspack_newsletters_registered_providers` filter hook can include their own class files extending `Newspack_Newsletters_Service_Provider` without passing the file path to the filter callback. The external plugin's class files must be included on the `init` hook in order to avoid a fatal error.
- Moves some code to handle legacy installations from when this plugin only handled Mailchimp as a provider to the memoization function, instead of in `Newspack_Newsletters::api_settings()`. This is being called before the `init` hook, so it was sometimes called before the service provider class was memoized, resulting in being intermittently unable to save changes to the selected service provider.

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

### How to test the changes in this Pull Request:

1. Start with a fresh testing site without Newspack Plugin and install/activate this branch.
2. Visit Newsletters > Settings and confirm that the settings are in a fresh state, e.g. the Service Provider dropdown shows "Select service provider" and all fields underneath are empty.
3. Using WP CLI, simulate a legacy installation by setting a value for the `newspack_newsletters_mailchimp_api_key` option.
4. Refresh Newsletters > Settings and confirm that Service Provider is automatically set to Mailchimp.
5. Confirm that you can change the Service Provider option and enter new settings, and that the changes persist after saving and refreshing the page.
6. Follow testing instructions in #1828, but in your test plugin, include your custom provider class on the `init` action hook, e.g.

```php
add_filter(
	'init',
	function() {
		include_once __DIR__ . '/class-newspack-newsletters-beehiiv.php';
	}
);
```

7. Enable the Newspack Plugin, delete the `newspack_newsletters_mailchimp_api_key`, `newspack_newsletters_service_provider`, and any other options you saved in step 5 and repeat steps 2–6 with the Newspack dashboard version of the Newsletters settings page.
8. Smoke test creating, editing, and sending newsletter campaigns with one of the core service providers: Mailchimp, ActiveCampaign, or Constant Contact.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
