### PR TITLE
feat: dont allow redirect to arbitrary urls

### DIFF
--- a/includes/tracking/class-click.php
+++ b/includes/tracking/class-click.php
@@ -160,8 +160,7 @@ final class Click {
 			$newsletter_content = (string) get_post_meta( $newsletter_id, 'newspack_email_html', true );
 			if (
 				false === stripos( $newsletter_content, $url_without_query_args ) &&
-				false === stripos( $newsletter_content, urlencode( $url_without_query_args ) ) && // URL might be encoded via a block pattern.
-				! $is_admin_user // Allow redirect for logged-in editor or admin users.
+				false === stripos( $newsletter_content, urlencode( $url_without_query_args ) ) // URL might be encoded via a block pattern.
 			) {
 				\wp_die( 'Invalid URL', '', 400 );
 				exit;


### PR DESCRIPTION
even for admins. reverts changes in #1635
The security trade off is worth for this not to work in an edge case

### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Do not allow arbitrary redirects for admins.

Reverts part of the changes from https://github.com/Automattic/newspack-newsletters/pull/1635 understanding that not supporting the edge case of someone testing the tracking on an unsaved Newsletter is a good trade off in favor of a more secure plugin.

### How to test the changes in this Pull Request:

1. Test click tracking and confirm it still works for a saved newsletter

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
