### PR TITLE
fix: dont check for current provider before init

### DIFF
--- a/includes/class-newspack-newsletters.php
+++ b/includes/class-newspack-newsletters.php
@@ -86,13 +86,6 @@ final class Newspack_Newsletters {
 		add_filter( 'render_block', [ __CLASS__, 'remove_email_only_block' ], 10, 2 );
 		add_action( 'pre_get_posts', [ __CLASS__, 'display_newsletters_in_archives' ] );
 		add_action( 'the_post', [ __CLASS__, 'fix_public_status' ] );
-
-		$needs_nag = is_admin() && ! self::is_service_provider_configured() && ! get_option( 'newspack_newsletters_activation_nag_viewed', false );
-		if ( $needs_nag ) {
-			add_action( 'admin_notices', [ __CLASS__, 'activation_nag' ] );
-			add_action( 'admin_enqueue_scripts', [ __CLASS__, 'activation_nag_dismissal_script' ] );
-			add_action( 'wp_ajax_newspack_newsletters_activation_nag_dismissal', [ __CLASS__, 'activation_nag_dismissal_ajax' ] );
-		}
 	}
 
 	/**
@@ -107,8 +100,16 @@ final class Newspack_Newsletters {
 		if ( ! $is_esp_manual && ! $service_provider && get_option( 'newspack_mailchimp_api_key', get_option( 'newspack_newsletters_mailchimp_api_key' ) ) ) {
 			// Legacy – Mailchimp provider set before multi-provider handling was set up.
 			self::set_service_provider( 'mailchimp' );
+			$service_provider = 'mailchimp';
 		}
 		self::$provider = self::get_service_provider_instance( $service_provider );
+
+		$needs_nag = is_admin() && ! self::is_service_provider_configured() && ! get_option( 'newspack_newsletters_activation_nag_viewed', false );
+		if ( $needs_nag ) {
+			add_action( 'admin_notices', [ __CLASS__, 'activation_nag' ] );
+			add_action( 'admin_enqueue_scripts', [ __CLASS__, 'activation_nag_dismissal_script' ] );
+			add_action( 'wp_ajax_newspack_newsletters_activation_nag_dismissal', [ __CLASS__, 'activation_nag_dismissal_ajax' ] );
+		}
 	}
 
 	/**

--- a/includes/class-send-lists.php
+++ b/includes/class-send-lists.php
@@ -27,15 +27,11 @@ class Send_Lists {
 	 * @return void
 	 */
 	public static function init() {
-		if ( ! self::should_initialize_send_lists() ) {
-			return;
-		}
-
 		\add_action( 'rest_api_init', [ __CLASS__, 'register_api_endpoints' ] );
 	}
 
 	/**
-	 * Check if we should initialize Send lists.
+	 * Check if we should initialize Send lists. Needs to be called after init.
 	 *
 	 * @return boolean
 	 */
@@ -52,6 +48,11 @@ class Send_Lists {
 	 * Register the endpoints needed to fetch send lists.
 	 */
 	public static function register_api_endpoints() {
+
+		if ( ! self::should_initialize_send_lists() ) {
+			return;
+		}
+
 		\register_rest_route(
 			Newspack_Newsletters::API_NAMESPACE,
 			'/send-lists',

--- a/includes/class-subscription-lists.php
+++ b/includes/class-subscription-lists.php
@@ -38,9 +38,6 @@ class Subscription_Lists {
 		add_action( 'init', [ __CLASS__, 'register_post_type' ] );
 		add_action( 'init', [ __CLASS__, 'migrate_lists' ], 11 );
 
-		if ( ! self::should_initialize_local_lists() ) {
-			return;
-		}
 		add_filter( 'wp_editor_settings', [ __CLASS__, 'filter_editor_settings' ], 10, 2 );
 		add_action( 'save_post', [ __CLASS__, 'save_post' ] );
 		add_action( 'admin_enqueue_scripts', [ __CLASS__, 'admin_enqueue_scripts' ] );
@@ -53,6 +50,11 @@ class Subscription_Lists {
 	 * Add custom CSS to the List post type edit screen
 	 */
 	public static function admin_enqueue_scripts() {
+
+		if ( ! self::should_initialize_local_lists() ) {
+			return;
+		}
+
 		if ( get_current_screen()->post_type === self::CPT ) {
 			wp_enqueue_style(
 				'newspack-newsletters-subscription-list-editor',
@@ -93,6 +95,11 @@ class Subscription_Lists {
 	 * @return array
 	 */
 	public static function filter_editor_settings( $settings, $editor_id ) {
+
+		if ( ! self::should_initialize_local_lists() ) {
+			return $settings;
+		}
+
 		if ( 'content' === $editor_id && get_current_screen()->post_type === self::CPT ) {
 			$settings['tinymce']       = false;
 			$settings['quicktags']     = false;
@@ -166,6 +173,11 @@ class Subscription_Lists {
 	 * @return void
 	 */
 	public static function add_metabox( $post ) {
+
+		if ( ! self::should_initialize_local_lists() ) {
+			return;
+		}
+
 		add_meta_box(
 			'newspack-newsletters-list-metabox',
 			__( 'Provider settings' ),
@@ -286,6 +298,10 @@ class Subscription_Lists {
 	 * @return void
 	 */
 	public static function save_post( $post_id ) {
+
+		if ( ! self::should_initialize_local_lists() ) {
+			return;
+		}
 
 		$post_type = sanitize_text_field( $_POST['post_type'] ?? '' );
 
@@ -635,6 +651,11 @@ class Subscription_Lists {
 	 * Outputs a title for the description field in the post editor.
 	 */
 	public static function edit_form_before_permalink() {
+
+		if ( ! self::should_initialize_local_lists() ) {
+			return;
+		}
+
 		if ( self::CPT === get_post_type() ) {
 			printf( '<h2>%s</h2>', esc_html__( 'Description', 'newspack-newsletters' ) );
 		}
@@ -644,6 +665,11 @@ class Subscription_Lists {
 	 * Outputs a link back to the Settings page above the title in the post editor.
 	 */
 	public static function edit_form_top() {
+
+		if ( ! self::should_initialize_local_lists() ) {
+			return;
+		}
+
 		if ( self::CPT === get_post_type() ) {
 			?>
 			<a href="<?php echo esc_url( Newspack_Newsletters_Settings::get_settings_url() ); ?>">


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes # .

### How to test the changes in this Pull Request:

1. Congifure some newsletters lists
2. On `trunk`, draft a newsletter and try to set the SEND TO field, confirm there's an error “No route found matching the request URL and method.”
3. Add the Newsletters Subscription block to a page, and confirm you can't configure it
4. Also confirm you see a admin notice at the dashboard saying that the plugin is not configured
5. Checkout this branch and confirm the above errors are fixed
6. Smoke test some basic features: Subscribing to newsletter, sending a test, sending a campaign and a RAS sync after a purchase


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
