### PR TITLE
fix: delete contact by email address, not user ID

### DIFF
--- a/includes/class-newspack-newsletters-contacts.php
+++ b/includes/class-newspack-newsletters-contacts.php
@@ -261,19 +261,14 @@ class Newspack_Newsletters_Contacts {
 	/**
 	 * Permanently delete a user subscription.
 	 *
-	 * @param int    $user_id User ID.
+	 * @param string $email Email address of deleted user.
 	 * @param string $context Context of the update for logging purposes.
 	 *
 	 * @return bool|WP_Error Whether the contact was deleted or error.
 	 */
-	public static function delete( $user_id, $context = 'Unknown' ) {
-		$user = get_user_by( 'id', $user_id );
-		if ( ! $user ) {
+	public static function delete( $email, $context = 'Unknown' ) {
+		if ( ! $email ) {
 			return new WP_Error( 'newspack_newsletters_invalid_user', __( 'Invalid user.' ) );
-		}
-		/** Only delete if email ownership is verified. */
-		if ( ! Newspack_Newsletters_Subscription::is_email_verified( $user_id ) ) {
-			return new \WP_Error( 'newspack_newsletters_email_not_verified', __( 'Email ownership is not verified.' ) );
 		}
 		$provider = Newspack_Newsletters::get_service_provider();
 		if ( empty( $provider ) ) {
@@ -282,7 +277,7 @@ class Newspack_Newsletters_Contacts {
 		if ( ! method_exists( $provider, 'delete_contact' ) ) {
 			return new WP_Error( 'newspack_newsletters_invalid_provider_method', __( 'Provider does not support deleting user subscriptions.' ) );
 		}
-		$result = $provider->delete_contact( $user->user_email );
+		$result = $provider->delete_contact( $email );
 
 		do_action(
 			'newspack_log',
@@ -294,7 +289,7 @@ class Newspack_Newsletters_Contacts {
 					'provider' => $provider->service,
 					'errors'   => is_wp_error( $result ) ? $result->get_error_message() : [],
 				],
-				'user_email' => $user->user_email,
+				'user_email' => $user['data']['user_email'],
 				'file'       => 'newspack_esp_sync',
 			]
 		);

--- a/includes/class-newspack-newsletters-subscription.php
+++ b/includes/class-newspack-newsletters-subscription.php
@@ -549,18 +549,6 @@ class Newspack_Newsletters_Subscription {
 	}
 
 	/**
-	 * Permanently delete a user subscription.
-	 *
-	 * @param int $user_id User ID.
-	 *
-	 * @return bool|WP_Error Whether the contact was deleted or error.
-	 */
-	public static function delete_user_subscription( $user_id ) {
-		_deprecated_function( __METHOD__, '2.21', 'Newspack_Newsletters_Contacts::delete' );
-		return Newspack_Newsletters_Contacts::delete( $user_id );
-	}
-
-	/**
 	 * Add a contact to ESP when a reader is registered.
 	 *
 	 * @param string         $email         Email address.

--- a/phpcsSniffs/Sniffs/NewspackNewslettersContactsMethodsSniff.php
+++ b/phpcsSniffs/Sniffs/NewspackNewslettersContactsMethodsSniff.php
@@ -47,7 +47,6 @@ class NewspackNewslettersContactsMethodsSniff implements PHP_CodeSniffer_Sniff {
 		'update_contact_lists_handling_local',
 		'add_contact_with_groups_and_tags',
 		'add_contact_to_provider',
-		'delete_user_subscription',
 		'update_contact_lists',
 		'upsert_contact',
 	];


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Related to https://github.com/Automattic/newspack-plugin/pull/4008. By the time the `Newspack_Newsletters_Contacts::delete()` method is called, the `$user` account will no longer exist, so this method will always return a `newspack_newsletters_invalid_user` error. This PR changes the method to use the deleted user's email address instead.

### How to test the changes in this Pull Request:

See testing instructions in https://github.com/Automattic/newspack-plugin/pull/4008.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
