### PR TITLE
feat: add a button to unschedule newsletters

### DIFF
--- a/src/components/send-button/index.js
+++ b/src/components/send-button/index.js
@@ -242,6 +242,14 @@ export default compose( [
 			savePost();
 		};
 
+		const unscheduleNewsletter = () => {
+			editPost( {
+				status: 'draft',
+				date: null // Reset the scheduled date.
+			} );
+			savePost();
+		};
+
 		// For sent newsletters, display the generic button text.
 		if ( isPublished || sent ) {
 			return (
@@ -300,6 +308,17 @@ export default compose( [
 
 		return (
 			<div style={{ display: 'flex' }}>
+				{ 'future' === status && (
+					<Button
+						className="newsletter-unschedule-button"
+						isBusy={ isSaving }
+						variant="tertiary"
+						disabled={ isSaving }
+						onClick={ unscheduleNewsletter }
+					>
+						{ __( 'Unschedule', 'newspack-newsletters' ) }
+					</Button>
+				) }
 				<PreviewHTMLButton />
 				<Button
 					className="editor-post-publish-button"

--- a/src/components/send-button/style.scss
+++ b/src/components/send-button/style.scss
@@ -56,7 +56,8 @@
 	}
 }
 
-.newsletter-preview-html-button {
+.newsletter-preview-html-button,
+.newsletter-unschedule-button {
 	margin-right: 8px;
 }
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Right now when you schedule a newsletter, there's not a clear way to unschedule it -- you can change the 'Publish' date to 'Now' and the status back to 'Draft' and click 'Send', but that's very not intuitive and kind of scary!

This PR adds an 'Unschedule' button to the newsletter editor header when you schedule a post that unsets the publish date, and switches the post status back to 'Draft'. I don't love the placement, but it seems like this is the best spot that doesn't require doing super hacky stuff to the header. I also thought about replacing the 'Scheduled' button, but once a newsletter is scheduled that acts as kind of a 'Save' button so that seemed like a bad idea.

See NPPM-343.

### How to test the changes in this Pull Request:

1. Create and schedule a newsletter. 
2. Note that there's no clear way to unschedule the newsletter:

<img src="https://github.com/user-attachments/assets/c67e041a-610c-4e41-a810-1bf312ea2be1" width="400">

3. Apply this PR and run `npm run build`.
4. Refresh the editor and confirm you now get an 'Unpublish' button that uses the tertiary style next to the Preview email and Scheduled buttons.

<img src="https://github.com/user-attachments/assets/74b62a22-50c8-443c-81e4-d0c0fd366a5d" width="500">

5. Try clicking the Unschedule button and confirm the newsletter returns to the pre-scheduled state: the Scheduled button should change to Send, and the Unschedule button should disappear. The Status should switch back to 'Draft' and the 'Publish' date should switch back to 'Immediately':

<img src="https://github.com/user-attachments/assets/b3fe524e-9b9f-49f2-acab-bb7e691f8323" width="550">

6. Confirm you can either successfully send or reschedule the newsletter.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
