### PR TITLE
fix: prevent HTML overwrite when post taken over

### DIFF
--- a/src/editor/mjml/index.js
+++ b/src/editor/mjml/index.js
@@ -60,6 +60,7 @@ function MJML() {
 		postId,
 		postTitle,
 		postType,
+		isTakeover,
 	} = useSelect( select => {
 		const {
 			didPostSaveRequestSucceed,
@@ -72,6 +73,7 @@ function MJML() {
 			isPostAutosavingLocked,
 			isAutosavingPost,
 			isCurrentPostPublished,
+			isPostLockTakeover,
 		} = select( 'core/editor' );
 
 		return {
@@ -85,6 +87,7 @@ function MJML() {
 			isSent: getCurrentPostAttribute( 'meta' ).newsletter_sent,
 			isAutosaving: isAutosavingPost(),
 			isAutosaveLocked: isPostAutosavingLocked(),
+			isTakeover: isPostLockTakeover(),
 		};
 	} );
 	const { createNotice } = useDispatch( 'core/notices' );
@@ -113,6 +116,7 @@ function MJML() {
 			! isAutosaving &&
 			! isPublishing &&
 			! isSent &&
+			! isTakeover &&
 			saveSucceeded
 		) {
 			refreshHtml();


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Prevents overwrite of email HTML when editing was taken over.

NPPM-2047

### How to test the changes in this Pull Request:

1. On `trunk`
1. You need 2 admin users, let's call them User A and User B.
1. Create a new newsletter as User A. Write some content in the newsletter. Leave the tab open.
1. In another browser or an incognito window, edit the post as User B. When it asks you if you want to take over editing, do so. Leave User A's tab open with the "User B has taken over editing" modal up.
1. Make some changes as User B and save the post. Examine the `newspack_email_html` metadata and verify it has your updates.
1. Open User A's window and wait for some ajax heartbeat requests. Examine the `newspack_email_html` metadata and you should see that it has the content as User A left it and does not have User B's updates.
2. Switch to this branch, observe the issue is not reproducible

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->