### PR TITLE
Register MailChimp newsletter meta later to fix issue from refactoring

### DIFF
--- a/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp-controller.php
+++ b/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp-controller.php
@@ -20,7 +20,7 @@ class Newspack_Newsletters_Mailchimp_Controller extends Newspack_Newsletters_Ser
 	 */
 	public function __construct( $mailchimp ) {
 		$this->service_provider = $mailchimp;
-		add_action( 'init', [ __CLASS__, 'register_meta' ] );
+		add_action( 'init', [ __CLASS__, 'register_meta' ], 99 ); // This current class is initialized at priority 10, so we need to register the meta later than that.
 		add_action( 'rest_api_init', [ $this, 'register_routes' ] );
 		parent::__construct( $mailchimp );
 	}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

**Note: This is a hotfix.**

Closes an issue reported by a publisher. 

After https://github.com/Automattic/newspack-newsletters/pull/1828, the MailChimp folder feature doesn't work any more. This is because the MailChimp class is initialized on the `init` hook at priority `10`, and when the class is initialized it registers the meta at `init` hook at priority `10`. Since `init` priority `10` has already happened, it won't fire again and the meta won't get registered. This PR solves it by registering the meta later.

### How to test the changes in this Pull Request:

1. On trunk with the MailChimp provider, create a newsletter draft, select a folder, and save. Observe the folder selection doesn't save and the network response does not list the folder meta:

<img width="385" alt="Screenshot 2025-06-19 at 3 24 45 PM" src="https://github.com/user-attachments/assets/71a34015-6b29-454b-b03b-85e7f7304e1e" />


2. Check out this PR. Select a folder and save the draft. Observe the folder selection saves and the network response includes the folder meta:

<img width="918" alt="Screenshot 2025-06-19 at 3 21 59 PM" src="https://github.com/user-attachments/assets/b05c9391-11cc-4292-b097-0ff67feea291" />


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
