### PR TITLE
Hotfix/ac empty message refs NPPM-2059

### DIFF
--- a/includes/service-providers/active_campaign/class-newspack-newsletters-active-campaign.php
+++ b/includes/service-providers/active_campaign/class-newspack-newsletters-active-campaign.php
@@ -1100,6 +1100,17 @@ final class Newspack_Newsletters_Active_Campaign extends \Newspack_Newsletters_S
 			return $sync_result;
 		}
 
+		$message = $this->api_v1_request( 'message_view', 'GET', [ 'query' => [ 'id' => $sync_result['message_id'] ] ] );
+		if ( is_wp_error( $message ) ) {
+			return $message;
+		}
+		if ( empty( $message['html'] ) ) {
+			return new \WP_Error(
+				'newspack_newsletters_active_campaign_message_html_missing',
+				__( 'Error creating campaign: Message HTML is missing. Campaign not sent.', 'newspack-newsletters' )
+			);
+		}
+
 		$from_name       = get_post_meta( $post->ID, 'senderName', true );
 		$from_email      = get_post_meta( $post->ID, 'senderEmail', true );
 		$send_list_id    = get_post_meta( $post->ID, 'send_list_id', true );

--- a/includes/service-providers/active_campaign/class-newspack-newsletters-active-campaign.php
+++ b/includes/service-providers/active_campaign/class-newspack-newsletters-active-campaign.php
@@ -198,6 +198,23 @@ final class Newspack_Newsletters_Active_Campaign extends \Newspack_Newsletters_S
 			return $response;
 		}
 		$body = json_decode( $response['body'], true );
+
+		do_action(
+			'newspack_log',
+			'newspack_newsletters_active_campaign_api_v1_request',
+			'API v1 Request',
+			[
+				'log_level' => 1,
+				'file'      => 'newspack_newsletters_active_campaign_api_v1_request',
+				'data'      => [
+					'action'        => $action,
+					'method'        => $method,
+					'options'       => $options,
+					'response_body' => $body,
+				],
+			]
+		);
+
 		if ( 1 !== $body['result_code'] ) {
 			$message = ! empty( $body['result_message'] ) ? $body['result_message'] : __( 'An error occurred while communicating with ActiveCampaign.', 'newspack-newsletters' );
 			return new \WP_Error(


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

We have had reports of campaigns being sent in Active Campaign without any contents. By looking at the "message" created in AC, it has an empty `html`.

There's no way I can reproduce how an empty message can be created, but this PR does two things:

* Always check if the message has contents before sending the campaign
* Adds the possibility to log the api requests

### How to test the changes in this Pull Request:

1. Test sending a campaign with Active Campaign and confirm it works as usual
2. On [line 1036](https://github.com/Automattic/newspack-newsletters/blob/hotfix%2Fac-empty-message/includes/service-providers/active_campaign/class-newspack-newsletters-active-campaign.php#L1036), force the `$content` to be an empty string
3. Compose a a new Newsletter and try to send it. Confirm you see an error in the Editor and that nothing gets sent.
4. Remove the change and try to send it again. Confirm it works

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
