### PR TITLE
fix: respect user permissions

### DIFF
--- a/includes/class-newspack-newsletters-ads.php
+++ b/includes/class-newspack-newsletters-ads.php
@@ -177,6 +177,11 @@ final class Newspack_Newsletters_Ads {
 	 * Add ads page link.
 	 */
 	public static function add_ads_page() {
+
+		if ( ! \Newspack_Newsletters::user_can_edit_newsletters() ) {
+			return;
+		}
+
 		add_submenu_page(
 			'edit.php?post_type=' . Newspack_Newsletters::NEWSPACK_NEWSLETTERS_CPT,
 			__( 'Newsletters Ads', 'newspack-newsletters' ),

--- a/includes/class-newspack-newsletters-settings.php
+++ b/includes/class-newspack-newsletters-settings.php
@@ -204,6 +204,11 @@ class Newspack_Newsletters_Settings {
 	 * Add options page
 	 */
 	public static function add_plugin_page() {
+
+		if ( ! \Newspack_Newsletters::user_can_edit_newsletters() ) {
+			return;
+		}
+
 		add_submenu_page(
 			'edit.php?post_type=' . Newspack_Newsletters::NEWSPACK_NEWSLETTERS_CPT,
 			esc_html__( 'Newsletters Settings', 'newspack-newsletters' ),

--- a/includes/class-newspack-newsletters.php
+++ b/includes/class-newspack-newsletters.php
@@ -601,6 +601,26 @@ final class Newspack_Newsletters {
 	}
 
 	/**
+	 * Check if the current user can edit newsletters.
+	 *
+	 * @param int $user_id Optional. User ID.
+	 * @return bool
+	 */
+	public static function user_can_edit_newsletters( $user_id = null ) {
+		if ( ! $user_id ) {
+			$user_id = get_current_user_id();
+		}
+
+		$post_type_object = get_post_type_object( self::NEWSPACK_NEWSLETTERS_CPT );
+
+		if ( ! $post_type_object ) {
+			return false;
+		}
+
+		return user_can( $user_id, $post_type_object->cap->edit_posts );
+	}
+
+	/**
 	 * Register blocks server-side for front-end rendering.
 	 */
 	public static function register_blocks() {

--- a/includes/tracking/class-admin.php
+++ b/includes/tracking/class-admin.php
@@ -60,6 +60,11 @@ final class Admin {
 	 * Add settings page submenu.
 	 */
 	public static function add_settings_page() {
+
+		if ( ! \Newspack_Newsletters::user_can_edit_newsletters() ) {
+			return;
+		}
+
 		\add_submenu_page(
 			'edit.php?post_type=' . \Newspack_Newsletters::NEWSPACK_NEWSLETTERS_CPT,
 			esc_html__( 'Newsletters Tracking Options', 'newspack-newsletters' ),


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes # .

### How to test the changes in this Pull Request:

Depends on https://github.com/Automattic/newspack-plugin/pull/4053

1. There are four scenarios to be tested, logged in as an editor

A - editor with permission to edit newsletters and Newspack plugin active
B - editor with permission to edit newsleters and Newspack plugin inactive
C - editor without permissino to edit newsletters and Newspack plugin active
D - editor without permission to edit newsleters and Newspack plugin inactive

In order to grant remove permissions to edit newsletters:

* Activate `capability-manager-enhanced` plugin and edit the Editor role 
* In the "Unique Post Type Capabilities" choose "Newsletters" and "Newsletter Ads" and click "Update"
* Deselect all capabilities in "Newsletters" and "Newsletter Ads" rows:

<img width="713" alt="image" src="https://github.com/user-attachments/assets/636ca3ce-12c2-487a-aac8-1d8de03e9fb6" />

Now make sure you see or don't see the Newsletters menu in the expected way in each situation, and things work as expected.

Known issue:

Even without any permissions to see Newsletters, you will still see the menu with the Tags and Categories items under it... 


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
