### PR TITLE
fix(layout): only migrate layout defaults from legacy meta if esp is not set to manual

### DIFF
--- a/includes/class-newspack-newsletters-layouts.php
+++ b/includes/class-newspack-newsletters-layouts.php
@@ -215,9 +215,10 @@ final class Newspack_Newsletters_Layouts {
 				];
 
 				// Migrate layout defaults from legacy meta, if it exists.
+				$is_esp_manual = 'manual' === Newspack_Newsletters::service_provider();
 				$campaign_defaults = $post->meta['campaign_defaults'];
 				$legacy_meta       = json_decode( get_post_meta( $post->ID, 'layout_defaults', true ), true );
-				if ( empty( $campaign_defaults ) && ! empty( $legacy_meta ) ) {
+				if ( empty( $campaign_defaults ) && ! empty( $legacy_meta ) && ! $is_esp_manual ) {
 					$campaign_defaults = [];
 					if ( ! empty( $legacy_meta['senderName'] ) ) {
 						$campaign_defaults['senderName'] = $legacy_meta['senderName'];


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

The provider variable will be null if the ESP is set to "manual". This leads to a reference error when migrating the campaign information in the file class-newspack-newsletters-layouts.php if the legacy meta field "layout_defaults" is set for a layout post type. This Pull Request checks if the ESP is set to manual and only migrates campaign defaults, if the provider is not set to the manual ESP.

Closes #1848 .

### How to test the changes in this Pull Request:

The bug appeared after updating from a very low plug-in (3.1.2) version to the most current version with some layouts created before the update. To reproduce this behaviour it is sufficient to add the legacy meta field "layout_defaults" to the post-meta database table as described below:

1. Create a user (custom) layout for a newsletter post
2. Add a database entry in post_meta for a layout post type with the legacy field "layout_defaults" as key and value {"senderEmail":"","senderName":"","newsletterData":[]}
3. Click "Create new newsletter" and observe that the layouts are not loading (Web console outputs a server error as response)
4. Checkout this branch
5. Reload the layouts selection page, which should display the layouts again

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
