### PR TITLE
feat(posts-inserter-block): handle custom bylines

### DIFF
--- a/includes/class-newspack-newsletters-editor.php
+++ b/includes/class-newspack-newsletters-editor.php
@@ -528,6 +528,21 @@ final class Newspack_Newsletters_Editor {
 			]
 		);
 
+		// Add custom byline info.
+		register_rest_field(
+			'post',
+			'newspack_custom_byline',
+			[
+				'get_callback' => [ __CLASS__, 'newspack_get_custom_byline' ],
+				'schema'       => [
+					'context' => [
+						'edit',
+					],
+					'type'    => 'string',
+				],
+			]
+		);
+
 		// Add sponsor info.
 		if ( function_exists( '\Newspack_Sponsors\get_all_sponsors' ) ) {
 			register_rest_field(
@@ -626,6 +641,7 @@ final class Newspack_Newsletters_Editor {
 	public static function newspack_get_author_info( $post ) {
 		$author_data = [];
 
+
 		if ( function_exists( 'get_coauthors' ) ) {
 			$authors = get_coauthors();
 
@@ -656,6 +672,34 @@ final class Newspack_Newsletters_Editor {
 
 		/* Return the author data */
 		return $author_data;
+	}
+
+	/**
+	 * Get custom byline for the REST /posts response.
+	 *
+	 * @param object $post Post object for the post being returned.
+	 * @return string|null Formatted custom byline HTML or null if not active.
+	 */
+	public static function newspack_get_custom_byline( $post ) {
+		if ( ! class_exists( 'Newspack\Bylines' ) || ! \Newspack\Bylines::is_enabled() ) {
+			return null;
+		}
+
+		$post_id       = $post['id'];
+		$byline_active = get_post_meta( $post_id, \Newspack\Bylines::META_KEY_ACTIVE, true );
+
+		if ( ! $byline_active ) {
+			return null;
+		}
+
+		$byline = get_post_meta( $post_id, \Newspack\Bylines::META_KEY_BYLINE, true );
+		
+		if ( empty( $byline ) ) {
+			return null;
+		}
+
+		// Process the byline shortcodes to get formatted HTML with links.
+		return \Newspack\Bylines::replace_author_shortcodes( $byline );
 	}
 
 	/**

--- a/includes/class-newspack-newsletters-editor.php
+++ b/includes/class-newspack-newsletters-editor.php
@@ -681,25 +681,11 @@ final class Newspack_Newsletters_Editor {
 	 * @return string|null Formatted custom byline HTML or null if not active.
 	 */
 	public static function newspack_get_custom_byline( $post ) {
-		if ( ! class_exists( 'Newspack\Bylines' ) || ! \Newspack\Bylines::is_enabled() ) {
+		if ( ! class_exists( 'Newspack\Bylines' ) ) {
 			return null;
 		}
 
-		$post_id       = $post['id'];
-		$byline_active = get_post_meta( $post_id, \Newspack\Bylines::META_KEY_ACTIVE, true );
-
-		if ( ! $byline_active ) {
-			return null;
-		}
-
-		$byline = get_post_meta( $post_id, \Newspack\Bylines::META_KEY_BYLINE, true );
-		
-		if ( empty( $byline ) ) {
-			return null;
-		}
-
-		// Process the byline shortcodes to get formatted HTML with links.
-		return \Newspack\Bylines::replace_author_shortcodes( $byline );
+		return \Newspack\Bylines::get_custom_byline_html( $post['id'] );
 	}
 
 	/**

--- a/src/editor/blocks/posts-inserter/utils.js
+++ b/src/editor/blocks/posts-inserter/utils.js
@@ -82,7 +82,20 @@ const getContinueReadingLinkBlockTemplate = ( post, { textFontSize, textColor } 
 };
 
 const getAuthorBlockTemplate = ( post, { textFontSize, textColor } ) => {
-	const { newspack_author_info } = post;
+	const { newspack_custom_byline, newspack_author_info } = post;
+
+	// Check for custom byline first.
+	if ( newspack_custom_byline ) {
+		return [
+			'core/heading',
+			assignFontSize( textFontSize, {
+				content: newspack_custom_byline,
+				fontSize: 'normal',
+				level: 6,
+				style: { color: { text: textColor } },
+			} ),
+		];
+	}
 
 	if ( Array.isArray( newspack_author_info ) && newspack_author_info.length ) {
 		const authorLinks = newspack_author_info.reduce( ( acc, author, index ) => {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

With this change, the Custom Bylines, a feature of the Newspack Plugin, will be handled in the Posts Inserter block.

Closes NPPM-2125

### How to test the changes in this Pull Request:

1. Add a custom byline to a recent post
2. Add Posts Inserter block to a newsletter
3. Observe the custom byline is rendered in place of the regular byline

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->