### PR TITLE
Fix/styling issues

### DIFF
--- a/includes/class-newspack-newsletters-renderer.php
+++ b/includes/class-newspack-newsletters-renderer.php
@@ -967,6 +967,28 @@ final class Newspack_Newsletters_Renderer {
 					$inner_blocks[ $no_width_cols_index ]['attrs']['width'] = ( 100 - $widths_sum ) / count( $no_width_cols_indexes ) . '%';
 				}
 
+				// Recalculate total width including no-width columns that were just assigned.
+				$total_width = 0;
+				foreach ( $inner_blocks as $block ) {
+					if ( isset( $block['attrs']['width'] ) ) {
+						$total_width += floatval( $block['attrs']['width'] );
+					}
+				}
+
+				// If total width exceeds 100%, adjust all columns proportionally.
+				if ( $total_width > 100 ) {
+					$excess = $total_width - 100;
+					$adjustment_per_column = $excess / count( $inner_blocks );
+					
+					foreach ( $inner_blocks as $i => $block ) {
+						if ( isset( $block['attrs']['width'] ) ) {
+							$current_width = floatval( $block['attrs']['width'] );
+							$new_width = max( 1, $current_width - $adjustment_per_column ); // Ensure minimum 1% width.
+							$inner_blocks[ $i ]['attrs']['width'] = $new_width . '%';
+						}
+					}
+				}
+
 				if ( isset( $attrs['color'] ) ) {
 					$default_attrs['color'] = $attrs['color'];
 				}

--- a/includes/class-newspack-newsletters.php
+++ b/includes/class-newspack-newsletters.php
@@ -1089,6 +1089,27 @@ final class Newspack_Newsletters {
 							padding: 0 32px;;
 						}
 					<?php endif; ?>
+
+					/* Social Links Block Styles */
+					.wp-block-social-links {
+						gap: 0 !important;
+					}
+					.wp-block-social-links.is-style-circle-black .wp-social-link {
+						background: black;
+						color: white;
+					}
+					.wp-block-social-links.is-style-filled-black .wp-social-link {
+						background: transparent;
+						color: black;
+					}
+					.wp-block-social-links.is-style-circle-white .wp-social-link {
+						background: white;
+						color: black;
+					}
+					.wp-block-social-links.is-style-filled-white .wp-social-link {
+						background: transparent;
+						color: white;
+					}
 				</style>
 			<?php
 		}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes two styling issues:

1. The social icons have had background removed in the editor and email, but not in the front-end
2. If columns were set up to sum to >100%, this would be handled gracefully in the editor and front-end, but not in the email

Closes NPPM-2140

### How to test the changes in this Pull Request:

1. On `trunk`, use this markup with social icons and misconfigured columns:

```html
<!-- wp:columns {"style":{"spacing":{"padding":{"right":"0","left":"0","top":"0","bottom":"0"}}},"backgroundColor":"dark-gray"} -->
<div class="wp-block-columns has-dark-gray-background-color has-background" style="padding-top:0;padding-right:0;padding-bottom:0;padding-left:0"><!-- wp:column {"width":"80%"} -->
<div class="wp-block-column" style="flex-basis:80%"><!-- wp:paragraph {"style":{"elements":{"link":{"color":{"text":"var:preset|color|white"}}},"typography":{"fontSize":"12px"}},"backgroundColor":"dark-gray","textColor":"white"} -->
<p class="has-white-color has-dark-gray-background-color has-text-color has-background has-link-color" style="font-size:12px"><strong>Yo</strong></p>
<!-- /wp:paragraph --></div>
<!-- /wp:column -->

<!-- wp:column {"width":"40%"} -->
<div class="wp-block-column" style="flex-basis:40%"><!-- wp:social-links {"size":"has-large-icon-size","className":"is-style-filled-white","layout":{"type":"flex","justifyContent":"right"}} -->
<ul class="wp-block-social-links has-large-icon-size is-style-filled-white"><!-- wp:social-link {"url":"https://www.facebook.com/illinoistimes/","service":"facebook"} /-->

<!-- wp:social-link {"url":"https://www.instagram.com/hello/","service":"instagram"} /-->

<!-- wp:social-link {"url":"https://x.com/hello","service":"x"} /--></ul>
<!-- /wp:social-links --></div>
<!-- /wp:column --></div>
<!-- /wp:columns -->
```

2. Observe the social icons have backgrounds in the web version (the WP native preview)
3. Observe the layout is broken (columns are stacked) in the email version ("Preview email" button)
4. Switch to this branch, observe both issues gone

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->