### PR TITLE
feat: ads placements

### DIFF
--- a/includes/ads/class-ads-placements.php
+++ b/includes/ads/class-ads-placements.php
@@ -100,6 +100,11 @@ final class Ads_Placements {
 				continue;
 			}
 
+			// Bail if the ad insertion strategy is not "placement".
+			if ( 'placement' !== get_post_meta( $ad->ID, 'insertion_strategy', true ) ) {
+				continue;
+			}
+
 			if ( ! empty( $newsletter_id ) ) {
 				$ad_categories = wp_get_post_terms( $ad->ID, 'category' );
 				// Skip if the ad is not in the same category as the newsletter.

--- a/includes/ads/class-ads-placements.php
+++ b/includes/ads/class-ads-placements.php
@@ -1,0 +1,67 @@
+<?php
+/**
+ * Newspack Newsletter Ads Placements.
+ *
+ * @package Newspack_Newsletters
+ */
+
+namespace Newspack_Newsletters;
+
+/**
+ * Ads Placements for Newsletters.
+ */
+final class Ads_Placements {
+
+	/**
+	 * Taxonomy name.
+	 *
+	 * @var string
+	 */
+	const TAXONOMY = 'newspack_nl_ad_placement';
+
+	/**
+	 * Initialize hooks.
+	 */
+	public static function init_hooks() {
+		add_action( 'init', [ __CLASS__, 'register_taxonomy' ] );
+	}
+
+	/**
+	 * Register placements.
+	 */
+	public static function register_taxonomy() {
+		register_taxonomy(
+			self::TAXONOMY,
+			[ Ads::CPT ],
+			[
+				'labels'            => [
+					'name'                     => __( 'Ad Placements', 'newspack-newsletters' ),
+					'singular_name'            => __( 'Ad Placement', 'newspack-newsletters' ),
+					'search_items'             => __( 'Search Ad Placements', 'newspack-newsletters' ),
+					'popular_items'            => __( 'Popular Ad Placements', 'newspack-newsletters' ),
+					'all_items'                => __( 'All Ad Placements', 'newspack-newsletters' ),
+					'parent_items'             => __( 'Parent Ad Placements', 'newspack-newsletters' ),
+					'parent_item'              => __( 'Parent Ad Placement', 'newspack-newsletters' ),
+					'name_field_description'   => __( 'The ad placement name', 'newspack-newsletters' ),
+					'slug_field_description'   => '', // There's no ad placement URL so let's skip slug field description.
+					'parent_field_description' => __( 'Assign a parent ad placement', 'newspack-newsletters' ),
+					'desc_field_description'   => __( 'Optional description for this ad placement', 'newspack-newsletters' ),
+					'edit_item'                => __( 'Edit Ad Placement', 'newspack-newsletters' ),
+					'view_item'                => __( 'View Ad Placement', 'newspack-newsletters' ),
+					'update_item'              => __( 'Update Ad Placement', 'newspack-newsletters' ),
+					'add_new_item'             => __( 'Add New Ad Placement', 'newspack-newsletters' ),
+					'new_item_name'            => __( 'New Ad Placement Name', 'newspack-newsletters' ),
+					'not_found'                => __( 'No ad placements found', 'newspack-newsletters' ),
+					'no_terms'                 => __( 'No ad placements', 'newspack-newsletters' ),
+					'filter_by_item'           => __( 'Filter by ad placement', 'newspack-newsletters' ),
+				],
+				'public'            => true,
+				'show_in_rest'      => true,
+				'hierarchical'      => false,
+				'show_admin_column' => true,
+				'rest_base'         => 'ad_placement',
+			]
+		);
+	}
+}
+Ads_Placements::init_hooks();

--- a/includes/ads/class-ads-placements.php
+++ b/includes/ads/class-ads-placements.php
@@ -59,6 +59,9 @@ final class Ads_Placements {
 				'show_in_rest'      => true,
 				'hierarchical'      => false,
 				'show_admin_column' => true,
+				'show_in_menu'      => false,
+				'show_in_nav_menus' => false,
+				'show_ui'           => false,
 				'rest_base'         => 'ad_placement',
 			]
 		);

--- a/includes/ads/class-ads-placements.php
+++ b/includes/ads/class-ads-placements.php
@@ -70,12 +70,12 @@ final class Ads_Placements {
 	/**
 	 * Get ad by placement.
 	 *
-	 * @param int $placement_id Placement ID.
-	 * @param int $newsletter_id Newsletter ID.
+	 * @param int      $placement_id  Placement ID.
+	 * @param int|null $newsletter_id Optional newsletter ID to match category and advertiser.
 	 *
 	 * @return \WP_Post|null Ad post object if found, null otherwise.
 	 */
-	public static function get_ad_by_placement( $placement_id, $newsletter_id ) {
+	public static function get_ad_by_placement( $placement_id, $newsletter_id = null ) {
 		$placement_ads = get_posts(
 			[
 				'post_type'      => Ads::CPT,
@@ -95,37 +95,38 @@ final class Ads_Placements {
 		}
 
 		$ads = [];
-		foreach ( $placement_ads as $placement_ad ) {
-			if ( ! Ads::is_ad_active( $placement_ad->ID, $newsletter_id ) ) {
+		foreach ( $placement_ads as $ad ) {
+			if ( ! Ads::is_ad_active( $ad->ID, $newsletter_id ) ) {
 				continue;
 			}
 
-			$ad_categories = wp_get_post_terms( $placement_ad->ID, 'category' );
-			// Skip if the ad is not in the same category as the post.
-			if ( ! empty( $ad_categories ) ) {
-				$newsletter_categories = wp_get_post_terms( $newsletter_id, 'category' );
-				if ( empty( array_intersect( wp_list_pluck( $ad_categories, 'term_id' ), wp_list_pluck( $newsletter_categories, 'term_id' ) ) ) ) {
-					continue;
+			if ( ! empty( $newsletter_id ) ) {
+				$ad_categories = wp_get_post_terms( $ad->ID, 'category' );
+				// Skip if the ad is not in the same category as the newsletter.
+				if ( ! empty( $ad_categories ) ) {
+					$newsletter_categories = wp_get_post_terms( $newsletter_id, 'category' );
+					if ( empty( array_intersect( wp_list_pluck( $ad_categories, 'term_id' ), wp_list_pluck( $newsletter_categories, 'term_id' ) ) ) ) {
+						continue;
+					}
+				}
+				$newsletter_advertisers = wp_get_post_terms( $newsletter_id, Ads::ADVERTISER_TAX );
+				// Skip if the newsletter has advertisers that does not match the ad.
+				if ( ! empty( $newsletter_advertisers ) ) {
+					$ad_advertisers = wp_get_post_terms( $ad->ID, Ads::ADVERTISER_TAX );
+					if ( empty( array_intersect( wp_list_pluck( $newsletter_advertisers, 'term_id' ), wp_list_pluck( $ad_advertisers, 'term_id' ) ) ) ) {
+						continue;
+					}
 				}
 			}
 
-			$newsletter_advertisers = wp_get_post_terms( $newsletter_id, Ads::ADVERTISER_TAX );
-			// Skip if the post has an advertiser and the ad is not from the same advertiser.
-			if ( ! empty( $newsletter_advertisers ) ) {
-				$ad_advertisers = wp_get_post_terms( $placement_ad->ID, Ads::ADVERTISER_TAX );
-				if ( empty( array_intersect( wp_list_pluck( $newsletter_advertisers, 'term_id' ), wp_list_pluck( $ad_advertisers, 'term_id' ) ) ) ) {
-					continue;
-				}
-			}
-
-			$ads[] = $placement_ad;
+			$ads[] = $ad;
 		}
 
 		if ( empty( $ads ) ) {
 			return null;
 		}
 
-		return array_shift( $ads );
+		return $ads[0];
 	}
 }
 Ads_Placements::init_hooks();

--- a/includes/ads/class-ads-placements.php
+++ b/includes/ads/class-ads-placements.php
@@ -63,5 +63,66 @@ final class Ads_Placements {
 			]
 		);
 	}
+
+	/**
+	 * Get ad by placement.
+	 *
+	 * @param int $placement_id Placement ID.
+	 * @param int $newsletter_id Newsletter ID.
+	 *
+	 * @return \WP_Post|null Ad post object if found, null otherwise.
+	 */
+	public static function get_ad_by_placement( $placement_id, $newsletter_id ) {
+		$placement_ads = get_posts(
+			[
+				'post_type'      => Ads::CPT,
+				'posts_per_page' => -1,
+				'tax_query'      => [ // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_tax_query
+					[
+						'taxonomy' => self::TAXONOMY,
+						'field'    => 'term_id',
+						'terms'    => $placement_id,
+					],
+				],
+			]
+		);
+
+		if ( empty( $placement_ads ) ) {
+			return null;
+		}
+
+		$ads = [];
+		foreach ( $placement_ads as $placement_ad ) {
+			if ( ! Ads::is_ad_active( $placement_ad->ID, $newsletter_id ) ) {
+				continue;
+			}
+
+			$ad_categories = wp_get_post_terms( $placement_ad->ID, 'category' );
+			// Skip if the ad is not in the same category as the post.
+			if ( ! empty( $ad_categories ) ) {
+				$newsletter_categories = wp_get_post_terms( $newsletter_id, 'category' );
+				if ( empty( array_intersect( wp_list_pluck( $ad_categories, 'term_id' ), wp_list_pluck( $newsletter_categories, 'term_id' ) ) ) ) {
+					continue;
+				}
+			}
+
+			$newsletter_advertisers = wp_get_post_terms( $newsletter_id, Ads::ADVERTISER_TAX );
+			// Skip if the post has an advertiser and the ad is not from the same advertiser.
+			if ( ! empty( $newsletter_advertisers ) ) {
+				$ad_advertisers = wp_get_post_terms( $placement_ad->ID, Ads::ADVERTISER_TAX );
+				if ( empty( array_intersect( wp_list_pluck( $newsletter_advertisers, 'term_id' ), wp_list_pluck( $ad_advertisers, 'term_id' ) ) ) ) {
+					continue;
+				}
+			}
+
+			$ads[] = $placement_ad;
+		}
+
+		if ( empty( $ads ) ) {
+			return null;
+		}
+
+		return array_shift( $ads );
+	}
 }
 Ads_Placements::init_hooks();

--- a/includes/ads/class-ads.php
+++ b/includes/ads/class-ads.php
@@ -5,23 +5,25 @@
  * @package Newspack
  */
 
+namespace Newspack_Newsletters;
+
+use Newspack_Newsletters;
+use Newspack_Newsletters_Letterhead;
+use DateTime;
+use WP_Query;
+use WP_Post;
+use WP_REST_Request;
+
 defined( 'ABSPATH' ) || exit;
 
 /**
  * Newspack Newsletters Ads Class.
  */
-final class Newspack_Newsletters_Ads {
+final class Ads {
 
 	const CPT = 'newspack_nl_ads_cpt';
 
 	const ADVERTISER_TAX = 'newspack_nl_advertiser';
-
-	/**
-	 * The single instance of the class.
-	 *
-	 * @var Newspack_Newsletters
-	 */
-	protected static $instance = null;
 
 	/**
 	 * Ads already inserted in the newsletter.
@@ -31,22 +33,9 @@ final class Newspack_Newsletters_Ads {
 	protected static $inserted_ads = [];
 
 	/**
-	 * Main Newspack Newsletter Ads Instance.
-	 * Ensures only one instance of Newspack Ads Instance is loaded or can be loaded.
-	 *
-	 * @return Newspack Ads Instance - Main instance.
+	 * Initialize hooks.
 	 */
-	public static function instance() {
-		if ( is_null( self::$instance ) ) {
-			self::$instance = new self();
-		}
-		return self::$instance;
-	}
-
-	/**
-	 * Constructor.
-	 */
-	public function __construct() {
+	public static function init_hooks() {
 		add_action( 'init', [ __CLASS__, 'register_ads_cpt' ] );
 		add_action( 'init', [ __CLASS__, 'register_meta' ] );
 		add_action( 'init', [ __CLASS__, 'register_newsletter_meta' ] );
@@ -64,6 +53,8 @@ final class Newspack_Newsletters_Ads {
 		add_action( 'manage_edit-' . self::CPT . '_sortable_columns', [ __CLASS__, 'sortable_columns' ] );
 		// Sorting.
 		add_action( 'pre_get_posts', [ __CLASS__, 'handle_sorting' ] );
+
+		require_once __DIR__ . '/class-ads-placements.php';
 	}
 
 	/**
@@ -303,7 +294,7 @@ final class Newspack_Newsletters_Ads {
 	 * Set default fields when Ad is created.
 	 *
 	 * @param int     $post_id ID of post being saved.
-	 * @param WP_POST $post The post being saved.
+	 * @param WP_Post $post The post being saved.
 	 * @param bool    $update True if this is an update, false if a newly created post.
 	 */
 	public static function ad_default_fields( $post_id, $post, $update ) {
@@ -375,7 +366,8 @@ final class Newspack_Newsletters_Ads {
 	 * Get properties required to render a useful modal in the editor that alerts
 	 * users of ads they're sending.
 	 *
-	 * @param WP_REST_REQUEST $request The WP Request Object.
+	 * @param WP_REST_Request $request The WP Request Object.
+	 *
 	 * @return array
 	 */
 	public static function get_ads_config( $request ) {
@@ -639,7 +631,7 @@ final class Newspack_Newsletters_Ads {
 	/**
 	 * Handle sorting.
 	 *
-	 * @param \WP_Query $query Query.
+	 * @param WP_Query $query Query.
 	 */
 	public static function handle_sorting( $query ) {
 		if ( ! is_admin() || ! $query->is_main_query() ) {
@@ -686,7 +678,7 @@ final class Newspack_Newsletters_Ads {
 	 * Some blocks should never have an ad right after them. For example, an ad right after a subheading
 	 * (header block) would not look good.
 	 *
-	 * @param object $block A block.
+	 * @param array $block A block.
 	 */
 	private static function can_block_be_followed_by_ad( $block ) {
 		if (
@@ -714,7 +706,7 @@ final class Newspack_Newsletters_Ads {
 	/**
 	 * Get content from a given block's inner blocks, and recursively from those blocks' inner blocks.
 	 *
-	 * @param object $block A block.
+	 * @param array $block A block.
 	 *
 	 * @return string The block's inner content.
 	 */
@@ -738,7 +730,7 @@ final class Newspack_Newsletters_Ads {
 	/**
 	 * Get content from given block, including content from the block's inner blocks, if any.
 	 *
-	 * @param object $block A block.
+	 * @param array $block A block.
 	 *
 	 * @return string The block's content.
 	 */
@@ -930,4 +922,4 @@ final class Newspack_Newsletters_Ads {
 		return $output;
 	}
 }
-Newspack_Newsletters_Ads::instance();
+Ads::init_hooks();

--- a/includes/ads/class-ads.php
+++ b/includes/ads/class-ads.php
@@ -215,12 +215,6 @@ final class Ads {
 	 * Register the custom post type for layouts.
 	 */
 	public static function register_ads_cpt() {
-		$newsletters_post_type_object = get_post_type_object( Newspack_Newsletters::NEWSPACK_NEWSLETTERS_CPT );
-		$can_edit_newsletters = current_user_can( $newsletters_post_type_object->cap->edit_posts );
-		if ( ! $can_edit_newsletters ) {
-			return;
-		}
-
 		$labels = [
 			'name'                     => _x( 'Newsletter Ads', 'post type general name', 'newspack-newsletters' ),
 			'singular_name'            => _x( 'Newsletter Ad', 'post type singular name', 'newspack-newsletters' ),

--- a/includes/ads/class-ads.php
+++ b/includes/ads/class-ads.php
@@ -184,7 +184,6 @@ final class Ads {
 	 */
 	public static function add_ads_page() {
 		$newsletter_ad_post_type_object = get_post_type_object( self::CPT );
-		$can_edit_newsletter_ads = current_user_can( $newsletter_ad_post_type_object->cap->edit_posts );
 
 		$page_title = apply_filters( 'newspack_newsletters_ads_page_title', __( 'Newsletters Ads', 'newspack-newsletters' ) );
 		$menu_title = apply_filters( 'newspack_newsletters_ads_menu_title', __( 'Ads', 'newspack-newsletters' ) );
@@ -445,7 +444,7 @@ final class Ads {
 	 * Get available ads for a newsletter.
 	 *
 	 * @param int  $newsletter_id   Newsletter post ID.
-	 * @param bool $skip_validation Whether to skip validation of ad categories and advertisers.
+	 * @param bool $skip_validation Whether to skip validation of ad categories, advertisers, and placements.
 	 *
 	 * @return WP_Post[] Array of ad posts.
 	 */
@@ -465,6 +464,10 @@ final class Ads {
 			}
 			// Skip if ad is not active.
 			if ( ! self::is_ad_active( $ad->ID, $newsletter_id ) ) {
+				continue;
+			}
+			// Skip if the ad insertion is via placement.
+			if ( ! empty( wp_get_post_terms( $ad->ID, Ads_Placements::TAXONOMY ) ) ) {
 				continue;
 			}
 			$ad_categories = wp_get_post_terms( $ad->ID, 'category' );

--- a/includes/ads/class-ads.php
+++ b/includes/ads/class-ads.php
@@ -461,7 +461,7 @@ final class Ads {
 				continue;
 			}
 			// Skip if the ad insertion is via placement.
-			if ( ! empty( wp_get_post_terms( $ad->ID, Ads_Placements::TAXONOMY ) ) ) {
+			if ( 'placement' === get_post_meta( $ad->ID, 'insertion_strategy', true ) ) {
 				continue;
 			}
 			$ad_categories = wp_get_post_terms( $ad->ID, 'category' );

--- a/includes/ads/class-ads.php
+++ b/includes/ads/class-ads.php
@@ -515,14 +515,14 @@ final class Ads {
 			$ads_by_position[ $position ][] = $ad;
 		}
 
+		ksort( $ads_by_position );
+
 		$flattened_ads = [];
 		foreach ( $ads_by_position as $position_ads ) {
 			foreach ( $position_ads as $ad ) {
 				$flattened_ads[] = $ad;
 			}
 		}
-
-		sort( $flattened_ads );
 		return $flattened_ads;
 	}
 

--- a/includes/class-newspack-newsletters-editor.php
+++ b/includes/class-newspack-newsletters-editor.php
@@ -87,7 +87,7 @@ final class Newspack_Newsletters_Editor {
 	private static function get_email_editor_cpts() {
 		$email_cpts = [
 			Newspack_Newsletters::NEWSPACK_NEWSLETTERS_CPT,
-			Newspack_Newsletters_Ads::CPT,
+			Newspack_Newsletters\Ads::CPT,
 		];
 		return apply_filters( 'newspack_newsletters_email_editor_cpts', $email_cpts );
 	}
@@ -321,7 +321,7 @@ final class Newspack_Newsletters_Editor {
 	public static function enqueue_block_editor_assets() {
 		// Remove the Ads CPT - it does not need MJML handling since ads
 		// will be injected into email content before it's converted to MJML.
-		$mjml_handling_post_types = array_values( array_diff( self::get_email_editor_cpts(), [ Newspack_Newsletters_Ads::CPT ] ) );
+		$mjml_handling_post_types = array_values( array_diff( self::get_email_editor_cpts(), [ Newspack_Newsletters\Ads::CPT ] ) );
 		$provider                 = Newspack_Newsletters::get_service_provider();
 		$conditional_tag_support  = false;
 
@@ -445,7 +445,7 @@ final class Newspack_Newsletters_Editor {
 	 * Is editing a newsletter ad?
 	 */
 	private static function is_editing_newsletter_ad() {
-		return Newspack_Newsletters_Ads::CPT === get_post_type();
+		return Newspack_Newsletters\Ads::CPT === get_post_type();
 	}
 
 	/**

--- a/includes/class-newspack-newsletters-renderer.php
+++ b/includes/class-newspack-newsletters-renderer.php
@@ -1150,7 +1150,11 @@ final class Newspack_Newsletters_Renderer {
 			case 'newspack-newsletters/ad':
 				$ad_post = false;
 				if ( ! empty( $attrs['adId'] ) ) {
-					$ad_post = get_post( $attrs['adId'] );
+					if ( strpos( $attrs['adId'], 'placement:' ) === 0 ) {
+						$ad_post = Newspack_Newsletters\Ads_Placements::get_ad_by_placement( str_replace( 'placement:', '', $attrs['adId'] ), self::$newsletter_id );
+					} else {
+						$ad_post = get_post( $attrs['adId'] );
+					}
 				} elseif ( ! empty( self::$newsletter_id ) ) {
 					$ads = Newspack_Newsletters\Ads::get_newsletter_ads( self::$newsletter_id );
 					foreach ( $ads as $ad ) {

--- a/includes/class-newspack-newsletters-renderer.php
+++ b/includes/class-newspack-newsletters-renderer.php
@@ -1152,9 +1152,9 @@ final class Newspack_Newsletters_Renderer {
 				if ( ! empty( $attrs['adId'] ) ) {
 					$ad_post = get_post( $attrs['adId'] );
 				} elseif ( ! empty( self::$newsletter_id ) ) {
-					$ads = Newspack_Newsletters_Ads::get_newsletter_ads( self::$newsletter_id );
+					$ads = Newspack_Newsletters\Ads::get_newsletter_ads( self::$newsletter_id );
 					foreach ( $ads as $ad ) {
-						if ( ! Newspack_Newsletters_Ads::is_ad_inserted( self::$newsletter_id, $ad->ID ) ) {
+						if ( ! Newspack_Newsletters\Ads::is_ad_inserted( self::$newsletter_id, $ad->ID ) ) {
 							$ad_post = $ad;
 							break;
 						}
@@ -1163,7 +1163,7 @@ final class Newspack_Newsletters_Renderer {
 				if ( $ad_post ) {
 					$block_mjml_markup = self::post_to_mjml_components( $ad_post );
 					if ( ! empty( self::$newsletter_id ) ) {
-						Newspack_Newsletters_Ads::mark_ad_inserted( self::$newsletter_id, $ad_post->ID );
+						Newspack_Newsletters\Ads::mark_ad_inserted( self::$newsletter_id, $ad_post->ID );
 					}
 				}
 				break;

--- a/includes/class-newspack-newsletters.php
+++ b/includes/class-newspack-newsletters.php
@@ -606,7 +606,7 @@ final class Newspack_Newsletters {
 	 */
 	public static function remove_admin_menu_items() {
 		$newsletter_post_type_object = get_post_type_object( self::NEWSPACK_NEWSLETTERS_CPT );
-		$newsletter_ad_post_type_object = get_post_type_object( Newspack_Newsletters_Ads::CPT );
+		$newsletter_ad_post_type_object = get_post_type_object( Newspack_Newsletters\Ads::CPT );
 
 		if ( $newsletter_post_type_object === null || $newsletter_ad_post_type_object === null ) {
 			return;
@@ -624,7 +624,7 @@ final class Newspack_Newsletters {
 			remove_submenu_page( $category_page_slug, 'edit-tags.php?taxonomy=post_tag&amp;post_type=' . self::NEWSPACK_NEWSLETTERS_CPT );
 		}
 
-		// Note: Newsletter Ads menu handling is done in Newspack_Newsletters_Ads::add_ads_page()
+		// Note: Newsletter Ads menu handling is done in Newspack_Newsletters\Ads::add_ads_page()
 		// which dynamically places the menu based on user capabilities.
 	}
 
@@ -1131,7 +1131,7 @@ final class Newspack_Newsletters {
 		$screen = get_current_screen();
 		if (
 			self::NEWSPACK_NEWSLETTERS_CPT !== $screen->post_type &&
-			Newspack_Newsletters_Ads::CPT !== $screen->post_type &&
+			Newspack_Newsletters\Ads::CPT !== $screen->post_type &&
 			Newspack\Newsletters\Subscription_Lists::CPT !== $screen->post_type
 		) {
 			return;

--- a/includes/tracking/class-admin.php
+++ b/includes/tracking/class-admin.php
@@ -23,9 +23,9 @@ final class Admin {
 		add_action( 'update_option_newspack_newsletters_use_click_tracking', [ __CLASS__, 'updated_option' ] );
 
 		// Newsletters Ads columns.
-		add_action( 'manage_' . \Newspack_Newsletters_Ads::CPT . '_posts_columns', [ __CLASS__, 'manage_ads_columns' ] );
-		add_action( 'manage_' . \Newspack_Newsletters_Ads::CPT . '_posts_custom_column', [ __CLASS__, 'custom_ads_column' ], 10, 2 );
-		add_action( 'manage_edit-' . \Newspack_Newsletters_Ads::CPT . '_sortable_columns', [ __CLASS__, 'sortable_ads_columns' ] );
+		add_action( 'manage_' . \Newspack_Newsletters\Ads::CPT . '_posts_columns', [ __CLASS__, 'manage_ads_columns' ] );
+		add_action( 'manage_' . \Newspack_Newsletters\Ads::CPT . '_posts_custom_column', [ __CLASS__, 'custom_ads_column' ], 10, 2 );
+		add_action( 'manage_edit-' . \Newspack_Newsletters\Ads::CPT . '_sortable_columns', [ __CLASS__, 'sortable_ads_columns' ] );
 
 		// Sorting.
 		add_action( 'pre_get_posts', [ __CLASS__, 'handle_sorting' ] );
@@ -258,7 +258,7 @@ final class Admin {
 			}
 		}
 
-		if ( \Newspack_Newsletters_Ads::CPT === $query->get( 'post_type' ) ) {
+		if ( \Newspack_Newsletters\Ads::CPT === $query->get( 'post_type' ) ) {
 			$orderby = $query->get( 'orderby' );
 			if ( 'impressions' === $orderby ) {
 				$query->set( 'meta_key', 'tracking_impressions' );

--- a/languages/newspack-newsletters.pot
+++ b/languages/newspack-newsletters.pot
@@ -9,7 +9,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2025-08-05T16:31:49+00:00\n"
+"POT-Creation-Date: 2025-08-05T19:59:30+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "X-Generator: WP-CLI 2.12.0\n"
 "X-Domain: newspack-newsletters\n"
@@ -120,186 +120,186 @@ msgstr ""
 msgid "Ads"
 msgstr ""
 
-#: includes/ads/class-ads.php:225
+#: includes/ads/class-ads.php:219
 msgctxt "post type general name"
 msgid "Newsletter Ads"
 msgstr ""
 
-#: includes/ads/class-ads.php:226
+#: includes/ads/class-ads.php:220
 msgctxt "post type singular name"
 msgid "Newsletter Ad"
 msgstr ""
 
-#: includes/ads/class-ads.php:227
+#: includes/ads/class-ads.php:221
 msgctxt "admin menu"
 msgid "Newsletter Ads"
 msgstr ""
 
-#: includes/ads/class-ads.php:228
+#: includes/ads/class-ads.php:222
 msgctxt "add new on admin bar"
 msgid "Newsletter Ad"
 msgstr ""
 
-#: includes/ads/class-ads.php:229
+#: includes/ads/class-ads.php:223
 msgctxt "popup"
 msgid "Add New"
 msgstr ""
 
-#: includes/ads/class-ads.php:230
+#: includes/ads/class-ads.php:224
 msgid "Add New Newsletter Ad"
 msgstr ""
 
-#: includes/ads/class-ads.php:231
+#: includes/ads/class-ads.php:225
 msgid "New Newsletter Ad"
 msgstr ""
 
-#: includes/ads/class-ads.php:232
+#: includes/ads/class-ads.php:226
 msgid "Edit Newsletter Ad"
 msgstr ""
 
-#: includes/ads/class-ads.php:233
+#: includes/ads/class-ads.php:227
 msgid "View Newsletter Ad"
 msgstr ""
 
-#: includes/ads/class-ads.php:234
+#: includes/ads/class-ads.php:228
 msgid "All Newsletter Ads"
 msgstr ""
 
-#: includes/ads/class-ads.php:235
+#: includes/ads/class-ads.php:229
 msgid "Search Newsletter Ads"
 msgstr ""
 
-#: includes/ads/class-ads.php:236
+#: includes/ads/class-ads.php:230
 msgid "Parent Newsletter Ads:"
 msgstr ""
 
-#: includes/ads/class-ads.php:237
+#: includes/ads/class-ads.php:231
 msgid "No Newsletter Ads found."
 msgstr ""
 
-#: includes/ads/class-ads.php:238
+#: includes/ads/class-ads.php:232
 msgid "No Newsletter Ads found in Trash."
 msgstr ""
 
-#: includes/ads/class-ads.php:239
+#: includes/ads/class-ads.php:233
 msgid "Newsletter Ads list"
 msgstr ""
 
-#: includes/ads/class-ads.php:240
+#: includes/ads/class-ads.php:234
 msgid "Newsletter Ad published"
 msgstr ""
 
-#: includes/ads/class-ads.php:241
+#: includes/ads/class-ads.php:235
 msgid "Newsletter Ad published privately"
 msgstr ""
 
-#: includes/ads/class-ads.php:242
+#: includes/ads/class-ads.php:236
 msgid "Newsletter Ad reverted to draft"
 msgstr ""
 
-#: includes/ads/class-ads.php:243
+#: includes/ads/class-ads.php:237
 msgid "Newsletter Ad scheduled"
 msgstr ""
 
-#: includes/ads/class-ads.php:244
+#: includes/ads/class-ads.php:238
 msgid "Newsletter Ad updated"
 msgstr ""
 
-#: includes/ads/class-ads.php:263
+#: includes/ads/class-ads.php:257
 msgid "Advertisers"
 msgstr ""
 
-#: includes/ads/class-ads.php:264
+#: includes/ads/class-ads.php:258
 msgid "Advertiser"
 msgstr ""
 
-#: includes/ads/class-ads.php:265
+#: includes/ads/class-ads.php:259
 msgid "Search Advertisers"
 msgstr ""
 
-#: includes/ads/class-ads.php:266
+#: includes/ads/class-ads.php:260
 msgid "Popular Advertisers"
 msgstr ""
 
-#: includes/ads/class-ads.php:267
+#: includes/ads/class-ads.php:261
 msgid "All Advertisers"
 msgstr ""
 
-#: includes/ads/class-ads.php:268
+#: includes/ads/class-ads.php:262
 msgid "Parent Advertisers"
 msgstr ""
 
-#: includes/ads/class-ads.php:269
+#: includes/ads/class-ads.php:263
 msgid "Parent Advertiser"
 msgstr ""
 
-#: includes/ads/class-ads.php:270
+#: includes/ads/class-ads.php:264
 msgid "The advertiser name"
 msgstr ""
 
-#: includes/ads/class-ads.php:272
+#: includes/ads/class-ads.php:266
 msgid "Assign a parent advertiser"
 msgstr ""
 
-#: includes/ads/class-ads.php:273
+#: includes/ads/class-ads.php:267
 msgid "Optional description for this advertiser"
 msgstr ""
 
-#: includes/ads/class-ads.php:274
+#: includes/ads/class-ads.php:268
 msgid "Edit Advertiser"
 msgstr ""
 
-#: includes/ads/class-ads.php:275
+#: includes/ads/class-ads.php:269
 msgid "View Advertiser"
 msgstr ""
 
-#: includes/ads/class-ads.php:276
+#: includes/ads/class-ads.php:270
 msgid "Update Advertiser"
 msgstr ""
 
-#: includes/ads/class-ads.php:277
+#: includes/ads/class-ads.php:271
 msgid "Add New Advertiser"
 msgstr ""
 
-#: includes/ads/class-ads.php:278
+#: includes/ads/class-ads.php:272
 msgid "New Advertiser Name"
 msgstr ""
 
-#: includes/ads/class-ads.php:279
+#: includes/ads/class-ads.php:273
 msgid "No advertisers found"
 msgstr ""
 
-#: includes/ads/class-ads.php:280
+#: includes/ads/class-ads.php:274
 msgid "No advertisers"
 msgstr ""
 
-#: includes/ads/class-ads.php:281
+#: includes/ads/class-ads.php:275
 msgid "Filter by advertiser"
 msgstr ""
 
-#: includes/ads/class-ads.php:283
+#: includes/ads/class-ads.php:277
 msgid "Newspack Newsletters Ads Advertisers"
 msgstr ""
 
-#: includes/ads/class-ads.php:382
+#: includes/ads/class-ads.php:376
 msgid "promotion"
 msgstr ""
 
-#: includes/ads/class-ads.php:382
+#: includes/ads/class-ads.php:376
 msgid "ad"
 msgstr ""
 
-#: includes/ads/class-ads.php:583
+#: includes/ads/class-ads.php:577
 msgid "Start Date"
 msgstr ""
 
-#: includes/ads/class-ads.php:584
+#: includes/ads/class-ads.php:578
 #: dist/adsEditor.js:19
 #: src/ads/editor/index.js:357
 msgid "Expiration Date"
 msgstr ""
 
-#: includes/ads/class-ads.php:585
+#: includes/ads/class-ads.php:579
 #: dist/adsEditor.js:13
 #: src/ads/editor/index.js:140
 msgid "Price"

--- a/languages/newspack-newsletters.pot
+++ b/languages/newspack-newsletters.pot
@@ -9,7 +9,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2025-08-01T20:08:43+00:00\n"
+"POT-Creation-Date: 2025-08-05T14:23:07+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "X-Generator: WP-CLI 2.12.0\n"
 "X-Domain: newspack-newsletters\n"
@@ -111,194 +111,195 @@ msgstr ""
 msgid "Filter by ad placement"
 msgstr ""
 
-#: includes/ads/class-ads.php:189
+#: includes/ads/class-ads.php:188
 msgid "Newsletters Ads"
 msgstr ""
 
-#: includes/ads/class-ads.php:190
+#: includes/ads/class-ads.php:189
+#: src/editor/blocks/ad/edit.js:102
 msgid "Ads"
 msgstr ""
 
-#: includes/ads/class-ads.php:226
+#: includes/ads/class-ads.php:225
 msgctxt "post type general name"
 msgid "Newsletter Ads"
 msgstr ""
 
-#: includes/ads/class-ads.php:227
+#: includes/ads/class-ads.php:226
 msgctxt "post type singular name"
 msgid "Newsletter Ad"
 msgstr ""
 
-#: includes/ads/class-ads.php:228
+#: includes/ads/class-ads.php:227
 msgctxt "admin menu"
 msgid "Newsletter Ads"
 msgstr ""
 
-#: includes/ads/class-ads.php:229
+#: includes/ads/class-ads.php:228
 msgctxt "add new on admin bar"
 msgid "Newsletter Ad"
 msgstr ""
 
-#: includes/ads/class-ads.php:230
+#: includes/ads/class-ads.php:229
 msgctxt "popup"
 msgid "Add New"
 msgstr ""
 
-#: includes/ads/class-ads.php:231
+#: includes/ads/class-ads.php:230
 msgid "Add New Newsletter Ad"
 msgstr ""
 
-#: includes/ads/class-ads.php:232
+#: includes/ads/class-ads.php:231
 msgid "New Newsletter Ad"
 msgstr ""
 
-#: includes/ads/class-ads.php:233
+#: includes/ads/class-ads.php:232
 msgid "Edit Newsletter Ad"
 msgstr ""
 
-#: includes/ads/class-ads.php:234
+#: includes/ads/class-ads.php:233
 msgid "View Newsletter Ad"
 msgstr ""
 
-#: includes/ads/class-ads.php:235
+#: includes/ads/class-ads.php:234
 msgid "All Newsletter Ads"
 msgstr ""
 
-#: includes/ads/class-ads.php:236
+#: includes/ads/class-ads.php:235
 msgid "Search Newsletter Ads"
 msgstr ""
 
-#: includes/ads/class-ads.php:237
+#: includes/ads/class-ads.php:236
 msgid "Parent Newsletter Ads:"
 msgstr ""
 
-#: includes/ads/class-ads.php:238
+#: includes/ads/class-ads.php:237
 msgid "No Newsletter Ads found."
 msgstr ""
 
-#: includes/ads/class-ads.php:239
+#: includes/ads/class-ads.php:238
 msgid "No Newsletter Ads found in Trash."
 msgstr ""
 
-#: includes/ads/class-ads.php:240
+#: includes/ads/class-ads.php:239
 msgid "Newsletter Ads list"
 msgstr ""
 
-#: includes/ads/class-ads.php:241
+#: includes/ads/class-ads.php:240
 msgid "Newsletter Ad published"
 msgstr ""
 
-#: includes/ads/class-ads.php:242
+#: includes/ads/class-ads.php:241
 msgid "Newsletter Ad published privately"
 msgstr ""
 
-#: includes/ads/class-ads.php:243
+#: includes/ads/class-ads.php:242
 msgid "Newsletter Ad reverted to draft"
 msgstr ""
 
-#: includes/ads/class-ads.php:244
+#: includes/ads/class-ads.php:243
 msgid "Newsletter Ad scheduled"
 msgstr ""
 
-#: includes/ads/class-ads.php:245
+#: includes/ads/class-ads.php:244
 msgid "Newsletter Ad updated"
 msgstr ""
 
-#: includes/ads/class-ads.php:264
+#: includes/ads/class-ads.php:263
 msgid "Advertisers"
 msgstr ""
 
-#: includes/ads/class-ads.php:265
+#: includes/ads/class-ads.php:264
 msgid "Advertiser"
 msgstr ""
 
-#: includes/ads/class-ads.php:266
+#: includes/ads/class-ads.php:265
 msgid "Search Advertisers"
 msgstr ""
 
-#: includes/ads/class-ads.php:267
+#: includes/ads/class-ads.php:266
 msgid "Popular Advertisers"
 msgstr ""
 
-#: includes/ads/class-ads.php:268
+#: includes/ads/class-ads.php:267
 msgid "All Advertisers"
 msgstr ""
 
-#: includes/ads/class-ads.php:269
+#: includes/ads/class-ads.php:268
 msgid "Parent Advertisers"
 msgstr ""
 
-#: includes/ads/class-ads.php:270
+#: includes/ads/class-ads.php:269
 msgid "Parent Advertiser"
 msgstr ""
 
-#: includes/ads/class-ads.php:271
+#: includes/ads/class-ads.php:270
 msgid "The advertiser name"
 msgstr ""
 
-#: includes/ads/class-ads.php:273
+#: includes/ads/class-ads.php:272
 msgid "Assign a parent advertiser"
 msgstr ""
 
-#: includes/ads/class-ads.php:274
+#: includes/ads/class-ads.php:273
 msgid "Optional description for this advertiser"
 msgstr ""
 
-#: includes/ads/class-ads.php:275
+#: includes/ads/class-ads.php:274
 msgid "Edit Advertiser"
 msgstr ""
 
-#: includes/ads/class-ads.php:276
+#: includes/ads/class-ads.php:275
 msgid "View Advertiser"
 msgstr ""
 
-#: includes/ads/class-ads.php:277
+#: includes/ads/class-ads.php:276
 msgid "Update Advertiser"
 msgstr ""
 
-#: includes/ads/class-ads.php:278
+#: includes/ads/class-ads.php:277
 msgid "Add New Advertiser"
 msgstr ""
 
-#: includes/ads/class-ads.php:279
+#: includes/ads/class-ads.php:278
 msgid "New Advertiser Name"
 msgstr ""
 
-#: includes/ads/class-ads.php:280
+#: includes/ads/class-ads.php:279
 msgid "No advertisers found"
 msgstr ""
 
-#: includes/ads/class-ads.php:281
+#: includes/ads/class-ads.php:280
 msgid "No advertisers"
 msgstr ""
 
-#: includes/ads/class-ads.php:282
+#: includes/ads/class-ads.php:281
 msgid "Filter by advertiser"
 msgstr ""
 
-#: includes/ads/class-ads.php:284
+#: includes/ads/class-ads.php:283
 msgid "Newspack Newsletters Ads Advertisers"
 msgstr ""
 
-#: includes/ads/class-ads.php:383
+#: includes/ads/class-ads.php:382
 msgid "promotion"
 msgstr ""
 
-#: includes/ads/class-ads.php:383
+#: includes/ads/class-ads.php:382
 msgid "ad"
 msgstr ""
 
-#: includes/ads/class-ads.php:580
+#: includes/ads/class-ads.php:583
 msgid "Start Date"
 msgstr ""
 
-#: includes/ads/class-ads.php:581
+#: includes/ads/class-ads.php:584
 #: dist/adsEditor.js:19
-#: src/ads/editor/index.js:306
+#: src/ads/editor/index.js:333
 msgid "Expiration Date"
 msgstr ""
 
-#: includes/ads/class-ads.php:582
+#: includes/ads/class-ads.php:585
 #: dist/adsEditor.js:13
 #: src/ads/editor/index.js:136
 msgid "Price"
@@ -1537,6 +1538,7 @@ msgstr ""
 #: dist/adsEditor.js:13
 #: src/ads/editor/index.js:164
 #: src/ads/editor/index.js:171
+#: src/editor/blocks/ad/edit.js:71
 msgid "Placement"
 msgstr ""
 
@@ -1555,22 +1557,27 @@ msgstr ""
 msgid "New Placement Name"
 msgstr ""
 
+#: dist/adsEditor.js:13
+#: src/ads/editor/index.js:211
+msgid "Press Enter to save the new placement."
+msgstr ""
+
 #. translators: %d: number.
 #: dist/adsEditor.js:16
-#: src/ads/editor/index.js:251
+#: src/ads/editor/index.js:278
 #, js-format
 msgid "The ad will be automatically inserted about %s into the newsletter content."
 msgstr ""
 
 #. translators: %d: number.
 #: dist/adsEditor.js:19
-#: src/ads/editor/index.js:274
+#: src/ads/editor/index.js:301
 #, js-format
 msgid "The ad will be automatically inserted after %d blocks of newsletter content."
 msgstr ""
 
 #: dist/adsEditor.js:19
-#: src/ads/editor/index.js:285
+#: src/ads/editor/index.js:312
 msgid "Custom Start Date"
 msgstr ""
 
@@ -2039,7 +2046,7 @@ msgstr ""
 
 #: dist/newsletterAdsEditor.js:1
 #: src/ads/newsletter-editor/disable-auto-ads.js:27
-#: src/editor/blocks/ad/edit.js:22
+#: src/editor/blocks/ad/edit.js:31
 msgid "ads"
 msgstr ""
 
@@ -2295,16 +2302,26 @@ msgstr ""
 msgid "These features will not be displayed correctly in an email, please remove them:"
 msgstr ""
 
-#: src/editor/blocks/ad/edit.js:50
-#: src/editor/blocks/ad/edit.js:66
+#: src/editor/blocks/ad/edit.js:59
+#: src/editor/blocks/ad/edit.js:88
 msgid "Automatic selection"
 msgstr ""
 
-#: src/editor/blocks/ad/edit.js:79
+#. translators: %s is the placement name
+#: src/editor/blocks/ad/edit.js:68
+#, js-format
+msgid "Placement: %s"
+msgstr ""
+
+#: src/editor/blocks/ad/edit.js:91
+msgid "Placements"
+msgstr ""
+
+#: src/editor/blocks/ad/edit.js:112
 msgid "By not selecting an ad, the system automatically chooses which ad should be rendered in this position."
 msgstr ""
 
-#: src/editor/blocks/ad/edit.js:87
+#: src/editor/blocks/ad/edit.js:120
 msgid "No ads are available. Make sure you have created ads and that they are scheduled to run on the newsletter's publish date."
 msgstr ""
 

--- a/languages/newspack-newsletters.pot
+++ b/languages/newspack-newsletters.pot
@@ -9,7 +9,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2025-07-30T10:05:52+00:00\n"
+"POT-Creation-Date: 2025-08-01T20:08:43+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "X-Generator: WP-CLI 2.12.0\n"
 "X-Domain: newspack-newsletters\n"
@@ -39,196 +39,268 @@ msgstr ""
 msgid "https://newspack.com/"
 msgstr ""
 
-#: includes/class-newspack-newsletters-ads.php:198
+#: includes/ads/class-ads-placements.php:38
+msgid "Ad Placements"
+msgstr ""
+
+#: includes/ads/class-ads-placements.php:39
+msgid "Ad Placement"
+msgstr ""
+
+#: includes/ads/class-ads-placements.php:40
+msgid "Search Ad Placements"
+msgstr ""
+
+#: includes/ads/class-ads-placements.php:41
+msgid "Popular Ad Placements"
+msgstr ""
+
+#: includes/ads/class-ads-placements.php:42
+msgid "All Ad Placements"
+msgstr ""
+
+#: includes/ads/class-ads-placements.php:43
+msgid "Parent Ad Placements"
+msgstr ""
+
+#: includes/ads/class-ads-placements.php:44
+msgid "Parent Ad Placement"
+msgstr ""
+
+#: includes/ads/class-ads-placements.php:45
+msgid "The ad placement name"
+msgstr ""
+
+#: includes/ads/class-ads-placements.php:47
+msgid "Assign a parent ad placement"
+msgstr ""
+
+#: includes/ads/class-ads-placements.php:48
+msgid "Optional description for this ad placement"
+msgstr ""
+
+#: includes/ads/class-ads-placements.php:49
+msgid "Edit Ad Placement"
+msgstr ""
+
+#: includes/ads/class-ads-placements.php:50
+msgid "View Ad Placement"
+msgstr ""
+
+#: includes/ads/class-ads-placements.php:51
+msgid "Update Ad Placement"
+msgstr ""
+
+#: includes/ads/class-ads-placements.php:52
+msgid "Add New Ad Placement"
+msgstr ""
+
+#: includes/ads/class-ads-placements.php:53
+msgid "New Ad Placement Name"
+msgstr ""
+
+#: includes/ads/class-ads-placements.php:54
+msgid "No ad placements found"
+msgstr ""
+
+#: includes/ads/class-ads-placements.php:55
+msgid "No ad placements"
+msgstr ""
+
+#: includes/ads/class-ads-placements.php:56
+msgid "Filter by ad placement"
+msgstr ""
+
+#: includes/ads/class-ads.php:189
 msgid "Newsletters Ads"
 msgstr ""
 
-#: includes/class-newspack-newsletters-ads.php:199
+#: includes/ads/class-ads.php:190
 msgid "Ads"
 msgstr ""
 
-#: includes/class-newspack-newsletters-ads.php:235
+#: includes/ads/class-ads.php:226
 msgctxt "post type general name"
 msgid "Newsletter Ads"
 msgstr ""
 
-#: includes/class-newspack-newsletters-ads.php:236
+#: includes/ads/class-ads.php:227
 msgctxt "post type singular name"
 msgid "Newsletter Ad"
 msgstr ""
 
-#: includes/class-newspack-newsletters-ads.php:237
+#: includes/ads/class-ads.php:228
 msgctxt "admin menu"
 msgid "Newsletter Ads"
 msgstr ""
 
-#: includes/class-newspack-newsletters-ads.php:238
+#: includes/ads/class-ads.php:229
 msgctxt "add new on admin bar"
 msgid "Newsletter Ad"
 msgstr ""
 
-#: includes/class-newspack-newsletters-ads.php:239
+#: includes/ads/class-ads.php:230
 msgctxt "popup"
 msgid "Add New"
 msgstr ""
 
-#: includes/class-newspack-newsletters-ads.php:240
+#: includes/ads/class-ads.php:231
 msgid "Add New Newsletter Ad"
 msgstr ""
 
-#: includes/class-newspack-newsletters-ads.php:241
+#: includes/ads/class-ads.php:232
 msgid "New Newsletter Ad"
 msgstr ""
 
-#: includes/class-newspack-newsletters-ads.php:242
+#: includes/ads/class-ads.php:233
 msgid "Edit Newsletter Ad"
 msgstr ""
 
-#: includes/class-newspack-newsletters-ads.php:243
+#: includes/ads/class-ads.php:234
 msgid "View Newsletter Ad"
 msgstr ""
 
-#: includes/class-newspack-newsletters-ads.php:244
+#: includes/ads/class-ads.php:235
 msgid "All Newsletter Ads"
 msgstr ""
 
-#: includes/class-newspack-newsletters-ads.php:245
+#: includes/ads/class-ads.php:236
 msgid "Search Newsletter Ads"
 msgstr ""
 
-#: includes/class-newspack-newsletters-ads.php:246
+#: includes/ads/class-ads.php:237
 msgid "Parent Newsletter Ads:"
 msgstr ""
 
-#: includes/class-newspack-newsletters-ads.php:247
+#: includes/ads/class-ads.php:238
 msgid "No Newsletter Ads found."
 msgstr ""
 
-#: includes/class-newspack-newsletters-ads.php:248
+#: includes/ads/class-ads.php:239
 msgid "No Newsletter Ads found in Trash."
 msgstr ""
 
-#: includes/class-newspack-newsletters-ads.php:249
+#: includes/ads/class-ads.php:240
 msgid "Newsletter Ads list"
 msgstr ""
 
-#: includes/class-newspack-newsletters-ads.php:250
+#: includes/ads/class-ads.php:241
 msgid "Newsletter Ad published"
 msgstr ""
 
-#: includes/class-newspack-newsletters-ads.php:251
+#: includes/ads/class-ads.php:242
 msgid "Newsletter Ad published privately"
 msgstr ""
 
-#: includes/class-newspack-newsletters-ads.php:252
+#: includes/ads/class-ads.php:243
 msgid "Newsletter Ad reverted to draft"
 msgstr ""
 
-#: includes/class-newspack-newsletters-ads.php:253
+#: includes/ads/class-ads.php:244
 msgid "Newsletter Ad scheduled"
 msgstr ""
 
-#: includes/class-newspack-newsletters-ads.php:254
+#: includes/ads/class-ads.php:245
 msgid "Newsletter Ad updated"
 msgstr ""
 
-#: includes/class-newspack-newsletters-ads.php:273
+#: includes/ads/class-ads.php:264
 msgid "Advertisers"
 msgstr ""
 
-#: includes/class-newspack-newsletters-ads.php:274
+#: includes/ads/class-ads.php:265
 msgid "Advertiser"
 msgstr ""
 
-#: includes/class-newspack-newsletters-ads.php:275
+#: includes/ads/class-ads.php:266
 msgid "Search Advertisers"
 msgstr ""
 
-#: includes/class-newspack-newsletters-ads.php:276
+#: includes/ads/class-ads.php:267
 msgid "Popular Advertisers"
 msgstr ""
 
-#: includes/class-newspack-newsletters-ads.php:277
+#: includes/ads/class-ads.php:268
 msgid "All Advertisers"
 msgstr ""
 
-#: includes/class-newspack-newsletters-ads.php:278
+#: includes/ads/class-ads.php:269
 msgid "Parent Advertisers"
 msgstr ""
 
-#: includes/class-newspack-newsletters-ads.php:279
+#: includes/ads/class-ads.php:270
 msgid "Parent Advertiser"
 msgstr ""
 
-#: includes/class-newspack-newsletters-ads.php:280
+#: includes/ads/class-ads.php:271
 msgid "The advertiser name"
 msgstr ""
 
-#: includes/class-newspack-newsletters-ads.php:282
+#: includes/ads/class-ads.php:273
 msgid "Assign a parent advertiser"
 msgstr ""
 
-#: includes/class-newspack-newsletters-ads.php:283
+#: includes/ads/class-ads.php:274
 msgid "Optional description for this advertiser"
 msgstr ""
 
-#: includes/class-newspack-newsletters-ads.php:284
+#: includes/ads/class-ads.php:275
 msgid "Edit Advertiser"
 msgstr ""
 
-#: includes/class-newspack-newsletters-ads.php:285
+#: includes/ads/class-ads.php:276
 msgid "View Advertiser"
 msgstr ""
 
-#: includes/class-newspack-newsletters-ads.php:286
+#: includes/ads/class-ads.php:277
 msgid "Update Advertiser"
 msgstr ""
 
-#: includes/class-newspack-newsletters-ads.php:287
+#: includes/ads/class-ads.php:278
 msgid "Add New Advertiser"
 msgstr ""
 
-#: includes/class-newspack-newsletters-ads.php:288
+#: includes/ads/class-ads.php:279
 msgid "New Advertiser Name"
 msgstr ""
 
-#: includes/class-newspack-newsletters-ads.php:289
+#: includes/ads/class-ads.php:280
 msgid "No advertisers found"
 msgstr ""
 
-#: includes/class-newspack-newsletters-ads.php:290
+#: includes/ads/class-ads.php:281
 msgid "No advertisers"
 msgstr ""
 
-#: includes/class-newspack-newsletters-ads.php:291
+#: includes/ads/class-ads.php:282
 msgid "Filter by advertiser"
 msgstr ""
 
-#: includes/class-newspack-newsletters-ads.php:293
+#: includes/ads/class-ads.php:284
 msgid "Newspack Newsletters Ads Advertisers"
 msgstr ""
 
-#: includes/class-newspack-newsletters-ads.php:391
+#: includes/ads/class-ads.php:383
 msgid "promotion"
 msgstr ""
 
-#: includes/class-newspack-newsletters-ads.php:391
+#: includes/ads/class-ads.php:383
 msgid "ad"
 msgstr ""
 
-#: includes/class-newspack-newsletters-ads.php:588
+#: includes/ads/class-ads.php:580
 msgid "Start Date"
 msgstr ""
 
-#: includes/class-newspack-newsletters-ads.php:589
+#: includes/ads/class-ads.php:581
 #: dist/adsEditor.js:19
-#: src/ads/editor/index.js:192
+#: src/ads/editor/index.js:306
 msgid "Expiration Date"
 msgstr ""
 
-#: includes/class-newspack-newsletters-ads.php:590
+#: includes/ads/class-ads.php:582
 #: dist/adsEditor.js:13
-#: src/ads/editor/index.js:109
+#: src/ads/editor/index.js:136
 msgid "Price"
 msgstr ""
 
@@ -1405,79 +1477,100 @@ msgid "You must select a list."
 msgstr ""
 
 #: dist/adsEditor.js:1
-#: src/ads/editor/index.js:48
+#: src/ads/editor/index.js:69
 msgid "The expiration date is set in the past. This ad will not be displayed."
 msgstr ""
 
 #. translators: %s: date.
 #: dist/adsEditor.js:4
-#: src/ads/editor/index.js:58
+#: src/ads/editor/index.js:79
 #, js-format
 msgid "The expiration date is set before the start date (%s). This ad will not be displayed."
 msgstr ""
 
 #. translators: %1$s: date, %2$s: date.
 #: dist/adsEditor.js:7
-#: src/ads/editor/index.js:70
+#: src/ads/editor/index.js:91
 #, js-format
 msgid "This ad will be displayed between %1$s and %2$s."
 msgstr ""
 
 #. translators: %s: date.
 #: dist/adsEditor.js:10
-#: src/ads/editor/index.js:77
+#: src/ads/editor/index.js:101
 #, js-format
 msgid "This ad will be displayed starting %s."
 msgstr ""
 
 #. translators: %s: date.
 #: dist/adsEditor.js:13
-#: src/ads/editor/index.js:83
+#: src/ads/editor/index.js:110
 #, js-format
 msgid "This ad will be displayed until %s."
 msgstr ""
 
 #: dist/adsEditor.js:13
-#: src/ads/editor/index.js:105
+#: src/ads/editor/index.js:132
 msgid "Ad settings"
 msgstr ""
 
 #: dist/adsEditor.js:13
-#: src/ads/editor/index.js:117
+#: src/ads/editor/index.js:144
 msgid "Insertion strategy"
 msgstr ""
 
 #: dist/adsEditor.js:13
-#: src/ads/editor/index.js:118
-msgid "Whether to calculation the ad insertion by percentage or block count."
+#: src/ads/editor/index.js:145
+msgid "Whether to insert the ad at a percentage or block count of the newsletter content or assigned to a placement."
 msgstr ""
 
 #: dist/adsEditor.js:13
-#: src/ads/editor/index.js:125
+#: src/ads/editor/index.js:156
 msgid "Percentage"
 msgstr ""
 
 #: dist/adsEditor.js:13
-#: src/ads/editor/index.js:126
+#: src/ads/editor/index.js:160
 msgid "Block count"
+msgstr ""
+
+#: dist/adsEditor.js:13
+#: src/ads/editor/index.js:164
+#: src/ads/editor/index.js:171
+msgid "Placement"
+msgstr ""
+
+#: dist/adsEditor.js:13
+#: src/ads/editor/index.js:187
+msgid "Select a placement"
+msgstr ""
+
+#: dist/adsEditor.js:13
+#: src/ads/editor/index.js:194
+msgid "New Placement"
+msgstr ""
+
+#: dist/adsEditor.js:13
+#: src/ads/editor/index.js:207
+msgid "New Placement Name"
 msgstr ""
 
 #. translators: %d: number.
 #: dist/adsEditor.js:16
-#: src/ads/editor/index.js:141
+#: src/ads/editor/index.js:251
 #, js-format
 msgid "The ad will be automatically inserted about %s into the newsletter content."
 msgstr ""
 
 #. translators: %d: number.
 #: dist/adsEditor.js:19
-#: src/ads/editor/index.js:162
+#: src/ads/editor/index.js:274
 #, js-format
 msgid "The ad will be automatically inserted after %d blocks of newsletter content."
 msgstr ""
 
 #: dist/adsEditor.js:19
-#: src/ads/editor/index.js:173
+#: src/ads/editor/index.js:285
 msgid "Custom Start Date"
 msgstr ""
 

--- a/languages/newspack-newsletters.pot
+++ b/languages/newspack-newsletters.pot
@@ -9,7 +9,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2025-08-05T14:23:07+00:00\n"
+"POT-Creation-Date: 2025-08-05T16:31:49+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "X-Generator: WP-CLI 2.12.0\n"
 "X-Domain: newspack-newsletters\n"
@@ -295,13 +295,13 @@ msgstr ""
 
 #: includes/ads/class-ads.php:584
 #: dist/adsEditor.js:19
-#: src/ads/editor/index.js:333
+#: src/ads/editor/index.js:357
 msgid "Expiration Date"
 msgstr ""
 
 #: includes/ads/class-ads.php:585
 #: dist/adsEditor.js:13
-#: src/ads/editor/index.js:136
+#: src/ads/editor/index.js:140
 msgid "Price"
 msgstr ""
 
@@ -487,6 +487,8 @@ msgid "List details"
 msgstr ""
 
 #: includes/class-newspack-newsletters-settings.php:329
+#: dist/adsEditor.js:1
+#: src/components/ad-placements/index.js:98
 #: src/newsletter-editor/sidebar/autocomplete.js:52
 msgid "Edit"
 msgstr ""
@@ -1478,106 +1480,154 @@ msgid "You must select a list."
 msgstr ""
 
 #: dist/adsEditor.js:1
-#: src/ads/editor/index.js:69
+#: src/components/ad-placements/index.js:61
+msgid "Placement Name"
+msgstr ""
+
+#: dist/adsEditor.js:1
+#: src/components/ad-placements/index.js:69
+#: src/components/send-button/index.js:372
+#: src/newsletter-editor/layout/index.js:244
+#: src/newsletter-editor/layout/index.js:275
+#: src/newsletter-editor/sidebar/autocomplete.js:123
+msgid "Cancel"
+msgstr ""
+
+#: dist/adsEditor.js:1
+#: src/components/ad-placements/index.js:77
+#: src/newsletter-editor/layout/index.js:241
+msgid "Save"
+msgstr ""
+
+#: dist/adsEditor.js:1
+#: src/components/ad-placements/index.js:107
+msgid "Are you sure you want to delete this placement?"
+msgstr ""
+
+#: dist/adsEditor.js:1
+#: src/components/ad-placements/index.js:122
+#: src/components/init-modal/screens/layout-picker/SingleLayoutPreview.js:105
+msgid "Delete"
+msgstr ""
+
+#: dist/adsEditor.js:1
+#: src/components/ad-placements/index.js:129
+msgid "Tip: Use the \"Newsletter Ad\" block to insert the ad placements into your newsletter content."
+msgstr ""
+
+#: dist/adsEditor.js:1
+#: dist/adsEditor.js:13
+#: src/ads/editor/index.js:198
+#: src/components/ad-placements/index.js:141
+msgid "New Placement"
+msgstr ""
+
+#: dist/adsEditor.js:1
+#: src/ads/editor/index.js:73
 msgid "The expiration date is set in the past. This ad will not be displayed."
 msgstr ""
 
 #. translators: %s: date.
 #: dist/adsEditor.js:4
-#: src/ads/editor/index.js:79
+#: src/ads/editor/index.js:83
 #, js-format
 msgid "The expiration date is set before the start date (%s). This ad will not be displayed."
 msgstr ""
 
 #. translators: %1$s: date, %2$s: date.
 #: dist/adsEditor.js:7
-#: src/ads/editor/index.js:91
+#: src/ads/editor/index.js:95
 #, js-format
 msgid "This ad will be displayed between %1$s and %2$s."
 msgstr ""
 
 #. translators: %s: date.
 #: dist/adsEditor.js:10
-#: src/ads/editor/index.js:101
+#: src/ads/editor/index.js:105
 #, js-format
 msgid "This ad will be displayed starting %s."
 msgstr ""
 
 #. translators: %s: date.
 #: dist/adsEditor.js:13
-#: src/ads/editor/index.js:110
+#: src/ads/editor/index.js:114
 #, js-format
 msgid "This ad will be displayed until %s."
 msgstr ""
 
 #: dist/adsEditor.js:13
-#: src/ads/editor/index.js:132
+#: src/ads/editor/index.js:136
 msgid "Ad settings"
 msgstr ""
 
 #: dist/adsEditor.js:13
-#: src/ads/editor/index.js:144
+#: src/ads/editor/index.js:148
 msgid "Insertion strategy"
 msgstr ""
 
 #: dist/adsEditor.js:13
-#: src/ads/editor/index.js:145
+#: src/ads/editor/index.js:149
 msgid "Whether to insert the ad at a percentage or block count of the newsletter content or assigned to a placement."
 msgstr ""
 
 #: dist/adsEditor.js:13
-#: src/ads/editor/index.js:156
+#: src/ads/editor/index.js:160
 msgid "Percentage"
 msgstr ""
 
 #: dist/adsEditor.js:13
-#: src/ads/editor/index.js:160
+#: src/ads/editor/index.js:164
 msgid "Block count"
 msgstr ""
 
 #: dist/adsEditor.js:13
-#: src/ads/editor/index.js:164
-#: src/ads/editor/index.js:171
+#: src/ads/editor/index.js:168
+#: src/ads/editor/index.js:175
 #: src/editor/blocks/ad/edit.js:71
 msgid "Placement"
 msgstr ""
 
 #: dist/adsEditor.js:13
-#: src/ads/editor/index.js:187
+#: src/ads/editor/index.js:191
 msgid "Select a placement"
 msgstr ""
 
 #: dist/adsEditor.js:13
-#: src/ads/editor/index.js:194
-msgid "New Placement"
-msgstr ""
-
-#: dist/adsEditor.js:13
-#: src/ads/editor/index.js:207
+#: src/ads/editor/index.js:211
 msgid "New Placement Name"
 msgstr ""
 
 #: dist/adsEditor.js:13
-#: src/ads/editor/index.js:211
+#: src/ads/editor/index.js:215
 msgid "Press Enter to save the new placement."
+msgstr ""
+
+#: dist/adsEditor.js:13
+#: src/ads/editor/index.js:270
+msgid "Manage placements"
+msgstr ""
+
+#: dist/adsEditor.js:13
+#: src/ads/editor/index.js:274
+msgid "Manage Ad Placements"
 msgstr ""
 
 #. translators: %d: number.
 #: dist/adsEditor.js:16
-#: src/ads/editor/index.js:278
+#: src/ads/editor/index.js:302
 #, js-format
 msgid "The ad will be automatically inserted about %s into the newsletter content."
 msgstr ""
 
 #. translators: %d: number.
 #: dist/adsEditor.js:19
-#: src/ads/editor/index.js:301
+#: src/ads/editor/index.js:325
 #, js-format
 msgid "The ad will be automatically inserted after %d blocks of newsletter content."
 msgstr ""
 
 #: dist/adsEditor.js:19
-#: src/ads/editor/index.js:312
+#: src/ads/editor/index.js:336
 msgid "Custom Start Date"
 msgstr ""
 
@@ -2189,10 +2239,6 @@ msgstr ""
 msgid "Are you sure you want to delete this layout?"
 msgstr ""
 
-#: src/components/init-modal/screens/layout-picker/SingleLayoutPreview.js:105
-msgid "Delete"
-msgstr ""
-
 #: src/components/send-button/index.js:65
 #: src/components/send-button/index.js:93
 #: src/components/send-button/index.js:97
@@ -2257,13 +2303,6 @@ msgstr ""
 
 #: src/components/send-button/index.js:344
 msgid "Send your newsletter?"
-msgstr ""
-
-#: src/components/send-button/index.js:372
-#: src/newsletter-editor/layout/index.js:244
-#: src/newsletter-editor/layout/index.js:275
-#: src/newsletter-editor/sidebar/autocomplete.js:123
-msgid "Cancel"
 msgstr ""
 
 #: src/components/with-api-handler/index.js:12
@@ -2767,10 +2806,6 @@ msgstr ""
 
 #: src/newsletter-editor/layout/index.js:229
 msgid "Title"
-msgstr ""
-
-#: src/newsletter-editor/layout/index.js:241
-msgid "Save"
 msgstr ""
 
 #: src/newsletter-editor/layout/index.js:253

--- a/newspack-newsletters.php
+++ b/newspack-newsletters.php
@@ -58,11 +58,11 @@ require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/class-newspack-newsle
 require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/class-newspack-newsletters-layouts.php';
 require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/class-newspack-newsletters-settings.php';
 require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/class-newspack-newsletters-renderer.php';
-require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/class-newspack-newsletters-ads.php';
 require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/class-newspack-newsletters-bulk-actions.php';
 require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/class-newspack-newsletters-quick-edit.php';
 require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/class-newspack-newsletters-embed.php';
 require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/class-newspack-newsletters-subscription-attempts.php';
+require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/ads/class-ads.php';
 require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/tracking/class-utils.php';
 require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/tracking/class-pixel.php';
 require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/tracking/class-click.php';

--- a/src/ads/editor/index.js
+++ b/src/ads/editor/index.js
@@ -3,7 +3,7 @@
  */
 import { __, sprintf } from '@wordpress/i18n';
 import { useSelect, useDispatch } from '@wordpress/data';
-import { Fragment } from '@wordpress/element';
+import { Fragment, useState } from '@wordpress/element';
 import {
 	PluginDocumentSettingPanel,
 	PluginPrePublishPanel,
@@ -28,9 +28,9 @@ function AdEdit() {
 		insertionStrategy,
 		positionInContent,
 		positionBlockCount,
-	} = useSelect( select => {
-		const { getEditedPostAttribute } = select( 'core/editor' );
-		const meta = getEditedPostAttribute( 'meta' );
+	} = useSelect(select => {
+		const { getEditedPostAttribute } = select('core/editor');
+		const meta = getEditedPostAttribute('meta');
 		return {
 			price: meta.price,
 			startDate: meta.start_date,
@@ -39,11 +39,32 @@ function AdEdit() {
 			positionInContent: meta.position_in_content,
 			positionBlockCount: meta.position_block_count,
 		};
-	} );
-	const { editPost } = useDispatch( 'core/editor' );
-	const { removeEditorPanel } = useDispatch( editPostStore );
+	});
+
+	const { placements, placement } = useSelect(select => {
+		return {
+			placements: select('core').getEntityRecords(
+				'taxonomy',
+				'newspack_nl_ad_placement',
+				{
+					per_page: -1,
+					hide_empty: false,
+				}
+			),
+			placement:
+				select('core/editor').getEditedPostAttribute('ad_placement') ||
+				'',
+		};
+	});
+	const [isNewPlacement, setIsNewPlacement] = useState(false);
+	const [newPlacementName, setNewPlacementName] = useState('');
+	const [isSavingPlacement, setIsSavingPlacement] = useState(false);
+
+	const { editPost } = useDispatch('core/editor');
+	const { saveEntityRecord } = useDispatch('core');
+	const { removeEditorPanel } = useDispatch(editPostStore);
 	const messages = [];
-	if ( expiryDate && ! isInTheFuture( expiryDate ) ) {
+	if (expiryDate && !isInTheFuture(expiryDate)) {
 		messages.push(
 			__(
 				'The expiration date is set in the past. This ad will not be displayed.',
@@ -51,7 +72,7 @@ function AdEdit() {
 			)
 		);
 	}
-	if ( startDate && startDate > expiryDate ) {
+	if (startDate && startDate > expiryDate) {
 		messages.push(
 			sprintf(
 				// translators: %s: date.
@@ -59,166 +80,269 @@ function AdEdit() {
 					'The expiration date is set before the start date (%s). This ad will not be displayed.',
 					'newspack-newsletters'
 				),
-				format( 'M j Y', startDate )
+				format('M j Y', startDate)
 			)
 		);
 	}
 	let defaultMessage;
-	if ( startDate && expiryDate ) {
+	if (startDate && expiryDate) {
 		defaultMessage = sprintf(
 			// translators: %1$s: date, %2$s: date.
-			__( 'This ad will be displayed between %1$s and %2$s.', 'newspack-newsletters' ),
-			format( 'M j Y', startDate ),
-			format( 'M j Y', expiryDate )
+			__(
+				'This ad will be displayed between %1$s and %2$s.',
+				'newspack-newsletters'
+			),
+			format('M j Y', startDate),
+			format('M j Y', expiryDate)
 		);
-	} else if ( startDate ) {
+	} else if (startDate) {
 		defaultMessage = sprintf(
 			// translators: %s: date.
-			__( 'This ad will be displayed starting %s.', 'newspack-newsletters' ),
-			format( 'M j Y', startDate )
+			__(
+				'This ad will be displayed starting %s.',
+				'newspack-newsletters'
+			),
+			format('M j Y', startDate)
 		);
-	} else if ( expiryDate ) {
+	} else if (expiryDate) {
 		defaultMessage = sprintf(
 			// translators: %s: date.
-			__( 'This ad will be displayed until %s.', 'newspack-newsletters' ),
-			format( 'M j Y', expiryDate )
+			__('This ad will be displayed until %s.', 'newspack-newsletters'),
+			format('M j Y', expiryDate)
 		);
 	}
 
 	let noticeProps;
-	if ( defaultMessage || messages.length ) {
+	if (defaultMessage || messages.length) {
 		noticeProps = {
 			children: messages.length
-				? messages.map( ( message, index ) => <p key={ index }>{ message }</p> )
+				? messages.map((message, index) => <p key={index}>{message}</p>)
 				: defaultMessage,
 			status: messages.length ? 'warning' : 'info',
 		};
 	}
 
 	// Remove the "post-status" (Summary) panel.
-	removeEditorPanel( 'post-status' );
+	removeEditorPanel('post-status');
 
 	return (
 		<Fragment>
 			<PluginDocumentSettingPanel
 				name="newsletters-ads-settings-panel"
-				title={ __( 'Ad settings', 'newspack-newsletters' ) }
+				title={__('Ad settings', 'newspack-newsletters')}
 			>
 				<TextControl
 					type="number"
-					label={ __( 'Price', 'newspack-newsletters' ) }
-					value={ price }
-					onChange={ val => editPost( { meta: { price: val } } ) }
-					min={ 0 }
-					step={ 0.01 }
+					label={__('Price', 'newspack-newsletters')}
+					value={price}
+					onChange={val => editPost({ meta: { price: val } })}
+					min={0}
+					step={0.01}
 				/>
 				<hr />
 				<SelectControl
-					label={ __( 'Insertion strategy', 'newspack-newsletters' ) }
-					help={ __(
-						'Whether to calculation the ad insertion by percentage or block count.',
+					label={__('Insertion strategy', 'newspack-newsletters')}
+					help={__(
+						'Whether to insert the ad at a percentage or block count of the newsletter content or assigned to a placement.',
 						'newspack-newsletters'
-					) }
-					value={ insertionStrategy }
-					onChange={ insertion_strategy => editPost( { meta: { insertion_strategy } } ) }
-					options={ [
-						{ value: 'percentage', label: __( 'Percentage', 'newspack-newsletters' ) },
-						{ value: 'block_count', label: __( 'Block count', 'newspack-newsletters' ) },
-					] }
+					)}
+					value={insertionStrategy}
+					onChange={insertion_strategy =>
+						editPost({ meta: { insertion_strategy } })
+					}
+					options={[
+						{
+							value: 'percentage',
+							label: __('Percentage', 'newspack-newsletters'),
+						},
+						{
+							value: 'block_count',
+							label: __('Block count', 'newspack-newsletters'),
+						},
+						{
+							value: 'placement',
+							label: __('Placement', 'newspack-newsletters'),
+						},
+					]}
 				/>
-				{ insertionStrategy === 'percentage' && (
+				{insertionStrategy === 'placement' && (
+					<>
+						<SelectControl
+							label={__('Placement', 'newspack-newsletters')}
+							value={isNewPlacement ? 'new' : placement}
+							onChange={value => {
+								if (!value) {
+									editPost({ ad_placement: null });
+									setIsNewPlacement(false);
+								} else if (value === 'new') {
+									setIsNewPlacement(true);
+								} else {
+									editPost({ ad_placement: [value] });
+									setIsNewPlacement(false);
+								}
+							}}
+							options={[
+								{
+									value: '',
+									label: __(
+										'Select a placement',
+										'newspack-newsletters'
+									),
+								},
+								{
+									value: 'new',
+									label: __(
+										'New Placement',
+										'newspack-newsletters'
+									),
+								},
+								...(placements || []).map(p => ({
+									value: p.id,
+									label: p.name,
+								})),
+							]}
+						/>
+						{isNewPlacement && (
+							<TextControl
+								label={__(
+									'New Placement Name',
+									'newspack-newsletters'
+								)}
+								value={newPlacementName}
+								disabled={isSavingPlacement}
+								onChange={setNewPlacementName}
+								onKeyDown={async ev => {
+									if (ev.key === 'Enter') {
+										setIsSavingPlacement(true);
+										const newPlacement =
+											await saveEntityRecord(
+												'taxonomy',
+												'newspack_nl_ad_placement',
+												{ name: newPlacementName }
+											);
+										if (newPlacement) {
+											await editPost({
+												ad_placement: [newPlacement.id],
+											});
+										}
+										setNewPlacementName('');
+										setIsNewPlacement(false);
+										setIsSavingPlacement(false);
+									}
+								}}
+							/>
+						)}
+					</>
+				)}
+				{insertionStrategy === 'percentage' && (
 					<Fragment>
 						<RangeControl
-							label={ __( 'Approximate position (in percent)' ) }
-							value={ positionInContent }
-							onChange={ position_in_content => editPost( { meta: { position_in_content } } ) }
-							min={ 0 }
-							max={ 100 }
+							label={__('Approximate position (in percent)')}
+							value={positionInContent}
+							onChange={position_in_content =>
+								editPost({ meta: { position_in_content } })
+							}
+							min={0}
+							max={100}
 						/>
 						<p>
-							{ sprintf(
+							{sprintf(
 								// translators: %d: number.
 								__(
 									'The ad will be automatically inserted about %s into the newsletter content.',
 									'newspack-newsletters'
 								),
 								positionInContent + '%'
-							) }
+							)}
 						</p>
 					</Fragment>
-				) }
-				{ insertionStrategy === 'block_count' && (
+				)}
+				{insertionStrategy === 'block_count' && (
 					<Fragment>
 						<RangeControl
-							label={ __( 'Approximate position (in blocks)' ) }
-							value={ positionBlockCount }
-							onChange={ position_block_count => editPost( { meta: { position_block_count } } ) }
-							min={ 0 }
-							max={ 30 }
+							label={__('Approximate position (in blocks)')}
+							value={positionBlockCount}
+							onChange={position_block_count =>
+								editPost({ meta: { position_block_count } })
+							}
+							min={0}
+							max={30}
 						/>
 						<p>
-							{ sprintf(
+							{sprintf(
 								// translators: %d: number.
 								__(
 									'The ad will be automatically inserted after %d blocks of newsletter content.',
 									'newspack-newsletters'
 								),
 								positionBlockCount
-							) }
+							)}
 						</p>
 					</Fragment>
-				) }
+				)}
 				<hr />
 				<ToggleControl
-					label={ __( 'Custom Start Date', 'newspack-newsletters' ) }
-					checked={ !! startDate }
-					onChange={ () => {
-						if ( startDate ) {
-							editPost( { meta: { start_date: null } } );
+					label={__('Custom Start Date', 'newspack-newsletters')}
+					checked={!!startDate}
+					onChange={() => {
+						if (startDate) {
+							editPost({ meta: { start_date: null } });
 						} else {
-							editPost( { meta: { start_date: new Date() } } );
+							editPost({ meta: { start_date: new Date() } });
 						}
-					} }
+					}}
 				/>
-				{ startDate ? (
+				{startDate ? (
 					<DatePicker
-						currentDate={ startDate }
-						onChange={ start_date => editPost( { meta: { start_date } } ) }
-						isInvalidDate={ date => ! isInTheFuture( date ) }
+						currentDate={startDate}
+						onChange={start_date =>
+							editPost({ meta: { start_date } })
+						}
+						isInvalidDate={date => !isInTheFuture(date)}
 					/>
-				) : null }
+				) : null}
 				<hr />
 				<ToggleControl
-					label={ __( 'Expiration Date', 'newspack-newsletters' ) }
-					checked={ !! expiryDate }
-					onChange={ () => {
-						if ( expiryDate ) {
-							editPost( { meta: { expiry_date: null } } );
+					label={__('Expiration Date', 'newspack-newsletters')}
+					checked={!!expiryDate}
+					onChange={() => {
+						if (expiryDate) {
+							editPost({ meta: { expiry_date: null } });
 						} else {
-							editPost( { meta: { expiry_date: startDate ? new Date( startDate ) : new Date() } } );
+							editPost({
+								meta: {
+									expiry_date: startDate
+										? new Date(startDate)
+										: new Date(),
+								},
+							});
 						}
-					} }
+					}}
 				/>
-				{ expiryDate ? (
+				{expiryDate ? (
 					<DatePicker
-						currentDate={ expiryDate }
-						onChange={ expiry_date => editPost( { meta: { expiry_date } } ) }
-						isInvalidDate={ date => {
-							return startDate ? date < new Date( startDate ) : ! isInTheFuture( date );
-						} }
+						currentDate={expiryDate}
+						onChange={expiry_date =>
+							editPost({ meta: { expiry_date } })
+						}
+						isInvalidDate={date => {
+							return startDate
+								? date < new Date(startDate)
+								: !isInTheFuture(date);
+						}}
 					/>
-				) : null }
+				) : null}
 			</PluginDocumentSettingPanel>
-			{ noticeProps ? (
+			{noticeProps ? (
 				<PluginPrePublishPanel>
-					<Notice isDismissible={ false } { ...noticeProps } />
+					<Notice isDismissible={false} {...noticeProps} />
 				</PluginPrePublishPanel>
-			) : null }
+			) : null}
 		</Fragment>
 	);
 }
 
-registerPlugin( 'newspack-newsletters-sidebar', {
+registerPlugin('newspack-newsletters-sidebar', {
 	render: AdEdit,
 	icon: null,
-} );
+});

--- a/src/ads/editor/index.js
+++ b/src/ads/editor/index.js
@@ -16,9 +16,12 @@ import {
 	DatePicker,
 	Notice,
 	RangeControl,
+	Button,
+	Modal,
 } from '@wordpress/components';
 import { format, isInTheFuture } from '@wordpress/date';
 import { SelectControl } from 'newspack-components';
+import AdPlacements from '../../components/ad-placements';
 
 function AdEdit() {
 	const {
@@ -59,6 +62,7 @@ function AdEdit() {
 	const [isNewPlacement, setIsNewPlacement] = useState(false);
 	const [newPlacementName, setNewPlacementName] = useState('');
 	const [isSavingPlacement, setIsSavingPlacement] = useState(false);
+	const [isManagingPlacements, setIsManagingPlacements] = useState(false);
 
 	const { editPost } = useDispatch('core/editor');
 	const { saveEntityRecord } = useDispatch('core');
@@ -258,6 +262,26 @@ function AdEdit() {
 									}
 								}}
 							/>
+						)}
+						<Button
+							variant="secondary"
+							onClick={() => setIsManagingPlacements(true)}
+						>
+							{__('Manage placements', 'newspack-newsletters')}
+						</Button>
+						{isManagingPlacements && (
+							<Modal
+								title={__(
+									'Manage Ad Placements',
+									'newspack-newsletters'
+								)}
+								size="small"
+								onRequestClose={() =>
+									setIsManagingPlacements(false)
+								}
+							>
+								<AdPlacements />
+							</Modal>
 						)}
 					</>
 				)}

--- a/src/ads/editor/index.js
+++ b/src/ads/editor/index.js
@@ -208,22 +208,49 @@ function AdEdit() {
 									'New Placement Name',
 									'newspack-newsletters'
 								)}
+								help={__(
+									'Press Enter to save the new placement.',
+									'newspack-newsletters'
+								)}
 								value={newPlacementName}
 								disabled={isSavingPlacement}
 								onChange={setNewPlacementName}
 								onKeyDown={async ev => {
 									if (ev.key === 'Enter') {
-										setIsSavingPlacement(true);
-										const newPlacement =
-											await saveEntityRecord(
-												'taxonomy',
-												'newspack_nl_ad_placement',
-												{ name: newPlacementName }
+										// If it matches an existing placement, use that.
+										const existingPlacement =
+											placements.find(
+												p =>
+													p.name
+														.toLowerCase()
+														.trim() ===
+													newPlacementName
+														.toLowerCase()
+														.trim()
 											);
-										if (newPlacement) {
-											await editPost({
-												ad_placement: [newPlacement.id],
+										if (existingPlacement) {
+											editPost({
+												ad_placement: [
+													existingPlacement.id,
+												],
 											});
+										} else {
+											setIsSavingPlacement(true);
+											const newPlacement =
+												await saveEntityRecord(
+													'taxonomy',
+													'newspack_nl_ad_placement',
+													{
+														name: newPlacementName.trim(),
+													}
+												);
+											if (newPlacement) {
+												await editPost({
+													ad_placement: [
+														newPlacement.id,
+													],
+												});
+											}
 										}
 										setNewPlacementName('');
 										setIsNewPlacement(false);

--- a/src/components/ad-placements/index.js
+++ b/src/components/ad-placements/index.js
@@ -1,0 +1,146 @@
+/* eslint-disable @wordpress/no-unsafe-wp-apis */
+import { __ } from '@wordpress/i18n';
+import { useSelect, useDispatch } from '@wordpress/data';
+import { useEffect, useState } from '@wordpress/element';
+import {
+	__experimentalVStack as VStack,
+	__experimentalHStack as HStack,
+	__experimentalText as Text,
+	Button,
+	TextControl,
+} from '@wordpress/components';
+
+export default function AdPlacements() {
+	const [editingPlacement, setEditingPlacement] = useState(false);
+	const [newPlacementName, setNewPlacementName] = useState('');
+	const [isSavingPlacement, setIsSavingPlacement] = useState(false);
+
+	const { placements } = useSelect(select => {
+		return {
+			placements: select('core').getEntityRecords(
+				'taxonomy',
+				'newspack_nl_ad_placement',
+				{ per_page: -1, hide_empty: false }
+			),
+		};
+	});
+
+	useEffect(() => {
+		if (editingPlacement) {
+			setNewPlacementName(
+				placements?.find(p => p.id === editingPlacement)?.name || ''
+			);
+		} else {
+			setNewPlacementName('');
+		}
+	}, [editingPlacement, placements]);
+
+	const handleSubmit = async ev => {
+		ev.preventDefault();
+		setIsSavingPlacement(true);
+		const record = {
+			name: newPlacementName,
+		};
+		if (true !== editingPlacement) {
+			record.id = editingPlacement;
+		}
+		await saveEntityRecord('taxonomy', 'newspack_nl_ad_placement', record);
+		setIsSavingPlacement(false);
+		setEditingPlacement(false);
+	};
+
+	const { saveEntityRecord, deleteEntityRecord } = useDispatch('core');
+
+	if (editingPlacement) {
+		return (
+			<form onSubmit={handleSubmit}>
+				<VStack spacing={4}>
+					<TextControl
+						value={newPlacementName}
+						onChange={setNewPlacementName}
+						label={__('Placement Name', 'newspack-newsletters')}
+					/>
+					<HStack justify="end">
+						<Button
+							variant="secondary"
+							onClick={() => setEditingPlacement(false)}
+							disabled={isSavingPlacement}
+						>
+							{__('Cancel', 'newspack-newsletters')}
+						</Button>
+						<Button
+							type="submit"
+							variant="primary"
+							disabled={isSavingPlacement || !newPlacementName}
+							isBusy={isSavingPlacement}
+						>
+							{__('Save', 'newspack-newsletters')}
+						</Button>
+					</HStack>
+				</VStack>
+			</form>
+		);
+	}
+
+	return (
+		<VStack spacing={4}>
+			{placements?.length > 0 && (
+				<VStack>
+					{placements?.map(placement => (
+						<HStack key={placement.id}>
+							<Text style={{ flex: 1 }}>{placement.name}</Text>
+							<Button
+								variant="link"
+								onClick={() =>
+									setEditingPlacement(placement.id)
+								}
+							>
+								{__('Edit', 'newspack-newsletters')}
+							</Button>
+							<Button
+								variant="link"
+								isDestructive
+								onClick={() => {
+									if (
+										// eslint-disable-next-line no-alert
+										confirm(
+											__(
+												'Are you sure you want to delete this placement?',
+												'newspack-newsletters'
+											)
+										)
+									) {
+										deleteEntityRecord(
+											'taxonomy',
+											'newspack_nl_ad_placement',
+											placement.id,
+											{ force: true }
+										);
+									}
+								}}
+							>
+								{__('Delete', 'newspack-newsletters')}
+							</Button>
+						</HStack>
+					))}
+				</VStack>
+			)}
+			<Text>
+				{__(
+					'Tip: Use the "Newsletter Ad" block to insert the ad placements into your newsletter content.',
+					'newspack-newsletters'
+				)}
+			</Text>
+			<HStack justify="end">
+				<Button
+					variant="secondary"
+					onClick={() => setEditingPlacement(true)}
+					isBusy={isSavingPlacement}
+					disabled={isSavingPlacement}
+				>
+					{__('New Placement', 'newspack-newsletters')}
+				</Button>
+			</HStack>
+		</VStack>
+	);
+}

--- a/src/editor/blocks/ad/edit.js
+++ b/src/editor/blocks/ad/edit.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import apiFetch from '@wordpress/api-fetch';
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import { useSelect } from '@wordpress/data';
 import { useState, useEffect, Fragment } from '@wordpress/element';
 import { SelectControl, PanelBody, Spinner, SVG } from '@wordpress/components';
@@ -12,103 +12,148 @@ import { NEWSLETTER_AD_CPT_SLUG } from '../../../utils/consts';
 
 import './editor.scss';
 
-export default function SubscribeEdit( { setAttributes, attributes: { adId } } ) {
-	const { postId } = useSelect( select => {
-		const { getCurrentPostId } = select( 'core/editor' );
+export default function SubscribeEdit({ setAttributes, attributes: { adId } }) {
+	const { postId } = useSelect(select => {
+		const { getCurrentPostId } = select('core/editor');
 		return { postId: getCurrentPostId() };
-	} );
-	const [ adsConfig, setAdsConfig ] = useState( {
+	});
+	const { placements } = useSelect(select => {
+		return {
+			placements: select('core').getEntityRecords(
+				'taxonomy',
+				'newspack_nl_ad_placement',
+				{ per_page: -1, hide_empty: false }
+			),
+		};
+	});
+	const [adsConfig, setAdsConfig] = useState({
 		count: 0,
-		label: __( 'ads', 'newspack-newsletters' ),
+		label: __('ads', 'newspack-newsletters'),
 		ads: [],
-	} );
-	const [ isEmpty, setIsEmpty ] = useState( false );
-	const [ inFlight, setInFlight ] = useState( false );
-	useEffect( () => {
-		setInFlight( true );
-		apiFetch( {
-			path: `/wp/v2/${ NEWSLETTER_AD_CPT_SLUG }/config/?postId=${ postId }`,
-		} )
-			.then( response => {
-				setAdsConfig( response );
-				if ( ! response.ads.length ) {
-					setIsEmpty( true );
+	});
+	const [isEmpty, setIsEmpty] = useState(false);
+	const [inFlight, setInFlight] = useState(false);
+	useEffect(() => {
+		setInFlight(true);
+		apiFetch({
+			path: `/wp/v2/${NEWSLETTER_AD_CPT_SLUG}/config/?postId=${postId}`,
+		})
+			.then(response => {
+				setAdsConfig(response);
+				if (!response.ads.length) {
+					setIsEmpty(true);
 				} else {
-					setIsEmpty( false );
+					setIsEmpty(false);
 				}
-			} )
-			.catch( e => {
-				console.warn( e ); // eslint-disable-line no-console
-			} )
-			.finally( () => {
-				setInFlight( false );
-			} );
-	}, [ postId ] );
+			})
+			.catch(e => {
+				console.warn(e); // eslint-disable-line no-console
+			})
+			.finally(() => {
+				setInFlight(false);
+			});
+	}, [postId]);
 	const containerHeight = 200;
 	function getAdTitle() {
-		if ( ! adId ) {
-			return __( 'Automatic selection', 'newspack-newsletters' );
+		if (!adId) {
+			return __('Automatic selection', 'newspack-newsletters');
 		}
-		const ad = adsConfig.ads.find( _ad => _ad.id.toString() === adId );
+		if (adId.startsWith('placement:')) {
+			const placement = placements?.find(
+				p => p.id.toString() === adId.split(':')[1]
+			);
+			return placement
+				? sprintf(
+						/* translators: %s is the placement name */
+						__('Placement: %s', 'newspack-newsletters'),
+						placement.name
+					)
+				: __('Placement', 'newspack-newsletters');
+		}
+		const ad = adsConfig.ads.find(_ad => _ad.id.toString() === adId);
 		return ad ? ad.title : '';
 	}
 	const blockProps = useBlockProps();
 	return (
-		<div { ...blockProps }>
+		<div {...blockProps}>
 			<InspectorControls>
-				<PanelBody title={ __( 'Ad Settings' ) }>
+				<PanelBody title={__('Ad Settings')}>
 					<SelectControl
-						label={ __( 'Ad' ) }
-						value={ adId }
-						disabled={ inFlight || isEmpty }
-						options={ [
-							{
-								label: __( 'Automatic selection', 'newspack-newsletters' ),
-								value: '',
-							},
-						].concat(
-							adsConfig.ads.map( ad => ( {
-								label: ad.title,
-								value: ad.id,
-							} ) )
-						) }
-						onChange={ val => setAttributes( { adId: val } ) }
-					/>
-					{ ! adId && ! isEmpty && (
+						label={__('Ad')}
+						value={adId}
+						disabled={inFlight || isEmpty}
+						onChange={val => setAttributes({ adId: val })}
+					>
+						<option value="">
+							{__('Automatic selection', 'newspack-newsletters')}
+						</option>
+						<optgroup
+							label={__('Placements', 'newspack-newsletters')}
+						>
+							{placements?.map(placement => (
+								<option
+									key={placement.id}
+									value={`placement:${placement.id}`}
+								>
+									{placement.name}
+								</option>
+							))}
+						</optgroup>
+						<optgroup label={__('Ads', 'newspack-newsletters')}>
+							{adsConfig.ads.map(ad => (
+								<option key={ad.id} value={ad.id}>
+									{ad.title}
+								</option>
+							))}
+						</optgroup>
+					</SelectControl>
+					{!adId && !isEmpty && (
 						<p>
-							{ __(
+							{__(
 								'By not selecting an ad, the system automatically chooses which ad should be rendered in this position.',
 								'newspack-newsletters'
-							) }
+							)}
 						</p>
-					) }
-					{ isEmpty ? (
+					)}
+					{isEmpty ? (
 						<p>
-							{ __(
+							{__(
 								"No ads are available. Make sure you have created ads and that they are scheduled to run on the newsletter's publish date.",
 								'newspack-newsletters'
-							) }
+							)}
 						</p>
-					) : null }
+					) : null}
 				</PanelBody>
 			</InspectorControls>
 			<div
 				className="newspack-newsletters-ad-block-placeholder"
-				style={ { width: 600, height: containerHeight } }
+				style={{ width: 600, height: containerHeight }}
 			>
 				<Fragment>
 					<SVG
 						className="newspack-newsletters-ad-block-mock"
-						viewBox={ '0 0 600 ' + containerHeight }
+						viewBox={'0 0 600 ' + containerHeight}
 					>
-						<rect width="600" height={ containerHeight } strokeDasharray="2" />
-						<line x1="0" y1="0" x2="100%" y2="100%" strokeDasharray="2" />
+						<rect
+							width="600"
+							height={containerHeight}
+							strokeDasharray="2"
+						/>
+						<line
+							x1="0"
+							y1="0"
+							x2="100%"
+							y2="100%"
+							strokeDasharray="2"
+						/>
 					</SVG>
-					{ ! inFlight && (
-						<span className="newspack-newsletters-ad-block-ad-label">{ getAdTitle() }</span>
-					) }
+					{!inFlight && (
+						<span className="newspack-newsletters-ad-block-ad-label">
+							{getAdTitle()}
+						</span>
+					)}
 				</Fragment>
-				{ inFlight && <Spinner /> }
+				{inFlight && <Spinner />}
 			</div>
 		</div>
 	);

--- a/tests/test-newsletter-ads.php
+++ b/tests/test-newsletter-ads.php
@@ -5,6 +5,9 @@
  * @package Newspack_Newsletters
  */
 
+use Newspack_Newsletters\Ads;
+use Newspack_Newsletters\Ads_Placements;
+
 /**
  * Newsletters Ads Test.
  */
@@ -51,5 +54,151 @@ class Newsletters_Newsletter_Ads_Test extends WP_UnitTestCase {
 		// Set expiry date to tomorrow.
 		update_post_meta( self::$ad_id, 'expiry_date', gmdate( 'Y-m-d', strtotime( '+1 day' ) ) );
 		$this->assertTrue( Newspack_Newsletters\Ads::is_ad_active( self::$ad_id ) );
+	}
+
+	/**
+	 * Test ad placement.
+	 */
+	public function test_ad_placement() {
+		$placement_id = self::factory()->term->create(
+			[
+				'taxonomy' => Ads_Placements::TAXONOMY,
+				'name'     => 'Test Placement',
+			]
+		);
+		$this->assertNotEmpty( $placement_id );
+
+		$ad_id = self::factory()->post->create(
+			[
+				'post_type'  => Newspack_Newsletters\Ads::CPT,
+				'post_title' => 'A sample ad',
+			]
+		);
+		wp_set_post_terms( $ad_id, [ $placement_id ], Ads_Placements::TAXONOMY );
+		$ad = Ads_Placements::get_ad_by_placement( $placement_id );
+		$this->assertNotEmpty( $ad );
+		$this->assertEquals(
+			$ad_id,
+			$ad->ID,
+			'Ad should fill for placement.'
+		);
+
+		$newsletter_id = self::factory()->post->create(
+			[
+				'post_type'  => Newspack_Newsletters::NEWSPACK_NEWSLETTERS_CPT,
+				'post_title' => 'A sample newsletter',
+			]
+		);
+		$ad = Ads_Placements::get_ad_by_placement( $placement_id, $newsletter_id );
+		$this->assertNotEmpty( $ad );
+		$this->assertEquals(
+			$ad_id,
+			$ad->ID,
+			'Ad should fill for placement with newsletter.'
+		);
+	}
+
+	/**
+	 * Test ad placement by category.
+	 */
+	public function test_ad_placement_by_category() {
+		$newsletter_id = self::factory()->post->create(
+			[
+				'post_type'  => Newspack_Newsletters::NEWSPACK_NEWSLETTERS_CPT,
+				'post_title' => 'A sample newsletter',
+			]
+		);
+
+		$category_id = self::factory()->term->create(
+			[
+				'taxonomy' => 'category',
+				'name'     => 'Test Category',
+			]
+		);
+
+		$ad_id = self::factory()->post->create(
+			[
+				'post_type'  => Newspack_Newsletters\Ads::CPT,
+				'post_title' => 'A sample ad',
+			]
+		);
+
+		$placement_id = self::factory()->term->create(
+			[
+				'taxonomy' => 'newspack_nl_ad_placement',
+				'name'     => 'Test Placement',
+			]
+		);
+		wp_set_post_terms( $ad_id, [ $placement_id ], Ads_Placements::TAXONOMY );
+
+		// Add the category to the ad.
+		wp_set_post_terms( $ad_id, [ $category_id ], 'category' );
+		$ad = Ads_Placements::get_ad_by_placement( $placement_id, $newsletter_id );
+		$this->assertEmpty(
+			$ad,
+			'Ad should not fill for newsletter without the category.'
+		);
+
+		// Add the category to the newsletter.
+		wp_set_post_terms( $newsletter_id, [ $category_id ], 'category' );
+		$ad = Ads_Placements::get_ad_by_placement( $placement_id, $newsletter_id );
+		$this->assertNotEmpty( $ad );
+		$this->assertEquals(
+			$ad_id,
+			$ad->ID,
+			'Ad should fill for newsletter with the category.'
+		);
+	}
+
+	/**
+	 * Test ad placement by advertiser.
+	 */
+	public function test_ad_placement_by_advertiser() {
+		$newsletter_id = self::factory()->post->create(
+			[
+				'post_type'  => Newspack_Newsletters::NEWSPACK_NEWSLETTERS_CPT,
+				'post_title' => 'A sample newsletter',
+			]
+		);
+
+		$ad_id = self::factory()->post->create(
+			[
+				'post_type'  => Newspack_Newsletters\Ads::CPT,
+				'post_title' => 'A sample ad',
+			]
+		);
+
+		$advertiser_id = self::factory()->term->create(
+			[
+				'taxonomy' => Ads::ADVERTISER_TAX,
+				'name'     => 'Test Advertiser',
+			]
+		);
+
+		$placement_id = self::factory()->term->create(
+			[
+				'taxonomy' => Ads_Placements::TAXONOMY,
+				'name'     => 'Test Placement',
+			]
+		);
+		wp_set_post_terms( $ad_id, [ $placement_id ], Ads_Placements::TAXONOMY );
+
+		// Add advertiser to newsletter.
+		wp_set_post_terms( $newsletter_id, [ $advertiser_id ], Ads::ADVERTISER_TAX );
+		$ad = Ads_Placements::get_ad_by_placement( $placement_id, $newsletter_id );
+		$this->assertEmpty(
+			$ad,
+			'Ad should not fill for newsletter with an advertiser that doesnt match the ad.'
+		);
+
+		// Add advertiser to ad.
+		wp_set_post_terms( $ad_id, [ $advertiser_id ], Ads::ADVERTISER_TAX );
+		$ad = Ads_Placements::get_ad_by_placement( $placement_id, $newsletter_id );
+		$this->assertNotEmpty( $ad );
+		$this->assertEquals(
+			$ad_id,
+			$ad->ID,
+			'Ad should fill for newsletter with matching advertiser.'
+		);
 	}
 }

--- a/tests/test-newsletter-ads.php
+++ b/tests/test-newsletter-ads.php
@@ -74,6 +74,7 @@ class Newsletters_Newsletter_Ads_Test extends WP_UnitTestCase {
 				'post_title' => 'A sample ad',
 			]
 		);
+		update_post_meta( $ad_id, 'insertion_strategy', 'placement' );
 		wp_set_post_terms( $ad_id, [ $placement_id ], Ads_Placements::TAXONOMY );
 		$ad = Ads_Placements::get_ad_by_placement( $placement_id );
 		$this->assertNotEmpty( $ad );
@@ -129,6 +130,7 @@ class Newsletters_Newsletter_Ads_Test extends WP_UnitTestCase {
 				'name'     => 'Test Placement',
 			]
 		);
+		update_post_meta( $ad_id, 'insertion_strategy', 'placement' );
 		wp_set_post_terms( $ad_id, [ $placement_id ], Ads_Placements::TAXONOMY );
 
 		// Add the category to the ad.
@@ -181,6 +183,7 @@ class Newsletters_Newsletter_Ads_Test extends WP_UnitTestCase {
 				'name'     => 'Test Placement',
 			]
 		);
+		update_post_meta( $ad_id, 'insertion_strategy', 'placement' );
 		wp_set_post_terms( $ad_id, [ $placement_id ], Ads_Placements::TAXONOMY );
 
 		// Add advertiser to newsletter.

--- a/tests/test-newsletter-ads.php
+++ b/tests/test-newsletter-ads.php
@@ -22,7 +22,7 @@ class Newsletters_Newsletter_Ads_Test extends WP_UnitTestCase {
 	public function test_creating_ad() {
 		self::$ad_id = self::factory()->post->create(
 			[
-				'post_type'    => Newspack_Newsletters_Ads::CPT,
+				'post_type'    => Newspack_Newsletters\Ads::CPT,
 				'post_title'   => 'A sample ad',
 				'post_content' => '<!-- wp:paragraph -->\n<p>Ad content.<\/p>\n<!-- \/wp:paragraph -->',
 			]
@@ -34,22 +34,22 @@ class Newsletters_Newsletter_Ads_Test extends WP_UnitTestCase {
 	 * Test active ad.
 	 */
 	public function test_is_active_ad() {
-		$this->assertTrue( Newspack_Newsletters_Ads::is_ad_active( self::$ad_id ) );
+		$this->assertTrue( Newspack_Newsletters\Ads::is_ad_active( self::$ad_id ) );
 
 		// Set start date to tomorrow.
 		update_post_meta( self::$ad_id, 'start_date', gmdate( 'Y-m-d', strtotime( '+1 day' ) ) );
-		$this->assertFalse( Newspack_Newsletters_Ads::is_ad_active( self::$ad_id ) );
+		$this->assertFalse( Newspack_Newsletters\Ads::is_ad_active( self::$ad_id ) );
 
 		// Set start date to yesterday.
 		update_post_meta( self::$ad_id, 'start_date', gmdate( 'Y-m-d', strtotime( '-1 day' ) ) );
-		$this->assertTrue( Newspack_Newsletters_Ads::is_ad_active( self::$ad_id ) );
+		$this->assertTrue( Newspack_Newsletters\Ads::is_ad_active( self::$ad_id ) );
 
 		// Set expiry date to yesterday.
 		update_post_meta( self::$ad_id, 'expiry_date', gmdate( 'Y-m-d', strtotime( '-1 day' ) ) );
-		$this->assertFalse( Newspack_Newsletters_Ads::is_ad_active( self::$ad_id ) );
+		$this->assertFalse( Newspack_Newsletters\Ads::is_ad_active( self::$ad_id ) );
 
 		// Set expiry date to tomorrow.
 		update_post_meta( self::$ad_id, 'expiry_date', gmdate( 'Y-m-d', strtotime( '+1 day' ) ) );
-		$this->assertTrue( Newspack_Newsletters_Ads::is_ad_active( self::$ad_id ) );
+		$this->assertTrue( Newspack_Newsletters\Ads::is_ad_active( self::$ad_id ) );
 	}
 }

--- a/tests/test-tracking.php
+++ b/tests/test-tracking.php
@@ -227,11 +227,11 @@ class Newsletters_Tracking_Test extends WP_UnitTestCase {
 	 */
 	public function test_process_logs_ads() {
 		$newsletter_id = $this->factory->post->create( [ 'post_type' => \Newspack_Newsletters::NEWSPACK_NEWSLETTERS_CPT ] );
-		$ad_id = $this->factory->post->create( [ 'post_type' => Newspack_Newsletters_Ads::CPT ] );
+		$ad_id = $this->factory->post->create( [ 'post_type' => Newspack_Newsletters\Ads::CPT ] );
 		$tracking_id = 'tracking_id_1';
 		update_post_meta( $newsletter_id, 'tracking_id', $tracking_id );
 
-		Newspack_Newsletters_Ads::mark_ad_inserted( $newsletter_id, $ad_id );
+		Newspack_Newsletters\Ads::mark_ad_inserted( $newsletter_id, $ad_id );
 
 		// phpcs:disable WordPressVIPMinimum.Functions.RestrictedFunctions
 		// Create a temporary log file.


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Introduces Ad Placements for Newsletters Ads.

Ads should have a new insertion strategy option called "Placement", which should also be an option in the Newsletter Ad block to select which placement to render in the newsletter.

When the insertion strategy is "Placement", the ad will no longer be eligible for automatic insertion and should only fill the slot if the newsletter has the Newsletter Ad block using the placement.

The category and advertiser rules also apply, so a placement can have multiple ads with different advertisers and categories, and it'll fill the slot according to the newsletter relationship with the taxonomies.

### Assigning an ad to a placement

<img width="2110" height="1430" alt="image" src="https://github.com/user-attachments/assets/50c68488-23ee-4d96-b36a-46c924dd05f7" />

<img width="280" src="https://github.com/user-attachments/assets/b0a982e0-6bee-4a97-8cd5-6569cea9e24d" />

### Managing placements

<img width="400" src="https://github.com/user-attachments/assets/5b4fe80f-1590-4825-aa95-0dbf72a1e881" />

<img width="400" src="https://github.com/user-attachments/assets/58a4134a-3f69-441b-8f27-f76bb2828ef1" />

### Rendering placement

<img width="2104" height="1480" alt="image" src="https://github.com/user-attachments/assets/687f1b43-87ab-4f9b-9b76-426807565d5f" />

<img width="2272" height="1528" alt="image" src="https://github.com/user-attachments/assets/4dbcc045-d8e9-43cc-94ad-c8b228d6ed8a" />

### How to test the changes in this Pull Request:

1. Checkout this branch and https://github.com/Automattic/newspack-plugin/pull/4131
2. Create a new newsletter ad and set the Insertion Strategy to "Placement"
3. Select "New Placement", enter a name and publish
4. Refresh the page and confirm the selected placement persists in the editor
5. Draft a new newsletter, preview and confirm the ad does not get automatically inserted
6. Add a Newsletter Ad block to the newsletter and select the placement
7. Preview the newsletter and confirm the ad renders
8. Edit the newsletter ad again and click "Manage placements"
9. Edit the existing placement, set a new name for it and save
10. Edit the newsletter draft and confirm the placement persisted and shows the new name
11. Back to the ad, click "Manage placements" again
12. Create and delete a few placements
13. Close the modal and confirm that the created placements are available for selection in the ad configuration

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
