### PR TITLE
fix(ads): register post type and taxonomy regardless of user session

### DIFF
--- a/includes/class-newspack-newsletters-ads.php
+++ b/includes/class-newspack-newsletters-ads.php
@@ -222,15 +222,9 @@ final class Newspack_Newsletters_Ads {
 	}
 
 	/**
-	 * Register the custom post type for layouts.
+	 * Register the custom post type for newsletters ads.
 	 */
 	public static function register_ads_cpt() {
-		$newsletters_post_type_object = get_post_type_object( Newspack_Newsletters::NEWSPACK_NEWSLETTERS_CPT );
-		$can_edit_newsletters = current_user_can( $newsletters_post_type_object->cap->edit_posts );
-		if ( ! $can_edit_newsletters ) {
-			return;
-		}
-
 		$labels = [
 			'name'                     => _x( 'Newsletter Ads', 'post type general name', 'newspack-newsletters' ),
 			'singular_name'            => _x( 'Newsletter Ad', 'post type singular name', 'newspack-newsletters' ),
@@ -255,13 +249,14 @@ final class Newspack_Newsletters_Ads {
 		];
 
 		$cpt_args = [
-			'public'       => false,
-			'labels'       => $labels,
-			'show_ui'      => true,
-			'show_in_menu' => false,
-			'show_in_rest' => true,
-			'supports'     => [ 'editor', 'title', 'custom-fields' ],
-			'taxonomies'   => [ 'category' ],
+			'public'          => false,
+			'labels'          => $labels,
+			'show_ui'         => true,
+			'show_in_menu'    => false,
+			'show_in_rest'    => true,
+			'supports'        => [ 'editor', 'title', 'custom-fields' ],
+			'taxonomies'      => [ 'category' ],
+			'capability_type' => 'newsletter_ad',
 		];
 		register_post_type( self::CPT, $cpt_args );
 
@@ -295,6 +290,12 @@ final class Newspack_Newsletters_Ads {
 				'hierarchical'      => true,
 				'show_in_rest'      => true,
 				'show_admin_column' => true,
+				'capabilities'      => [
+					'manage_terms' => 'manage_newsletter_ads',
+					'edit_terms'   => 'edit_newsletter_ads',
+					'delete_terms' => 'delete_newsletter_ads',
+					'assign_terms' => 'assign_newsletter_ads',
+				],
 			]
 		);
 	}

--- a/languages/newspack-newsletters.pot
+++ b/languages/newspack-newsletters.pot
@@ -9,7 +9,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2025-07-30T10:05:52+00:00\n"
+"POT-Creation-Date: 2025-08-05T20:17:36+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "X-Generator: WP-CLI 2.12.0\n"
 "X-Domain: newspack-newsletters\n"
@@ -47,186 +47,186 @@ msgstr ""
 msgid "Ads"
 msgstr ""
 
-#: includes/class-newspack-newsletters-ads.php:235
+#: includes/class-newspack-newsletters-ads.php:229
 msgctxt "post type general name"
 msgid "Newsletter Ads"
 msgstr ""
 
-#: includes/class-newspack-newsletters-ads.php:236
+#: includes/class-newspack-newsletters-ads.php:230
 msgctxt "post type singular name"
 msgid "Newsletter Ad"
 msgstr ""
 
-#: includes/class-newspack-newsletters-ads.php:237
+#: includes/class-newspack-newsletters-ads.php:231
 msgctxt "admin menu"
 msgid "Newsletter Ads"
 msgstr ""
 
-#: includes/class-newspack-newsletters-ads.php:238
+#: includes/class-newspack-newsletters-ads.php:232
 msgctxt "add new on admin bar"
 msgid "Newsletter Ad"
 msgstr ""
 
-#: includes/class-newspack-newsletters-ads.php:239
+#: includes/class-newspack-newsletters-ads.php:233
 msgctxt "popup"
 msgid "Add New"
 msgstr ""
 
-#: includes/class-newspack-newsletters-ads.php:240
+#: includes/class-newspack-newsletters-ads.php:234
 msgid "Add New Newsletter Ad"
 msgstr ""
 
-#: includes/class-newspack-newsletters-ads.php:241
+#: includes/class-newspack-newsletters-ads.php:235
 msgid "New Newsletter Ad"
 msgstr ""
 
-#: includes/class-newspack-newsletters-ads.php:242
+#: includes/class-newspack-newsletters-ads.php:236
 msgid "Edit Newsletter Ad"
 msgstr ""
 
-#: includes/class-newspack-newsletters-ads.php:243
+#: includes/class-newspack-newsletters-ads.php:237
 msgid "View Newsletter Ad"
 msgstr ""
 
-#: includes/class-newspack-newsletters-ads.php:244
+#: includes/class-newspack-newsletters-ads.php:238
 msgid "All Newsletter Ads"
 msgstr ""
 
-#: includes/class-newspack-newsletters-ads.php:245
+#: includes/class-newspack-newsletters-ads.php:239
 msgid "Search Newsletter Ads"
 msgstr ""
 
-#: includes/class-newspack-newsletters-ads.php:246
+#: includes/class-newspack-newsletters-ads.php:240
 msgid "Parent Newsletter Ads:"
 msgstr ""
 
-#: includes/class-newspack-newsletters-ads.php:247
+#: includes/class-newspack-newsletters-ads.php:241
 msgid "No Newsletter Ads found."
 msgstr ""
 
-#: includes/class-newspack-newsletters-ads.php:248
+#: includes/class-newspack-newsletters-ads.php:242
 msgid "No Newsletter Ads found in Trash."
 msgstr ""
 
-#: includes/class-newspack-newsletters-ads.php:249
+#: includes/class-newspack-newsletters-ads.php:243
 msgid "Newsletter Ads list"
 msgstr ""
 
-#: includes/class-newspack-newsletters-ads.php:250
+#: includes/class-newspack-newsletters-ads.php:244
 msgid "Newsletter Ad published"
 msgstr ""
 
-#: includes/class-newspack-newsletters-ads.php:251
+#: includes/class-newspack-newsletters-ads.php:245
 msgid "Newsletter Ad published privately"
 msgstr ""
 
-#: includes/class-newspack-newsletters-ads.php:252
+#: includes/class-newspack-newsletters-ads.php:246
 msgid "Newsletter Ad reverted to draft"
 msgstr ""
 
-#: includes/class-newspack-newsletters-ads.php:253
+#: includes/class-newspack-newsletters-ads.php:247
 msgid "Newsletter Ad scheduled"
 msgstr ""
 
-#: includes/class-newspack-newsletters-ads.php:254
+#: includes/class-newspack-newsletters-ads.php:248
 msgid "Newsletter Ad updated"
 msgstr ""
 
-#: includes/class-newspack-newsletters-ads.php:273
+#: includes/class-newspack-newsletters-ads.php:268
 msgid "Advertisers"
 msgstr ""
 
-#: includes/class-newspack-newsletters-ads.php:274
+#: includes/class-newspack-newsletters-ads.php:269
 msgid "Advertiser"
 msgstr ""
 
-#: includes/class-newspack-newsletters-ads.php:275
+#: includes/class-newspack-newsletters-ads.php:270
 msgid "Search Advertisers"
 msgstr ""
 
-#: includes/class-newspack-newsletters-ads.php:276
+#: includes/class-newspack-newsletters-ads.php:271
 msgid "Popular Advertisers"
 msgstr ""
 
-#: includes/class-newspack-newsletters-ads.php:277
+#: includes/class-newspack-newsletters-ads.php:272
 msgid "All Advertisers"
 msgstr ""
 
-#: includes/class-newspack-newsletters-ads.php:278
+#: includes/class-newspack-newsletters-ads.php:273
 msgid "Parent Advertisers"
 msgstr ""
 
-#: includes/class-newspack-newsletters-ads.php:279
+#: includes/class-newspack-newsletters-ads.php:274
 msgid "Parent Advertiser"
 msgstr ""
 
-#: includes/class-newspack-newsletters-ads.php:280
+#: includes/class-newspack-newsletters-ads.php:275
 msgid "The advertiser name"
 msgstr ""
 
-#: includes/class-newspack-newsletters-ads.php:282
+#: includes/class-newspack-newsletters-ads.php:277
 msgid "Assign a parent advertiser"
 msgstr ""
 
-#: includes/class-newspack-newsletters-ads.php:283
+#: includes/class-newspack-newsletters-ads.php:278
 msgid "Optional description for this advertiser"
 msgstr ""
 
-#: includes/class-newspack-newsletters-ads.php:284
+#: includes/class-newspack-newsletters-ads.php:279
 msgid "Edit Advertiser"
 msgstr ""
 
-#: includes/class-newspack-newsletters-ads.php:285
+#: includes/class-newspack-newsletters-ads.php:280
 msgid "View Advertiser"
 msgstr ""
 
-#: includes/class-newspack-newsletters-ads.php:286
+#: includes/class-newspack-newsletters-ads.php:281
 msgid "Update Advertiser"
 msgstr ""
 
-#: includes/class-newspack-newsletters-ads.php:287
+#: includes/class-newspack-newsletters-ads.php:282
 msgid "Add New Advertiser"
 msgstr ""
 
-#: includes/class-newspack-newsletters-ads.php:288
+#: includes/class-newspack-newsletters-ads.php:283
 msgid "New Advertiser Name"
 msgstr ""
 
-#: includes/class-newspack-newsletters-ads.php:289
+#: includes/class-newspack-newsletters-ads.php:284
 msgid "No advertisers found"
 msgstr ""
 
-#: includes/class-newspack-newsletters-ads.php:290
+#: includes/class-newspack-newsletters-ads.php:285
 msgid "No advertisers"
 msgstr ""
 
-#: includes/class-newspack-newsletters-ads.php:291
+#: includes/class-newspack-newsletters-ads.php:286
 msgid "Filter by advertiser"
 msgstr ""
 
-#: includes/class-newspack-newsletters-ads.php:293
+#: includes/class-newspack-newsletters-ads.php:288
 msgid "Newspack Newsletters Ads Advertisers"
 msgstr ""
 
-#: includes/class-newspack-newsletters-ads.php:391
+#: includes/class-newspack-newsletters-ads.php:392
 msgid "promotion"
 msgstr ""
 
-#: includes/class-newspack-newsletters-ads.php:391
+#: includes/class-newspack-newsletters-ads.php:392
 msgid "ad"
 msgstr ""
 
-#: includes/class-newspack-newsletters-ads.php:588
+#: includes/class-newspack-newsletters-ads.php:589
 msgid "Start Date"
 msgstr ""
 
-#: includes/class-newspack-newsletters-ads.php:589
+#: includes/class-newspack-newsletters-ads.php:590
 #: dist/adsEditor.js:19
 #: src/ads/editor/index.js:192
 msgid "Expiration Date"
 msgstr ""
 
-#: includes/class-newspack-newsletters-ads.php:590
+#: includes/class-newspack-newsletters-ads.php:591
 #: dist/adsEditor.js:13
 #: src/ads/editor/index.js:109
 msgid "Price"


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes # .

### How to test the changes in this Pull Request:

1.
2.
3.

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
