### PR TITLE
hotfix(ads): ads in scheduled newsletters

### DIFF
--- a/includes/class-newspack-newsletters-ads.php
+++ b/includes/class-newspack-newsletters-ads.php
@@ -53,6 +53,7 @@ final class Newspack_Newsletters_Ads {
 		add_action( 'save_post_' . self::CPT, [ __CLASS__, 'ad_default_fields' ], 10, 3 );
 		add_action( 'rest_api_init', [ __CLASS__, 'rest_api_init' ] );
 		add_action( 'admin_menu', [ __CLASS__, 'add_ads_page' ] );
+		add_action( 'current_screen', [ __CLASS__, 'prevent_direct_taxonomy_access' ] );
 		add_filter( 'get_post_metadata', [ __CLASS__, 'migrate_diable_ads' ], 10, 4 );
 		add_action( 'newspack_newsletters_tracking_pixel_seen', [ __CLASS__, 'track_ad_impression' ], 10, 2 );
 		add_action( 'newspack_newsletters_bulk_tracking_pixel_seen', [ __CLASS__, 'bulk_track_ad_impression' ], 10, 2 );
@@ -222,14 +223,31 @@ final class Newspack_Newsletters_Ads {
 	}
 
 	/**
+	 * Prevent direct access to the advertiser taxonomy admin page if user can't edit ads.
+	 *
+	 * @param string $screen The screen ID used to identify the current admin screen context.
+	 */
+	public static function prevent_direct_taxonomy_access( $screen ) {
+		// Check if we're on the taxonomy edit page for our advertiser taxonomy.
+		if ( $screen && 'edit-tags' === $screen->base && self::ADVERTISER_TAX === $screen->taxonomy ) {
+			$newsletter_ads_post_type_object = get_post_type_object( self::CPT );
+			$can_edit_newsletter_ads = current_user_can( $newsletter_ads_post_type_object->cap->edit_posts );
+
+			// If user can't edit ads, redirect them away.
+			if ( ! $can_edit_newsletter_ads ) {
+				wp_die(
+					esc_html__( 'Sorry, you are not allowed to manage newsletter advertisers.', 'newspack-newsletters' ),
+					esc_html__( 'You need permission to manage newsletter ads', 'newspack-newsletters' ),
+					403
+				);
+			}
+		}
+	}
+
+	/**
 	 * Register the custom post type for layouts.
 	 */
 	public static function register_ads_cpt() {
-		$newsletters_post_type_object = get_post_type_object( Newspack_Newsletters::NEWSPACK_NEWSLETTERS_CPT );
-		$can_edit_newsletters = current_user_can( $newsletters_post_type_object->cap->edit_posts );
-		if ( ! $can_edit_newsletters ) {
-			return;
-		}
 
 		$labels = [
 			'name'                     => _x( 'Newsletter Ads', 'post type general name', 'newspack-newsletters' ),


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes an issue with how Newsletter Ads permissions were handled. Ads were registered with a `current_user_can` check, effectively only allowing WP to handle Ads with a signed-in user with the capability. Therefore, if a newsletter was scheduled to send, at the time of sending the ads would not be populated.

Closes NPPD-787

### How to test the changes in this Pull Request:

1. (use `capability-manager-enhanced` plugin to manage capabilities)
2. Confirm that as an admin, you can see `/wp-admin/edit.php?post_type=newspack_nl_cpt` and `np.eu.ngrok.io/wp-admin/edit.php?post_type=newspack_nl_ads_cpt` and the respective menu items (Newsletters → All Newsletters, Newsletters → Advertising)
3. Go to `/wp-admin/admin.php?page=pp-capabilities` and select a role other than admin (e.g. editor), in "Unique Post Type Capabilities" select Newsletters Newsletter Ads, click "Update"
4. Adjust the caps to make the editor only capable of editing Newsletters
5. Log in as the editor and confirm you can access and see menu items for only Newsletters
6. Adjust the caps to test other permutations: only Ads, both Ads and Newsletters, neither

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->