### PR TITLE
fix: handle scheduled in past sending

### DIFF
--- a/languages/newspack-newsletters.pot
+++ b/languages/newspack-newsletters.pot
@@ -9,7 +9,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2025-07-30T10:05:52+00:00\n"
+"POT-Creation-Date: 2025-08-07T20:47:14+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "X-Generator: WP-CLI 2.12.0\n"
 "X-Domain: newspack-newsletters\n"
@@ -2099,67 +2099,68 @@ msgstr ""
 msgid "Preview email"
 msgstr ""
 
-#: src/components/send-button/index.js:190
+#: src/components/send-button/index.js:194
 msgid "Sending"
 msgstr ""
 
-#: src/components/send-button/index.js:193
+#: src/components/send-button/index.js:197
 msgid "Sent and Published"
 msgstr ""
 
-#: src/components/send-button/index.js:194
+#: src/components/send-button/index.js:198
 msgid "Sent"
 msgstr ""
 
-#: src/components/send-button/index.js:198
-msgid "Scheduled"
-msgstr ""
-
-#: src/components/send-button/index.js:200
-msgid "Schedule sending"
-msgstr ""
-
-#: src/components/send-button/index.js:203
-msgid "Send and Publish"
-msgstr ""
-
-#: src/components/send-button/index.js:204
+#: src/components/send-button/index.js:201
+#: src/components/send-button/index.js:210
 msgid "Send"
 msgstr ""
 
+#: src/components/send-button/index.js:204
+msgid "Scheduled"
+msgstr ""
+
+#: src/components/send-button/index.js:206
+msgid "Schedule sending"
+msgstr ""
+
 #: src/components/send-button/index.js:209
+msgid "Send and Publish"
+msgstr ""
+
+#: src/components/send-button/index.js:215
 msgid "Updating…"
 msgstr ""
 
-#: src/components/send-button/index.js:211
+#: src/components/send-button/index.js:217
 msgid "Update and copy HTML"
 msgstr ""
 
-#: src/components/send-button/index.js:213
+#: src/components/send-button/index.js:219
 msgid "Update"
 msgstr ""
 
-#: src/components/send-button/index.js:234
+#: src/components/send-button/index.js:240
 msgid "Mark as sent and publish"
 msgstr ""
 
-#: src/components/send-button/index.js:235
+#: src/components/send-button/index.js:241
 msgid "Mark as sent"
 msgstr ""
 
-#: src/components/send-button/index.js:279
+#: src/components/send-button/index.js:285
 msgid "Newsletter HTML"
 msgstr ""
 
-#: src/components/send-button/index.js:319
+#: src/components/send-button/index.js:325
 msgid "Unschedule"
 msgstr ""
 
-#: src/components/send-button/index.js:344
+#: src/components/send-button/index.js:354
 msgid "Send your newsletter?"
 msgstr ""
 
-#: src/components/send-button/index.js:372
+#: src/components/send-button/index.js:382
 #: src/newsletter-editor/layout/index.js:244
 #: src/newsletter-editor/layout/index.js:275
 #: src/newsletter-editor/sidebar/autocomplete.js:123


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes an issue where a newsletter scheduled in the past would under certain conditions be sent without the confirmation modal.

Closes NPPM-2138

### How to test the changes in this Pull Request:

1. On `trunk`, create a new newsletter, fill in the required Campaign fields in the sidebar, and then
    1. set a publishing date in the past 
    2. save draft
    3. set status to "Scheduled" - the past date should already be prefilled
4. Hit "Scheduled" (the "Send" button)
5. Observe no pre-send modal, the newsletter is sent immediatelly
6. Switch to this branch, redo the setup, observe the button is now labelled "Send" - since there's no scheduling for a date in the past
7. Hit "Send", observe the confirmation modal is visible

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->