### PR TITLE
fix: respect block spacing when rendering

### DIFF
--- a/includes/class-newspack-newsletters-renderer.php
+++ b/includes/class-newspack-newsletters-renderer.php
@@ -349,9 +349,18 @@ final class Newspack_Newsletters_Renderer {
 		}
 
 		if ( isset( $attrs['style']['spacing']['padding'] ) ) {
-			$padding = $attrs['style']['spacing']['padding'];
+			$padding = array_merge(
+				// Make sure we have all padding values set.
+				[
+					'top'    => '0',
+					'right'  => '0',
+					'bottom' => '0',
+					'left'   => '0',
+				],
+				$attrs['style']['spacing']['padding']
+			);
 			foreach ( $padding as $key => $value ) {
-				$padding[ $key ] = self::get_spacing_value( $value, $key );
+				$padding[ $key ] = self::get_spacing_value( $value );
 			}
 			$attrs['padding'] = sprintf( '%s %s %s %s', $padding['top'], $padding['right'], $padding['bottom'], $padding['left'] );
 		}
@@ -547,7 +556,7 @@ final class Newspack_Newsletters_Renderer {
 		// Default attributes for the column which will envelop the component.
 		$column_attrs = array_merge(
 			array(
-				'padding' => '12px',
+				'padding' => isset( $attrs['padding'] ) ? $attrs['padding'] : '12px',
 			)
 		);
 
@@ -979,7 +988,7 @@ final class Newspack_Newsletters_Renderer {
 				if ( $total_width > 100 ) {
 					$excess = $total_width - 100;
 					$adjustment_per_column = $excess / count( $inner_blocks );
-					
+
 					foreach ( $inner_blocks as $i => $block ) {
 						if ( isset( $block['attrs']['width'] ) ) {
 							$current_width = floatval( $block['attrs']['width'] );

--- a/tests/test-renderer.php
+++ b/tests/test-renderer.php
@@ -51,7 +51,7 @@ class Newsletters_Renderer_Test extends WP_UnitTestCase {
 					'innerHTML'    => $inner_html,
 				]
 			),
-			'<mj-section textColor="vivid-purple" color="#db18e6 !important" background-color="#4aadd7 !important" font-size="16px" padding="0"><mj-column padding="12px" width="100%"><mj-text padding="0" line-height="1.5" font-size="16px"  textColor="vivid-purple" color="#db18e6 !important" container-background-color="#4aadd7 !important">' . $inner_html . '</mj-text></mj-column></mj-section>',
+			'<mj-section textColor="vivid-purple" color="#db18e6 !important" background-color="#4aadd7 !important" font-size="16px" padding="0"><mj-column padding="0" width="100%"><mj-text padding="0" line-height="1.5" font-size="16px"  textColor="vivid-purple" color="#db18e6 !important" container-background-color="#4aadd7 !important">' . $inner_html . '</mj-text></mj-column></mj-section>',
 			'Renders styled paragraph'
 		);
 	}


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes https://linear.app/a8c/issue/NPPM-2165/newsletters-editor-not-respecting-padding

This PR fixes an issue where the newsletters renderer is not respecting the custom padding set by blocks. This is because we always the column padding to 12px regardless of whether there is custom padding set via the editor. 

Editor:
![Screenshot 2025-08-14 at 16 12 03](https://github.com/user-attachments/assets/198a9989-1640-4c32-8114-66806dfede61)

Preview:
![Screenshot 2025-08-14 at 16 11 54](https://github.com/user-attachments/assets/df3f501d-8a80-4a52-94d6-17ae87449382)


### How to test the changes in this Pull Request:

1. Open any newsletter in the editor or create a new one
2. Add a buttons block, center a single button, then add text directly below
3. Remove bottom padding from the buttons block and top padding from t he paragraph block
4. Render a preview via the Preview email button
5. Verify the spacing is respected and other blocks are rendered with the expected spacing
6. Send a test email and repeat step 5 for the email

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
