### PR TITLE
fix(ads): only apply click tracking to ad links

### DIFF
--- a/includes/class-newspack-newsletters-renderer.php
+++ b/includes/class-newspack-newsletters-renderer.php
@@ -979,7 +979,7 @@ final class Newspack_Newsletters_Renderer {
 				if ( $total_width > 100 ) {
 					$excess = $total_width - 100;
 					$adjustment_per_column = $excess / count( $inner_blocks );
-					
+
 					foreach ( $inner_blocks as $i => $block ) {
 						if ( isset( $block['attrs']['width'] ) ) {
 							$current_width = floatval( $block['attrs']['width'] );

--- a/includes/tracking/class-click.php
+++ b/includes/tracking/class-click.php
@@ -7,6 +7,8 @@
 
 namespace Newspack_Newsletters\Tracking;
 
+use Newspack_Newsletters\Ads;
+
 /**
  * Tracking Click-Tracking Class.
  */
@@ -101,6 +103,9 @@ final class Click {
 			return $url;
 		}
 		if ( ! $post ) {
+			return $url;
+		}
+		if ( $post->post_type !== Ads::CPT ) {
 			return $url;
 		}
 		return self::get_proxied_url( $post->ID, $url );

--- a/tests/test-tracking.php
+++ b/tests/test-tracking.php
@@ -7,6 +7,7 @@
 
 use Newspack_Newsletters\Tracking\Pixel;
 use Newspack_Newsletters\Tracking\Click;
+use Newspack_Newsletters\Ads;
 
 /**
  * Newsletters Tracking Test.
@@ -57,8 +58,8 @@ class Newsletters_Tracking_Test extends WP_UnitTestCase {
 		$content  = "<!-- wp:paragraph -->\n<p><a href=\"https://google.com\">Link</a><\/p>\n<!-- \/wp:paragraph -->";
 		$post_id  = $this->factory->post->create(
 			[
-				'post_type'    => \Newspack_Newsletters::NEWSPACK_NEWSLETTERS_CPT,
-				'post_title'   => 'A newsletter with link.',
+				'post_type'    => Ads::CPT,
+				'post_title'   => 'A newsletter ad with link.',
 				'post_content' => $content,
 			]
 		);
@@ -101,6 +102,32 @@ class Newsletters_Tracking_Test extends WP_UnitTestCase {
 		// Assert clicked twice.
 		$clicks = \get_post_meta( $post_id, 'tracking_clicks', true );
 		$this->assertEquals( 2, $clicks );
+		$post_id = $this->factory->post->create(
+			[
+				'post_type'    => \Newspack_Newsletters::NEWSPACK_NEWSLETTERS_CPT,
+				'post_title'   => 'A newsletter with link.',
+				'post_content' => $content,
+			]
+		);
+		// Ensure the newspack_email_html meta is set.
+		update_post_meta( $post_id, 'newspack_email_html', $content );
+
+		$post     = \get_post( $post_id );
+		$rendered = Newspack_Newsletters_Renderer::post_to_mjml_components( $post );
+
+		// Fetch the link URL from body.
+		$pattern = '/href="([^"]*)"/i';
+		$matches = [];
+		preg_match( $pattern, $rendered, $matches );
+		$link_url   = $matches[1];
+		$parsed_url = \wp_parse_url( $link_url );
+		$args       = \wp_parse_args( $parsed_url['query'] );
+
+		// Ensure id, url, em, and np_newsletters_click are NOT present.
+		$this->assertArrayNotHasKey( 'id', $args );
+		$this->assertArrayNotHasKey( 'url', $args );
+		$this->assertArrayNotHasKey( 'em', $args );
+		$this->assertArrayNotHasKey( 'np_newsletters_click', $args );
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes https://linear.app/a8c/issue/NPPM-2154/newsletter-link-tracking-inquiry-nedbluelena

This PR only applies click tracking url params to links that are part of a newsletter ad. Seems this is the only case in which click tracking is used, and at least one publisher is running into issues with parsing messy newsletter links in reports.

![Screenshot 2025-08-15 at 14 42 12](https://github.com/user-attachments/assets/a8c67e81-c7b1-42a7-b785-8ff44e9bc8d1)

### How to test the changes in this Pull Request:

1. Enable click tracking via Newsletters > Settings > Tracking
2. Create a new newsletter ad, and add some links
3. Create a new newsletter, adding some links and ensuring the ad from step 1 is inserted
4. Send a test email
5. In the test email confirm that the links not associated with the ad don't have our click tracking url params attached, and that links associated with the ad do.

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
