### PR TITLE
feat(layouts): persist automatic ads option

### DIFF
--- a/includes/class-newspack-newsletters-layouts.php
+++ b/includes/class-newspack-newsletters-layouts.php
@@ -79,6 +79,7 @@ final class Newspack_Newsletters_Layouts {
 		\register_meta( 'post', 'text_color', $meta_default_params );
 		\register_meta( 'post', 'custom_css', $meta_default_params );
 		\register_meta( 'post', 'campaign_defaults', $meta_default_params );
+		\register_meta( 'post', 'disable_auto_ads', array_merge( $meta_default_params, [ 'type' => 'boolean' ] ) );
 	}
 
 	/**
@@ -212,6 +213,7 @@ final class Newspack_Newsletters_Layouts {
 					'font_header'       => get_post_meta( $post->ID, 'font_header', true ),
 					'custom_css'        => get_post_meta( $post->ID, 'custom_css', true ),
 					'campaign_defaults' => get_post_meta( $post->ID, 'campaign_defaults', true ),
+					'disable_auto_ads'  => get_post_meta( $post->ID, 'disable_auto_ads', true ),
 				];
 
 				// Migrate layout defaults from legacy meta, if it exists.

--- a/src/newsletter-editor/layout/index.js
+++ b/src/newsletter-editor/layout/index.js
@@ -38,6 +38,7 @@ export default compose( [
 			senderName,
 			send_list_id,
 			send_sublist_id,
+			disable_auto_ads,
 		} = meta;
 		const layoutMeta = {
 			background_color,
@@ -45,6 +46,7 @@ export default compose( [
 			font_body,
 			font_header,
 			custom_css,
+			disable_auto_ads,
 		};
 
 		// ESP-agnostic sender and send_to defaults.


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Closes NPPD-798 

Store and apply the "Enable automatic insertion of ads" option in the layout.

### How to test the changes in this Pull Request:

1. Checkout this branch and draft a new newsletter
2. Toggle the "Enable automatic insertion of ads" off and save the draft as a newsletter layout
3. Start a new newsletter and select the saved layout
4. Confirm the draft has "Enable automatic insertion of ads" toggled off

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
