### PR TITLE
feat(activecampaign): custom address ID via constant

### DIFF
--- a/includes/service-providers/active_campaign/class-newspack-newsletters-active-campaign.php
+++ b/includes/service-providers/active_campaign/class-newspack-newsletters-active-campaign.php
@@ -764,6 +764,18 @@ final class Newspack_Newsletters_Active_Campaign extends \Newspack_Newsletters_S
 	}
 
 	/**
+	 * Get the address ID to be used for the campaign. Default to 0, which will use AC default address.
+	 *
+	 * @return int
+	 */
+	private function get_address_id() {
+		if ( ! defined( 'NEWSPACK_NEWSLETTERS_ACTIVE_CAMPAIGN_ADDRESS_ID' ) ) {
+			return 0;
+		}
+		return NEWSPACK_NEWSLETTERS_ACTIVE_CAMPAIGN_ADDRESS_ID;
+	}
+
+	/**
 	 * Given legacy newsletterData, extract sender and send-to info.
 	 *
 	 * @param array $newsletter_data Newsletter data from the ESP.
@@ -1147,6 +1159,7 @@ final class Newspack_Newsletters_Active_Campaign extends \Newspack_Newsletters_S
 			'segmentid'                             => $send_sublist_id ?? 0, // 0 = No segment.
 			'p[' . $send_list_id . ']'              => $send_list_id,
 			'm[' . $sync_result['message_id'] . ']' => 100, // 100 = 100% of contacts will receive this.
+			'addressid'                             => $this->get_address_id(),
 		];
 		if ( defined( 'NEWSPACK_NEWSLETTERS_AC_DISABLE_LINK_TRACKING' ) && NEWSPACK_NEWSLETTERS_AC_DISABLE_LINK_TRACKING ) {
 			$campaign_data['tracklinks'] = 'none';


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Add support for a custom address ID for ActiveCampaign newsletters

### How to test the changes in this Pull Request:

1. Make sure you have multiple addresses in our AC account
2. With AC configured as your ESP, send a newsletter and confirm the default behavior to use the default address in the footer is unchanged
3. Fetch our addresses to determine which to use:

```sh
curl --request GET \
     --url https://[account-name].api-us1.com/api/3/addresses \
     --header 'Api-Token: [api-token]' \
     --header 'accept: application/json'
```

4. Get the ID of an address that is not the default
5. Set the constant in your `wp-config.php`: `define( 'NEWSPACK_NEWSLETTERS_ACTIVE_CAMPAIGN_ADDRESS_ID', 2 );`
6. Send a newsletter and confirm the footer address is the one set

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
