### PR TITLE
fix: reset newsletter list when not found in ESP

### DIFF
--- a/src/ads/newsletter-editor/disable-auto-ads.js
+++ b/src/ads/newsletter-editor/disable-auto-ads.js
@@ -15,7 +15,7 @@ export default function DisableAutoAds( { saveOnToggle = false } ) {
 		const { getBlocks } = select( 'core/block-editor' );
 		const meta = getEditedPostAttribute( 'meta' );
 		return {
-			disableAutoAds: meta.disable_auto_ads,
+			disableAutoAds: !! meta.disable_auto_ads,
 			postId: getCurrentPostId(),
 			isSaving: isSavingPost(),
 			postBlocks: getBlocks(),

--- a/src/newsletter-editor/sidebar/send-to.js
+++ b/src/newsletter-editor/sidebar/send-to.js
@@ -62,7 +62,31 @@ const SendTo = () => {
 			fetchSendLists( { type: 'sublist', parent_id: listId }, true );
 			updateMeta( { send_sublist_id: null } );
 		}
-	}, [ newsletterData, listId, sublistId ] );
+
+		// If the list ID doesn't match any fetched lists reset the list and sublist IDs.
+		if ( listId && ! lists.find( item => item.id.toString() === listId.toString() ) ) {
+			updateMeta( { send_list_id: null, send_sublist_id: null } );
+			setError(
+				sprintf(
+					// Translators: Error shown when we can't find the selected list for a newsletter. %s is the ESP's label for the list entity.
+					__( 'Could not find the selected %s. It may have been deleted in your email service provider.', 'newspack-newsletters' ),
+					listLabel
+				)
+			);
+		}
+
+		// If the sublist ID doesn't match any fetched sublists reset the sublist ID.
+		if ( sublistId && listId && ! sublists?.find( item => item.id.toString() === sublistId.toString() ) ) {
+			updateMeta( { send_sublist_id: null } );
+			setError(
+				sprintf(
+					// Translators: Error shown when we can't find the selected sublist for a newsletter. %s is the ESP's label for the sublist entity or entities.
+					__( 'Could not find the selected %s. It may have been deleted in your email service provider.', 'newspack-newsletters' ),
+					sublistLabel
+				)
+			);
+		}
+	}, [ newsletterData?.lists, newsletterData?.sublists, listId, sublistId ] );
 
 	const renderSelectedSummary = () => {
 		if ( ! selectedList?.name || ( selectedSublist && ! selectedSublist.name ) ) {


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes https://linear.app/a8c/issue/NPPM-2202/newspack-newsletter-inconsistent-send-failures

This PR fixes an issue where a layout with invalid list data will cause new newsletters to be send-able with no list data.

### How to test the changes in this Pull Request:

You will need two different ESP accounts to test this.

1. As admin, ensure your ESP is connected
2. Create a new newsletter
3. Enter sender information and select a list and sublist
4. Save the current newsletter as a new layout
5. Now go to Newsletter > Settings and connect the second ESP account
6. Go back to Newsletters and create a new newsletter from the saved layout from step 4
7. On `release`, the newsletter will become send-able after the draft is saved. You will also notice the lists section of the sidebar seems to be stuck attempting to fetch lists. On this branch, you should see an error in this section letting you know the list could not be found and the newsletter will not be send-able.

Before:
![Screenshot 2025-08-29 at 15 16 33](https://github.com/user-attachments/assets/fc28cf3d-ffe7-4799-b577-09927c33aad4)

After:
![Screenshot 2025-08-29 at 17 31 58](https://github.com/user-attachments/assets/477825a0-0510-4b4d-933c-4ef75a1034e4)

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
