### PR TITLE
feat: keep line breaks on lists descriptions

### DIFF
--- a/src/blocks/subscribe/edit.js
+++ b/src/blocks/subscribe/edit.js
@@ -4,14 +4,13 @@
  * External dependencies.
  */
 import classnames from 'classnames';
-import React from 'react';
 
 /**
  * WordPress dependencies
  */
 import apiFetch from '@wordpress/api-fetch';
 import { __, sprintf } from '@wordpress/i18n';
-import { useState, useEffect } from '@wordpress/element';
+import { Fragment, useState, useEffect } from '@wordpress/element';
 import {
 	TextControl,
 	ToggleControl,
@@ -343,11 +342,11 @@ export default function SubscribeEdit( {
 															<span className="list-title">{ listConfig[ listId ]?.title }</span>
 															{ displayDescription && (
 																<span className="list-description">
-																	{ listConfig[ listId ]?.description?.split( '\n' ).map( ( line, index ) => (
-																		<React.Fragment key={ index }>
+																	{ listConfig[ listId ]?.description?.split( '\n' ).map( ( line, index, arr ) => (
+																		<Fragment key={ index }>
 																			{ line }
-																			{ index < listConfig[ listId ].description.split( '\n' ).length - 1 && <br /> }
-																		</React.Fragment>
+																			{ index < arr.length - 1 && <br /> }
+																		</Fragment>
 																	) ) }
 																</span>
 															) }

--- a/src/blocks/subscribe/edit.js
+++ b/src/blocks/subscribe/edit.js
@@ -4,6 +4,7 @@
  * External dependencies.
  */
 import classnames from 'classnames';
+import React from 'react';
 
 /**
  * WordPress dependencies
@@ -342,7 +343,12 @@ export default function SubscribeEdit( {
 															<span className="list-title">{ listConfig[ listId ]?.title }</span>
 															{ displayDescription && (
 																<span className="list-description">
-																	{ listConfig[ listId ]?.description }
+																	{ listConfig[ listId ]?.description?.split( '\n' ).map( ( line, index ) => (
+																		<React.Fragment key={ index }>
+																			{ line }
+																			{ index < listConfig[ listId ].description.split( '\n' ).length - 1 && <br /> }
+																		</React.Fragment>
+																	) ) }
 																</span>
 															) }
 														</label>

--- a/src/blocks/subscribe/index.php
+++ b/src/blocks/subscribe/index.php
@@ -216,7 +216,7 @@ function render_block( $attrs ) {
 									<label for="<?php echo \esc_attr( $checkbox_id ); ?>">
 										<span class="list-title"><?php echo \esc_html( $list['title'] ); ?></span>
 										<?php if ( $attrs['displayDescription'] ) : ?>
-											<span class="list-description"><?php echo \esc_html( $list['description'] ); ?></span>
+											<span class="list-description"><?php echo nl2br( \esc_html( $list['description'] ) ); ?></span>
 										<?php endif; ?>
 									</label>
 								</span>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Some publishers want to have a little more flexibility when writing the lists descriptions. Maybe we can add a rich editor to that field, but as a short term solution, one thing that was asked was the ability to add line breaks.

This PR adds it.

### How to test the changes in this Pull Request:

1. Go to Newsletters Settings
2. Edit a few lists descriptions adding line breaks to it
3. Go to the editor and add a Newsletter Subscription block
4. Confirm the line breaks are displayed in the block
5. Save the post and visit it. Confirm the line breaks are also maintained in the front end
6. Test all layouts
7. Test it without the main Newspack plugin, saving the description through the native WP settings page

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
