### PR TITLE
fix: check whether useNewsletterData is retrieving

### DIFF
--- a/src/components/send-button/index.js
+++ b/src/components/send-button/index.js
@@ -171,7 +171,7 @@ export default compose( [
 		}, [ saveDidSucceed ] );
 
 		const { is_public } = meta;
-		const newsletterData = useNewsletterData();
+		const { newsletterData } = useNewsletterData();
 
 		const newsletterValidationErrors = validateNewsletter( meta );
 
@@ -255,7 +255,7 @@ export default compose( [
 			} );
 			savePost();
 		};
-		
+
 		// For sent newsletters, display the generic button text.
 		if ( isPublished || sent ) {
 			return (

--- a/src/newsletter-editor/campaign-link/index.js
+++ b/src/newsletter-editor/campaign-link/index.js
@@ -11,7 +11,7 @@ import { getServiceProvider } from '../../service-providers';
 import { useNewsletterData } from '../../newsletter-editor/store';
 
 export default function CampaignLink() {
-	const newsletterData = useNewsletterData();
+	const { newsletterData } = useNewsletterData();
 	if ( ! newsletterData.link ) {
 		return null;
 	}

--- a/src/newsletter-editor/sidebar/index.js
+++ b/src/newsletter-editor/sidebar/index.js
@@ -42,7 +42,7 @@ const Sidebar = ( {
 } ) => {
 	const [ plainTextTitle, setPlainTextTitle ] = useState( null );
 	const isRetrieving = useIsRetrieving();
-	const newsletterData = useNewsletterData();
+	const { newsletterData } = useNewsletterData();
 	const newsletterDataError = useNewsletterDataError();
 	const campaign = newsletterData?.campaign;
 	const updateMeta = ( toUpdate ) => editPost( { meta: toUpdate } );

--- a/src/newsletter-editor/sidebar/send-to.js
+++ b/src/newsletter-editor/sidebar/send-to.js
@@ -30,7 +30,7 @@ const SendTo = () => {
 	const editPost = useDispatch( 'core/editor' ).editPost;
 	const updateMeta = ( meta ) => editPost( { meta } );
 
-	const { newsletterData: { lists = [], sublists, send_list_id = null, send_sublist_id = null }, isRetrieving } = useNewsletterData();
+	const { newsletterData: { lists = [], sublists, send_list_id = null, send_sublist_id = null }, isRetrievingLists, hasRetrievedLists } = useNewsletterData();
 	const { labels } = newspack_newsletters_data || {};
 	const listLabel = labels?.list || __( 'list', 'newspack-newsletters' );
 	const sublistLabel = labels?.sublist || __( 'sublist', 'newspack-newsletters' );
@@ -45,7 +45,11 @@ const SendTo = () => {
 		}
 	}, [] );
 
+	// Handle fetching lists and sublists as needed.
 	useEffect( () => {
+		if ( isRetrievingLists ) {
+			return;
+		}
 		// If we have a selected list ID but no list info, fetch it.
 		if ( listId && ! selectedList ) {
 			fetchSendLists( { ids: [ listId ] } );
@@ -61,10 +65,11 @@ const SendTo = () => {
 			fetchSendLists( { type: 'sublist', parent_id: listId }, true );
 			updateMeta( { send_sublist_id: null } );
 		}
-	}, [ lists, sublists, listId, sublistId ] );
+	}, [ listId, sublistId ] );
 
+	// Handle cases where the selected list or sublist is no longer valid.
 	useEffect( () => {
-		if ( isRetrieving || ! lists.length ) {
+		if ( isRetrievingLists || ! hasRetrievedLists || ! lists.length ) {
 			return;
 		}
 		// If the list ID doesn't match any fetched lists reset the list and sublist IDs.
@@ -79,9 +84,8 @@ const SendTo = () => {
 			);
 			return;
 		}
-
 		// If the sublist ID doesn't match any fetched sublists reset the sublist ID.
-		if ( sublistId && listId && ! sublists?.find( item => item.id.toString() === sublistId.toString() ) ) {
+		if ( listId && sublistId && ! sublists?.find( item => item.id.toString() === sublistId.toString() ) ) {
 			updateMeta( { send_sublist_id: null } );
 			setError(
 				sprintf(
@@ -91,7 +95,7 @@ const SendTo = () => {
 				)
 			);
 		}
-	}, [ isRetrieving, lists, sublists ] );
+	}, [ lists, sublists ] );
 
 	const renderSelectedSummary = () => {
 		if ( ! selectedList?.name || ( selectedSublist && ! selectedSublist.name ) ) {

--- a/src/newsletter-editor/sidebar/send-to.js
+++ b/src/newsletter-editor/sidebar/send-to.js
@@ -12,7 +12,7 @@ import { useEffect, useState } from '@wordpress/element';
  * Internal dependencies
  */
 import Autocomplete from './autocomplete';
-import { fetchSendLists, useIsRetrieving, useNewsletterData } from '../store';
+import { fetchSendLists, useNewsletterData } from '../store';
 import { usePrevious } from '../utils';
 
 // The container for list + sublist autocomplete fields.
@@ -30,9 +30,7 @@ const SendTo = () => {
 	const editPost = useDispatch( 'core/editor' ).editPost;
 	const updateMeta = ( meta ) => editPost( { meta } );
 
-	const newsletterData = useNewsletterData();
-	const isRetrieving = useIsRetrieving();
-	const { lists = [], sublists } = newsletterData; // All ESPs have lists, but not all have sublists.
+	const { newsletterData: { lists = [], sublists, send_list_id = null, send_sublist_id = null }, isRetrieving } = useNewsletterData();
 	const { labels } = newspack_newsletters_data || {};
 	const listLabel = labels?.list || __( 'list', 'newspack-newsletters' );
 	const sublistLabel = labels?.sublist || __( 'sublist', 'newspack-newsletters' );
@@ -63,10 +61,10 @@ const SendTo = () => {
 			fetchSendLists( { type: 'sublist', parent_id: listId }, true );
 			updateMeta( { send_sublist_id: null } );
 		}
-	}, [ newsletterData, listId, sublistId ] );
+	}, [ lists, sublists, listId, sublistId ] );
 
 	useEffect( () => {
-		if ( isRetrieving || ! ( lists?.length || sublists?.length ) ) {
+		if ( isRetrieving || ! lists.length ) {
 			return;
 		}
 		// If the list ID doesn't match any fetched lists reset the list and sublist IDs.
@@ -152,7 +150,7 @@ const SendTo = () => {
 				</Notice>
 			) }
 			{
-				( newsletterData?.send_list_id || newsletterData?.send_sublist_id ) && (
+				( send_list_id || send_sublist_id ) && (
 					<Notice status="success" isDismissible={ false }>
 						{ __( 'Updated send-to info fetched from ESP.', 'newspack-newsletters' ) }
 					</Notice>

--- a/src/newsletter-editor/sidebar/send-to.js
+++ b/src/newsletter-editor/sidebar/send-to.js
@@ -12,7 +12,7 @@ import { useEffect, useState } from '@wordpress/element';
  * Internal dependencies
  */
 import Autocomplete from './autocomplete';
-import { fetchSendLists, useNewsletterData } from '../store';
+import { fetchSendLists, useIsRetrieving, useNewsletterData } from '../store';
 import { usePrevious } from '../utils';
 
 // The container for list + sublist autocomplete fields.
@@ -31,6 +31,7 @@ const SendTo = () => {
 	const updateMeta = ( meta ) => editPost( { meta } );
 
 	const newsletterData = useNewsletterData();
+	const isRetrieving = useIsRetrieving();
 	const { lists = [], sublists } = newsletterData; // All ESPs have lists, but not all have sublists.
 	const { labels } = newspack_newsletters_data || {};
 	const listLabel = labels?.list || __( 'list', 'newspack-newsletters' );
@@ -62,7 +63,12 @@ const SendTo = () => {
 			fetchSendLists( { type: 'sublist', parent_id: listId }, true );
 			updateMeta( { send_sublist_id: null } );
 		}
+	}, [ newsletterData, listId, sublistId ] );
 
+	useEffect( () => {
+		if ( isRetrieving || ! ( lists?.length || sublists?.length ) ) {
+			return;
+		}
 		// If the list ID doesn't match any fetched lists reset the list and sublist IDs.
 		if ( listId && ! lists.find( item => item.id.toString() === listId.toString() ) ) {
 			updateMeta( { send_list_id: null, send_sublist_id: null } );
@@ -73,6 +79,7 @@ const SendTo = () => {
 					listLabel
 				)
 			);
+			return;
 		}
 
 		// If the sublist ID doesn't match any fetched sublists reset the sublist ID.
@@ -86,7 +93,7 @@ const SendTo = () => {
 				)
 			);
 		}
-	}, [ newsletterData?.lists, newsletterData?.sublists, listId, sublistId ] );
+	}, [ isRetrieving, lists, sublists ] );
 
 	const renderSelectedSummary = () => {
 		if ( ! selectedList?.name || ( selectedSublist && ! selectedSublist.name ) ) {

--- a/src/newsletter-editor/sidebar/sender.js
+++ b/src/newsletter-editor/sidebar/sender.js
@@ -25,7 +25,7 @@ const Sender = (
 		updateMeta
 	}
 ) => {
-	const newsletterData = useNewsletterData();
+	const { newsletterData } = useNewsletterData();
 	const { allowed_sender_domains: allowedDomains, allowed_sender_emails: allowedEmails = null, email_settings_url: settingsUrl } = newsletterData;
 	const senderEmailClasses = classnames(
 		'newspack-newsletters__email-textcontrol',

--- a/src/newsletter-editor/store.js
+++ b/src/newsletter-editor/store.js
@@ -28,7 +28,9 @@ import { debounce, sortBy } from 'lodash';
 export const STORE_NAMESPACE = 'newspack/newsletters';
 
 const DEFAULT_STATE = {
-	isRetrieving: false,
+	isRetrievingData: false,
+	isRetrievingLists: false,
+	isRetrievingSyncErrors: false,
 	isRefreshingHtml: false,
 	newsletterData: {},
 	shouldSendTest: false,
@@ -37,8 +39,12 @@ const DEFAULT_STATE = {
 const createAction = type => payload => ( { type, payload } );
 const reducer = ( state = DEFAULT_STATE, { type, payload = {} } ) => {
 	switch ( type ) {
-		case 'SET_IS_RETRIEVING':
-			return { ...state, isRetrieving: payload };
+		case 'SET_IS_RETRIEVING_DATA':
+			return { ...state, isRetrievingData: payload };
+		case 'SET_IS_RETRIEVING_LISTS':
+			return { ...state, isRetrievingLists: payload };
+		case 'SET_IS_RETRIEVING_SYNC_ERRORS':
+			return { ...state, isRetrievingSyncErrors: payload };
 		case 'SET_IS_REFRESHING_HTML':
 			return { ...state, isRefreshingHtml: payload };
 		case 'SET_DATA':
@@ -53,14 +59,18 @@ const reducer = ( state = DEFAULT_STATE, { type, payload = {} } ) => {
 
 const actions = {
 	// Regular actions.
-	setIsRetrieving: createAction( 'SET_IS_RETRIEVING' ),
+	setIsRetrievingData: createAction( 'SET_IS_RETRIEVING_DATA' ),
+	setIsRetrievingLists: createAction( 'SET_IS_RETRIEVING_LISTS' ),
+	setIsRetrievingSyncErrors: createAction( 'SET_IS_RETRIEVING_SYNC_ERRORS' ),
 	setIsRefreshingHtml: createAction( 'SET_IS_REFRESHING_HTML' ),
 	setData: createAction( 'SET_DATA' ),
 	setError: createAction( 'SET_ERROR' ),
 };
 
 const selectors = {
-	getIsRetrieving: state => state.isRetrieving,
+	getIsRetrievingData: state => state.isRetrievingData,
+	getIsRetrievingLists: state => state.isRetrievingLists,
+	getIsRetrievingSyncErrors: state => state.isRetrievingSyncErrors,
 	getIsRefreshingHtml: state => state.isRefreshingHtml,
 	getData: state => state.newsletterData || {},
 	getError: state => state.error,
@@ -77,9 +87,10 @@ export const registerStore = () => register( store );
 
 // Hook to use the retrieval status from any editor component.
 export const useIsRetrieving = () =>
-	useSelect( select =>
-		select( STORE_NAMESPACE ).getIsRetrieving()
-	);
+	useSelect( select => {
+		const { getIsRetrievingData, getIsRetrievingLists, getIsRetrievingSyncErrors } = select( STORE_NAMESPACE );
+		return getIsRetrievingData() || getIsRetrievingLists() || getIsRetrievingSyncErrors();
+	} );
 
 // Hook to use the refresh HTML status from any editor component.
 export const useIsRefreshingHtml = () =>
@@ -89,9 +100,13 @@ export const useIsRefreshingHtml = () =>
 
 // Hook to use the newsletter data from any editor component.
 export const useNewsletterData = () =>
-	useSelect( select =>
-		select( STORE_NAMESPACE ).getData()
-	);
+	useSelect( select => {
+		const { getData, getIsRetrievingData } = select( STORE_NAMESPACE );
+		return {
+			newsletterData: getData(),
+			isRetrieving: getIsRetrievingData(),
+		}
+	} );
 
 // Hook to use newsletter data fetch errors from any editor component.
 export const useNewsletterDataError = () =>
@@ -99,10 +114,17 @@ export const useNewsletterDataError = () =>
 		select( STORE_NAMESPACE ).getError()
 	);
 
+// Dispatcher to update data retrieval status in the store.
+export const updateIsRetrievingData = isRetrieving =>
+	dispatch( STORE_NAMESPACE ).setIsRetrievingData( isRetrieving );
 
-// Dispatcher to update retrieval status in the store.
-export const updateIsRetrieving = isRetrieving =>
-	dispatch( STORE_NAMESPACE ).setIsRetrieving( isRetrieving );
+// Dispatcher to update data retrieval status in the store.
+export const updateIsRetrievingLists = isRetrieving =>
+	dispatch( STORE_NAMESPACE ).setIsRetrievingLists( isRetrieving );
+
+// Dispatcher to update error retrieval status in the store.
+export const updateIsRetrievingSyncErrors = isRetrieving =>
+	dispatch( STORE_NAMESPACE ).setIsRetrievingSyncErrors( isRetrieving );
 
 // Dispatcher to update refreshing HTML status in the store.
 export const updateIsRefreshingHtml = isRetrieving =>
@@ -122,11 +144,11 @@ export const fetchNewsletterData = async postId => {
 		return;
 	}
 
-	const isRetrieving = coreSelect( STORE_NAMESPACE ).getIsRetrieving();
+	const isRetrieving = coreSelect( STORE_NAMESPACE ).getIsRetrievingData();
 	if ( isRetrieving ) {
 		return;
 	}
-	updateIsRetrieving( true );
+	updateIsRetrievingData( true );
 	updateNewsletterDataError( null );
 	try {
 		const { name } = getServiceProvider();
@@ -147,7 +169,7 @@ export const fetchNewsletterData = async postId => {
 	} catch ( error ) {
 		updateNewsletterDataError( error );
 	}
-	updateIsRetrieving( false );
+	updateIsRetrievingData( false );
 	return true;
 };
 
@@ -157,11 +179,11 @@ export const fetchSyncErrors = async postId => {
 		return;
 	}
 
-	const isRetrieving = coreSelect( STORE_NAMESPACE ).getIsRetrieving();
+	const isRetrieving = coreSelect( STORE_NAMESPACE ).getIsRetrievingSyncErrors();
 	if ( isRetrieving ) {
 		return;
 	}
-	updateIsRetrieving( true );
+	updateIsRetrievingSyncErrors( true );
 	updateNewsletterDataError( null );
 	try {
 		const response = await apiFetch( {
@@ -173,7 +195,7 @@ export const fetchSyncErrors = async postId => {
 	} catch ( error ) {
 		updateNewsletterDataError( error );
 	}
-	updateIsRetrieving( false );
+	updateIsRetrievingSyncErrors( false );
 	return true;
 }
 
@@ -224,11 +246,11 @@ export const fetchSendLists = debounce( async ( opts, replace = false ) => {
 		const updatedSendLists = replace ? [] : [ ...sendLists ];
 
 		// If no existing items found, fetch from the ESP.
-		const isRetrieving = coreSelect( STORE_NAMESPACE ).getIsRetrieving();
+		const isRetrieving = coreSelect( STORE_NAMESPACE ).getIsRetrievingLists();
 		if ( isRetrieving ) {
 			return;
 		}
-		updateIsRetrieving( true );
+		updateIsRetrievingLists( true );
 		const response = await apiFetch( {
 			path: addQueryArgs(
 				'/newspack-newsletters/v1/send-lists',
@@ -251,5 +273,5 @@ export const fetchSendLists = debounce( async ( opts, replace = false ) => {
 	} catch ( error ) {
 		updateNewsletterDataError( error );
 	}
-	updateIsRetrieving( false );
+	updateIsRetrievingLists( false );
 }, 500 );

--- a/src/newsletter-editor/store.js
+++ b/src/newsletter-editor/store.js
@@ -28,6 +28,9 @@ import { debounce, sortBy } from 'lodash';
 export const STORE_NAMESPACE = 'newspack/newsletters';
 
 const DEFAULT_STATE = {
+	hasRetrievedData: false,
+	hasRetrievedLists: false,
+	hasRetrievedSyncErrors: false,
 	isRetrievingData: false,
 	isRetrievingLists: false,
 	isRetrievingSyncErrors: false,
@@ -45,6 +48,12 @@ const reducer = ( state = DEFAULT_STATE, { type, payload = {} } ) => {
 			return { ...state, isRetrievingLists: payload };
 		case 'SET_IS_RETRIEVING_SYNC_ERRORS':
 			return { ...state, isRetrievingSyncErrors: payload };
+		case 'SET_HAS_RETRIEVED_DATA':
+			return { ...state, hasRetrievedData: payload };
+		case 'SET_HAS_RETRIEVED_LISTS':
+			return { ...state, hasRetrievedLists: payload };
+		case 'SET_HAS_RETRIEVED_SYNC_ERRORS':
+			return { ...state, hasRetrievedSyncErrors: payload };
 		case 'SET_IS_REFRESHING_HTML':
 			return { ...state, isRefreshingHtml: payload };
 		case 'SET_DATA':
@@ -62,6 +71,9 @@ const actions = {
 	setIsRetrievingData: createAction( 'SET_IS_RETRIEVING_DATA' ),
 	setIsRetrievingLists: createAction( 'SET_IS_RETRIEVING_LISTS' ),
 	setIsRetrievingSyncErrors: createAction( 'SET_IS_RETRIEVING_SYNC_ERRORS' ),
+	setHasRetrievedData: createAction( 'SET_HAS_RETRIEVED_DATA' ),
+	setHasRetrievedLists: createAction( 'SET_HAS_RETRIEVED_LISTS' ),
+	setHasRetrievedSyncErrors: createAction( 'SET_HAS_RETRIEVED_SYNC_ERRORS' ),
 	setIsRefreshingHtml: createAction( 'SET_IS_REFRESHING_HTML' ),
 	setData: createAction( 'SET_DATA' ),
 	setError: createAction( 'SET_ERROR' ),
@@ -71,6 +83,9 @@ const selectors = {
 	getIsRetrievingData: state => state.isRetrievingData,
 	getIsRetrievingLists: state => state.isRetrievingLists,
 	getIsRetrievingSyncErrors: state => state.isRetrievingSyncErrors,
+	getHasRetrievedData: state => state.hasRetrievedData,
+	getHasRetrievedLists: state => state.hasRetrievedLists,
+	getHasRetrievedSyncErrors: state => state.hasRetrievedSyncErrors,
 	getIsRefreshingHtml: state => state.isRefreshingHtml,
 	getData: state => state.newsletterData || {},
 	getError: state => state.error,
@@ -101,10 +116,13 @@ export const useIsRefreshingHtml = () =>
 // Hook to use the newsletter data from any editor component.
 export const useNewsletterData = () =>
 	useSelect( select => {
-		const { getData, getIsRetrievingData } = select( STORE_NAMESPACE );
+		const { getData, getIsRetrievingData, getIsRetrievingLists } = select( STORE_NAMESPACE );
 		return {
 			newsletterData: getData(),
-			isRetrieving: getIsRetrievingData(),
+			isRetrievingData: getIsRetrievingData(),
+			isRetrievingLists: getIsRetrievingLists(),
+			hasRetrievedData: select( STORE_NAMESPACE ).getHasRetrievedData(),
+			hasRetrievedLists: select( STORE_NAMESPACE ).getHasRetrievedLists(),
 		}
 	} );
 
@@ -125,6 +143,18 @@ export const updateIsRetrievingLists = isRetrieving =>
 // Dispatcher to update error retrieval status in the store.
 export const updateIsRetrievingSyncErrors = isRetrieving =>
 	dispatch( STORE_NAMESPACE ).setIsRetrievingSyncErrors( isRetrieving );
+
+// Dispatcher to update data retrieved status in the store.
+export const updateHasRetrievedData = hasRetrieved =>
+	dispatch( STORE_NAMESPACE ).setHasRetrievedData( hasRetrieved );
+
+// Dispatcher to update lists retrieved status in the store.
+export const updateHasRetrievedLists = hasRetrieved =>
+	dispatch( STORE_NAMESPACE ).setHasRetrievedLists( hasRetrieved );
+
+// Dispatcher to update sync errors retrieved status in the store.
+export const updateHasRetrievedSyncErrors = hasRetrieved =>
+	dispatch( STORE_NAMESPACE ).setHasRetrievedSyncErrors( hasRetrieved );
 
 // Dispatcher to update refreshing HTML status in the store.
 export const updateIsRefreshingHtml = isRetrieving =>
@@ -148,6 +178,7 @@ export const fetchNewsletterData = async postId => {
 	if ( isRetrieving ) {
 		return;
 	}
+	updateHasRetrievedData( false );
 	updateIsRetrievingData( true );
 	updateNewsletterDataError( null );
 	try {
@@ -166,8 +197,10 @@ export const fetchNewsletterData = async postId => {
 			updatedNewsletterData.sublists = newsletterData.sublists;
 		}
 		updateNewsletterData( updatedNewsletterData );
+		updateHasRetrievedData( true );
 	} catch ( error ) {
 		updateNewsletterDataError( error );
+		updateHasRetrievedData( false );
 	}
 	updateIsRetrievingData( false );
 	return true;
@@ -250,6 +283,7 @@ export const fetchSendLists = debounce( async ( opts, replace = false ) => {
 		if ( isRetrieving ) {
 			return;
 		}
+		updateHasRetrievedLists( false );
 		updateIsRetrievingLists( true );
 		const response = await apiFetch( {
 			path: addQueryArgs(
@@ -270,8 +304,10 @@ export const fetchSendLists = debounce( async ( opts, replace = false ) => {
 		}
 
 		updateNewsletterData( updatedNewsletterData );
+		updateHasRetrievedLists( true );
 	} catch ( error ) {
 		updateNewsletterDataError( error );
+		updateHasRetrievedLists( false );
 	}
 	updateIsRetrievingLists( false );
 }, 500 );

--- a/src/service-providers/mailchimp/ProviderSidebar.js
+++ b/src/service-providers/mailchimp/ProviderSidebar.js
@@ -14,7 +14,7 @@ export const ProviderSidebar = ( {
 	meta,
 	updateMeta,
 } ) => {
-	const newsletterData = useNewsletterData();
+	const { newsletterData } = useNewsletterData();
 	const { campaign, folders } = newsletterData;
 
 	const getFolderOptions = () => {


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Hotfix https://github.com/Automattic/newspack-newsletters/pull/1905 looks to have broken sublists when creating from a layout.

This PR fixes this by ensuring we wait until newsletter data has finished fetching from the backend BEFORE clearing any list or sublist id meta.

### How to test the changes in this Pull Request:

This PR is simplest to test if you have two accounts for the same ESP

1. As admin, ensure your ESP is connected and has at least one sublist/group created
2. Create a new newsletter
3. Enter sender information and select a list and sublist
4. Save the current newsletter as a new layout
5. Exit and create a new newsletter using this new layout
6. On `release`, the sublist will be cleared with an error. On this branch it should not.
7. Now go to Newsletter > Settings and connect the second ESP account
8. Go back to Newsletters and create a new newsletter from the saved layout from step 4
9. Ensure both List and Sublists are cleared with an error

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
