### PR TITLE
fix: only throw error if we have fetched lists/sublists

### DIFF
--- a/src/newsletter-editor/sidebar/send-to.js
+++ b/src/newsletter-editor/sidebar/send-to.js
@@ -12,7 +12,7 @@ import { useEffect, useState } from '@wordpress/element';
  * Internal dependencies
  */
 import Autocomplete from './autocomplete';
-import { fetchSendLists, useNewsletterData } from '../store';
+import { fetchSendLists, useIsRetrieving, useNewsletterData } from '../store';
 import { usePrevious } from '../utils';
 
 // The container for list + sublist autocomplete fields.
@@ -31,6 +31,7 @@ const SendTo = () => {
 	const updateMeta = ( meta ) => editPost( { meta } );
 
 	const newsletterData = useNewsletterData();
+	const isRetrieving = useIsRetrieving();
 	const { lists = [], sublists } = newsletterData; // All ESPs have lists, but not all have sublists.
 	const { labels } = newspack_newsletters_data || {};
 	const listLabel = labels?.list || __( 'list', 'newspack-newsletters' );
@@ -64,7 +65,7 @@ const SendTo = () => {
 		}
 
 		// If the list ID doesn't match any fetched lists reset the list and sublist IDs.
-		if ( listId && ! lists.find( item => item.id.toString() === listId.toString() ) ) {
+		if ( ! isRetrieving && listId && lists.length > 0 && ! lists.find( item => item.id.toString() === listId.toString() ) ) {
 			updateMeta( { send_list_id: null, send_sublist_id: null } );
 			setError(
 				sprintf(
@@ -76,7 +77,7 @@ const SendTo = () => {
 		}
 
 		// If the sublist ID doesn't match any fetched sublists reset the sublist ID.
-		if ( sublistId && listId && ! sublists?.find( item => item.id.toString() === sublistId.toString() ) ) {
+		if ( ! isRetrieving && sublistId && sublists.length > 0 && listId && ! sublists?.find( item => item.id.toString() === sublistId.toString() ) ) {
 			updateMeta( { send_sublist_id: null } );
 			setError(
 				sprintf(
@@ -86,7 +87,7 @@ const SendTo = () => {
 				)
 			);
 		}
-	}, [ newsletterData?.lists, newsletterData?.sublists, listId, sublistId ] );
+	}, [ newsletterData?.lists, newsletterData?.sublists, listId, sublistId, isRetrieving ] );
 
 	const renderSelectedSummary = () => {
 		if ( ! selectedList?.name || ( selectedSublist && ! selectedSublist.name ) ) {


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes # .

### How to test the changes in this Pull Request:

1.
2.
3.

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
