### PR TITLE
hotfix: email html update handling

### DIFF
--- a/src/components/send-button/index.js
+++ b/src/components/send-button/index.js
@@ -47,8 +47,8 @@ function PreviewHTML() {
 
 	useEffect( () => {
 		if ( ! previewHtml ) {
-			refreshEmailHtml( postId, postTitle, postContent ).then( refreshedHtml => {
-				setPreviewHtml( refreshedHtml );
+			refreshEmailHtml( postId, postTitle, postContent ).then( ( { html } ) => {
+				setPreviewHtml( html );
 			} );
 		}
 	}, [] );
@@ -111,7 +111,8 @@ function PreviewHTMLButton() {
 export default compose( [
 	withDispatch( dispatch => {
 		const { editPost, savePost } = dispatch( 'core/editor' );
-		return { editPost, savePost };
+		const { createNotice } = dispatch( 'core/notices' );
+		return { editPost, savePost, createNotice };
 	} ),
 	withSelect( ( select ) => {
 		const {
@@ -125,7 +126,10 @@ export default compose( [
 			isSavingPost,
 			isEditedPostBeingScheduled,
 			isCurrentPostPublished,
+			getEditedPostContent,
+			getCurrentPostId,
 		} = select( 'core/editor' );
+
 		return {
 			isPublishable: isEditedPostPublishable(),
 			isSaveable: isEditedPostSaveable(),
@@ -139,12 +143,16 @@ export default compose( [
 			sent: getCurrentPostAttribute( 'meta' ).newsletter_sent,
 			isPublished: isCurrentPostPublished(),
 			postDate: getEditedPostAttribute( 'date' ),
+			postContent: getEditedPostContent(),
+			postId: getCurrentPostId(),
+			postTitle: getEditedPostAttribute( 'title' ),
 		};
 	} ),
 ] )(
 	( {
 		editPost,
 		savePost,
+		createNotice,
 		isPublishable,
 		isSaveable,
 		isSaving,
@@ -157,11 +165,11 @@ export default compose( [
 		sent,
 		isPublished,
 		postDate,
+		postContent,
+		postId,
+		postTitle,
 	} ) => {
 		const [ modalVisible, setModalVisible ] = useState( false );
-
-		// Check if we're scheduling with a past date
-		const isSchedulingInPast = status = 'future' && postDate && new Date( postDate ) < new Date();
 
 		// If the save request failed, close any open modals so the error message can be seen underneath.
 		useEffect( () => {
@@ -197,11 +205,14 @@ export default compose( [
 					? __( 'Sent and Published', 'newspack-newsletters' )
 					: __( 'Sent', 'newspack-newsletters' );
 			}
-		} else if ( isSchedulingInPast ) {
-			label = __( 'Send', 'newspack-newsletters' );
 		} else if ( 'future' === status ) {
-			// Scheduled to be sent
-			label = __( 'Scheduled', 'newspack-newsletters' );
+			if ( postDate && new Date( postDate ) < new Date() ) {
+				// Scheduled, but in the past ¯\_(ツ)_/¯.
+				label = __( 'Send', 'newspack-newsletters' );
+			} else {
+				// Scheduled to be sent.
+				label = __( 'Scheduled', 'newspack-newsletters' );
+			}
 		} else if ( isEditedPostBeingScheduled ) {
 			label = __( 'Schedule sending', 'newspack-newsletters' );
 		} else {
@@ -312,6 +323,20 @@ export default compose( [
 			);
 		}
 
+		const handleModalOpen = async () => {
+			const res = await refreshEmailHtml( postId, postTitle, postContent );
+			if ( res.result === 'success' ) {
+				setModalVisible( true );
+			} else {
+				let noticeString = __( 'Something went wrong when converting the post to email', 'newspack-newsletters' );
+				if ( res.error?.message ) {
+					noticeString += `: ${res.error.message}`
+				}
+				createNotice( 'error', noticeString );
+				setModalVisible( false );
+			}
+		}
+
 		return (
 			<div style={{ display: 'flex' }}>
 				{ 'future' === status && (
@@ -330,20 +355,7 @@ export default compose( [
 					className="editor-post-publish-button"
 					isBusy={ isSaving && 'publish' === status }
 					variant="primary"
-					onClick={ async () => {
-						if ( isSchedulingInPast ) {
-							setModalVisible( true );
-						} else {
-							try {
-								await savePost();
-								if ( saveDidSucceed ) {
-									setModalVisible( true );
-								}
-							} catch ( e ) {
-								setModalVisible( false );
-							}
-						}
-					} }
+					onClick={ handleModalOpen }
 					disabled={ ! isButtonEnabled }
 				>
 					{ label }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes an issue introduced in https://github.com/Automattic/newspack-newsletters/pull/1886 and adds error handling in post-to-email-html conversion. 

The original flow relied on `savePost()` before opening the modal, but this created a race condition where the modal could open before HTML refresh completed. The email HTML refreshing was the intended side effect of the post saving – in this PR, the email HTML is refreshed explicitly. This has created the possiblity of a race condition - the email HTML could have been stale at the time of sending, only being updated _after_ sending.

See NPPM-2201

### How to test the changes in this Pull Request:

I could not reproduce the race condition locally, but the guardrails can be tested anyway.

1. Create a new newsletter and fill in the fields required for sending (sender fields, list)
1. In network tab, block requests to `/newspack-newsletters/v1/post-mjml`
1. Click "Send", observe an error message
1. Switch to `release` branch, reload the editor, observe no error message on hitting "Send" 
1. Follow the steps in https://github.com/Automattic/newspack-newsletters/pull/1886 to make sure the bug fixed there is still fixed

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->