### PR TITLE
fix: persist meta populated from layout for new drafts

### DIFF
--- a/src/components/init-modal/screens/layout-picker/index.js
+++ b/src/components/init-modal/screens/layout-picker/index.js
@@ -34,7 +34,7 @@ const LAYOUTS_TABS = [
 ];
 
 export default function LayoutPicker() {
-	const { savePost, editPost, resetEditorBlocks } = useDispatch( 'core/editor' );
+	const { editPost, resetEditorBlocks } = useDispatch( 'core/editor' );
 	const { layouts, isFetchingLayouts, deleteLayoutPost } = useLayoutsState();
 
 	const insertLayout = layoutId => {
@@ -44,7 +44,6 @@ export default function LayoutPicker() {
 		}
 		editPost( { meta: { template_id: layoutId, ...meta } } );
 		resetEditorBlocks( post_content ? parse( post_content ) : [] );
-		savePost();
 	};
 
 	const [ selectedLayoutId, setSelectedLayoutId ] = useState( null );

--- a/src/newsletter-editor/sidebar/index.js
+++ b/src/newsletter-editor/sidebar/index.js
@@ -37,6 +37,7 @@ const Sidebar = ( {
 	status,
 	campaignName,
 	previewText,
+	savePost,
 	stringifiedCampaignDefaults,
 	postId,
 } ) => {
@@ -122,7 +123,9 @@ const Sidebar = ( {
 				updatedMeta.send_sublist_id = campaignDefaults.send_sublist_id;
 			}
 			if ( Object.keys( updatedMeta ).length ) {
+				updatedMeta.stringifiedCampaignDefaults = '';
 				updateMeta( updatedMeta );
+				savePost();
 			}
 		}
 	}, [ stringifiedCampaignDefaults ] );
@@ -260,8 +263,8 @@ export default compose( [
 		};
 	} ),
 	withDispatch( dispatch => {
-		const { editPost } = dispatch( 'core/editor' );
+		const { editPost, savePost } = dispatch( 'core/editor' );
 		const { createErrorNotice } = dispatch( 'core/notices' );
-		return { editPost, createErrorNotice };
+		return { editPost, savePost, createErrorNotice };
 	} ),
 ] )( Sidebar );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes an issue where newly created drafts don't get saved with meta populated from selecting a custom layout, causing any manual changes to be continually overwritten by the layout's values until the draft is manually saved.

### How to test the changes in this Pull Request:

1. On `release`, create a new newsletter draft using a custom layout that has sender name/email and send list/sublist set.
2. After the editor populates all of the layout's content and meta, do NOT save the post.
3. Still without saving, change the sender name/email and send list/sublist, then click away from the newsletter sidebar (such as selecting a block). Click back into the newsletter settings sidebar and observe that your changes have been overwritten by the layout's default values.
4. Check out this branch and repeat all steps with a new newsletter draft created from a custom layout. Confirm that after selecting the layout, any unsaved changes persist in newsletter settings throughout the editor session.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
