### PR TITLE
fix: trigger save before opening send modal

### DIFF
--- a/src/components/send-button/index.js
+++ b/src/components/send-button/index.js
@@ -325,7 +325,8 @@ export default compose( [
 
 		const handleModalOpen = async () => {
 			const res = await refreshEmailHtml( postId, postTitle, postContent );
-			if ( res.result === 'success' ) {
+			await savePost();
+			if ( res.result === 'success' && saveDidSucceed ) {
 				setModalVisible( true );
 			} else {
 				let noticeString = __( 'Something went wrong when converting the post to email', 'newspack-newsletters' );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

#1909 fixed a potential race condition that could occur when clicking the "Send" button where a campaign could possibly be sent before email HTML finished refreshing (or if the request to refresh email HTML fails independently of the send request). However, this inadvertently changed editor behavior by not saving the post (and therefore not triggering a sync to the ESP campaign) when clicking the "Send" button. Editors had become accustomed to being certain that the preview shown in the pre-send modal would match the sent campaign content, but without the pre-send save/sync, this is not the case unless the editor manually saves the draft first.

This attempts to plug that hole by retaining the fix from #1909 (explicitly refreshing email HTML before opening the pre-send modal) but also re-adding a `savePost` request after this occurs. This results in multiple email refresh requests happening and a potentially slower pre-send modal response, but at least ensures that the campaign content and info are synced to the ESP before the campaign is sent. This might also avoid issues where send-to and sender info isn't synced to the campaign before sending if the draft isn't manually saved first.

### How to test the changes in this Pull Request:

1. On `release`, start a new newsletter draft and save it.
2. Fill in the required sender/send-to info, edit the draft's content, then _without clicking "save draft" first_ click "send".
3. Observe that in the pre-send modal, the preview shows the content and sender/send-to info as edited (but not saved) in step 2.
4. Click "send" from the pre-send modal. Observe that the campaign is sent with sender/send-to info and content matching the draft when last manually saved in step 1, rather than as edited and shown in the preview during step 3.
5. Check out this branch and repeat all steps with a new newsletter draft.
6. This time, confirm that the sent campaign always matches the info and content as shown in the pre-send modal.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
