### PR TITLE
fix: avoid errors

### DIFF
--- a/includes/service-providers/active_campaign/class-newspack-newsletters-active-campaign.php
+++ b/includes/service-providers/active_campaign/class-newspack-newsletters-active-campaign.php
@@ -327,6 +327,10 @@ final class Newspack_Newsletters_Active_Campaign extends \Newspack_Newsletters_S
 			'GET'
 		);
 
+		if ( is_wp_error( $result ) ) {
+			return $result;
+		}
+
 		return array_values(
 			array_map(
 				function ( $tag ) {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

This avoids a fatal error seen in some sites:

```
Cannot use object of type WP_Error as array in /wordpress/plugins/newspack-newsletters/3.21.0/includes/service-providers/active_campaign/class-newspack-newsletters-active-campaign.php:335
```

### How to test the changes in this Pull Request:

1. Check the code
2. smoke test

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
