### PR TITLE
fix(active-campaign): update api request header

### DIFF
--- a/includes/service-providers/active_campaign/class-newspack-newsletters-active-campaign.php
+++ b/includes/service-providers/active_campaign/class-newspack-newsletters-active-campaign.php
@@ -170,13 +170,11 @@ final class Newspack_Newsletters_Active_Campaign extends \Newspack_Newsletters_S
 			$options_query = $options['query'];
 			unset( $options['query'] );
 		}
-		$content_type = 'application/json';
-		$url          = rtrim( $credentials['url'], '/' ) . $api_path;
-		$body         = null;
-		$params       = wp_parse_args( $options_query, $params );
+		$url    = rtrim( $credentials['url'], '/' ) . $api_path;
+		$body   = null;
+		$params = wp_parse_args( $options_query, $params );
 		if ( 'POST' === $method ) {
-			$content_type = 'application/x-www-form-urlencoded';
-			$body         = wp_parse_args(
+			$body = wp_parse_args(
 				isset( $options['body'] ) ? $options['body'] : [],
 				$params
 			);
@@ -187,7 +185,7 @@ final class Newspack_Newsletters_Active_Campaign extends \Newspack_Newsletters_S
 			'method'  => $method,
 			'timeout' => 45, // phpcs:ignore WordPressVIPMinimum.Performance.RemoteRequestTimeout.timeout_timeout
 			'headers' => [
-				'Content-Type' => $content_type,
+				'Content-Type' => 'application/json',
 				'Accept'       => 'application/json',
 				'API-TOKEN'    => $credentials['key'],
 			],
@@ -326,6 +324,10 @@ final class Newspack_Newsletters_Active_Campaign extends \Newspack_Newsletters_S
 			sprintf( 'contacts/%d/contactTags', $contact_data['id'] ),
 			'GET'
 		);
+
+		if ( is_wp_error( $result ) ) {
+			return $result;
+		}
 
 		return array_values(
 			array_map(

--- a/includes/service-providers/active_campaign/class-newspack-newsletters-active-campaign.php
+++ b/includes/service-providers/active_campaign/class-newspack-newsletters-active-campaign.php
@@ -181,7 +181,7 @@ final class Newspack_Newsletters_Active_Campaign extends \Newspack_Newsletters_S
 		} else {
 			$url = add_query_arg( $params, $url );
 		}
-		$args     = [
+		$args = [
 			'method'  => $method,
 			'timeout' => 45, // phpcs:ignore WordPressVIPMinimum.Performance.RemoteRequestTimeout.timeout_timeout
 			'headers' => [
@@ -189,8 +189,10 @@ final class Newspack_Newsletters_Active_Campaign extends \Newspack_Newsletters_S
 				'Accept'       => 'application/json',
 				'API-TOKEN'    => $credentials['key'],
 			],
-			'body'    => $body,
 		];
+		if ( $body ) {
+			$args['body'] = wp_json_encode( $body );
+		}
 		$response = wp_safe_remote_request( $url, $args + $options );
 		if ( is_wp_error( $response ) ) {
 			return $response;


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes https://linear.app/a8c/issue/NPPM-2282/activecampaign-newsletters-failing-to-send-with-missing-address

This fixes an issue where our POST requests are rejected by AC due to an invalid header and body.

### How to test the changes in this Pull Request:

1. Set up AC as ESP
2. Send an email to a list
3. Confirm the email is sent successfully

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
