### PR TITLE
fix(mailchimp): strip protocol strings from link-based merge tags

### DIFF
--- a/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp.php
+++ b/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp.php
@@ -1183,7 +1183,7 @@ final class Newspack_Newsletters_Mailchimp extends \Newspack_Newsletters_Service
 	 */
 	public function newsletter_content( $content ) {
 		// Strip protocol prefixes from link-based Mailchimp merge tags.
-		$content = preg_replace( '/href="https?:\/\/\*\|/', 'href="*|', $content );
+		$content = preg_replace( '/href="(?:https?:)?\/\/\*\|/', 'href="*|', $content );
 		return $content;
 	}
 

--- a/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp.php
+++ b/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp.php
@@ -59,6 +59,7 @@ final class Newspack_Newsletters_Mailchimp extends \Newspack_Newsletters_Service
 		$this->controller = new Newspack_Newsletters_Mailchimp_Controller( $this );
 		Newspack_Newsletters_Mailchimp_Cached_Data::init();
 
+		add_filter( 'newspack_newsletters_newsletter_content', [ $this, 'newsletter_content' ], 1, 2 );
 		add_action( 'updated_post_meta', [ $this, 'save' ], 10, 4 );
 		add_action( 'wp_trash_post', [ $this, 'trash' ], 10, 1 );
 		add_filter( 'newspack_newsletters_process_link', [ $this, 'process_link' ], 10, 2 );
@@ -1172,6 +1173,18 @@ final class Newspack_Newsletters_Mailchimp extends \Newspack_Newsletters_Service
 			set_transient( $transient_name, 'Mailchimp campaign sync error: ' . wp_specialchars_decode( $e->getMessage(), ENT_QUOTES ), 45 );
 			return new WP_Error( 'newspack_newsletters_mailchimp_error', $e->getMessage() );
 		}
+	}
+
+	/**
+	 * Filter newsletter content prior to converting to MJML.
+	 *
+	 * @param string $content The post content.
+	 * @return string The filtered post content.
+	 */
+	public function newsletter_content( $content ) {
+		// Strip protocol prefixes from link-based Mailchimp merge tags.
+		$content = preg_replace( '/href="https?:\/\/\*\|/', 'href="*|', $content );
+		return $content;
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Mailchimp requires that email sent through its service includes a footer with certain info. [More info here](https://mailchimp.com/help/about-campaign-footers/#Required_footer_content). If you create an email campaign using custom HTML content and it doesn't contain the necessary merge tags toward the bottom of the email, Mailchimp will [automatically append a standard email footer](https://mailchimp.com/help/customize-your-footer-content/#Troubleshooting_the_extra_footer) with the legally required info.

Newspack Newsletters users can customize their email layouts and/or content to include a custom footer, but because the WordPress block editor automatically appends a `http://` or `https://` protocol string to any text link's `href` attribute (so that `<a href="*|UNSUB|*">` becomes `<a href="https://*|UNSUB|*">`), Mailchimp fails to detect the required merge tags even if they're present in the email content and will append its own footer, resulting in a double footer.

This PR fixes the issue by filtering the post content just prior to being converted to MJML and using regex to strip protocol strings from any `href` attributes that contain a Mailchimp merge tag. 

Closes NPPM-2277.

### How to test the changes in this Pull Request:

1. Connect your test site to a Mailchimp account.
2. On `release`, create a newsletter draft and add a custom footer to the bottom of the content. Here's some test content with the required merge tags that you can copy/paste into your draft:

```html
<!-- wp:group {"layout":{"type":"constrained"}} -->
<div class="wp-block-group"><!-- wp:paragraph {"align":"center","fontSize":"small"} -->
<p class="has-text-align-center has-small-font-size">This email was sent to *|EMAIL|*. *|LIST:DESCRIPTION|*<br><a href="*|ABOUT_LIST|*" target="_blank" rel="noreferrer noopener"><em>why did I get this?</em></a>    <a href="*|UNSUB|*" target="_blank" rel="noreferrer noopener">unsubscribe from this list</a>    <a href="*|UPDATE_PROFILE|*" target="_blank" rel="noreferrer noopener">update subscription preferences</a><br>*|LIST:ADDRESSLINE|*</p>
<!-- /wp:paragraph -->

<!-- wp:paragraph {"align":"center","fontSize":"small"} -->
<p class="has-text-align-center has-small-font-size">*|REWARDS|*</p>
<!-- /wp:paragraph --></div>
<!-- /wp:group -->
```

3. Save the draft. 
4. View the campaign in Mailchimp and observe that Mailchimp has appended its own footer below the custom one in your email content.
5. Check out this branch and re-save the newsletter draft in the WP editor.
6. View the campaign in Mailchimp again and confirm that there's no extra Mailchimp footer below your custom footer.
7. Edit the links in the footer content and manually add different protocol strings to the links containing merge tags: `http://`, `https://`, and `//` (protocol-relative). Save again, view in Mailchimp and confirm that there's still no extra Mailchimp footer below your custom footer.
8. Review the new unit tests and confirm they make sense and are passing below 👇 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
