### PR TITLE
fix(activecampaign): only trigger contact deletion when in change email context

### DIFF
--- a/includes/class-newspack-newsletters-contacts.php
+++ b/includes/class-newspack-newsletters-contacts.php
@@ -141,6 +141,10 @@ class Newspack_Newsletters_Contacts {
 
 		$contact['existing_contact_data'] = \is_wp_error( $existing_contact ) ? false : $existing_contact;
 		$is_updating                      = \is_wp_error( $existing_contact ) ? false : true;
+		// Set a flag to indicate the contact is being updated via an email change action.
+		if ( $is_updating && 'Email_Change' === $context ) {
+			$contact['is_email_change'] = true;
+		}
 
 		/**
 		 * Filters the contact before passing on to the API.

--- a/includes/service-providers/active_campaign/class-newspack-newsletters-active-campaign.php
+++ b/includes/service-providers/active_campaign/class-newspack-newsletters-active-campaign.php
@@ -1415,7 +1415,7 @@ final class Newspack_Newsletters_Active_Campaign extends \Newspack_Newsletters_S
 		}
 
 		$contact_data          = $this->get_contact_data( $email );
-		$existing_email        = isset( $contact['existing_contact_data']['email'] ) ? $contact['existing_contact_data']['email'] : '';
+		$existing_email        = isset( $contact['existing_contact_data']['email'] ) ? trim( strtolower( $contact['existing_contact_data']['email'] ) ) : '';
 		$existing_contact_data = $this->get_contact_data( $existing_email );
 		if ( ! is_wp_error( $contact_data ) || ! is_wp_error( $existing_contact_data ) ) {
 			$action               = 'contact_edit';

--- a/includes/service-providers/active_campaign/class-newspack-newsletters-active-campaign.php
+++ b/includes/service-providers/active_campaign/class-newspack-newsletters-active-campaign.php
@@ -1349,7 +1349,7 @@ final class Newspack_Newsletters_Active_Campaign extends \Newspack_Newsletters_S
 			$contact['metadata'] = [];
 		}
 		$action  = 'contact_add';
-		$email   = $contact['email'];
+		$email   = trim( strtolower( $contact['email'] ) );
 		$payload = [
 			'email' => $email,
 		];
@@ -1421,11 +1421,14 @@ final class Newspack_Newsletters_Active_Campaign extends \Newspack_Newsletters_S
 			$action               = 'contact_edit';
 			$payload['id']        = is_wp_error( $contact_data ) ? $existing_contact_data['id'] : $contact_data['id'];
 			$payload['overwrite'] = 0;
-			// If the email address exists, but is different from the one we're trying to upsert, delete the existing contact.
+			// For email changes, if the email address exists, but is different from the one we're trying to upsert, delete the existing contact.
 			if ( ! is_wp_error( $contact_data ) && ! is_wp_error( $existing_contact_data ) && $existing_email !== $email ) {
-				$delete_res = $this->delete_contact( $existing_email );
-				if ( is_wp_error( $delete_res ) ) {
-					Newspack_Newsletters_Logger::log( 'Error deleting existing contact during upsert: ' . $delete_res->get_error_message() );
+				$is_email_change = isset( $contact['is_email_change'] ) && $contact['is_email_change'];
+				if ( $is_email_change ) {
+					$delete_res = $this->delete_contact( $existing_email );
+					if ( is_wp_error( $delete_res ) ) {
+						Newspack_Newsletters_Logger::log( 'Error deleting existing contact during upsert: ' . $delete_res->get_error_message() );
+					}
 				}
 			}
 		}

--- a/includes/service-providers/constant_contact/class-newspack-newsletters-constant-contact.php
+++ b/includes/service-providers/constant_contact/class-newspack-newsletters-constant-contact.php
@@ -1201,9 +1201,9 @@ final class Newspack_Newsletters_Constant_Contact extends \Newspack_Newsletters_
 			}
 		}
 
-		$email = $contact['email'];
+		$email = trim( strtolower( $contact['email'] ) );
 		if ( isset( $contact['existing_contact_data']['email_address'] ) ) {
-			$existing_email = $contact['existing_contact_data']['email_address'];
+			$existing_email = trim( strtolower( $contact['existing_contact_data']['email_address'] ) );
 			if ( $existing_email->address !== $email ) {
 				$data['email_address'] = $email;
 				$email                 = $existing_email->address;

--- a/includes/service-providers/constant_contact/class-newspack-newsletters-constant-contact.php
+++ b/includes/service-providers/constant_contact/class-newspack-newsletters-constant-contact.php
@@ -1202,7 +1202,7 @@ final class Newspack_Newsletters_Constant_Contact extends \Newspack_Newsletters_
 		}
 
 		$email = trim( strtolower( $contact['email'] ) );
-		if ( isset( $contact['existing_contact_data']['email_address'] ) ) {
+		if ( isset( $contact['existing_contact_data']['email_address']->address ) ) {
 			$existing_email = trim( strtolower( $contact['existing_contact_data']['email_address'] ) );
 			if ( $existing_email->address !== $email ) {
 				$data['email_address'] = $email;

--- a/includes/service-providers/constant_contact/class-newspack-newsletters-constant-contact.php
+++ b/includes/service-providers/constant_contact/class-newspack-newsletters-constant-contact.php
@@ -1203,10 +1203,10 @@ final class Newspack_Newsletters_Constant_Contact extends \Newspack_Newsletters_
 
 		$email = trim( strtolower( $contact['email'] ) );
 		if ( isset( $contact['existing_contact_data']['email_address']->address ) ) {
-			$existing_email = trim( strtolower( $contact['existing_contact_data']['email_address'] ) );
+			$existing_email = trim( strtolower( $contact['existing_contact_data']['email_address']->address ) );
 			if ( $existing_email->address !== $email ) {
 				$data['email_address'] = $email;
-				$email                 = $existing_email->address;
+				$email                 = $existing_email;
 			}
 		}
 		$result = $cc->upsert_contact( $email, $data );

--- a/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp.php
+++ b/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp.php
@@ -1781,7 +1781,7 @@ final class Newspack_Newsletters_Mailchimp extends \Newspack_Newsletters_Service
 		if ( false === $list_id ) {
 			return new WP_Error( 'newspack_newsletters_mailchimp_list_id', __( 'Missing list id.' ) );
 		}
-		$email_address = $contact['email'];
+		$email_address = trim( strtolower( $contact['email'] ) );
 		// If contact was added in this execution, we can return the previous
 		// result and bail.
 		$cache_key = md5( $list_id . $email_address . wp_json_encode( $tags ) . wp_json_encode( $interests ) );
@@ -1828,9 +1828,9 @@ final class Newspack_Newsletters_Mailchimp extends \Newspack_Newsletters_Service
 				$update_payload['interests'] = $interests;
 			}
 			$member_hash            = Mailchimp::subscriberHash( $email_address );
-			$existing_email_address = isset( $contact['existing_contact_data']['email_address'] ) ? $contact['existing_contact_data']['email_address'] : null;
+			$existing_email_address = isset( $contact['existing_contact_data']['email_address'] ) ? trim( strtolower( $contact['existing_contact_data']['email_address'] ) ) : null;
 			$existing_member_hash   = $existing_email_address ? Mailchimp::subscriberHash( $existing_email_address ) : null;
-			$is_email_update        = $existing_email_address && $existing_email_address !== $email_address;
+			$is_email_update        = $existing_email_address && isset( $contact['is_email_change'] ) && $contact['is_email_change'] && $existing_email_address !== $email_address;
 			$is_subscribed          = isset( $update_payload['status'] ) && 'subscribed' === $update_payload['status'];
 
 			// Mailchimp only allows subscribed contacts to update the email address field


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes https://linear.app/a8c/issue/NPPM-2296/urgent-issue-with-newsletter-sign-ups-deleting-contacts-i

This fixes an issue where re-submitting a newsletter subscription form with the same email but with different casing would trigger the email change logic during upserts.

We fix this by:

1. Normalizing the casing for email before upserting
2. Adding a flag for email change upserts to indicate when the email change logic should be triggered.

### How to test the changes in this Pull Request:

1. Set up ActiveCampaign as the ESP
2. Add a newsletter subscription block to any page or post
3. Subscribe as a reader using lower case for the email
4. Confirm the contact has been added in Active Campaign
5. Re-submit newsletter subscription form as reader, but make capitalize any letter in the email address
6. On `release` the initial email address will be deleted and a new contact with the capitalized email will be created. On this branch the contact should remain unchanged.\
7. Repeat the above tests with Mailchimp

Test email change flow
8. Now go to my account as the reader, and complete the email change flow
9. Confirm the initial ActiveCampaign contact is correctly deleted and a new email is created using the new email address.

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
