### PR TITLE
hotfix: fix borders and padding in email HTML

### DIFF
--- a/includes/class-newspack-newsletters-renderer.php
+++ b/includes/class-newspack-newsletters-renderer.php
@@ -565,8 +565,17 @@ final class Newspack_Newsletters_Renderer {
 			// Replace <mark /> with <span />.
 			$inner_html = preg_replace( '/<mark\s(.+?)>(.+?)<\/mark>/is', '<span $1>$2</span>', $inner_html );
 
-			// Remove border styles from inner html to avoid duplicate borders, as border styles are applied to the container mj-section.
-			$inner_html = preg_replace( '/border-(.*);/is', '', $inner_html );
+			// Remove border styles from inner html to avoid duplicate borders, as border styles are applied to the container.
+			if ( isset( $attrs['border'] ) ) {
+				$inner_html = preg_replace( '/border-(.*);/is', '', $inner_html );
+				$inner_html = preg_replace( '/border-(.*)"/is', '"', $inner_html );
+			}
+
+			// Remove padding styles from inner html to avoid duplicate paddings, as padding styles are applied to the container.
+			if ( isset( $attrs['padding'] ) ) {
+				$inner_html = preg_replace( '/padding-(.*);/is', '', $inner_html );
+				$inner_html = preg_replace( '/padding-(.*)"/is', '"', $inner_html );
+			}
 		}
 
 		switch ( $block_name ) {
@@ -622,6 +631,11 @@ final class Newspack_Newsletters_Renderer {
 				if ( isset( $text_attrs['background-color'] ) ) {
 					$text_attrs['container-background-color'] = $text_attrs['background-color'];
 					unset( $text_attrs['background-color'] );
+				}
+
+				// Padding is applied to the container element, so we need to remove it from the text attributes.
+				if ( isset( $text_attrs['padding'] ) ) {
+					unset( $text_attrs['padding'] );
 				}
 
 				// Handle link colors.

--- a/includes/class-newspack-newsletters-renderer.php
+++ b/includes/class-newspack-newsletters-renderer.php
@@ -379,9 +379,6 @@ final class Newspack_Newsletters_Renderer {
 			$border_style = isset( $attrs['style']['border']['style'] ) ? $attrs['style']['border']['style'] : 'solid';
 			$attrs['border'] = $attrs['style']['border']['width'] . ' ' . $border_style . ' ' . $border_color;
 		}
-		if ( ! isset( $attrs['padding'] ) && isset( $attrs['background-color'] ) ) {
-			$attrs['padding'] = '0';
-		}
 
 		if ( isset( $attrs['textAlign'] ) && ! isset( $attrs['align'] ) ) {
 			$attrs['align'] = $attrs['textAlign'];
@@ -558,10 +555,8 @@ final class Newspack_Newsletters_Renderer {
 		);
 
 		// Default attributes for the column which will envelop the component.
-		$column_attrs = array_merge(
-			array(
-				'padding' => isset( $attrs['padding'] ) ? $attrs['padding'] : '12px',
-			)
+		$column_attrs = array(
+			'padding' => isset( $attrs['padding'] ) ? $attrs['padding'] : '12px',
 		);
 
 		$font_family = 'core/heading' === $block_name ? self::$font_header : self::$font_body;
@@ -569,6 +564,9 @@ final class Newspack_Newsletters_Renderer {
 		if ( ! empty( $inner_html ) ) {
 			// Replace <mark /> with <span />.
 			$inner_html = preg_replace( '/<mark\s(.+?)>(.+?)<\/mark>/is', '<span $1>$2</span>', $inner_html );
+
+			// Remove border styles from inner html to avoid duplicate borders, as border styles are applied to the container mj-section.
+			$inner_html = preg_replace( '/border-(.*);/is', '', $inner_html );
 		}
 
 		switch ( $block_name ) {

--- a/includes/class-newspack-newsletters-renderer.php
+++ b/includes/class-newspack-newsletters-renderer.php
@@ -633,10 +633,8 @@ final class Newspack_Newsletters_Renderer {
 					unset( $text_attrs['background-color'] );
 				}
 
-				// Padding is applied to the container element, so we need to remove it from the text attributes.
-				if ( isset( $text_attrs['padding'] ) ) {
-					unset( $text_attrs['padding'] );
-				}
+				// Padding is applied to the container element, so we need to remove it from block attributes.
+				$text_attrs['padding'] = '0';
 
 				// Handle link colors.
 				if ( isset( $attrs['link'] ) ) {

--- a/includes/class-newspack-newsletters-renderer.php
+++ b/includes/class-newspack-newsletters-renderer.php
@@ -246,6 +246,9 @@ final class Newspack_Newsletters_Renderer {
 		if ( isset( $block_attrs['backgroundColor'], self::$color_palette[ $block_attrs['backgroundColor'] ] ) ) {
 			$colors['background-color'] = self::$color_palette[ $block_attrs['backgroundColor'] ];
 		}
+		if ( isset( $block_attrs['borderColor'], self::$color_palette[ $block_attrs['borderColor'] ] ) ) {
+			$colors['border-color'] = self::$color_palette[ $block_attrs['borderColor'] ];
+		}
 		// customBackgroundColor is set inline, but not on mjml wrapper element.
 		if ( isset( $block_attrs['customBackgroundColor'] ) ) {
 			$colors['background-color'] = $block_attrs['customBackgroundColor'];
@@ -371,17 +374,11 @@ final class Newspack_Newsletters_Renderer {
 		if ( isset( $attrs['style']['border']['radius'] ) ) {
 			$attrs['borderRadius'] = $attrs['style']['border']['radius'];
 		}
-
-		// Remove block-only attributes.
-		array_map(
-			function ( $key ) use ( &$attrs ) {
-				if ( isset( $attrs[ $key ] ) ) {
-					unset( $attrs[ $key ] );
-				}
-			},
-			[ 'customBackgroundColor', 'customTextColor', 'customFontSize', 'fontSize', 'backgroundColor', 'style' ]
-		);
-
+		if ( isset( $attrs['style']['border']['width'] ) ) {
+			$border_color = isset( $attrs['border-color'] ) ? $attrs['border-color'] : 'black';
+			$border_style = isset( $attrs['style']['border']['style'] ) ? $attrs['style']['border']['style'] : 'solid';
+			$attrs['border'] = $attrs['style']['border']['width'] . ' ' . $border_style . ' ' . $border_color;
+		}
 		if ( ! isset( $attrs['padding'] ) && isset( $attrs['background-color'] ) ) {
 			$attrs['padding'] = '0';
 		}
@@ -533,11 +530,18 @@ final class Newspack_Newsletters_Renderer {
 			];
 		}
 
-		// Remove attributes that are not supported by MJML.
+		// Remove block-only attributes and attributes that are not supported by MJML.
 		$unsupported_attrs = [
 			'newsletterVisibility',
 			'conditionalBefore',
 			'conditionalAfter',
+			'customBackgroundColor',
+			'customTextColor',
+			'customFontSize',
+			'fontSize',
+			'backgroundColor',
+			'borderColor',
+			'style',
 		];
 		foreach ( $unsupported_attrs as $attr ) {
 			if ( isset( $attrs[ $attr ] ) ) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
 			"version": "3.23.2",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@wordpress/icons": "^10.29.0",
+				"@wordpress/icons": "^10.31.0",
 				"classnames": "^2.5.1",
 				"mjml-browser": "^4.15.3",
 				"newspack-components": "^3.1.0",
@@ -6629,15 +6629,15 @@
 			}
 		},
 		"node_modules/@wordpress/element": {
-			"version": "6.29.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-6.29.0.tgz",
-			"integrity": "sha512-hQZuSjFKrHnAeVmfQftcaG5r5Vu4nAhSeRGbx4CUeK0+BngWJpjaPfdieQ/QytSQTSQm3fEfIMsHJUKXopv7ug==",
+			"version": "6.31.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-6.31.0.tgz",
+			"integrity": "sha512-KOier6Y4b4Y5yEV1GYen81R9gCEOvJT6eVbsc93w2fFEKi2FK/oI7IKzGv9GeJMkoCWvTSX6C/ZYTWk6fCUfeA==",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@babel/runtime": "7.25.7",
 				"@types/react": "^18.2.79",
 				"@types/react-dom": "^18.2.25",
-				"@wordpress/escape-html": "^3.29.0",
+				"@wordpress/escape-html": "^3.31.0",
 				"change-case": "^4.1.2",
 				"is-plain-object": "^5.0.0",
 				"react": "^18.3.0",
@@ -6649,9 +6649,9 @@
 			}
 		},
 		"node_modules/@wordpress/escape-html": {
-			"version": "3.29.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-3.29.0.tgz",
-			"integrity": "sha512-Nk3k0G04PfX34HSk9B8TcPJsn3kwigQrQi4UXgEtxcELoBWIwbLjn3J3dvNDNEy88kS9oCae5lChzCKo3bY7AA==",
+			"version": "3.31.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-3.31.0.tgz",
+			"integrity": "sha512-9g9qd7Q16PWDeYEa2dU+84d1SvjP4LfS7n7AuXkwl5+F7KfL2nZTmDTHWutw9jVjdDAGmjm1VNIj4ydQk9vaLA==",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@babel/runtime": "7.25.7"
@@ -6745,14 +6745,14 @@
 			}
 		},
 		"node_modules/@wordpress/icons": {
-			"version": "10.29.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-10.29.0.tgz",
-			"integrity": "sha512-d3Kdz1ML97kSR7wt1iSQVwGYrWnvKvvgTKvt3BBs3YFAEHJXcn9DXaET9OXQ47eYTASW3O8dme/jGNNiQ42gBA==",
+			"version": "10.31.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-10.31.0.tgz",
+			"integrity": "sha512-Bfwt3SyjqClG6mwY78zhlzVRRW/OIqej09NLOGO0CDtjfrgQqD5HAK8kk2CayQr4hWeKMoFxzPBevMxWumBMPA==",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@babel/runtime": "7.25.7",
-				"@wordpress/element": "^6.29.0",
-				"@wordpress/primitives": "^4.29.0"
+				"@wordpress/element": "^6.31.0",
+				"@wordpress/primitives": "^4.31.0"
 			},
 			"engines": {
 				"node": ">=18.12.0",
@@ -7041,13 +7041,13 @@
 			}
 		},
 		"node_modules/@wordpress/primitives": {
-			"version": "4.29.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/primitives/-/primitives-4.29.0.tgz",
-			"integrity": "sha512-zwKHZqpRCligQjmaJA3gHW8WpvdJzUYjsFoI4LkcZlaD6aF7GZOuRH0NGg192RLQgklDSOB7vdGbxc6UEbHwyw==",
+			"version": "4.31.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/primitives/-/primitives-4.31.0.tgz",
+			"integrity": "sha512-cY4EKYQRqHu9NZuoWchxc/KWiofwGskzxz0oCfgbdkRlfTag8yBjWMayz+fRNaenw0l5pzLyIg3rcNDN8xLezw==",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@babel/runtime": "7.25.7",
-				"@wordpress/element": "^6.29.0",
+				"@wordpress/element": "^6.31.0",
 				"clsx": "^2.1.1"
 			},
 			"engines": {

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
 		"url": "https://github.com/Automattic/newspack-newsletters/issues"
 	},
 	"dependencies": {
-		"@wordpress/icons": "^10.29.0",
+		"@wordpress/icons": "^10.31.0",
 		"classnames": "^2.5.1",
 		"mjml-browser": "^4.15.3",
 		"newspack-components": "^3.1.0",

--- a/tests/test-renderer.php
+++ b/tests/test-renderer.php
@@ -51,7 +51,7 @@ class Newsletters_Renderer_Test extends WP_UnitTestCase {
 					'innerHTML'    => $inner_html,
 				]
 			),
-			'<mj-section textColor="vivid-purple" color="#db18e6 !important" background-color="#4aadd7 !important" font-size="16px" padding="0"><mj-column padding="0" width="100%"><mj-text padding="0" line-height="1.5" font-size="16px"  textColor="vivid-purple" color="#db18e6 !important" container-background-color="#4aadd7 !important">' . $inner_html . '</mj-text></mj-column></mj-section>',
+			'<mj-section textColor="vivid-purple" color="#db18e6 !important" background-color="#4aadd7 !important" font-size="16px" padding="0"><mj-column padding="12px" width="100%"><mj-text padding="0" line-height="1.5" font-size="16px"  textColor="vivid-purple" color="#db18e6 !important" container-background-color="#4aadd7 !important">' . $inner_html . '</mj-text></mj-column></mj-section>',
 			'Renders styled paragraph'
 		);
 	}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes some inconsistencies related to borders and padding in the MJML renderer that results in misstyled elements in the final email HTML.

Note that border styles aren't enabled by default in the Newspack classic theme, but it's still possible to create blocks with border styles using the code editor and adding the correct block attributes. Border styles are available by default in the block theme.

Closes NPPM-2286 and NPPM-2287.

### How to test the changes in this Pull Request:

1. On `release`, create a newsletter draft and add several blocks with different border and padding attributes. We want a mix of paragraphs, heading blocks, and Group blocks containing both. Here's some test content you can copy and paste into your draft:

<details>
<summary>Expand for test content</summary>

```html
<!-- wp:group {"style":{"border":{"width":"4px"}},"borderColor":"primary","layout":{"type":"constrained"}} -->
<div class="wp-block-group has-border-color has-primary-border-color" style="border-width:4px"><!-- wp:paragraph -->
<p>A paragraph inside a Group block. The Group block has a 4px solid border with the theme's primary color.</p>
<!-- /wp:paragraph --></div>
<!-- /wp:group -->

<!-- wp:separator {"opacity":"css","backgroundColor":"light-gray"} -->
<hr class="wp-block-separator has-text-color has-light-gray-color has-css-opacity has-light-gray-background-color has-background"/>
<!-- /wp:separator -->

<!-- wp:spacer {"height":"16px"} -->
<div style="height:16px" aria-hidden="true" class="wp-block-spacer"></div>
<!-- /wp:spacer -->

<!-- wp:paragraph {"style":{"border":{"width":"6px"}},"backgroundColor":"light-gray","borderColor":"accent"} -->
<p class="has-border-color has-accent-border-color has-light-gray-background-color has-background" style="border-width:6px">A paragraph with a 6px solid border with no color defined, with a light-gray background color.</p>
<!-- /wp:paragraph -->

<!-- wp:separator {"opacity":"css","backgroundColor":"light-gray"} -->
<hr class="wp-block-separator has-text-color has-light-gray-color has-css-opacity has-light-gray-background-color has-background"/>
<!-- /wp:separator -->

<!-- wp:spacer {"height":"16px"} -->
<div style="height:16px" aria-hidden="true" class="wp-block-spacer"></div>
<!-- /wp:spacer -->

<!-- wp:paragraph {"style":{"border":{"width":"6px","style":"dashed"}}} -->
<p style="border-style:dashed;border-width:6px">A paragraph with a 6px dashed border with the theme's primary color and no background color.</p>
<!-- /wp:paragraph -->

<!-- wp:separator {"opacity":"css","backgroundColor":"light-gray"} -->
<hr class="wp-block-separator has-text-color has-light-gray-color has-css-opacity has-light-gray-background-color has-background"/>
<!-- /wp:separator -->

<!-- wp:spacer {"height":"16px"} -->
<div style="height:16px" aria-hidden="true" class="wp-block-spacer"></div>
<!-- /wp:spacer -->

<!-- wp:group {"style":{"spacing":{"padding":{"top":"40px","bottom":"40px","left":"40px","right":"40px"}}},"backgroundColor":"primary","layout":{"type":"constrained"}} -->
<div class="wp-block-group has-primary-background-color has-background" style="padding-top:40px;padding-right:40px;padding-bottom:40px;padding-left:40px"><!-- wp:paragraph {"backgroundColor":"light-gray"} -->
<p class="has-light-gray-background-color has-background">Paragraph inside a Group block with 40px padding</p>
<!-- /wp:paragraph --></div>
<!-- /wp:group -->

<!-- wp:separator {"opacity":"css","backgroundColor":"light-gray"} -->
<hr class="wp-block-separator has-text-color has-light-gray-color has-css-opacity has-light-gray-background-color has-background"/>
<!-- /wp:separator -->

<!-- wp:spacer {"height":"16px"} -->
<div style="height:16px" aria-hidden="true" class="wp-block-spacer"></div>
<!-- /wp:spacer -->

<!-- wp:paragraph {"style":{"elements":{"link":{"color":{"text":"var:preset|color|white"}}},"spacing":{"padding":{"top":"30px","bottom":"30px","left":"60px","right":"60px"}}},"backgroundColor":"primary-variation","textColor":"white"} -->
<p class="has-white-color has-primary-variation-background-color has-text-color has-background has-link-color" style="padding-top:30px;padding-right:60px;padding-bottom:30px;padding-left:60px">Paragraph with 30px x 60px padding</p>
<!-- /wp:paragraph -->
```

</details>

2. Save the draft and then wait for the sync to the connected ESP to complete.
3. Click "View Campaign in <ESP>" to view the email HTML in the ESP and observe that:

  - Borders are totally missing
  - Padding values are doubled or inconsistent, and don't visually match the amount of padding configured and shown in the WP editor
  - Blocks with a background color set have no padding, regardless of the block's padding settings

<img width="620" height="957" alt="Screenshot 2025-10-06 at 10 59 33 AM" src="https://github.com/user-attachments/assets/6aacb761-07c1-477e-8705-da43c22e3e43" />

4. Check out this branch, re-save the draft, and wait for it to resync to the ESP.
5. View the email in the ESP and confirm that styles now closely match what's shown in the WP editor.

<img width="622" height="862" alt="Screenshot 2025-10-06 at 11 29 59 AM" src="https://github.com/user-attachments/assets/58079502-994c-468a-8f5e-f76958beb736" />
   
### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
