### PR TITLE
fix(activecampaign): add required sdate param

### DIFF
--- a/includes/service-providers/active_campaign/class-newspack-newsletters-active-campaign.php
+++ b/includes/service-providers/active_campaign/class-newspack-newsletters-active-campaign.php
@@ -1256,6 +1256,7 @@ final class Newspack_Newsletters_Active_Campaign extends \Newspack_Newsletters_S
 		}
 		update_post_meta( $post_id, 'ac_campaign_id', $campaign['id'] );
 		$campaign_id = $campaign['id'];
+		// See https://www.activecampaign.com/api/example.php?call=campaign_status.
 		$send_result = $this->api_v1_request(
 			'campaign_status',
 			'GET',
@@ -1263,6 +1264,7 @@ final class Newspack_Newsletters_Active_Campaign extends \Newspack_Newsletters_S
 				'query' => [
 					'id'     => $campaign_id,
 					'status' => 1, // 0 = draft, 1 = scheduled, 2 = sending, 3 = paused, 4 = stopped, 5 = completed.
+					'sdate'  => '', // Empty means send immediately.
 				],
 			]
 		);

--- a/includes/service-providers/active_campaign/class-newspack-newsletters-active-campaign.php
+++ b/includes/service-providers/active_campaign/class-newspack-newsletters-active-campaign.php
@@ -215,6 +215,13 @@ final class Newspack_Newsletters_Active_Campaign extends \Newspack_Newsletters_S
 			]
 		);
 
+		if ( ! $body ) {
+			return new \WP_Error(
+				'newspack_newsletters_active_campaign_api_error',
+				! empty( $response['response']['message'] ) ? $response['response']['message'] : __( 'An error occurred while communicating with ActiveCampaign.', 'newspack-newsletters' )
+			);
+		}
+
 		if ( 1 !== $body['result_code'] ) {
 			$message = ! empty( $body['result_message'] ) ? $body['result_message'] : __( 'An error occurred while communicating with ActiveCampaign.', 'newspack-newsletters' );
 			return new \WP_Error(


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes https://linear.app/a8c/issue/NPPM-2282/activecampaign-newsletters-failing-to-send-with-missing-address

This PR fixes an issue where the ActiveCampaign `campaign_status` endpoint now has an additional required param that we weren't sending. As a result we were getting a 500 response which prevented newsletters from being sent when AC was the ESP.

This PR fixes this by adding an empty `sdate` which appears to be what the folks at AC would like us to do per this example they sent: https://newspack-pub.slack.com/archives/C0378FGQEHZ/p1759799213791039?thread_ts=1759332744.564689&cid=C0378FGQEHZ

### How to test the changes in this Pull Request:

1. Set up AC as your ESP
2. Send a newsletter to any list
3. Verify the newsletter is sent successfully with no errors

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
