### PR TITLE
feat(visibility-attribute): support email-only blocks

### DIFF
--- a/src/editor/blocks/visibility-attribute/index.js
+++ b/src/editor/blocks/visibility-attribute/index.js
@@ -121,7 +121,7 @@ const withVisibilityControl = createHigherOrderComponent(
 								} }
 								help={
 									isEmailOnlyBlock ? __(
-										"This block can't be visible on the web version of the newsletter.",
+										'This block is only available in the email version of the newsletter.',
 										'newspack-newsletters'
 									) : __(
 										"If the newsletter is going to be viewable publicly on this site, select here if you'd like this block to be visible in a particular version.",

--- a/src/editor/blocks/visibility-attribute/index.js
+++ b/src/editor/blocks/visibility-attribute/index.js
@@ -29,6 +29,11 @@ import './style.scss';
 
 const ATTRIBUTE_NAME = 'newsletterVisibility';
 
+const EMAIL_ONLY_BLOCKS = [
+	'newspack-newsletters/ad',
+	'newspack-newsletters/share',
+];
+
 const visibilityOptions = [
 	{
 		label: __( 'Email and Web', 'newspack-newsletters' ),
@@ -63,7 +68,8 @@ const withVisibilityControl = createHigherOrderComponent(
 			} )
 		)( props => {
 			const { attributes, setAttributes } = props;
-			const value = attributes[ ATTRIBUTE_NAME ];
+			const isEmailOnlyBlock = EMAIL_ONLY_BLOCKS.includes( props.name );
+			const value = isEmailOnlyBlock ? 'email' : attributes[ ATTRIBUTE_NAME ];
 			if ( ! props.is_public ) {
 				return <BlockEdit { ...props } />;
 			}
@@ -92,6 +98,7 @@ const withVisibilityControl = createHigherOrderComponent(
 													} }
 													onClose={ onClose }
 													role="menuitemradio"
+													disabled={ isEmailOnlyBlock }
 												>
 													{ entry.label }
 												</MenuItem>
@@ -112,10 +119,16 @@ const withVisibilityControl = createHigherOrderComponent(
 								onChange={ selected => {
 									setAttributes( { [ ATTRIBUTE_NAME ]: selected } );
 								} }
-								help={ __(
-									"If the newsletter is going to be viewable publicly on this site, select here if you'd like this block to be visible in a particular version.",
-									'newspack-newsletters'
-								) }
+								help={
+									isEmailOnlyBlock ? __(
+										"This block can't be visible on the web version of the newsletter.",
+										'newspack-newsletters'
+									) : __(
+										"If the newsletter is going to be viewable publicly on this site, select here if you'd like this block to be visible in a particular version.",
+										'newspack-newsletters'
+									)
+								}
+								disabled={ isEmailOnlyBlock }
 							/>
 						</PanelBody>
 					</InspectorControls>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

NPPM-2099

Change the visibility attribute control so it reflects email-only blocks:

<img width="992" height="482" alt="image" src="https://github.com/user-attachments/assets/a474329f-fa5f-47a5-9e03-dfeebf422297" />

The "Newsletter Ad" and "Share Newsletter" blocks, which don't render in the web version, should now have the select disabled and locked in the "Email" option. The control help should also display "This block is only available in the email version of the newsletter." instead of the regular text.

### How to test the changes in this Pull Request:

1. Draft a new newsletter and add a paragraph, a Newsletter Ad, and a Share Newsletter blocks
2. Toggle "Public Newsletter" in the post editor
3. Edit each block and confirm that the paragraph block can select different visibility options and the Newsletter Ad and Share Newsletter blocks don't, as exemplified in the image above

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
