### PR TITLE
fix: revert border and padding html hotfix

### DIFF
--- a/includes/class-newspack-newsletters-renderer.php
+++ b/includes/class-newspack-newsletters-renderer.php
@@ -246,9 +246,6 @@ final class Newspack_Newsletters_Renderer {
 		if ( isset( $block_attrs['backgroundColor'], self::$color_palette[ $block_attrs['backgroundColor'] ] ) ) {
 			$colors['background-color'] = self::$color_palette[ $block_attrs['backgroundColor'] ];
 		}
-		if ( isset( $block_attrs['borderColor'], self::$color_palette[ $block_attrs['borderColor'] ] ) ) {
-			$colors['border-color'] = self::$color_palette[ $block_attrs['borderColor'] ];
-		}
 		// customBackgroundColor is set inline, but not on mjml wrapper element.
 		if ( isset( $block_attrs['customBackgroundColor'] ) ) {
 			$colors['background-color'] = $block_attrs['customBackgroundColor'];
@@ -374,10 +371,19 @@ final class Newspack_Newsletters_Renderer {
 		if ( isset( $attrs['style']['border']['radius'] ) ) {
 			$attrs['borderRadius'] = $attrs['style']['border']['radius'];
 		}
-		if ( isset( $attrs['style']['border']['width'] ) ) {
-			$border_color = isset( $attrs['border-color'] ) ? $attrs['border-color'] : 'black';
-			$border_style = isset( $attrs['style']['border']['style'] ) ? $attrs['style']['border']['style'] : 'solid';
-			$attrs['border'] = $attrs['style']['border']['width'] . ' ' . $border_style . ' ' . $border_color;
+
+		// Remove block-only attributes.
+		array_map(
+			function ( $key ) use ( &$attrs ) {
+				if ( isset( $attrs[ $key ] ) ) {
+					unset( $attrs[ $key ] );
+				}
+			},
+			[ 'customBackgroundColor', 'customTextColor', 'customFontSize', 'fontSize', 'backgroundColor', 'style' ]
+		);
+
+		if ( ! isset( $attrs['padding'] ) && isset( $attrs['background-color'] ) ) {
+			$attrs['padding'] = '0';
 		}
 
 		if ( isset( $attrs['textAlign'] ) && ! isset( $attrs['align'] ) ) {
@@ -527,18 +533,11 @@ final class Newspack_Newsletters_Renderer {
 			];
 		}
 
-		// Remove block-only attributes and attributes that are not supported by MJML.
+		// Remove attributes that are not supported by MJML.
 		$unsupported_attrs = [
 			'newsletterVisibility',
 			'conditionalBefore',
 			'conditionalAfter',
-			'customBackgroundColor',
-			'customTextColor',
-			'customFontSize',
-			'fontSize',
-			'backgroundColor',
-			'borderColor',
-			'style',
 		];
 		foreach ( $unsupported_attrs as $attr ) {
 			if ( isset( $attrs[ $attr ] ) ) {
@@ -555,8 +554,10 @@ final class Newspack_Newsletters_Renderer {
 		);
 
 		// Default attributes for the column which will envelop the component.
-		$column_attrs = array(
-			'padding' => isset( $attrs['padding'] ) ? $attrs['padding'] : '12px',
+		$column_attrs = array_merge(
+			array(
+				'padding' => isset( $attrs['padding'] ) ? $attrs['padding'] : '12px',
+			)
 		);
 
 		$font_family = 'core/heading' === $block_name ? self::$font_header : self::$font_body;
@@ -564,18 +565,6 @@ final class Newspack_Newsletters_Renderer {
 		if ( ! empty( $inner_html ) ) {
 			// Replace <mark /> with <span />.
 			$inner_html = preg_replace( '/<mark\s(.+?)>(.+?)<\/mark>/is', '<span $1>$2</span>', $inner_html );
-
-			// Remove border styles from inner html to avoid duplicate borders, as border styles are applied to the container.
-			if ( isset( $attrs['border'] ) ) {
-				$inner_html = preg_replace( '/border-(.*);/is', '', $inner_html );
-				$inner_html = preg_replace( '/border-(.*)"/is', '"', $inner_html );
-			}
-
-			// Remove padding styles from inner html to avoid duplicate paddings, as padding styles are applied to the container.
-			if ( isset( $attrs['padding'] ) ) {
-				$inner_html = preg_replace( '/padding-(.*);/is', '', $inner_html );
-				$inner_html = preg_replace( '/padding-(.*)"/is', '"', $inner_html );
-			}
 		}
 
 		switch ( $block_name ) {
@@ -632,9 +621,6 @@ final class Newspack_Newsletters_Renderer {
 					$text_attrs['container-background-color'] = $text_attrs['background-color'];
 					unset( $text_attrs['background-color'] );
 				}
-
-				// Padding is applied to the container element, so we need to remove it from block attributes.
-				$text_attrs['padding'] = '0';
 
 				// Handle link colors.
 				if ( isset( $attrs['link'] ) ) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
 			"version": "3.23.6",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@wordpress/icons": "^10.31.0",
+				"@wordpress/icons": "^10.29.0",
 				"classnames": "^2.5.1",
 				"mjml-browser": "^4.15.3",
 				"newspack-components": "^3.1.0",
@@ -6629,15 +6629,15 @@
 			}
 		},
 		"node_modules/@wordpress/element": {
-			"version": "6.31.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-6.31.0.tgz",
-			"integrity": "sha512-KOier6Y4b4Y5yEV1GYen81R9gCEOvJT6eVbsc93w2fFEKi2FK/oI7IKzGv9GeJMkoCWvTSX6C/ZYTWk6fCUfeA==",
+			"version": "6.29.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-6.29.0.tgz",
+			"integrity": "sha512-hQZuSjFKrHnAeVmfQftcaG5r5Vu4nAhSeRGbx4CUeK0+BngWJpjaPfdieQ/QytSQTSQm3fEfIMsHJUKXopv7ug==",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@babel/runtime": "7.25.7",
 				"@types/react": "^18.2.79",
 				"@types/react-dom": "^18.2.25",
-				"@wordpress/escape-html": "^3.31.0",
+				"@wordpress/escape-html": "^3.29.0",
 				"change-case": "^4.1.2",
 				"is-plain-object": "^5.0.0",
 				"react": "^18.3.0",
@@ -6649,9 +6649,9 @@
 			}
 		},
 		"node_modules/@wordpress/escape-html": {
-			"version": "3.31.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-3.31.0.tgz",
-			"integrity": "sha512-9g9qd7Q16PWDeYEa2dU+84d1SvjP4LfS7n7AuXkwl5+F7KfL2nZTmDTHWutw9jVjdDAGmjm1VNIj4ydQk9vaLA==",
+			"version": "3.29.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-3.29.0.tgz",
+			"integrity": "sha512-Nk3k0G04PfX34HSk9B8TcPJsn3kwigQrQi4UXgEtxcELoBWIwbLjn3J3dvNDNEy88kS9oCae5lChzCKo3bY7AA==",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@babel/runtime": "7.25.7"
@@ -6745,14 +6745,14 @@
 			}
 		},
 		"node_modules/@wordpress/icons": {
-			"version": "10.31.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-10.31.0.tgz",
-			"integrity": "sha512-Bfwt3SyjqClG6mwY78zhlzVRRW/OIqej09NLOGO0CDtjfrgQqD5HAK8kk2CayQr4hWeKMoFxzPBevMxWumBMPA==",
+			"version": "10.29.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/icons/-/icons-10.29.0.tgz",
+			"integrity": "sha512-d3Kdz1ML97kSR7wt1iSQVwGYrWnvKvvgTKvt3BBs3YFAEHJXcn9DXaET9OXQ47eYTASW3O8dme/jGNNiQ42gBA==",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@babel/runtime": "7.25.7",
-				"@wordpress/element": "^6.31.0",
-				"@wordpress/primitives": "^4.31.0"
+				"@wordpress/element": "^6.29.0",
+				"@wordpress/primitives": "^4.29.0"
 			},
 			"engines": {
 				"node": ">=18.12.0",
@@ -7041,13 +7041,13 @@
 			}
 		},
 		"node_modules/@wordpress/primitives": {
-			"version": "4.31.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/primitives/-/primitives-4.31.0.tgz",
-			"integrity": "sha512-cY4EKYQRqHu9NZuoWchxc/KWiofwGskzxz0oCfgbdkRlfTag8yBjWMayz+fRNaenw0l5pzLyIg3rcNDN8xLezw==",
+			"version": "4.29.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/primitives/-/primitives-4.29.0.tgz",
+			"integrity": "sha512-zwKHZqpRCligQjmaJA3gHW8WpvdJzUYjsFoI4LkcZlaD6aF7GZOuRH0NGg192RLQgklDSOB7vdGbxc6UEbHwyw==",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@babel/runtime": "7.25.7",
-				"@wordpress/element": "^6.31.0",
+				"@wordpress/element": "^6.29.0",
 				"clsx": "^2.1.1"
 			},
 			"engines": {

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
 		"url": "https://github.com/Automattic/newspack-newsletters/issues"
 	},
 	"dependencies": {
-		"@wordpress/icons": "^10.31.0",
+		"@wordpress/icons": "^10.29.0",
 		"classnames": "^2.5.1",
 		"mjml-browser": "^4.15.3",
 		"newspack-components": "^3.1.0",

--- a/tests/test-renderer.php
+++ b/tests/test-renderer.php
@@ -51,7 +51,7 @@ class Newsletters_Renderer_Test extends WP_UnitTestCase {
 					'innerHTML'    => $inner_html,
 				]
 			),
-			'<mj-section textColor="vivid-purple" color="#db18e6 !important" background-color="#4aadd7 !important" font-size="16px" padding="0"><mj-column padding="12px" width="100%"><mj-text padding="0" line-height="1.5" font-size="16px"  textColor="vivid-purple" color="#db18e6 !important" container-background-color="#4aadd7 !important">' . $inner_html . '</mj-text></mj-column></mj-section>',
+			'<mj-section textColor="vivid-purple" color="#db18e6 !important" background-color="#4aadd7 !important" font-size="16px" padding="0"><mj-column padding="0" width="100%"><mj-text padding="0" line-height="1.5" font-size="16px"  textColor="vivid-purple" color="#db18e6 !important" container-background-color="#4aadd7 !important">' . $inner_html . '</mj-text></mj-column></mj-section>',
 			'Renders styled paragraph'
 		);
 	}


### PR DESCRIPTION
This reverts commit fdd5d2d857807c4304bbf6a3b276672fc359f3ef.

### All Submissions:

* [ ] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Reverts https://github.com/Automattic/newspack-newsletters/pull/1939

See https://a8c.slack.com/archives/G012YAG1WSU/p1760463747904329

### How to test the changes in this Pull Request:

1. Ensure editing and sending newsletters still works

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
