### PR TITLE
fix(dependencies): restore last known working package version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,13 +11,13 @@
 			"dependencies": {
 				"@wordpress/icons": "^10.29.0",
 				"classnames": "^2.5.1",
-				"mjml-browser": "^4.16.1",
+				"mjml-browser": "^4.15.3",
 				"newspack-components": "^3.1.0",
 				"qs": "^6.14.0"
 			},
 			"devDependencies": {
 				"@rushstack/eslint-patch": "^1.12.0",
-				"@wordpress/browserslist-config": "^6.32.0",
+				"@wordpress/browserslist-config": "^6.31.0",
 				"eslint": "^8.57.0",
 				"lint-staged": "^15.5.1",
 				"newspack-scripts": "^5.5.2",
@@ -6199,9 +6199,9 @@
 			}
 		},
 		"node_modules/@wordpress/browserslist-config": {
-			"version": "6.32.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/browserslist-config/-/browserslist-config-6.32.0.tgz",
-			"integrity": "sha512-8NemosyPrey1yswd6LH8vX9mcRF6Xmqt2mKUCspnmEX4KvayyezmtJPh2EQo3GfySVHGWePzb0yfMYEqDdsC0Q==",
+			"version": "6.31.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/browserslist-config/-/browserslist-config-6.31.0.tgz",
+			"integrity": "sha512-ZZZz/VjbHyDEc6/yOzyjyDkBAPbn5+nuDgujwm/GXTo2u0RoyiPTl/uuRsqz32JYhRHMhETxsQPdMZfrAh9lkg==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"engines": {
@@ -6639,7 +6639,11 @@
 				"@types/react-dom": "^18.2.25",
 				"@wordpress/escape-html": "^3.29.0",
 				"change-case": "^4.1.2",
+				"is-plain-object": "^5.0.0",
 				"react": "^18.3.0",
+				"react-dom": "^18.3.0"
+			},
+			"engines": {
 				"node": ">=18.12.0",
 				"npm": ">=8.19.2"
 			}
@@ -17220,9 +17224,7 @@
 			}
 		},
 		"node_modules/mjml-browser": {
-			"version": "4.16.1",
-			"resolved": "https://registry.npmjs.org/mjml-browser/-/mjml-browser-4.16.1.tgz",
-			"integrity": "sha512-u64DmRomxI1QoSRjn3PoPzFYFHt3O9vAt8OMR1oZN3u7ovfTN5jTpnKaxliBdU4L+UtVGGlTLzoY7qSmhJEOEw==",
+			"version": "4.15.3",
 			"license": "MIT"
 		},
 		"node_modules/mkdirp-classic": {

--- a/package.json
+++ b/package.json
@@ -41,13 +41,13 @@
 	"dependencies": {
 		"@wordpress/icons": "^10.29.0",
 		"classnames": "^2.5.1",
-		"mjml-browser": "^4.16.1",
+		"mjml-browser": "^4.15.3",
 		"newspack-components": "^3.1.0",
 		"qs": "^6.14.0"
 	},
 	"devDependencies": {
 		"@rushstack/eslint-patch": "^1.12.0",
-		"@wordpress/browserslist-config": "^6.32.0",
+		"@wordpress/browserslist-config": "^6.31.0",
 		"eslint": "^8.57.0",
 		"lint-staged": "^15.5.1",
 		"newspack-scripts": "^5.5.2",


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

One of these dependabot updates caused build errors. Let's get back to the last known working version of `package-lock.json` and go from there

### How to test the changes in this Pull Request:

1. Run `npm start` and confirm that it works

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
