### PR TITLE
fix: potential fatal errors due to assumed data types

### DIFF
--- a/includes/class-newspack-newsletters-subscription.php
+++ b/includes/class-newspack-newsletters-subscription.php
@@ -472,7 +472,7 @@ class Newspack_Newsletters_Subscription {
 			if ( is_object( $intent ) || is_numeric( $intent ) ) {
 				$intent = self::get_subscription_intent( $intent );
 			}
-			if ( count( $intent['errors'] ) > 3 ) {
+			if ( is_array( $intent['errors'] ) && count( $intent['errors'] ) > 3 ) {
 				Newspack_Newsletters_Logger::log( 'Too many errors for contact ' . $intent['contact']['email'] . '. Removing intent.' );
 				self::remove_subscription_intent( $intent['id'] );
 				continue;
@@ -490,6 +490,9 @@ class Newspack_Newsletters_Subscription {
 				$email = $contact['email'];
 				if ( $user ) {
 					update_user_meta( $user->ID, 'newspack_newsletters_subscription_error', $result->get_error_message() );
+				}
+				if ( ! is_array( $intent['errors'] ) ) {
+					$intent['errors'] = [];
 				}
 				$intent['errors'][] = $result->get_error_message();
 				\update_post_meta( $intent['id'], 'errors', $intent['errors'] );

--- a/includes/class-newspack-newsletters.php
+++ b/includes/class-newspack-newsletters.php
@@ -1328,10 +1328,11 @@ final class Newspack_Newsletters {
 		}
 
 		/** Detect meta that determines the sent state */
-		$sent         = get_post_meta( $post_id, 'newsletter_sent', true );
-		$post_status  = get_post_status( $post_id );
-		$is_published = 'publish' === $post_status || 'private' === $post_status;
-		$publish_date = $is_published ? get_post_datetime( $post_id, 'date', 'gmt' )->getTimestamp() : 0;
+		$sent          = get_post_meta( $post_id, 'newsletter_sent', true );
+		$post_status   = get_post_status( $post_id );
+		$is_published  = 'publish' === $post_status || 'private' === $post_status;
+		$post_datetime = $is_published ? get_post_datetime( $post_id, 'date', 'gmt' ) : false;
+		$publish_date  = $post_datetime ? $post_datetime->getTimestamp() : 0;
 		if ( 0 < $sent && $sent === $publish_date ) {
 			return $sent;
 		}

--- a/tests/test-controlled-statuses.php
+++ b/tests/test-controlled-statuses.php
@@ -68,4 +68,61 @@ class Newsletter_Controlled_Statuses_Test extends WP_UnitTestCase {
 		$result_post = get_post( $post_id );
 		$this->assertEquals( 'publish', $result_post->post_status );
 	}
+
+	/**
+	 * Test that is_newsletter_sent handles valid and invalid publish dates correctly.
+	 */
+	public function test_is_newsletter_sent_with_invalid_date() {
+		global $wpdb;
+
+		// Create a newsletter post with a valid post date.
+		$post_id = self::factory()->post->create(
+			[
+				'post_type'   => \Newspack_Newsletters::NEWSPACK_NEWSLETTERS_CPT,
+				'post_status' => 'draft',
+				'post_date'   => '2024-01-15 10:00:00',
+			]
+		);
+		$result = \Newspack_Newsletters::is_newsletter_sent( $post_id );
+		$this->assertFalse( $result, 'Should return false for a draft post' );
+
+		// Publish the post.
+		wp_update_post(
+			[
+				'ID'          => $post_id,
+				'post_status' => 'publish',
+			]
+		);
+
+		// Test that the function returns a valid timestamp with valid publish date.
+		$result = \Newspack_Newsletters::is_newsletter_sent( $post_id );
+		$this->assertNotFalse( $result, 'Should return a timestamp for a published post with valid date' );
+		$this->assertIsInt( $result, 'Should return an integer timestamp' );
+		$this->assertGreaterThan( 0, $result, 'Timestamp should be greater than 0' );
+
+		// Verify the timestamp matches the publish date.
+		$post_datetime = get_post_datetime( $post_id, 'date', 'gmt' );
+		$expected_timestamp = $post_datetime->getTimestamp();
+		$this->assertEquals( $expected_timestamp, $result, 'Should return the publish date timestamp' );
+
+		// Update the post date to an invalid value using direct database update
+		// to bypass WordPress validation that might prevent setting invalid dates.
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery
+		$wpdb->update(
+			$wpdb->posts,
+			[
+				'post_date'     => '0000-00-00 00:00:00',
+				'post_date_gmt' => '0000-00-00 00:00:00',
+			],
+			[ 'ID' => $post_id ],
+			[ '%s', '%s' ],
+			[ '%d' ]
+		);
+		clean_post_cache( $post_id );
+
+		$result = \Newspack_Newsletters::is_newsletter_sent( $post_id );
+
+		// Assert that the function returns false for invalid date.
+		$this->assertFalse( $result, 'Should return false for post with invalid publish date' );
+	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes two areas that could cause potential fatal errors if the data being parsed isn't of the expected type. We've seen both happen on live publisher sites, so we know it's possible.

Closes NPPM-2358.

### How to test the changes in this Pull Request:

Kind of hard to test these without manually modifying some data in the DB. The new unit test should cover the fatal for the `Newspack_Newsletters::is_sent()` method. For the `Newspack_Newsletters_Subscription::process_subscription_intents()` method, you could try subscribing via the Newsletter Subscription Form block, finding the subscription intent post that's created for that, and then manually updating the value of the subscription intent's `errors` meta to a string. But the fix is straightforward so I'm not sure it's necessary to do so.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
