### PR TITLE
Use continue instead of return when bulk tracking pixel processing

### DIFF
--- a/includes/tracking/class-pixel.php
+++ b/includes/tracking/class-pixel.php
@@ -196,7 +196,7 @@ final class Pixel {
 
 			// Bail if tracking ID mismatch.
 			if ( $newsletter_tracking_id !== $tracking_id ) {
-				return;
+				break;
 			}
 
 			$pixel_seen = \get_post_meta( $newsletter_id, 'tracking_pixel_seen', true );

--- a/includes/tracking/class-pixel.php
+++ b/includes/tracking/class-pixel.php
@@ -196,7 +196,7 @@ final class Pixel {
 
 			// Bail if tracking ID mismatch.
 			if ( $newsletter_tracking_id !== $tracking_id ) {
-				break;
+				continue;
 			}
 
 			$pixel_seen = \get_post_meta( $newsletter_id, 'tracking_pixel_seen', true );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Currently the function that records log views uses a `return` if it encounters an invalid newsletter tracking ID. When that happens, all of the other events after it in the list get thrown away and are not tracked. Using `break` is better IMO, so any valid events after the invalid one get processed.

### How to test the changes in this Pull Request:

Not sure, but I encountered it in the wild. Something like this:

1. Have a log file with multiple newsletter's tracking pixels. 
2. Manually delete or change the tracking ID meta on one of the newsletters, so the check fails.
3. `wp shell` and `Newspack_Newsletters\Tracking\Pixel::process_logs()`
4. Observe the data for events after the invalid newsletter isn't recorded.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
