### PR TITLE
fix: allow updates to scheduled newsletter posts

### DIFF
--- a/src/components/send-button/index.js
+++ b/src/components/send-button/index.js
@@ -194,6 +194,7 @@ export default compose( [
 			isSaveable &&
 			! isPublished &&
 			! isSaving &&
+			'future' !== status &&
 			( newsletterData.campaign || 'manual' === serviceProviderName ) &&
 			0 === newsletterValidationErrors.length;
 		let label;
@@ -268,9 +269,20 @@ export default compose( [
 		};
 
 		// For sent newsletters, display the generic button text.
-		if ( isPublished || sent ) {
+		if ( isPublished || sent || 'future' === status ) {
 			return (
 				<div style={{ display: 'flex' }}>
+					{ 'future' === status && (
+						<Button
+							className="newsletter-unschedule-button"
+							isBusy={ isSaving }
+							variant="tertiary"
+							disabled={ isSaving }
+							onClick={ unscheduleNewsletter }
+						>
+							{ __( 'Unschedule', 'newspack-newsletters' ) }
+						</Button>
+					) }
 					<PreviewHTMLButton />
 					<Button
 						className="editor-post-publish-button"
@@ -340,17 +352,6 @@ export default compose( [
 
 		return (
 			<div style={{ display: 'flex' }}>
-				{ 'future' === status && (
-					<Button
-						className="newsletter-unschedule-button"
-						isBusy={ isSaving }
-						variant="tertiary"
-						disabled={ isSaving }
-						onClick={ unscheduleNewsletter }
-					>
-						{ __( 'Unschedule', 'newspack-newsletters' ) }
-					</Button>
-				) }
 				<PreviewHTMLButton />
 				<Button
 					className="editor-post-publish-button"

--- a/src/newsletter-editor/layout/index.js
+++ b/src/newsletter-editor/layout/index.js
@@ -11,7 +11,7 @@ import { parse, serialize } from '@wordpress/blocks';
 import { __ } from '@wordpress/i18n';
 import { withDispatch, withSelect } from '@wordpress/data';
 import { useState, useEffect, useMemo } from '@wordpress/element';
-import { BaseControl,Button, Modal, TextControl, Spinner } from '@wordpress/components';
+import { BaseControl, Button, Modal, TextControl, Spinner } from '@wordpress/components';
 
 /**
  * Internal dependencies

--- a/src/newsletter-editor/layout/index.js
+++ b/src/newsletter-editor/layout/index.js
@@ -10,8 +10,8 @@ import { compose } from '@wordpress/compose';
 import { parse, serialize } from '@wordpress/blocks';
 import { __ } from '@wordpress/i18n';
 import { withDispatch, withSelect } from '@wordpress/data';
-import { Fragment, useState, useEffect, useMemo } from '@wordpress/element';
-import { Button, Modal, TextControl, Spinner } from '@wordpress/components';
+import { useState, useEffect, useMemo } from '@wordpress/element';
+import { BaseControl,Button, Modal, TextControl, Spinner } from '@wordpress/components';
 
 /**
  * Internal dependencies
@@ -68,6 +68,7 @@ export default compose( [
 			isEditedPostEmpty: isEditedPostEmpty(),
 			currentPostId: getCurrentPostId(),
 			layoutMeta,
+			postStatus: getEditedPostAttribute( 'status' ),
 		};
 	} ),
 	withDispatch( dispatch => {
@@ -92,7 +93,8 @@ export default compose( [
 		postBlocks,
 		postTitle,
 		isEditedPostEmpty,
-		layoutMeta
+		layoutMeta,
+		postStatus,
 	} ) => {
 		const [ warningModalVisible, setWarningModalVisible ] = useState( false );
 		const { layouts, isFetchingLayouts } = useLayoutsState();
@@ -164,7 +166,7 @@ export default compose( [
 		const isUsingCustomLayout = isUserDefinedLayout( usedLayout );
 
 		return (
-			<Fragment>
+			<BaseControl id="newspack-newsletters-layouts" help={ postStatus === 'future' && __( 'Unschedule this newsletter to edit layout.', 'newspack-newsletters' ) }>
 				{ Boolean( layoutId && isFetchingLayouts ) && (
 					<div className="newspack-newsletters-layouts__spinner">
 						<Spinner />
@@ -190,7 +192,7 @@ export default compose( [
 				<div className="newspack-newsletters-buttons-group">
 					<Button
 						variant="secondary"
-						disabled={ isEditedPostEmpty || isSavingLayout }
+						disabled={ isEditedPostEmpty || isSavingLayout || postStatus === 'future' }
 						onClick={ () => setIsManageModalVisible( true ) }
 						__next40pxDefaultSize
 					>
@@ -200,7 +202,7 @@ export default compose( [
 					{ isUsingCustomLayout && (
 						<Button
 							variant="secondary"
-							disabled={ isPostContentSameAsLayout || ( isSavingLayout && isManageModalVisible ) }
+							disabled={ isPostContentSameAsLayout || ( isSavingLayout && isManageModalVisible ) || postStatus === 'future' }
 							isBusy={ isSavingLayout && ! isManageModalVisible }
 							onClick={ handeLayoutUpdate }
 							__next40pxDefaultSize
@@ -212,7 +214,7 @@ export default compose( [
 					<Button
 						variant="secondary"
 						isDestructive
-						disabled={ isEditedPostEmpty || isSavingLayout }
+						disabled={ isEditedPostEmpty || isSavingLayout || postStatus === 'future' }
 						onClick={ () => setWarningModalVisible( true ) }
 						__next40pxDefaultSize
 					>
@@ -279,7 +281,7 @@ export default compose( [
 						</div>
 					</Modal>
 				) }
-			</Fragment>
+			</BaseControl>
 		);
 	}
 );

--- a/src/newsletter-editor/sidebar/autocomplete.js
+++ b/src/newsletter-editor/sidebar/autocomplete.js
@@ -31,7 +31,7 @@ const Autocomplete = ( {
 			<BaseControl
 				id="newspack-newsletters__send-to-info"
 				help={ postStatus === 'future' && sprintf(
-					// Translators: Message shown while fetching list or sublist info. %s is the provider's label for the given entity type (list or sublist).
+					// Translators: Message shown when a newsletter is scheduled and the user cannot edit the list or sublist. %s is the provider's label for the given entity type (list or sublist).
 					__( 'Unschedule this newsletter to edit %s.', 'newspack-newsletters' ),
 					label.toLowerCase()
 				) }

--- a/src/newsletter-editor/sidebar/autocomplete.js
+++ b/src/newsletter-editor/sidebar/autocomplete.js
@@ -20,6 +20,7 @@ const Autocomplete = ( {
 	onInputChange,
 	reset,
 	selectedInfo,
+	postStatus,
 } ) => {
 	const [ isEditing, setIsEditing ] = useState( false );
 	const isRetrieving = useIsRetrieving();
@@ -27,54 +28,68 @@ const Autocomplete = ( {
 
 	if ( selectedInfo && ! isEditing ) {
 		return (
-			<div className="newspack-newsletters__send-to">
-				<p className="newspack-newsletters__send-to-details">
-					{ selectedInfo.name }
-					<span>
-						{ selectedInfo.entity_type.charAt(0).toUpperCase() + selectedInfo.entity_type.slice(1) }
-						{ selectedInfo?.hasOwnProperty( 'count' )
-							? ' • ' +
-							sprintf(
-									// Translators: If available, show a contact count alongside the selected item's type. %s is the number of contacts in the item.
-									_n( '%s contact', '%s contacts', selectedInfo.count, 'newspack-newsletters' ),
-									selectedInfo.count.toLocaleString()
-							)
-							: '' }
-					</span>
-				</p>
-				<ButtonGroup>
-					<Button
-						disabled={ isRetrieving }
-						onClick={ () => setIsEditing( true ) }
-						size="small"
-						variant="secondary"
-					>
-						{ __( 'Edit', 'newspack-newsletters' ) }
-					</Button>
-					<Button
-						disabled={ isRetrieving }
-						onClick={ reset }
-						size="small"
-						variant="secondary"
-					>
-						{ __( 'Clear', 'newspack-newsletters' ) }
-					</Button>
-					{ selectedInfo?.edit_link && (
+			<BaseControl
+				id="newspack-newsletters__send-to-info"
+				help={ postStatus === 'future' && sprintf(
+					// Translators: Message shown while fetching list or sublist info. %s is the provider's label for the given entity type (list or sublist).
+					__( 'Unschedule this newsletter to edit %s.', 'newspack-newsletters' ),
+					label.toLowerCase()
+				) }
+			>
+				<div className="newspack-newsletters__send-to">
+					<p className="newspack-newsletters__send-to-details">
+						{ selectedInfo.name }
+						<span>
+							{ selectedInfo.entity_type.charAt(0).toUpperCase() + selectedInfo.entity_type.slice(1) }
+							{ selectedInfo?.hasOwnProperty( 'count' )
+								? ' • ' +
+								sprintf(
+										// Translators: If available, show a contact count alongside the selected item's type. %s is the number of contacts in the item.
+										_n( '%s contact', '%s contacts', selectedInfo.count, 'newspack-newsletters' ),
+										selectedInfo.count.toLocaleString()
+								)
+								: '' }
+						</span>
+					</p>
+					<ButtonGroup>
 						<Button
-							disabled={ isRetrieving }
-							href={ selectedInfo.edit_link }
+							disabled={ isRetrieving || postStatus === 'future' }
+							onClick={ () => setIsEditing( true ) }
 							size="small"
-							target="_blank"
 							variant="secondary"
-							rel="noopener noreferrer"
 						>
-							{ __( 'Manage', 'newspack-newsletters' ) }
-							<Icon icon={ external } size={ 14 } />
+							{ __( 'Edit', 'newspack-newsletters' ) }
 						</Button>
-					) }
-				</ButtonGroup>
-			</div>
+						<Button
+							disabled={ isRetrieving || postStatus === 'future' }
+							onClick={ reset }
+							size="small"
+							variant="secondary"
+						>
+							{ __( 'Clear', 'newspack-newsletters' ) }
+						</Button>
+						{ selectedInfo?.edit_link && (
+							<Button
+								disabled={ isRetrieving }
+								href={ selectedInfo.edit_link }
+								size="small"
+								target="_blank"
+								variant="secondary"
+								rel="noopener noreferrer"
+							>
+								{ __( 'Manage', 'newspack-newsletters' ) }
+								<Icon icon={ external } size={ 14 } />
+							</Button>
+						) }
+					</ButtonGroup>
+				</div>
+			</BaseControl>
 		);
+	}
+
+	// Don't allow adding send-to info for scheduled newsletters.
+	if ( postStatus === 'future' ) {
+		return null;
 	}
 
 	return (

--- a/src/newsletter-editor/sidebar/index.js
+++ b/src/newsletter-editor/sidebar/index.js
@@ -235,6 +235,7 @@ const Sidebar = ( {
 				senderEmail={ senderEmail }
 				senderName={ senderName }
 				updateMeta={ updateMeta }
+				postStatus={ status }
 			/>
 			{
 				isSupportedESP() && (

--- a/src/newsletter-editor/sidebar/send-to.js
+++ b/src/newsletter-editor/sidebar/send-to.js
@@ -18,12 +18,13 @@ import { usePrevious } from '../utils';
 // The container for list + sublist autocomplete fields.
 const SendTo = () => {
 	const [ error, setError ] = useState( null );
-	const { listId, sublistId } = useSelect( select => {
+	const { listId, sublistId, postStatus } = useSelect( select => {
 		const { getEditedPostAttribute } = select( 'core/editor' );
 		const meta = getEditedPostAttribute( 'meta' );
 		return {
 			listId: meta.send_list_id,
 			sublistId: meta.send_sublist_id,
+			postStatus: getEditedPostAttribute( 'status' ),
 		};
 	} );
 
@@ -189,6 +190,7 @@ const SendTo = () => {
 				selectedInfo={ selectedList }
 				setError={ setError }
 				updateMeta={ updateMeta }
+				postStatus={ postStatus }
 			/>
 			{
 				sublists && listId && (
@@ -229,6 +231,7 @@ const SendTo = () => {
 						selectedInfo={ selectedSublist }
 						setError={ setError }
 						updateMeta={ updateMeta }
+						postStatus={ postStatus }
 					/>
 				)
 			}

--- a/src/newsletter-editor/sidebar/sender.js
+++ b/src/newsletter-editor/sidebar/sender.js
@@ -22,7 +22,8 @@ const Sender = (
 		inFlight,
 		senderEmail,
 		senderName,
-		updateMeta
+		updateMeta,
+		postStatus
 	}
 ) => {
 	const { newsletterData } = useNewsletterData();
@@ -54,8 +55,9 @@ const Sender = (
 			<TextControl
 				label={ __( 'Name', 'newspack-newsletters' ) }
 				className="newspack-newsletters__name-textcontrol"
+				help={ postStatus === 'future' && __( 'Unschedule this newsletter to edit sender info.', 'newspack-newsletters' ) }
 				value={ senderName }
-				disabled={ inFlight }
+				disabled={ inFlight || postStatus === 'future' }
 				onChange={ value => updateMeta( { senderName: value } ) }
 				placeholder={ __( 'The campaign’s sender name.', 'newspack-newsletters' ) }
 			/>
@@ -66,7 +68,7 @@ const Sender = (
 					className={ senderEmailClasses }
 					value={ senderEmail }
 					type="email"
-					disabled={ inFlight }
+					disabled={ inFlight || postStatus === 'future' }
 					onChange={ value => updateMeta( { senderEmail: value } ) }
 					placeholder={ __( 'The campaign’s sender email.', 'newspack-newsletters' ) }
 				/>

--- a/src/newsletter-editor/sidebar/sender.js
+++ b/src/newsletter-editor/sidebar/sender.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { __, sprintf } from '@wordpress/i18n';
-import { Button, Notice, SelectControl, TextControl } from '@wordpress/components';
+import { BaseControl, Button, Notice, SelectControl, TextControl } from '@wordpress/components';
 import { Icon, external } from '@wordpress/icons';
 
 /**
@@ -32,7 +32,7 @@ const Sender = (
 		'newspack-newsletters__email-textcontrol',
 		errors.newspack_newsletters_unverified_sender_domain && 'newspack-newsletters__error'
 	);
-	const validDomainsMessage = allowedDomains?.length && allowedDomains.every( domain => ! senderEmail || ! senderEmail.includes( domain ) ) ?
+	const validDomainsMessage = postStatus !== 'future' && allowedDomains?.length && allowedDomains.every( domain => ! senderEmail || ! senderEmail.includes( domain ) ) ?
 		sprintf(
 			/* translators: %s: list of allowed domains */
 			__( 'Sender email must contain one of the following domains: %s', 'newspack-newsletters' ),
@@ -41,7 +41,7 @@ const Sender = (
 		'';
 
 	return (
-		<>
+		<BaseControl id="newspack-newsletters__sender" help={ postStatus === 'future' && __( 'Unschedule this newsletter to edit sender info.', 'newspack-newsletters' ) }>
 			<strong className="newspack-newsletters__label">
 				{ __( 'Sender', 'newspack-newsletters' ) }
 			</strong>
@@ -55,7 +55,6 @@ const Sender = (
 			<TextControl
 				label={ __( 'Name', 'newspack-newsletters' ) }
 				className="newspack-newsletters__name-textcontrol"
-				help={ postStatus === 'future' && __( 'Unschedule this newsletter to edit sender info.', 'newspack-newsletters' ) }
 				value={ senderName }
 				disabled={ inFlight || postStatus === 'future' }
 				onChange={ value => updateMeta( { senderName: value } ) }
@@ -68,7 +67,7 @@ const Sender = (
 					className={ senderEmailClasses }
 					value={ senderEmail }
 					type="email"
-					disabled={ inFlight || postStatus === 'future' }
+					disabled={ postStatus === 'future' }
 					onChange={ value => updateMeta( { senderEmail: value } ) }
 					placeholder={ __( 'The campaign’s sender email.', 'newspack-newsletters' ) }
 				/>
@@ -83,6 +82,7 @@ const Sender = (
 					{ allowedEmails.length && (
 						<SelectControl
 							label={ __( 'Email', 'newspack-newsletters' ) }
+							disabled={ inFlight || postStatus === 'future' }
 							help={ __(
 								'Select a verified sender email.',
 								'newspack-newsletters'
@@ -117,7 +117,7 @@ const Sender = (
 					) }
 				</>
 			) }
-		</>
+		</BaseControl>
 	);
 }
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Currently, once a newsletter post has been scheduled for a future send, there's no dedicated "Update" button in the editor to save changes to the post attributes or content. Instead, there's only a "Scheduled" button which when clicked opens the pre-send modal. The lack of a dedicated "update" or "save" button puts the editor in a confusing state where it's unclear whether or how a scheduled newsletter can be updated before it gets sent.

This PR hides the pre-send modal button for scheduled posts, and instead shows the regular "Update" button which should allow for simple updates to the content. Because editing sender, send-to, or layout attributes could cause the send to fail due to invalid data, these controls are disabled while the post is in scheduled status. To edit them again, the post must be unscheduled first to enforce send data validation.

In practice, a scheduled newsletter can be saved by going through the pre-send modal again (and scheduling it again), sending a test email, or hitting the command/control+S keyboard shortcut, so the proposed change should actually help prevent unwanted changes to scheduled posts by disabling the UI for critical data.

Related to NPPM-2403.

### How to test the changes in this Pull Request:

1. Check out this branch.
2. Create a new newsletter, fill in the required campaign info, and schedule it for sending at a future time.
3. While the post is scheduled but before the scheduled time, confirm that the "Update" button is enabled and allows saving edits to the post's content and attributes.
4. Confirm that while the post is in "scheduled" status, certain post settings that could invalidate the send are disabled (sender, send-to, and layout):

<img width="279" height="685" alt="Screenshot 2025-11-17 at 5 43 03 PM" src="https://github.com/user-attachments/assets/41983da3-30b4-4fa8-ad91-ee13038883bc" />

5. Make some edits to the scheduled post and save.
6. After the scheduled time elapses, confirm that newsletter is sent and that the email sent by the connected ESP reflects the latest edits from step 5.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
