### PR TITLE
fix: remove stretchy paragraphy, heading block variations from newsletter

### DIFF
--- a/src/editor/index.js
+++ b/src/editor/index.js
@@ -45,6 +45,9 @@ domReady( () => {
 	unregisterBlockVariation( 'core/group', 'group-row' );
 	/* Unregister "grid" group block variation */
 	unregisterBlockVariation( 'core/group', 'group-grid' );
+	/* Unregister "stretchy" heading and paragraphblock variations */
+	unregisterBlockVariation( 'core/heading', 'stretchy-heading' );
+	unregisterBlockVariation( 'core/paragraph', 'stretchy-paragraph' );
 } );
 
 /* Remove Duotone filters */


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

WordPress 6.9 adds a new 'stretchy' block variation for the Paragraph and Heading blocks, which uses CSS to scale up the text to fit the available horizontal space. 

This style doesn't work in newsletters/email clients, so this PR removes the option from the Newsletter.

### How to test the changes in this Pull Request:

1. On a test site running the latest WP 6.9 RC, create a new newsletter.
2. Try to add a Heading or Paragraph block and note you have an option to use a 'stretchy' variation.

<img width="627" height="161" alt="CleanShot 2025-11-18 at 15 42 06" src="https://github.com/user-attachments/assets/f19bb9ff-2f47-4c78-8e70-00b17a5bccae" />

3. Apply this PR and run `npm run build`.
4. Confirm you no longer have the stretchy variations available.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
