### PR TITLE
fix: remove 'hide block' option for Newsletters

### DIFF
--- a/src/editor/index.js
+++ b/src/editor/index.js
@@ -63,6 +63,10 @@ addFilter( 'blocks.registerBlockType', 'newspack-newsletters/core-blocks', ( set
 	if ( 'core/group' === name ) {
 		settings.supports = { ...settings.supports, align: [ 'full' ] };
 	}
+
+	/* Remove 'Hide' option for all blocks */
+	settings.supports = { ...settings.supports, blockVisibility: false };
+
 	return settings;
 } );
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

WordPress 6.9 introduces a new 'hide block' option in the block toolbar. In my testing, it looks like hiding blocks in Newsletters work in the editor but not in the sent newsletter. This PR hides the option from the Newsletter editor.

### How to test the changes in this Pull Request:

1. On a test site running the latest version of the WP 6.9 RC, create a new newsletter and add some content.
2. Using the option in the block toolbar, hide at least one block:

<img width="750" height="705" alt="CleanShot 2025-11-20 at 10 06 24" src="https://github.com/user-attachments/assets/50440155-72a9-4984-875e-97480fd2aa6b" />

3. Send yourself a test newsletter; note the hidden block is still there.
4. Apply this PR and run `npm run build`.
5. Confirm that the 'Hide' option is no longer available in the block toolbar.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
