### PR TITLE
feat: add support for WP 6.9's Notes feature to Newsletters

### DIFF
--- a/includes/class-newspack-newsletters.php
+++ b/includes/class-newspack-newsletters.php
@@ -579,7 +579,16 @@ final class Newspack_Newsletters {
 			'item_link_description'    => __( 'A link to a newsletter.', 'newspack-newsletters' ),
 		];
 
-		$supports = [ 'author', 'editor', 'title', 'custom-fields', 'newspack_blocks', 'revisions', 'thumbnail', 'excerpt' ];
+		$supports = [
+			'author',
+			'editor' => [ 'notes' => true ],
+			'title',
+			'custom-fields',
+			'newspack_blocks',
+			'revisions',
+			'thumbnail',
+			'excerpt',
+		];
 
 		if ( get_option( 'newspack_newsletters_support_comments' ) ) {
 			$supports[] = 'comments';


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

By default, the new Notes feature coming in WordPress 6.9 is only available in Posts and Pages. This PR adds the functionality to our Newsletters, too.

Note: I'm not sure if it makes sense to rush this as a hotfix ahead of the WP 6.9 release next week, or let it go though the usual slower testing cycle. Adding support didn't seem to add any issues in my testing -- the notes act like they do with posts and pages -- but it might be good to see how this feature lands with our publishes with those post types before adding it elsewhere.

### How to test the changes in this Pull Request:

1. Start on a test site running the latest WP 6.9 RC.
2. Create a new newsletter and add some content.
3. Try out adding notes to some different blocks:
    * Add them to Core and custom blocks
    * Reply to comments
    * Mark them as resolved
    * Try opening and closing the Notes panel 
4. Try sending a test message with notes attached to the blocks.
5. Set the newsletter to be published when sent, and send it to an actual (test) list of subscribers.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
