### PR TITLE
fix(mjml): escape values when converting post to MJML

### DIFF
--- a/includes/email-template.mjml.php
+++ b/includes/email-template.mjml.php
@@ -10,7 +10,7 @@
 
 <mjml>
 	<mj-head>
-		<mj-title><?php echo htmlentities( $title ); ?></mj-title>
+		<mj-title><?php echo esc_html( $title ); ?></mj-title>
 		<mj-style>
 		<?php
 			$default_css = file_get_contents( dirname( __FILE__ ) . '/email-template-mjml.css' );
@@ -22,14 +22,14 @@
 		?>
 		</mj-style>
 		<?php if ( isset( $preview_text ) ): ?>
-			<mj-preview><?php echo $preview_text; ?></mj-preview>
+			<mj-preview><?php echo esc_html( $preview_text ); ?></mj-preview>
 		<?php endif; ?>
 		<mj-attributes>
-			<mj-all color="<?php echo $text_color ?? '#000000'; ?>" />
-			<mj-text color="<?php echo $text_color ?? '#000000'; ?>" />
+			<mj-all color="<?php echo esc_attr( $text_color ?? '#000000' ); ?>" />
+			<mj-text color="<?php echo esc_attr( $text_color ?? '#000000' ); ?>" />
 		</mj-attributes>
 	</mj-head>
-	<mj-body background-color="<?php echo $background_color; ?>" css-class="updated-<?php echo $updated; ?>">
+	<mj-body background-color="<?php echo esc_attr( $background_color ); ?>" css-class="updated-<?php echo esc_attr( $updated ); ?>">
 		<?php echo $body; ?>
 		<?php do_action( 'newspack_newsletters_editor_mjml_body', $post ); ?>
 	</mj-body>

--- a/includes/email-template.mjml.php
+++ b/includes/email-template.mjml.php
@@ -10,7 +10,7 @@
 
 <mjml>
 	<mj-head>
-		<mj-title><?php echo $title; ?></mj-title>
+		<mj-title><?php echo htmlentities( $title ); ?></mj-title>
 		<mj-style>
 		<?php
 			$default_css = file_get_contents( dirname( __FILE__ ) . '/email-template-mjml.css' );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Ensures that all user input is escaped before being converted to MJML.

### How to test the changes in this Pull Request:

1. On `release`, create a draft newsletter and add a title that contains HTML-unfriendly characters, such as `"` or `&`.
2. Save the draft and observe an error in response to the `/post-mjml` XHR request:

<img width="1517" height="351" alt="Screenshot 2025-11-25 at 3 51 09 PM" src="https://github.com/user-attachments/assets/5f579155-1666-4299-ab01-4febfbb58531" />

3. Check out this branch and save again, and confirm that the post saves successfully.
4. Edit newsletter content, change the global fonts, text color, and background color, etc. and confirm that the email HTML matches the saved draft when synced to the ESP and sent as a test email.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
