### PR TITLE
feat: default mailchimp footer

### DIFF
--- a/includes/class-newspack-newsletters-editor.php
+++ b/includes/class-newspack-newsletters-editor.php
@@ -415,6 +415,13 @@ final class Newspack_Newsletters_Editor {
 				filemtime( NEWSPACK_NEWSLETTERS_PLUGIN_FILE . 'dist/newsletterEditor.js' ),
 				true
 			);
+			\wp_localize_script(
+				'newspack-newsletters-newsletter-editor',
+				'newspack_newsletters_editor_data',
+				[
+					'mailchimp_default_footer' => wp_kses_post( Newspack_Newsletters_Mailchimp_Default_Footer::get_footer_content() ),
+				]
+			);
 			\wp_enqueue_script(
 				'newspack-newsletters-ads-editor',
 				plugins_url( '../dist/newsletterAdsEditor.js', __FILE__ ),

--- a/includes/class-newspack-newsletters-settings.php
+++ b/includes/class-newspack-newsletters-settings.php
@@ -87,6 +87,15 @@ class Newspack_Newsletters_Settings {
 				'onboarding'  => true,
 			),
 			array(
+				'description'       => esc_html__( 'Append recommended Mailchimp footer to layouts', 'newspack-newsletters' ),
+				'key'               => 'newspack_mailchimp_auto_append_footer',
+				'type'              => 'checkbox',
+				'default'           => false,
+				'provider'          => 'mailchimp',
+				'sanitize_callback' => 'boolval',
+				'onboarding'        => true,
+			),
+			array(
 				'description' => esc_html__( 'Constant Contact API Key', 'newspack-newsletters' ),
 				'key'         => 'newspack_newsletters_constant_contact_api_key',
 				'type'        => 'text',

--- a/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp-default-footer.php
+++ b/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp-default-footer.php
@@ -33,7 +33,7 @@ class Newspack_Newsletters_Mailchimp_Default_Footer {
 		if ( function_exists( 'wc_get_account_endpoint_url' ) && class_exists( 'Newspack\Reader_Activation' ) && method_exists( 'Newspack\Reader_Activation', 'is_enabled' ) && \Newspack\Reader_Activation::is_enabled() ) {
 			$manage_preferences_url = wc_get_account_endpoint_url( Newspack_Newsletters_Subscription::WC_ENDPOINT );
 		}
-		return '<!-- wp:paragraph {"align":"center","fontSize":"small"} --><p class="has-text-align-center has-small-font-size"><br>This email was sent to *|EMAIL|*<br><a href="' . $manage_preferences_url . '">Update your preferences</a>&nbsp;—&nbsp;<a href="http://*|UNSUB|*">Unsubscribe from all *|LIST:COMPANY|* newsletters</a><br>*|LIST_ADDRESSLINE_TEXT|**|IF:REWARDS|*<br><br>*|HTML:REWARDS|* *|END:IF|*</p><!-- /wp:paragraph -->';
+		return '<!-- wp:paragraph {"align":"center","fontSize":"small"} --><p class="has-text-align-center has-small-font-size"><br>This email was sent to *|EMAIL|*<br><a href="' . esc_url( $manage_preferences_url ) . '">Update your preferences</a>&nbsp;—&nbsp;<a href="http://*|UNSUB|*">Unsubscribe from all *|LIST:COMPANY|* newsletters</a><br>*|LIST_ADDRESSLINE_TEXT|**|IF:REWARDS|*<br><br>*|HTML:REWARDS|* *|END:IF|*</p><!-- /wp:paragraph -->';
 	}
 
 	/**

--- a/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp-default-footer.php
+++ b/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp-default-footer.php
@@ -30,7 +30,7 @@ class Newspack_Newsletters_Mailchimp_Default_Footer {
 			return '';
 		}
 		$manage_preferences_url = 'http://*|UPDATE_PROFILE|*';
-		if ( function_exists( 'wc_get_account_endpoint_url' ) && class_exists( 'Newspack\Reader_Activation' ) && method_exists( 'Newspack\Reader_Activation', 'is_enabled' ) && \Newspack\Reader_Activation::is_enabled() ) {
+		if ( function_exists( 'wc_get_account_endpoint_url' ) && method_exists( 'Newspack\Reader_Activation', 'is_enabled' ) && \Newspack\Reader_Activation::is_enabled() ) {
 			$manage_preferences_url = wc_get_account_endpoint_url( Newspack_Newsletters_Subscription::WC_ENDPOINT );
 		}
 		return '<!-- wp:paragraph {"align":"center","fontSize":"small"} --><p class="has-text-align-center has-small-font-size"><br>This email was sent to *|EMAIL|*<br><a href="' . esc_url( $manage_preferences_url ) . '">Update your preferences</a>&nbsp;—&nbsp;<a href="http://*|UNSUB|*">Unsubscribe from all *|LIST:COMPANY|* newsletters</a><br>*|LIST_ADDRESSLINE_TEXT|**|IF:REWARDS|*<br><br>*|HTML:REWARDS|* *|END:IF|*</p><!-- /wp:paragraph -->';

--- a/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp-default-footer.php
+++ b/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp-default-footer.php
@@ -1,0 +1,59 @@
+<?php
+/**
+ * Service Provider: Mailchimp Default Footer
+ *
+ * @package Newspack
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Usage reports for Mailchimp.
+ */
+class Newspack_Newsletters_Mailchimp_Default_Footer {
+
+	/**
+	 * Initialize hooks.
+	 */
+	public static function init() {
+		add_action( 'admin_footer', [ __CLASS__, 'add_footer_content_to_editor' ] );
+	}
+	/**
+	 * Get the default Mailchimp footer content.
+	 *
+	 * @return string Footer content.
+	 */
+	public static function get_footer_content() {
+
+		$should_append_footer = get_option( 'newspack_mailchimp_auto_append_footer', false );
+		if ( ! $should_append_footer ) {
+			return '';
+		}
+		$manage_preferences_url = 'http://*|UPDATE_PROFILE|*';
+		if ( function_exists( 'wc_get_account_endpoint_url' ) && class_exists( 'Newspack\Reader_Activation' ) && method_exists( 'Newspack\Reader_Activation', 'is_enabled' ) && \Newspack\Reader_Activation::is_enabled() ) {
+			$manage_preferences_url = wc_get_account_endpoint_url( Newspack_Newsletters_Subscription::WC_ENDPOINT );
+		}
+		return '<!-- wp:paragraph {"align":"center","fontSize":"small"} --><p class="has-text-align-center has-small-font-size"><br>This email was sent to *|EMAIL|*<br><a href="' . $manage_preferences_url . '">Update your preferences</a>&nbsp;—&nbsp;<a href="http://*|UNSUB|*">Unsubscribe from all *|LIST:COMPANY|* newsletters</a><br>*|LIST_ADDRESSLINE_TEXT|**|IF:REWARDS|*<br><br>*|HTML:REWARDS|* *|END:IF|*</p><!-- /wp:paragraph -->';
+	}
+
+	/**
+	 * Add the default footer content to the editor.
+	 */
+	public static function add_footer_content_to_editor() {
+		$screen = get_current_screen();
+		if ( Newspack_Newsletters::NEWSPACK_NEWSLETTERS_CPT !== $screen->post_type ) {
+			return;
+		}
+		$footer_content = self::get_footer_content();
+		if ( empty( $footer_content ) ) {
+			return;
+		}
+		?>
+		<script type="text/javascript">
+			window.newspackMailchimpDefaultFooter = '<?php echo $footer_content; // phpcs:ignore?>';
+		</script>
+		<?php
+	}
+}
+
+Newspack_Newsletters_Mailchimp_Default_Footer::init();

--- a/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp-default-footer.php
+++ b/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp-default-footer.php
@@ -8,7 +8,7 @@
 defined( 'ABSPATH' ) || exit;
 
 /**
- * Usage reports for Mailchimp.
+ * Append default Mailchimp footer to all newsletter drafts when `newspack_mailchimp_auto_append_footer` is true.
  */
 class Newspack_Newsletters_Mailchimp_Default_Footer {
 

--- a/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp-default-footer.php
+++ b/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp-default-footer.php
@@ -27,6 +27,15 @@ class Newspack_Newsletters_Mailchimp_Default_Footer {
 		if ( function_exists( 'wc_get_account_endpoint_url' ) && method_exists( 'Newspack\Reader_Activation', 'is_enabled' ) && \Newspack\Reader_Activation::is_enabled() ) {
 			$manage_preferences_url = wc_get_account_endpoint_url( Newspack_Newsletters_Subscription::WC_ENDPOINT );
 		}
-		return '<!-- wp:paragraph {"align":"center","fontSize":"small"} --><p class="has-text-align-center has-small-font-size"><br>This email was sent to *|EMAIL|*<br><a href="' . esc_url( $manage_preferences_url ) . '">Update your preferences</a>&nbsp;—&nbsp;<a href="http://*|UNSUB|*">Unsubscribe from all *|LIST:COMPANY|* newsletters</a><br>*|LIST_ADDRESSLINE_TEXT|**|IF:REWARDS|*<br><br>*|HTML:REWARDS|* *|END:IF|*</p><!-- /wp:paragraph -->';
+
+		// Translators: %s is replaced with the *|EMAIL|* Mailchimp merge tag.
+		$sent_to = sprintf( __( 'This email was sent to %s', 'newspack-newsletters' ), '*|EMAIL|*' );
+
+		$unsubscribe_this = __( 'Unsubscribe from this newsletter', 'newspack-newsletters' );
+
+		// Translators: %s is replaced with the *|LIST:COMPANY|* mailchimp merge tag.
+		$unsubscribe_all = sprintf( __( 'Opt out of all emails from %s', 'newspack-newsletters' ), '*|LIST:COMPANY|*' );
+
+		return '<!-- wp:paragraph {"align":"center","fontSize":"small"} --><p class="has-text-align-center has-small-font-size"><br>' . $sent_to . '<br><a href="' . esc_url( $manage_preferences_url ) . '">' . $unsubscribe_this . '</a>&nbsp;—&nbsp;<a href="http://*|UNSUB|*">' . $unsubscribe_all . '</a><br>*|LIST_ADDRESSLINE_TEXT|**|IF:REWARDS|*<br><br>*|HTML:REWARDS|* *|END:IF|*</p><!-- /wp:paragraph -->';
 	}
 }

--- a/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp-default-footer.php
+++ b/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp-default-footer.php
@@ -13,12 +13,6 @@ defined( 'ABSPATH' ) || exit;
 class Newspack_Newsletters_Mailchimp_Default_Footer {
 
 	/**
-	 * Initialize hooks.
-	 */
-	public static function init() {
-		add_action( 'admin_footer', [ __CLASS__, 'add_footer_content_to_editor' ] );
-	}
-	/**
 	 * Get the default Mailchimp footer content.
 	 *
 	 * @return string Footer content.
@@ -35,25 +29,4 @@ class Newspack_Newsletters_Mailchimp_Default_Footer {
 		}
 		return '<!-- wp:paragraph {"align":"center","fontSize":"small"} --><p class="has-text-align-center has-small-font-size"><br>This email was sent to *|EMAIL|*<br><a href="' . esc_url( $manage_preferences_url ) . '">Update your preferences</a>&nbsp;—&nbsp;<a href="http://*|UNSUB|*">Unsubscribe from all *|LIST:COMPANY|* newsletters</a><br>*|LIST_ADDRESSLINE_TEXT|**|IF:REWARDS|*<br><br>*|HTML:REWARDS|* *|END:IF|*</p><!-- /wp:paragraph -->';
 	}
-
-	/**
-	 * Add the default footer content to the editor.
-	 */
-	public static function add_footer_content_to_editor() {
-		$screen = get_current_screen();
-		if ( Newspack_Newsletters::NEWSPACK_NEWSLETTERS_CPT !== $screen->post_type ) {
-			return;
-		}
-		$footer_content = self::get_footer_content();
-		if ( empty( $footer_content ) ) {
-			return;
-		}
-		?>
-		<script type="text/javascript">
-			window.newspackMailchimpDefaultFooter = '<?php echo $footer_content; // phpcs:ignore?>';
-		</script>
-		<?php
-	}
 }
-
-Newspack_Newsletters_Mailchimp_Default_Footer::init();

--- a/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp-default-footer.php
+++ b/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp-default-footer.php
@@ -25,7 +25,7 @@ class Newspack_Newsletters_Mailchimp_Default_Footer {
 	 */
 	public static function get_footer_content() {
 
-		$should_append_footer = get_option( 'newspack_mailchimp_auto_append_footer', false );
+		$should_append_footer = 'mailchimp' === Newspack_Newsletters::service_provider() && get_option( 'newspack_mailchimp_auto_append_footer', false );
 		if ( ! $should_append_footer ) {
 			return '';
 		}

--- a/newspack-newsletters.php
+++ b/newspack-newsletters.php
@@ -42,6 +42,7 @@ require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/service-providers/mai
 require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp-usage-reports.php';
 require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp-notes.php';
 require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp-subscription-list-trait.php';
+require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp-default-footer.php';
 require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/service-providers/constant_contact/class-newspack-newsletters-constant-contact.php';
 require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/service-providers/constant_contact/class-newspack-newsletters-constant-contact-controller.php';
 require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/service-providers/constant_contact/class-newspack-newsletters-constant-contact-sdk.php';

--- a/src/components/init-modal/screens/layout-picker/index.js
+++ b/src/components/init-modal/screens/layout-picker/index.js
@@ -43,8 +43,10 @@ export default function LayoutPicker() {
 			meta.stringifiedCampaignDefaults = meta.campaign_defaults;
 		}
 
-		// Append default Mailchimp footer if available.
-		post_content += window.newspack_newsletters_editor_data?.mailchimp_default_footer || '';
+		// Append default Mailchimp footer if available. Only if "*|UNSUB|*" tag is not already present.
+		if ( post_content && ! post_content.includes( '*|UNSUB|*' ) ) {
+			post_content += window.newspack_newsletters_editor_data?.mailchimp_default_footer || '';
+		}
 
 		editPost( { meta: { template_id: layoutId, ...meta } } );
 		resetEditorBlocks( post_content ? parse( post_content ) : [] );

--- a/src/components/init-modal/screens/layout-picker/index.js
+++ b/src/components/init-modal/screens/layout-picker/index.js
@@ -38,7 +38,7 @@ export default function LayoutPicker() {
 	const { layouts, isFetchingLayouts, deleteLayoutPost } = useLayoutsState();
 
 	const insertLayout = layoutId => {
-		let { post_content, meta = {} } = find( layouts, { ID: layoutId } ) || {};
+		let { post_content = '', meta = {} } = find( layouts, { ID: layoutId } ) || {};
 		if ( meta.campaign_defaults && 'string' === typeof meta.campaign_defaults ) {
 			meta.stringifiedCampaignDefaults = meta.campaign_defaults;
 		}

--- a/src/components/init-modal/screens/layout-picker/index.js
+++ b/src/components/init-modal/screens/layout-picker/index.js
@@ -44,7 +44,7 @@ export default function LayoutPicker() {
 		}
 
 		// Append default Mailchimp footer if available.
-		post_content += window.newspackMailchimpDefaultFooter || '';
+		post_content += window.newspack_newsletters_editor_data?.mailchimp_default_footer || '';
 
 		editPost( { meta: { template_id: layoutId, ...meta } } );
 		resetEditorBlocks( post_content ? parse( post_content ) : [] );

--- a/src/components/init-modal/screens/layout-picker/index.js
+++ b/src/components/init-modal/screens/layout-picker/index.js
@@ -38,10 +38,14 @@ export default function LayoutPicker() {
 	const { layouts, isFetchingLayouts, deleteLayoutPost } = useLayoutsState();
 
 	const insertLayout = layoutId => {
-		const { post_content, meta = {} } = find( layouts, { ID: layoutId } ) || {};
+		let { post_content, meta = {} } = find( layouts, { ID: layoutId } ) || {};
 		if ( meta.campaign_defaults && 'string' === typeof meta.campaign_defaults ) {
 			meta.stringifiedCampaignDefaults = meta.campaign_defaults;
 		}
+
+		// Append default Mailchimp footer if available.
+		post_content += window.newspackMailchimpDefaultFooter || '';
+
 		editPost( { meta: { template_id: layoutId, ...meta } } );
 		resetEditorBlocks( post_content ? parse( post_content ) : [] );
 	};


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

See pamTN9-ccQ-p2

### How to test the changes in this Pull Request:

1. Configure Mailchimp as your ESP
2. Go to Settings and enable the option to append the recommended footer
3. Create a new newsletter, select a Layout and use it
4. Confirm that the footer is appended to the end of the Newsletter
5. Send the newsletter and confirm all the links in the footer work as expected
6. Check that with RAS enabled the link takes you to My Account, and with RAS disabled it takes you to Mailchimp preferences


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
