### PR TITLE
fix(my-account): subscription button style

### DIFF
--- a/includes/class-newspack-newsletters-subscription.php
+++ b/includes/class-newspack-newsletters-subscription.php
@@ -1015,7 +1015,7 @@ class Newspack_Newsletters_Subscription {
 							<?php endforeach; ?>
 						</ul>
 					</div>
-					<button type="submit"><?php _e( 'Update subscriptions', 'newspack-newsletters' ); ?></button>
+					<button class="newspack-ui__button newspack-ui__button--primary" type="submit"><?php _e( 'Update subscriptions', 'newspack-newsletters' ); ?></button>
 				</form>
 			<?php endif; ?>
 		</div>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

NPPD-986

Apply Newspack UI classes to the "Update subscription" button under the My Account Newsletters page.

| Before | After |
| --- | --- |
| <img width="1010" height="444" alt="image" src="https://github.com/user-attachments/assets/b3cb0d0c-e424-42d5-baba-f1811e5cc1b1" /> | <img width="1010" height="443" alt="image" src="https://github.com/user-attachments/assets/c799b3e1-cc4a-4968-a626-9b592ba5980e" /> |


### How to test the changes in this Pull Request:

1. Make sure you have `define( 'NEWSPACK_MY_ACCOUNT_VERSION', '1.0.0' );` in your wp config
2. As a reader, navigate to "My Account -> Newsletters"
3. Confirm the button style matches the buttons from "My Account -> Payment Information"

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
