### PR TITLE
fix: rename blockVisibility to visibility

### DIFF
--- a/src/editor/index.js
+++ b/src/editor/index.js
@@ -65,7 +65,7 @@ addFilter( 'blocks.registerBlockType', 'newspack-newsletters/core-blocks', ( set
 	}
 
 	/* Remove 'Hide' option for all blocks */
-	settings.supports = { ...settings.supports, blockVisibility: false };
+	settings.supports = { ...settings.supports, visibility: false };
 
 	return settings;
 } );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

In https://github.com/Automattic/newspack-newsletters/pull/1968, we hid the new 'Hide' option for blocks in the Newsletter posts since the blocks weren't hidden in the sent newsletters.

In https://github.com/WordPress/gutenberg/pull/73432, the support was renamed from `blockVisibility` to `visibility` to avoid clashes with the Block Visibility plugin; this caused our fix to stop working. 

This PR updates the name to match.

### How to test the changes in this Pull Request:

1. Follow the test steps in https://github.com/Automattic/newspack-newsletters/pull/1968 on a site running WP 6.9 and confirm that the 'Hide' option doesn't appear in the block toolbar.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
