### PR TITLE
fix: make sure a log file always exists

### DIFF
--- a/includes/tracking/class-pixel.php
+++ b/includes/tracking/class-pixel.php
@@ -435,6 +435,9 @@ final class Pixel {
 					self::rotate_log_file();
 				}
 			}
+		} else {
+			// If the log file doesn't exist, create a new one.
+			self::rotate_log_file();
 		}
 	}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

If the log file doesn't exist for any reason, make sure we are not stuck and create one.

### How to test the changes in this Pull Request:

1. `wp option delete newspack_newsletters_tracking_pixel_previous_log_file`
2. `wp option delete newspack_newsletters_pixel_log_offset`
3. `rm wp-content/np-newsletters-pixel.php`
4. Invoke `Newspack_Newsletters\Tracking\Pixel::process_logs()`
5. On `release` see that the new tracking file "np-newsletter-pixel.php" is never created
6. On this branch, confirm that the tracking file is created and the newspack_newsletters_pixel_log_offset is updated
7.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
