### PR TITLE
fix(premium-newsletters): if available, use ESP_Sync to sync premium lists

### DIFF
--- a/includes/plugins/woocommerce-memberships/class-woocommerce-memberships.php
+++ b/includes/plugins/woocommerce-memberships/class-woocommerce-memberships.php
@@ -195,8 +195,21 @@ class Woocommerce_Memberships {
 	public static function sync_user_lists( $user_id, $user_email, $lists_to_add, $lists_to_remove, $context ) {
 		$result = false;
 		if ( method_exists( 'Newspack\Reader_Activation\ESP_Sync', 'can_esp_sync' ) && method_exists( 'Newspack\Reader_Activation\Sync\WooCommerce', 'get_contact_from_customer' ) && ESP_Sync::can_esp_sync() ) {
-			$contact = Sync\WooCommerce::get_contact_from_customer( new \WC_Customer( $user_id ) );
-			$result = ESP_Sync::sync( $contact, $context, null, $lists_to_add, $lists_to_remove );
+			$provider = Newspack_Newsletters::get_service_provider();
+			$contact  = Sync\WooCommerce::get_contact_from_customer( new \WC_Customer( $user_id ) );
+			$result   = ESP_Sync::sync( $contact, $context, null, $lists_to_add, $lists_to_remove );
+
+			/**
+			 * Fires after a contact's lists are updated.
+			 *
+			 * @param string        $provider        The provider name.
+			 * @param string        $user_email           Contact email address.
+			 * @param string[]      $lists_to_add    Array of list IDs to subscribe the contact to.
+			 * @param string[]      $lists_to_remove Array of list IDs to remove the contact from.
+			 * @param bool|WP_Error $result          True if the contact was updated or error if failed.
+			 * @param string        $context         Context of the update for logging purposes.
+			 */
+			do_action( 'newspack_newsletters_update_contact_lists', $provider->service, $user_email, $lists_to_add, $lists_to_remove, $result, $context );
 		} else {
 			$result = Newspack_Newsletters_Contacts::add_and_remove_lists( $user_email, $lists_to_add, $lists_to_remove, $context );
 		}

--- a/includes/plugins/woocommerce-memberships/class-woocommerce-memberships.php
+++ b/includes/plugins/woocommerce-memberships/class-woocommerce-memberships.php
@@ -7,6 +7,7 @@
 
 namespace Newspack_Newsletters\Plugins;
 
+use Newspack_Newsletters;
 use Newspack\Reader_Activation\ESP_Sync;
 use Newspack\Reader_Activation\Sync;
 use Newspack\Newsletters\Subscription_List;

--- a/includes/plugins/woocommerce-memberships/class-woocommerce-memberships.php
+++ b/includes/plugins/woocommerce-memberships/class-woocommerce-memberships.php
@@ -7,9 +7,10 @@
 
 namespace Newspack_Newsletters\Plugins;
 
+use Newspack\Reader_Activation\ESP_Sync;
+use Newspack\Reader_Activation\Sync;
 use Newspack\Newsletters\Subscription_List;
 use Newspack\Newsletters\Subscription_Lists;
-use Newspack_Newsletters;
 use Newspack_Newsletters_Contacts;
 use Newspack_Newsletters_Logger;
 
@@ -181,6 +182,28 @@ class Woocommerce_Memberships {
 	}
 
 	/**
+	 * Sync the user's subscribed lists to the ESP.
+	 * If ESP_Sync is enabled, add to the sync queue. Otherwise, use the service provider's API.
+	 *
+	 * @param int    $user_id The user ID.
+	 * @param string $user_email The user's email address.
+	 * @param array  $lists_to_add The lists to add.
+	 * @param array  $lists_to_remove The lists to remove.
+	 * @param string $context The context.
+	 * @return bool|WP_Error
+	 */
+	public static function sync_user_lists( $user_id, $user_email, $lists_to_add, $lists_to_remove, $context ) {
+		$result = false;
+		if ( method_exists( 'Newspack\Reader_Activation\ESP_Sync', 'can_esp_sync' ) && method_exists( 'Newspack\Reader_Activation\Sync\WooCommerce', 'get_contact_from_customer' ) && ESP_Sync::can_esp_sync() ) {
+			$contact = Sync\WooCommerce::get_contact_from_customer( new \WC_Customer( $user_id ) );
+			$result = ESP_Sync::sync( $contact, $context, null, $lists_to_add, $lists_to_remove );
+		} else {
+			$result = Newspack_Newsletters_Contacts::add_and_remove_lists( $user_email, $lists_to_add, $lists_to_remove, $context );
+		}
+		return $result;
+	}
+
+	/**
 	 * Removes user from membership-tied lists associated with a membership plan
 	 *
 	 * @param \WC_Memberships_User_Membership $user_membership The User Membership object.
@@ -236,7 +259,12 @@ class Woocommerce_Memberships {
 
 		self::update_user_lists_on_deactivation( $user->ID, $user_membership->get_id(), $existing_lists );
 
-		Newspack_Newsletters_Contacts::add_and_remove_lists( $user_email, [], $lists_to_remove, 'Removing user from lists tied to Memberships being marked as inactive' );
+		$result = self::sync_user_lists( $user->ID, $user_email, [], $lists_to_remove, 'Removing user from lists tied to Memberships being marked as inactive' );
+		if ( is_wp_error( $result ) ) {
+			Newspack_Newsletters_Logger::log( 'An error occured while updating user lists for ' . $user_email . ': ' . $result->get_error_message() );
+			return;
+		}
+
 		Newspack_Newsletters_Logger::log( 'Reader ' . $user_email . ' removed from the following lists: ' . implode( ', ', $lists_to_remove ) );
 	}
 
@@ -374,8 +402,7 @@ class Woocommerce_Memberships {
 			return;
 		}
 
-		$result = Newspack_Newsletters_Contacts::add_and_remove_lists( $user_email, $lists_to_add, [], 'Adding user to lists tied to Memberships being marked as active' );
-
+		$result = self::sync_user_lists( $user_id, $user_email, $lists_to_add, [], 'Adding user to lists tied to Memberships being marked as active' );
 		if ( is_wp_error( $result ) ) {
 			Newspack_Newsletters_Logger::log( 'An error occured while updating lists for ' . $user_email . ': ' . $result->get_error_message() );
 			return;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Along with https://github.com/Automattic/newspack-plugin/pull/4353, tries to avoid potential race conditions by putting any automated requests to add or remove a contact from premium newsletter lists due to Woo Memberships activity in the main plugin's ESP sync queue.

Theory: currently, if ESP syncing is enabled in the main plugin, contact data is synced via the `ESP_Sync` class which queues and batches sync requests to minimize the number of roundtrip requests to the ESP, while also avoiding race conditions by ensuring that the data/payloads from queued requests are processed in the order they are initiated. However, adding/removing a member from premium newsletter lists happens outside of this sync queue, and for a brand-new contact it calls the [same `Newspack_Newsletters_Contacts::upsert` method](https://github.com/Automattic/newspack-newsletters/blob/hotfix/premium-newsletters-via-sync-queue/includes/service-providers/class-newspack-newsletters-service-provider.php#L694) as the queued syncs, which could potentially cause a race condition between the two methods. Handling premium newsletters lists through the `ESP_Sync` queue should ensure that they're handled in the proper order with respect to other concurrent contact data sync requests.

If the main plugin's `ESP_Sync` class is not available for whatever reason, we will fall back to the internal methods which just fires direct API requests to the ESP. But all Newspack-hosted sites who are using premium newsletters are using the main plugin as well, so this fallback shouldn't be necessary for platform sites.

Closes NPPM-2400.

### How to test the changes in this Pull Request:

1. Check out this branch and https://github.com/Automattic/newspack-plugin/pull/4353. Set up your test site with Audience Management + Woo Memberships and a memberships plan which restricts one or more Subscription Lists items by subscription purchase. Also make sure debug logging is turned on and that `NEWSPACK_LOG_LEVEL` is at 2 or above so sync activity is logged to your debug.log.
2. In **Audience > Configuration**, make sure the restricted newsletter lists are NOT added under "Present newsletter signup after checkout and registration".
3. As a reader, purchase the required subscription.
4. Watch your debug.log and confirm that the following events happen in this specific order (there may be other logs in between, but these are the important ones to look for):

  - `[NEWSPACK-NEWSLETTERS][Newspack_Newsletters\Plugins\Woocommerce_Memberships::add_user_to_lists]: Membership activated for <user email>`
  - `[NEWSPACK][Newspack\Reader_Activation\Sync\Metadata::normalize_contact_data]: Normalizing contact data for reader ESP sync`: This creates the new contact via the `upsert` method and adds the premium lists in the same request.
  - `[NEWSPACK-NEWSLETTERS][Newspack_Newsletters_Contacts::upsert]: Adding contact to list(s): <audience ID>, <premium list IDs>. Provider is mailchimp.` Make sure this includes the audience plus premium list tags or groups
  - `[NEWSPACK-NEWSLETTERS][Newspack_Newsletters\Plugins\Woocommerce_Memberships::add_user_to_lists]: Reader <user email> added to the following lists: <audience ID>, <premium list IDs>`: Make sure this still includes the audience plus premium list tags or groups

5. In your ESP's dashboard, confirm that the contact was added to your master list and also got the correct tags/groups/etc. associated with your premium lists.
6. As an admin, find the reader's subscription and manually process a renewal via Order Actions:

<img width="289" height="157" alt="Screenshot 2025-12-10 at 11 46 48 AM" src="https://github.com/user-attachments/assets/74bbf271-56b7-483d-b7dd-8eb2ac4ca049" />

7. Watch the debug.log and confirm that the following events happen in this order. The sequence of events should be that the user gets removed from premium lists while the order is processing, then automatically re-added once payment succeeds:

  - `[NEWSPACK-NEWSLETTERS][Newspack_Newsletters\Plugins\Woocommerce_Memberships::handle_membership_status_change]: Membership status for <user email> changed from active to paused`
  - `[NEWSPACK][Newspack\Reader_Activation\Sync\Metadata::normalize_contact_data]: Normalizing contact data for reader ESP sync:`: this syncs the `on-hold` membership status change to the master list
  - `[NEWSPACK-NEWSLETTERS][Newspack_Newsletters_Contacts::upsert]: Adding contact to list(s): 03c5305286. Provider is mailchimp.`
  - `[NEWSPACK-NEWSLETTERS][Newspack_Newsletters\Plugins\Woocommerce_Memberships::remove_user_from_lists]: Reader <user email> removed from the following lists:` make sure this mentions the premium lists
  - `[NEWSPACK-NEWSLETTERS][Newspack_Newsletters\Plugins\Woocommerce_Memberships::handle_membership_status_change]: Membership status for <user_email> changed from paused to active`
  - `[NEWSPACK-NEWSLETTERS][Newspack_Newsletters\Plugins\Woocommerce_Memberships::add_user_to_lists]: Membership activated for <user_email>`
  - `[NEWSPACK][Newspack\Reader_Activation\Sync\Metadata::normalize_contact_data]: Normalizing contact data for reader ESP sync:`: This syncs the `active` membership status change to the master list
  - `[NEWSPACK-NEWSLETTERS][Newspack_Newsletters_Contacts::upsert]: Adding contact to list(s): <audience ID>, <premium list IDs>. Provider is mailchimp.` Make sure this includes the audience plus premium list tags or groups
  - `[NEWSPACK-NEWSLETTERS][Newspack_Newsletters\Plugins\Woocommerce_Memberships::add_user_to_lists]: Reader <user email> added to the following lists: <audience ID>, <premium list IDs>`: Make sure this still includes the audience plus premium list tags or groups

8. In your ESP's dashboard, confirm that the contact was added to your master list and also got the correct tags/groups/etc. associated with your premium lists.
9. In **Audience > Configuration**, add both the restricted newsletter lists under "Present newsletter signup after checkout and registration".
10. In a new reader session, purchase the required subscription. After completing the transaction, but BEFORE dismissing or submitting the form for the post-checkout newsletter signup form, confirm that the contact is synced to the ESP's master list but is NOT yet added to the premium lists.
11. As the reader, manually sign up for the premium lists via the post-checkout signup modal.
12. Confirm that the contact is added to the premium lists in the ESP.
13. As an admin, process a renewal for this reader's subscription and confirm that the reader is removed and then re-added to the premium lists, exactly as in step 7.
14. As the reader, unsubscribe from the premium lists via My Account > Newsletters.
15. As an admin, process a renewal for the reader's subscription and confirm that the reader is NOT re-added to the premium lists after successful renewal (because they weren't subscribed to the lists when the renewal started).

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
