### PR TITLE
feat: rename tracking

### DIFF
--- a/includes/tracking/class-admin.php
+++ b/includes/tracking/class-admin.php
@@ -62,8 +62,8 @@ final class Admin {
 	public static function add_settings_page() {
 		\add_submenu_page(
 			'edit.php?post_type=' . \Newspack_Newsletters::NEWSPACK_NEWSLETTERS_CPT,
-			esc_html__( 'Newsletters Tracking Options', 'newspack-newsletters' ),
-			esc_html__( 'Tracking', 'newspack-newsletters' ),
+			esc_html__( 'Newsletters Ads Tracking Options', 'newspack-newsletters' ),
+			esc_html__( 'Ads Tracking', 'newspack-newsletters' ),
 			'manage_options',
 			'newspack-newsletters-tracking',
 			[ __CLASS__, 'render_settings_page' ]
@@ -76,7 +76,7 @@ final class Admin {
 	public static function render_settings_page() {
 		?>
 		<div class="wrap">
-			<h1><?php esc_html_e( 'Newsletters Tracking Options', 'newspack-newsletters' ); ?></h1>
+			<h1><?php esc_html_e( 'Newsletters Ads Tracking Options', 'newspack-newsletters' ); ?></h1>
 			<form method="post" action="options.php">
 				<?php
 				\settings_fields( 'newspack_newsletters_tracking' );
@@ -99,7 +99,7 @@ final class Admin {
 				'name'              => 'newspack_newsletters_use_tracking_pixel',
 				'type'              => 'boolean',
 				'label_for'         => 'use_tracking_pixel',
-				'description'       => __( 'Enable tracking pixel', 'newspack-newsletters' ),
+				'description'       => __( 'Track the impressions of ads in your newsletter', 'newspack-newsletters' ),
 				'sanitize_callback' => [ __CLASS__, 'sanitize_boolean' ],
 				'default'           => true,
 			],
@@ -107,7 +107,7 @@ final class Admin {
 				'name'              => 'newspack_newsletters_use_click_tracking',
 				'type'              => 'boolean',
 				'label_for'         => 'use_click_tracking',
-				'description'       => __( 'Enable click-tracking', 'newspack-newsletters' ),
+				'description'       => __( 'Track the clicks on ads in your newsletter', 'newspack-newsletters' ),
 				'sanitize_callback' => [ __CLASS__, 'sanitize_boolean' ],
 				'default'           => true,
 			],


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Tracking is only meant to track Ads. We only track clicks on ads. We only show the number on ads. We need the settings screen to reflect that.

### How to test the changes in this Pull Request:

1. Deactivate newspack-plugin, if enabled
2. Check the new menu copy and confim the changes look good

<img width="523" height="438" alt="image" src="https://github.com/user-attachments/assets/3a189c72-eaaa-4dfc-b69c-c00755081150" />



### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
