### PR TITLE
fix(memberships-cli): avoid reuse of variable name

### DIFF
--- a/includes/plugins/woocommerce-memberships/class-sync-membership-tied-subscribers-cli.php
+++ b/includes/plugins/woocommerce-memberships/class-sync-membership-tied-subscribers-cli.php
@@ -171,12 +171,12 @@ Note that if a member has unsubscribed from a list, but has an active membership
 					}
 
 					$restricted_lists = [];
-					foreach ( $rule->get_object_ids() as $list_id ) {
+					foreach ( $rule->get_object_ids() as $restricted_list_id ) {
 						try {
-							$list = new \Newspack\Newsletters\Subscription_List( $list_id );
+							$list = new \Newspack\Newsletters\Subscription_List( $restricted_list_id );
 							$restricted_lists[] = $list;
 						} catch ( \Throwable $th ) {
-							\WP_CLI::warning( sprintf( 'Could not get subscription list for ID %d: %s', $list_id, $th->getMessage() ) );
+							\WP_CLI::warning( sprintf( 'Could not get subscription list for ID %d: %s', $restricted_list_id, $th->getMessage() ) );
 							continue;
 						}
 					}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes a bug in the CLI script to sync subscription lists restricted by membership plans. The reuse of the variable name `$list_id` causes the script to think that a `--list-id` arg is passed with the value of the first found restricted list, even when no arg is passed.

### How to test the changes in this Pull Request:

1. Create a membership plan restricting more than one subscription list and tied to an active subscription purchase.
2. As a reader, purchase the required subscription product.
3. On `release`, run `wp newspack-newsletters sync-membership-tied-subscribers --verbose` and observe that only one restricted list is added to the applicable reader(s), and that the script output states `Skipping list <list name>` for all others.
4. Check out this branch, re-run the script, and confirm that the script doesn't skip any restricted lists.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
