### PR TITLE
fix: Updates prompt when previously selected list is unavailable

### DIFF
--- a/languages/newspack-newsletters.pot
+++ b/languages/newspack-newsletters.pot
@@ -1804,7 +1804,7 @@ msgstr ""
 
 #: dist/blocks.js:4
 #: src/blocks/subscribe/edit.js:308
-msgid "A previously selected list is no longer available. Please, revise the subscription lists selection."
+msgid "A previously selected list is no longer available. Please revise the subscription lists selection."
 msgstr ""
 
 #: dist/blocks.js:4

--- a/languages/newspack-newsletters.pot
+++ b/languages/newspack-newsletters.pot
@@ -1804,7 +1804,7 @@ msgstr ""
 
 #: dist/blocks.js:4
 #: src/blocks/subscribe/edit.js:308
-msgid "A previously selected list is no longer available. Please revise the subscription lists selection."
+msgid "A previously selected list is no longer available. Please revise the subscription list selection."
 msgstr ""
 
 #: dist/blocks.js:4


### PR DESCRIPTION
### All Submissions:

* [X] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [X] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Removes an unnecessary comma, and changes a plural noun to individual, in the prompt displayed when a previously selected list is no longer available.

### How to test the changes in this Pull Request:

1. Insert a Newsletter Subscription Form block without having selected a list.
2. Navigate to `/wp-admin/edit.php?post_type=newspack_nl_cpt&page=newspack-newsletters-settings-admin`
3. Select a list
4. Reload the post editor with the form block.
5. Observe the warning message:

```
A previously selected list is no longer available. Please, revise the subscription list selection.
```

![please-revise](https://github.com/user-attachments/assets/d89144b2-2378-440e-9817-9e5e50403927)

6. Merge this branch.
7. Observe the warning message:

```
A previously selected list is no longer available. Please revise the subscription list selection.
```

### Other information:

* [X] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
