### PR TITLE
fix(ads): start/end date value format

### DIFF
--- a/includes/ads/class-ads.php
+++ b/includes/ads/class-ads.php
@@ -615,14 +615,14 @@ final class Ads {
 		if ( 'start_date' === $column_name ) {
 			$start_date = get_post_meta( $post_id, 'start_date', true );
 			if ( ! empty( $start_date ) ) {
-				echo esc_html( wp_date( get_option( 'date_format' ), strtotime( $start_date ) ) );
+				echo esc_html( wp_date( __( 'F j, Y' ), strtotime( $start_date ) ) );
 			} else {
 				echo '—';
 			}
 		} elseif ( 'expiry_date' === $column_name ) {
 			$expiry_date = get_post_meta( $post_id, 'expiry_date', true );
 			if ( ! empty( $expiry_date ) ) {
-				echo esc_html( wp_date( get_option( 'date_format' ), strtotime( $expiry_date ) ) );
+				echo esc_html( wp_date( __( 'F j, Y' ), strtotime( $expiry_date ) ) );
 			} else {
 				echo '—';
 			}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

NPPM-2482

Start/end dates for newsletter ads do not consider time. It's uncommon, but `get_option( 'date_format' )` may include the time, which can display a value that is misleading to the user.

### How to test the changes in this Pull Request:

1. While on trunk, navigate to Settings -> General
2. Modify date format to `F j, Y, g:i a`
3. Navigate to `Newsletters -> Ads` and create an ad with start and end dates
4. Back to the `Newsletters -> Ads` table, confirm the value renders the time
5. Checkout this branch, refresh the page, and confirm the time is omitted

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
