### PR TITLE
fix(newsletters): hide Jetpack stats column on newsletters

### DIFF
--- a/includes/class-newspack-newsletters.php
+++ b/includes/class-newspack-newsletters.php
@@ -77,6 +77,7 @@ final class Newspack_Newsletters {
 		add_action( 'wp_head', [ __CLASS__, 'public_newsletter_custom_style' ], 10, 2 );
 		add_filter( 'display_post_states', [ __CLASS__, 'display_post_states' ], 10, 2 );
 		add_filter( 'manage_' . self::NEWSPACK_NEWSLETTERS_CPT . '_posts_columns', [ __CLASS__, 'add_public_page_column' ] );
+		add_filter( 'manage_' . self::NEWSPACK_NEWSLETTERS_CPT . '_posts_columns', [ __CLASS__, 'remove_stats_column' ], 99 );
 		add_action( 'manage_' . self::NEWSPACK_NEWSLETTERS_CPT . '_posts_custom_column', [ __CLASS__, 'public_page_column_content' ], 10, 2 );
 		add_filter( 'post_row_actions', [ __CLASS__, 'display_view_or_preview_link_in_admin' ] );
 		add_filter( 'jetpack_relatedposts_filter_options', [ __CLASS__, 'disable_jetpack_related_posts' ] );
@@ -737,6 +738,18 @@ final class Newspack_Newsletters {
 	 */
 	public static function add_public_page_column( $columns ) {
 		return array_merge( $columns, [ 'public_page' => __( 'Public page', 'newspack-newsletters' ) ] );
+	}
+
+	/**
+	 * Remove the Jetpack Stats column from the Newsletters admin list table.
+	 *
+	 * @param array $columns Newsletters columns.
+	 *
+	 * @return array
+	 */
+	public static function remove_stats_column( $columns ) {
+		unset( $columns['stats'] );
+		return $columns;
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

The Stats column in Newsletters is confusing as it gives the appearance that the stats are from Newspack click tracking, which they aren't (it's actually from Jetpack). To eliminate this confusion, we are simply removing the stats column. 

`NPPM - 2414`

### How to test the changes in this Pull Request:

**Before applying this PR (to reproduce the issue):**

1. Test this on a site with Jetpack enabled
2. Go to **Newsletters -> All Newsletters** and verify that you see the Stats column.

<img width="1389" height="597" alt="Screenshot 2026-01-21 at 3 32 56 PM" src="https://github.com/user-attachments/assets/f999728f-2b14-4f35-90e5-fff5abaf9777" />

**After applying this PR:**

1. View the same **Newsletters -> All Newsletters** page, and the Stats column will be removed.

<img width="1386" height="554" alt="Screenshot 2026-01-21 at 3 47 35 PM" src="https://github.com/user-attachments/assets/2256d793-ef80-4c90-a2ec-52ccd521dec5" />


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

