### PR TITLE
fix: restore newsletter rendering of RDB blocks using get_value()

### DIFF
--- a/includes/class-newspack-newsletters-editor.php
+++ b/includes/class-newspack-newsletters-editor.php
@@ -415,13 +415,15 @@ final class Newspack_Newsletters_Editor {
 				filemtime( NEWSPACK_NEWSLETTERS_PLUGIN_FILE . 'dist/newsletterEditor.js' ),
 				true
 			);
-			\wp_localize_script(
-				'newspack-newsletters-newsletter-editor',
-				'newspack_newsletters_editor_data',
-				[
-					'mailchimp_default_footer' => wp_kses_post( Newspack_Newsletters_Mailchimp_Default_Footer::get_footer_content() ),
-				]
-			);
+			if ( class_exists( 'Newspack_Newsletters_Mailchimp_Default_Footer' ) ) {
+				\wp_localize_script(
+					'newspack-newsletters-newsletter-editor',
+					'newspack_newsletters_editor_data',
+					[
+						'mailchimp_default_footer' => wp_kses_post( Newspack_Newsletters_Mailchimp_Default_Footer::get_footer_content() ),
+					]
+				);
+			}
 			\wp_enqueue_script(
 				'newspack-newsletters-ads-editor',
 				plugins_url( '../dist/newsletterAdsEditor.js', __FILE__ ),

--- a/includes/class-newspack-newsletters-renderer.php
+++ b/includes/class-newspack-newsletters-renderer.php
@@ -515,7 +515,9 @@ final class Newspack_Newsletters_Renderer {
 	 * Expand template blocks for multiple query results.
 	 * Creates a copy of inner blocks for each result with the appropriate index.
 	 *
-	 * Heavily inspired by new RDB preview rendering.
+	 * Heavily inspired by new RDB preview rendering.  See changes to
+	 * src/block-editor/binding-sources/remote-data-binding.ts at
+	 * https://github.com/Automattic/remote-data-blocks/commit/a4b9249e248140c741e987f949b215be5edabf1d
 	 *
 	 * @param array $inner_blocks The inner blocks to clone.
 	 * @param array $results      The query results.

--- a/includes/class-newspack-newsletters-renderer.php
+++ b/includes/class-newspack-newsletters-renderer.php
@@ -812,9 +812,9 @@ final class Newspack_Newsletters_Renderer {
 	 */
 	private static function update_link_text_in_html( $html, $text ) {
 		return preg_replace_callback(
-			'/>([^<]*)<\/a>/',
+			'/(>)(.*?)(<\/a>)/s',
 			function ( $matches ) use ( $text ) {
-				return '>' . wp_kses_post( $text ) . '</a>';
+				return $matches[1] . wp_kses_post( $text ) . $matches[3];
 			},
 			$html
 		);

--- a/includes/class-newspack-newsletters-renderer.php
+++ b/includes/class-newspack-newsletters-renderer.php
@@ -1638,8 +1638,7 @@ final class Newspack_Newsletters_Renderer {
 
 		$is_posts_inserter_block = 'newspack-newsletters/posts-inserter' == $block_name;
 		$is_grouped_block        = in_array( $block_name, [ 'core/group', 'core/list', 'core/list-item', 'core/quote' ], true );
-		// Remote Data Blocks are rendered to HTML then converted to MJML with proper structure,
-		// so they should not be wrapped in additional section/column elements.
+		// Remote Data Blocks require special handling to resolve bindings.
 		$is_rdb_block = strpos( $block_name, 'remote-data-blocks/' ) === 0;
 
 		if (

--- a/includes/class-newspack-newsletters-renderer.php
+++ b/includes/class-newspack-newsletters-renderer.php
@@ -498,6 +498,305 @@ final class Newspack_Newsletters_Renderer {
 	}
 
 	/**
+	 * Get Remote Data Blocks context from a container block.
+	 *
+	 * @param array $block The block array.
+	 * @return array The remote data context or empty array if not found.
+	 */
+	private static function get_rdb_context( $block ) {
+		// Remote data is stored in the block's remoteData attribute.
+		if ( isset( $block['attrs']['remoteData'] ) ) {
+			return $block['attrs']['remoteData'];
+		}
+		return [];
+	}
+
+	/**
+	 * Expand template blocks for multiple query results.
+	 * Creates a copy of inner blocks for each result with the appropriate index.
+	 *
+	 * Heavily inspired by new RDB preview rendering.
+	 *
+	 * @param array $inner_blocks The inner blocks to clone.
+	 * @param array $results      The query results.
+	 * @param array $remote_data  The full remote data context.
+	 * @return array Expanded array of blocks with indices set.
+	 */
+	private static function expand_rdb_template_blocks( $inner_blocks, $results, $remote_data ) {
+		$expanded_blocks = [];
+
+		foreach ( $results as $index => $result ) {
+			$source_args = [
+				'block'            => $remote_data['blockName'] ?? '',
+				'enabledOverrides' => $remote_data['enabledOverrides'] ?? [],
+				'index'            => $index,
+				'queryKey'         => $remote_data['queryKey'] ?? null,
+				'queryInputs'      => $remote_data['queryInputs'] ?? null,
+			];
+
+			$cloned_blocks = self::clone_blocks_with_index( $inner_blocks, $source_args );
+			$expanded_blocks = array_merge( $expanded_blocks, $cloned_blocks );
+		}
+
+		return $expanded_blocks;
+	}
+
+	/**
+	 * Deep clone blocks and merge source args into all binding configurations.
+	 *
+	 * @param array $blocks      The blocks to clone.
+	 * @param array $source_args The source args to merge (including index).
+	 * @return array Cloned blocks with updated binding args.
+	 */
+	private static function clone_blocks_with_index( $blocks, $source_args ) {
+		$cloned = [];
+
+		foreach ( $blocks as $block ) {
+			$cloned_block = $block;
+
+			// Update bindings in the block's attributes metadata.
+			if ( isset( $cloned_block['attrs']['metadata']['bindings'] ) ) {
+				foreach ( $cloned_block['attrs']['metadata']['bindings'] as $target => $binding ) {
+					if ( isset( $binding['source'] ) && 'remote-data/binding' === $binding['source'] ) {
+						$cloned_block['attrs']['metadata']['bindings'][ $target ]['args'] = array_merge(
+							$binding['args'] ?? [],
+							$source_args
+						);
+					}
+				}
+			}
+
+			// Recursively process inner blocks.
+			if ( ! empty( $cloned_block['innerBlocks'] ) ) {
+				$cloned_block['innerBlocks'] = self::clone_blocks_with_index( $cloned_block['innerBlocks'], $source_args );
+			}
+
+			$cloned[] = $cloned_block;
+		}
+
+		return $cloned;
+	}
+
+	/**
+	 * Resolve Remote Data Blocks bindings for a block and its children.
+	 * Updates innerHTML with resolved values.
+	 *
+	 * @param array $block       The block to resolve.
+	 * @param array $remote_data The remote data context.
+	 * @return array The block with resolved bindings and updated innerHTML.
+	 */
+	private static function resolve_rdb_block_bindings( $block, $remote_data ) {
+		// Check if RDB's BlockBindings class is available.
+		if ( ! class_exists( 'RemoteDataBlocks\Editor\DataBinding\BlockBindings' ) ) {
+			return $block;
+		}
+
+		$resolved_block = $block;
+
+		// Check if block has bindings.
+		if ( isset( $resolved_block['attrs']['metadata']['bindings'] ) ) {
+			$resolved_attrs = [];
+
+			// Build a block array with injected context for BlockBindings::get_value().
+			$block_with_context = [
+				'context'    => [
+					'remote-data-blocks/remoteData' => $remote_data,
+				],
+				'attributes' => $resolved_block['attrs'],
+				'name'       => $resolved_block['blockName'],
+			];
+
+			foreach ( $resolved_block['attrs']['metadata']['bindings'] as $target => $binding ) {
+				if ( isset( $binding['source'] ) && 'remote-data/binding' === $binding['source'] ) {
+					$source_args = $binding['args'] ?? [];
+					$value = \RemoteDataBlocks\Editor\DataBinding\BlockBindings::get_value(
+						$source_args,
+						$block_with_context,
+						$target
+					);
+
+					if ( null !== $value ) {
+						$resolved_attrs[ $target ] = $value;
+					}
+				}
+			}
+
+			// Update innerHTML with resolved values.
+			if ( ! empty( $resolved_attrs ) ) {
+				$resolved_block = self::update_block_inner_html( $resolved_block, $resolved_attrs );
+			}
+		}
+
+		// Recursively resolve inner blocks.
+		if ( ! empty( $resolved_block['innerBlocks'] ) ) {
+			$resolved_inner_blocks = [];
+			foreach ( $resolved_block['innerBlocks'] as $inner_block ) {
+				$resolved_inner_blocks[] = self::resolve_rdb_block_bindings( $inner_block, $remote_data );
+			}
+			$resolved_block['innerBlocks'] = $resolved_inner_blocks;
+		}
+
+		return $resolved_block;
+	}
+
+	/**
+	 * Update block innerHTML based on resolved attribute values.
+	 *
+	 * @param array $block          The block to update.
+	 * @param array $resolved_attrs The resolved attribute values.
+	 * @return array The block with updated innerHTML.
+	 */
+	private static function update_block_inner_html( $block, $resolved_attrs ) {
+		$block_name = $block['blockName'];
+		$inner_html = $block['innerHTML'] ?? '';
+
+		switch ( $block_name ) {
+			case 'core/paragraph':
+				if ( isset( $resolved_attrs['content'] ) ) {
+					$inner_html = self::reconstruct_paragraph_html( $inner_html, $resolved_attrs['content'] );
+				}
+				break;
+
+			case 'core/heading':
+				if ( isset( $resolved_attrs['content'] ) ) {
+					$level = $block['attrs']['level'] ?? 2;
+					$inner_html = self::reconstruct_heading_html( $inner_html, $resolved_attrs['content'], $level );
+				}
+				break;
+
+			case 'core/image':
+				if ( isset( $resolved_attrs['url'] ) ) {
+					$inner_html = self::update_src_in_html( $inner_html, $resolved_attrs['url'] );
+				}
+				if ( isset( $resolved_attrs['alt'] ) ) {
+					$inner_html = self::update_alt_in_html( $inner_html, $resolved_attrs['alt'] );
+				}
+				break;
+
+			case 'core/button':
+				if ( isset( $resolved_attrs['url'] ) ) {
+					$inner_html = self::update_href_in_html( $inner_html, $resolved_attrs['url'] );
+				}
+				if ( isset( $resolved_attrs['text'] ) ) {
+					$inner_html = self::update_link_text_in_html( $inner_html, $resolved_attrs['text'] );
+				}
+				break;
+		}
+
+		$block['innerHTML'] = $inner_html;
+
+		// Also update innerContent to match.
+		if ( isset( $block['innerContent'] ) && is_array( $block['innerContent'] ) ) {
+			// For blocks without inner blocks, innerContent is typically a single-element array.
+			if ( count( $block['innerContent'] ) === 1 && null !== $block['innerContent'][0] ) {
+				$block['innerContent'][0] = $inner_html;
+			}
+		}
+
+		return $block;
+	}
+
+	/**
+	 * Reconstruct paragraph HTML with new content.
+	 *
+	 * @param string $original_html The original innerHTML.
+	 * @param string $content       The new content.
+	 * @return string The reconstructed HTML.
+	 */
+	private static function reconstruct_paragraph_html( $original_html, $content ) {
+		$clean_content = self::cleanup_rdb_html( $content );
+
+		// Try to preserve existing attributes by replacing content within <p> tags.
+		if ( preg_match( '/<p([^>]*)>.*<\/p>/is', $original_html, $matches ) ) {
+			return '<p' . $matches[1] . '>' . $clean_content . '</p>';
+		}
+		// Fallback: create simple paragraph.
+		return '<p>' . $clean_content . '</p>';
+	}
+
+	/**
+	 * Reconstruct heading HTML with new content.
+	 *
+	 * @param string $original_html The original innerHTML.
+	 * @param string $content       The new content.
+	 * @param int    $level         The heading level.
+	 * @return string The reconstructed HTML.
+	 */
+	private static function reconstruct_heading_html( $original_html, $content, $level ) {
+		$clean_content = self::cleanup_rdb_html( $content );
+		$tag = 'h' . intval( $level );
+		// Try to preserve existing attributes.
+		if ( preg_match( '/<' . $tag . '([^>]*)>.*<\/' . $tag . '>/is', $original_html, $matches ) ) {
+			return '<' . $tag . $matches[1] . '>' . $clean_content . '</' . $tag . '>';
+		}
+		// Fallback: create simple heading.
+		return '<' . $tag . '>' . $clean_content . '</' . $tag . '>';
+	}
+
+	/**
+	 * Update src attribute in HTML (for images).
+	 *
+	 * @param string $html The original HTML.
+	 * @param string $url  The new URL.
+	 * @return string The updated HTML.
+	 */
+	private static function update_src_in_html( $html, $url ) {
+		// Replace src attribute value.
+		return preg_replace( '/src="[^"]*"/', 'src="' . esc_url( $url ) . '"', $html );
+	}
+
+	/**
+	 * Update alt attribute in HTML (for images).
+	 *
+	 * @param string $html The original HTML.
+	 * @param string $alt  The new alt text.
+	 * @return string The updated HTML.
+	 */
+	private static function update_alt_in_html( $html, $alt ) {
+		// Replace alt attribute value.
+		if ( preg_match( '/alt="[^"]*"/', $html ) ) {
+			return preg_replace( '/alt="[^"]*"/', 'alt="' . esc_attr( $alt ) . '"', $html );
+		}
+		// Add alt if not present.
+		return preg_replace( '/<img/', '<img alt="' . esc_attr( $alt ) . '"', $html );
+	}
+
+	/**
+	 * Update href attribute in HTML (for links/buttons).
+	 *
+	 * @param string $html The original HTML.
+	 * @param string $href The new href value.
+	 * @return string The updated HTML.
+	 */
+	private static function update_href_in_html( $html, $href ) {
+		return preg_replace( '/href="[^"]*"/', 'href="' . esc_url( $href ) . '"', $html );
+	}
+
+	/**
+	 * Update link text in HTML.
+	 *
+	 * @param string $html The original HTML.
+	 * @param string $text The new link text.
+	 * @return string The updated HTML.
+	 */
+	private static function update_link_text_in_html( $html, $text ) {
+		return preg_replace( '/>([^<]*)<\/a>/', '>' . $text . '</a>', $html );
+	}
+
+	/**
+	 * RDB-specific HTML fixes.
+	 *
+	 * @param string $content Content from block binding.
+	 * @return string Content with RDB-specific fixes applied.
+	 */
+	private static function cleanup_rdb_html( $content ) {
+		if ( preg_match( '/^(.*<span class="rdb-block-label">.*<\/span>)(.*)$/is', $content, $matches ) ) {
+			return $matches[1] . ': ' . $matches[2];
+		}
+		return $content;
+	}
+
+	/**
 	 * Convert a Gutenberg block to an MJML component.
 	 * MJML component will be put in an mj-column in an mj-section for consistent layout,
 	 * unless it's a group or a columns block.
@@ -1239,6 +1538,12 @@ final class Newspack_Newsletters_Renderer {
 
 			/**
 			 * Remote Data Blocks.
+			 *
+			 * These blocks use WordPress Block Bindings API--values are
+			 * resolved at render time, not persisted to post content.
+			 *
+			 * Following recent changes, binding values are not persisted to
+			 * post content; we resolve using RDB's BlockBindings methods.
 			 */
 			case 'remote-data-blocks/foundation-event':
 			case 'remote-data-blocks/foundation-events':
@@ -1247,8 +1552,47 @@ final class Newspack_Newsletters_Renderer {
 			case 'remote-data-blocks/foundation-movie':
 			case 'remote-data-blocks/foundation-movies':
 			case 'remote-data-blocks/template':
-				foreach ( $inner_blocks as $block ) {
-					$markup .= self::render_mjml_component( $block, false, false, $default_attrs );
+				// Existing (broken) handling if no RDB support available.
+				if ( ! class_exists( 'RemoteDataBlocks\Editor\DataBinding\BlockBindings' ) ) {
+					$markup = '';
+					foreach ( $inner_blocks as $block ) {
+						$markup .= self::render_mjml_component( $block, false, false, $default_attrs );
+					}
+					$block_mjml_markup = $markup;
+					break;
+				}
+
+				// Attempt to propagate RDB context to inner blocks.
+				$remote_data = self::get_rdb_context( $block );
+				$results = $remote_data['results'] ?? [];
+
+				// Expand for multiple results, or add index 0 for single result.
+				if ( count( $results ) > 1 ) {
+					$blocks_to_render = self::expand_rdb_template_blocks( $inner_blocks, $results, $remote_data );
+				} else {
+					// Single result or empty - add index 0.
+					$source_args = [
+						'block'            => $remote_data['blockName'] ?? '',
+						'enabledOverrides' => $remote_data['enabledOverrides'] ?? [],
+						'index'            => 0,
+						'queryKey'         => $remote_data['queryKey'] ?? null,
+						'queryInputs'      => $remote_data['queryInputs'] ?? null,
+					];
+					$blocks_to_render = self::clone_blocks_with_index( $inner_blocks, $source_args );
+				}
+
+				// Resolve bindings and update innerHTML.
+				$resolved_blocks = array_map(
+					function ( $b ) use ( $remote_data ) {
+						return self::resolve_rdb_block_bindings( $b, $remote_data );
+					},
+					$blocks_to_render
+				);
+
+				// Render through normal MJML pipeline.
+				$markup = '';
+				foreach ( $resolved_blocks as $resolved_block ) {
+					$markup .= self::render_mjml_component( $resolved_block, $is_in_column, $is_in_group, $default_attrs );
 				}
 				$block_mjml_markup = $markup;
 				break;
@@ -1257,11 +1601,15 @@ final class Newspack_Newsletters_Renderer {
 
 		$is_posts_inserter_block = 'newspack-newsletters/posts-inserter' == $block_name;
 		$is_grouped_block        = in_array( $block_name, [ 'core/group', 'core/list', 'core/list-item', 'core/quote' ], true );
+		// Remote Data Blocks are rendered to HTML then converted to MJML with proper structure,
+		// so they should not be wrapped in additional section/column elements.
+		$is_rdb_block = strpos( $block_name, 'remote-data-blocks/' ) === 0;
 
 		if (
 			! $is_in_column &&
 			! $is_in_list_or_quote &&
 			! $is_grouped_block &&
+			! $is_rdb_block &&
 			'core/buttons' != $block_name &&
 			'core/columns' != $block_name &&
 			'core/column' != $block_name &&
@@ -1272,7 +1620,7 @@ final class Newspack_Newsletters_Renderer {
 			$block_mjml_markup     = '<mj-column ' . self::array_to_attributes( $column_attrs ) . '>' . $block_mjml_markup . '</mj-column>';
 		}
 
-		if ( ! $is_in_column && ! $is_in_list_or_quote && ! $is_posts_inserter_block ) {
+		if ( ! $is_in_column && ! $is_in_list_or_quote && ! $is_posts_inserter_block && ! $is_rdb_block ) {
 			$block_mjml_markup = '<mj-section ' . self::array_to_attributes( $section_attrs ) . '>' . $block_mjml_markup . '</mj-section>';
 		}
 

--- a/includes/class-newspack-newsletters-renderer.php
+++ b/includes/class-newspack-newsletters-renderer.php
@@ -621,8 +621,14 @@ final class Newspack_Newsletters_Renderer {
 				}
 			}
 
-			// Update innerHTML with resolved values.
+			// Persist resolved values to block attrs and update innerHTML where needed.
 			if ( ! empty( $resolved_attrs ) ) {
+				if ( ! isset( $resolved_block['attrs'] ) || ! is_array( $resolved_block['attrs'] ) ) {
+					$resolved_block['attrs'] = [];
+				}
+				foreach ( $resolved_attrs as $attr_key => $attr_value ) {
+					$resolved_block['attrs'][ $attr_key ] = $attr_value;
+				}
 				$resolved_block = self::update_block_inner_html( $resolved_block, $resolved_attrs );
 			}
 		}
@@ -1556,7 +1562,7 @@ final class Newspack_Newsletters_Renderer {
 				if ( ! class_exists( 'RemoteDataBlocks\Editor\DataBinding\BlockBindings' ) ) {
 					$markup = '';
 					foreach ( $inner_blocks as $block ) {
-						$markup .= self::render_mjml_component( $block, false, false, $default_attrs );
+						$markup .= self::render_mjml_component( $block, $is_in_column, $is_in_group, $default_attrs );
 					}
 					$block_mjml_markup = $markup;
 					break;

--- a/includes/class-newspack-newsletters-renderer.php
+++ b/includes/class-newspack-newsletters-renderer.php
@@ -812,7 +812,7 @@ final class Newspack_Newsletters_Renderer {
 	 */
 	private static function update_link_text_in_html( $html, $text ) {
 		return preg_replace_callback(
-			'/(>)(.*?)(<\/a>)/s',
+			'/(<a[^>]*>)(.*?)(<\/a>)/s',
 			function ( $matches ) use ( $text ) {
 				return $matches[1] . wp_kses_post( $text ) . $matches[3];
 			},
@@ -1156,16 +1156,17 @@ final class Newspack_Newsletters_Renderer {
 					$dom = new DomDocument();
 					libxml_use_internal_errors( true );
 					$dom->loadHTML( htmlspecialchars_decode( htmlentities( mb_convert_encoding( $button_block['innerHTML'], 'UTF-8', get_bloginfo( 'charset' ) ) ) ) );
-					$xpath         = new DOMXpath( $dom );
-					$anchor        = $xpath->query( '//a' )[0];
-					$attrs         = self::process_attributes( $button_block['attrs'] );
-					$text          = $anchor->textContent; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
-					$border_radius = isset( $attrs['borderRadius'] ) ? $attrs['borderRadius'] : '999px';
-					$is_outlined   = isset( $attrs['className'] ) && 'is-style-outline' == $attrs['className'];
+					$xpath  = new DOMXpath( $dom );
+					$anchor = $xpath->query( '//a' )[0];
 
 					if ( ! $anchor ) {
 						break;
 					}
+
+					$attrs         = self::process_attributes( $button_block['attrs'] );
+					$text          = $anchor->textContent; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+					$border_radius = isset( $attrs['borderRadius'] ) ? $attrs['borderRadius'] : '999px';
+					$is_outlined   = isset( $attrs['className'] ) && 'is-style-outline' == $attrs['className'];
 
 					$default_button_attrs = array(
 						'align'         => $alignment,

--- a/includes/class-newspack-newsletters-renderer.php
+++ b/includes/class-newspack-newsletters-renderer.php
@@ -748,7 +748,13 @@ final class Newspack_Newsletters_Renderer {
 	 */
 	private static function update_src_in_html( $html, $url ) {
 		// Replace src attribute value.
-		return preg_replace( '/src="[^"]*"/', 'src="' . esc_url( $url ) . '"', $html );
+		return preg_replace_callback(
+			'/src="[^"]*"/',
+			function ( $matches ) use ( $url ) {
+				return 'src="' . esc_url( $url ) . '"';
+			},
+			$html
+		);
 	}
 
 	/**
@@ -761,10 +767,23 @@ final class Newspack_Newsletters_Renderer {
 	private static function update_alt_in_html( $html, $alt ) {
 		// Replace alt attribute value.
 		if ( preg_match( '/alt="[^"]*"/', $html ) ) {
-			return preg_replace( '/alt="[^"]*"/', 'alt="' . esc_attr( $alt ) . '"', $html );
+			return preg_replace_callback(
+				'/alt="[^"]*"/',
+				function ( $matches ) use ( $alt ) {
+					return 'alt="' . esc_attr( $alt ) . '"';
+				},
+				$html
+			);
 		}
+
 		// Add alt if not present.
-		return preg_replace( '/<img/', '<img alt="' . esc_attr( $alt ) . '"', $html );
+		return preg_replace_callback(
+			'/<img/',
+			function ( $matches ) use ( $alt ) {
+				return '<img alt="' . esc_attr( $alt ) . '"';
+			},
+			$html
+		);
 	}
 
 	/**
@@ -775,7 +794,13 @@ final class Newspack_Newsletters_Renderer {
 	 * @return string The updated HTML.
 	 */
 	private static function update_href_in_html( $html, $href ) {
-		return preg_replace( '/href="[^"]*"/', 'href="' . esc_url( $href ) . '"', $html );
+		return preg_replace_callback(
+			'/href="[^"]*"/',
+			function ( $matches ) use ( $href ) {
+				return 'href="' . esc_url( $href ) . '"';
+			},
+			$html
+		);
 	}
 
 	/**
@@ -786,7 +811,13 @@ final class Newspack_Newsletters_Renderer {
 	 * @return string The updated HTML.
 	 */
 	private static function update_link_text_in_html( $html, $text ) {
-		return preg_replace( '/>([^<]*)<\/a>/', '>' . $text . '</a>', $html );
+		return preg_replace_callback(
+			'/>([^<]*)<\/a>/',
+			function ( $matches ) use ( $text ) {
+				return '>' . wp_kses_post( $text ) . '</a>';
+			},
+			$html
+		);
 	}
 
 	/**
@@ -797,9 +828,9 @@ final class Newspack_Newsletters_Renderer {
 	 */
 	private static function cleanup_rdb_html( $content ) {
 		if ( preg_match( '/^(.*<span class="rdb-block-label">.*<\/span>)(.*)$/is', $content, $matches ) ) {
-			return $matches[1] . ': ' . $matches[2];
+			$content = $matches[1] . ': ' . $matches[2];
 		}
-		return $content;
+		return wp_kses_post( $content );
 	}
 
 	/**

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -52,7 +52,9 @@ require_once 'mocks/wc-memberships.php';
 require_once 'mocks/wp-cli.php';
 
 // Stubs for RDB methods.
-require_once __DIR__ . '/mocks/class-blockbindings.php';
+if ( ! class_exists( 'BlockBindings' ) ) {
+	require_once __DIR__ . '/mocks/class-blockbindings.php';
+}
 
 // Abstract ESP tests.
 require_once 'abstract-esp-tests.php';

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -51,6 +51,9 @@ require_once 'mocks/wc-memberships.php';
 // WC CLI mock.
 require_once 'mocks/wp-cli.php';
 
+// Stubs for RDB methods.
+require_once __DIR__ . '/mocks/class-blockbindings.php';
+
 // Abstract ESP tests.
 require_once 'abstract-esp-tests.php';
 

--- a/tests/mocks/class-blockbindings.php
+++ b/tests/mocks/class-blockbindings.php
@@ -1,0 +1,63 @@
+<?php
+/**
+ * Mock BlockBindings class for testing RDB integration.
+ *
+ * @package Newspack_Newsletters
+ */
+
+namespace RemoteDataBlocks\Editor\DataBinding;
+
+/**
+ * Mock BlockBindings class to stub RDB's get_value() method for testing.
+ * This must be loaded before the real RDB plugin to take precedence.
+ */
+class BlockBindings {
+	/**
+	 * Stubbed return values keyed by attribute name.
+	 *
+	 * @var array
+	 */
+	public static $stub_values = [];
+
+	/**
+	 * Recorded calls for assertion.
+	 *
+	 * @var array
+	 */
+	public static $calls = [];
+
+	/**
+	 * Reset stub state between tests.
+	 */
+	public static function reset() {
+		self::$stub_values = [];
+		self::$calls       = [];
+	}
+
+	/**
+	 * Set stub values for get_value() calls.
+	 *
+	 * @param array $values Map of attribute names to return values.
+	 */
+	public static function set_stub_values( $values ) {
+		self::$stub_values = $values;
+	}
+
+	/**
+	 * Mock implementation of get_value().
+	 *
+	 * @param array  $source_args    The source arguments from the binding.
+	 * @param mixed  $block          The block (WP_Block or array).
+	 * @param string $attribute_name The attribute being bound.
+	 * @return string|null The stubbed value or null.
+	 */
+	public static function get_value( $source_args, $block, $attribute_name ) {
+		self::$calls[] = [
+			'source_args'    => $source_args,
+			'block'          => $block,
+			'attribute_name' => $attribute_name,
+		];
+
+		return self::$stub_values[ $attribute_name ] ?? null;
+	}
+}

--- a/tests/mocks/class-blockbindings.php
+++ b/tests/mocks/class-blockbindings.php
@@ -7,11 +7,11 @@
 
 namespace RemoteDataBlocks\Editor\DataBinding;
 
-/**
- * Mock BlockBindings class to stub RDB's get_value() method for testing.
- * This must be loaded before the real RDB plugin to take precedence.
- */
 if ( ! class_exists( '\RemoteDataBlocks\Editor\DataBinding\BlockBindings' ) ) {
+	/**
+	 * Mock BlockBindings class to stub RDB's get_value() method for testing.
+	 * This must be loaded before the real RDB plugin to take precedence.
+	 */
 	class BlockBindings {
 		/**
 		 * Stubbed return values keyed by attribute name.

--- a/tests/mocks/class-blockbindings.php
+++ b/tests/mocks/class-blockbindings.php
@@ -11,53 +11,55 @@ namespace RemoteDataBlocks\Editor\DataBinding;
  * Mock BlockBindings class to stub RDB's get_value() method for testing.
  * This must be loaded before the real RDB plugin to take precedence.
  */
-class BlockBindings {
-	/**
-	 * Stubbed return values keyed by attribute name.
-	 *
-	 * @var array
-	 */
-	public static $stub_values = [];
+if ( ! class_exists( '\RemoteDataBlocks\Editor\DataBinding\BlockBindings' ) ) {
+	class BlockBindings {
+		/**
+		 * Stubbed return values keyed by attribute name.
+		 *
+		 * @var array
+		 */
+		public static $stub_values = [];
 
-	/**
-	 * Recorded calls for assertion.
-	 *
-	 * @var array
-	 */
-	public static $calls = [];
+		/**
+		 * Recorded calls for assertion.
+		 *
+		 * @var array
+		 */
+		public static $calls = [];
 
-	/**
-	 * Reset stub state between tests.
-	 */
-	public static function reset() {
-		self::$stub_values = [];
-		self::$calls       = [];
-	}
+		/**
+		 * Reset stub state between tests.
+		 */
+		public static function reset() {
+			self::$stub_values = [];
+			self::$calls       = [];
+		}
 
-	/**
-	 * Set stub values for get_value() calls.
-	 *
-	 * @param array $values Map of attribute names to return values.
-	 */
-	public static function set_stub_values( $values ) {
-		self::$stub_values = $values;
-	}
+		/**
+		 * Set stub values for get_value() calls.
+		 *
+		 * @param array $values Map of attribute names to return values.
+		 */
+		public static function set_stub_values( $values ) {
+			self::$stub_values = $values;
+		}
 
-	/**
-	 * Mock implementation of get_value().
-	 *
-	 * @param array  $source_args    The source arguments from the binding.
-	 * @param mixed  $block          The block (WP_Block or array).
-	 * @param string $attribute_name The attribute being bound.
-	 * @return string|null The stubbed value or null.
-	 */
-	public static function get_value( $source_args, $block, $attribute_name ) {
-		self::$calls[] = [
-			'source_args'    => $source_args,
-			'block'          => $block,
-			'attribute_name' => $attribute_name,
-		];
+		/**
+		 * Mock implementation of get_value().
+		 *
+		 * @param array  $source_args    The source arguments from the binding.
+		 * @param mixed  $block          The block (WP_Block or array).
+		 * @param string $attribute_name The attribute being bound.
+		 * @return string|null The stubbed value or null.
+		 */
+		public static function get_value( $source_args, $block, $attribute_name ) {
+			self::$calls[] = [
+				'source_args'    => $source_args,
+				'block'          => $block,
+				'attribute_name' => $attribute_name,
+			];
 
-		return self::$stub_values[ $attribute_name ] ?? null;
+			return self::$stub_values[ $attribute_name ] ?? null;
+		}
 	}
 }

--- a/tests/test-renderer.php
+++ b/tests/test-renderer.php
@@ -11,6 +11,15 @@
 class Newsletters_Renderer_Test extends WP_UnitTestCase {
 
 	/**
+	 * Clean up after each test.
+	 */
+	public function tear_down() {
+		parent::tear_down();
+		// Reset stub RDB to prevent test pollution.
+		\RemoteDataBlocks\Editor\DataBinding\BlockBindings::reset();
+	}
+
+	/**
 	 * Test the MJML rendering function.
 	 */
 	public function test_render_mjml_component() {
@@ -555,6 +564,593 @@ class Newsletters_Renderer_Test extends WP_UnitTestCase {
 			Newspack_Newsletters_Renderer::remove_unwanted_style_properties( [ 'padding', 'border' ], $html ),
 			'<p class="has-text-align-center has-primary-variation-color has-light-gray-background-color has-text-color has-background has-normal-font-size" style="font-size:12px;">First paragraph with the word "padding" outside of style attribute</p><p class="has-text-align-center has-primary-variation-color has-light-gray-background-color has-text-color has-background has-normal-font-size" style="">Second paragraph with the word "padding" outside of style attribute</p>',
 			'Works with multiple style attributes in the same HTML string.'
+		);
+	}
+
+	/**
+	 * Test RDB block rendering with resolved bindings for a single result.
+	 *
+	 * @covers Newspack_Newsletters_Renderer::render_mjml_component
+	 * @covers Newspack_Newsletters_Renderer::get_rdb_context
+	 * @covers Newspack_Newsletters_Renderer::clone_blocks_with_index
+	 * @covers Newspack_Newsletters_Renderer::resolve_rdb_block_bindings
+	 * @covers Newspack_Newsletters_Renderer::update_block_inner_html
+	 * @covers Newspack_Newsletters_Renderer::reconstruct_paragraph_html
+	 */
+	public function test_render_rdb_block_with_single_result() {
+		// Reset the mock.
+		\RemoteDataBlocks\Editor\DataBinding\BlockBindings::reset();
+		\RemoteDataBlocks\Editor\DataBinding\BlockBindings::set_stub_values(
+			[
+				'content' => 'Resolved Event Title',
+			]
+		);
+
+		$block = [
+			'blockName'    => 'remote-data-blocks/foundation-event',
+			'attrs'        => [
+				'remoteData' => [
+					'blockName'        => 'remote-data-blocks/foundation-event',
+					'results'          => [ [ 'title' => 'Event 1' ] ],
+					'enabledOverrides' => [],
+					'queryInputs'      => [],
+				],
+			],
+			'innerBlocks'  => [
+				[
+					'blockName'    => 'core/paragraph',
+					'attrs'        => [
+						'metadata' => [
+							'bindings' => [
+								'content' => [
+									'source' => 'remote-data/binding',
+									'args'   => [
+										'field' => 'title',
+									],
+								],
+							],
+						],
+					],
+					'innerBlocks'  => [],
+					'innerContent' => [ '<p>Placeholder</p>' ],
+					'innerHTML'    => '<p>Placeholder</p>',
+				],
+			],
+			'innerContent' => [ '<div>', null, '</div>' ],
+			'innerHTML'    => '<div></div>',
+		];
+
+		$result = Newspack_Newsletters_Renderer::render_mjml_component( $block );
+
+		// Verify that BlockBindings::get_value() was called.
+		$calls = \RemoteDataBlocks\Editor\DataBinding\BlockBindings::$calls;
+		$this->assertNotEmpty( $calls, 'BlockBindings::get_value() should have been called' );
+		$this->assertEquals( 'content', $calls[0]['attribute_name'], 'Should resolve content binding' );
+
+		// Verify the resolved content appears in the output.
+		$this->assertStringContainsString(
+			'Resolved Event Title',
+			$result,
+			'Output should contain the resolved binding value'
+		);
+
+		// Verify the output contains mj-text (from MJML pipeline).
+		$this->assertStringContainsString(
+			'<mj-text',
+			$result,
+			'Output should be rendered through the MJML pipeline'
+		);
+	}
+
+	/**
+	 * Test RDB block rendering with multiple results (template looping).
+	 *
+	 * @covers Newspack_Newsletters_Renderer::render_mjml_component
+	 * @covers Newspack_Newsletters_Renderer::get_rdb_context
+	 * @covers Newspack_Newsletters_Renderer::expand_rdb_template_blocks
+	 * @covers Newspack_Newsletters_Renderer::clone_blocks_with_index
+	 * @covers Newspack_Newsletters_Renderer::resolve_rdb_block_bindings
+	 * @covers Newspack_Newsletters_Renderer::update_block_inner_html
+	 * @covers Newspack_Newsletters_Renderer::reconstruct_paragraph_html
+	 */
+	public function test_render_rdb_block_with_multiple_results() {
+		// Reset the mock.
+		\RemoteDataBlocks\Editor\DataBinding\BlockBindings::reset();
+		\RemoteDataBlocks\Editor\DataBinding\BlockBindings::set_stub_values(
+			[
+				'content' => 'Event Title',
+			]
+		);
+
+		$block = [
+			'blockName'    => 'remote-data-blocks/template',
+			'attrs'        => [
+				'remoteData' => [
+					'blockName'        => 'remote-data-blocks/template',
+					'results'          => [
+						[ 'title' => 'Event 1' ],
+						[ 'title' => 'Event 2' ],
+						[ 'title' => 'Event 3' ],
+					],
+					'enabledOverrides' => [],
+					'queryInputs'      => [],
+				],
+			],
+			'innerBlocks'  => [
+				[
+					'blockName'    => 'core/paragraph',
+					'attrs'        => [
+						'metadata' => [
+							'bindings' => [
+								'content' => [
+									'source' => 'remote-data/binding',
+									'args'   => [
+										'field' => 'title',
+									],
+								],
+							],
+						],
+					],
+					'innerBlocks'  => [],
+					'innerContent' => [ '<p>Placeholder</p>' ],
+					'innerHTML'    => '<p>Placeholder</p>',
+				],
+			],
+			'innerContent' => [ '<div>', null, '</div>' ],
+			'innerHTML'    => '<div></div>',
+		];
+
+		$result = Newspack_Newsletters_Renderer::render_mjml_component( $block );
+
+		// Verify that BlockBindings::get_value() was called for each result.
+		$calls = \RemoteDataBlocks\Editor\DataBinding\BlockBindings::$calls;
+		$this->assertCount( 3, $calls, 'BlockBindings::get_value() should be called once per result' );
+
+		// Verify each call has the correct index.
+		$this->assertEquals( 0, $calls[0]['source_args']['index'], 'First call should have index 0' );
+		$this->assertEquals( 1, $calls[1]['source_args']['index'], 'Second call should have index 1' );
+		$this->assertEquals( 2, $calls[2]['source_args']['index'], 'Third call should have index 2' );
+
+		// Verify the output contains multiple mj-text elements (one per result).
+		$this->assertEquals(
+			3,
+			substr_count( $result, '<mj-text' ),
+			'Output should contain 3 mj-text elements for 3 results'
+		);
+	}
+
+	/**
+	 * Test RDB blocks are not wrapped in extra section/column elements.
+	 *
+	 * @covers Newspack_Newsletters_Renderer::render_mjml_component
+	 */
+	public function test_rdb_block_no_extra_wrapping() {
+		// Reset the mock.
+		\RemoteDataBlocks\Editor\DataBinding\BlockBindings::reset();
+		\RemoteDataBlocks\Editor\DataBinding\BlockBindings::set_stub_values(
+			[
+				'content' => 'Test Content',
+			]
+		);
+
+		$block = [
+			'blockName'    => 'remote-data-blocks/foundation-event',
+			'attrs'        => [
+				'remoteData' => [
+					'blockName'        => 'remote-data-blocks/foundation-event',
+					'results'          => [ [ 'title' => 'Event' ] ],
+					'enabledOverrides' => [],
+					'queryInputs'      => [],
+				],
+			],
+			'innerBlocks'  => [
+				[
+					'blockName'    => 'core/paragraph',
+					'attrs'        => [
+						'metadata' => [
+							'bindings' => [
+								'content' => [
+									'source' => 'remote-data/binding',
+									'args'   => [ 'field' => 'title' ],
+								],
+							],
+						],
+					],
+					'innerBlocks'  => [],
+					'innerContent' => [ '<p>Placeholder</p>' ],
+					'innerHTML'    => '<p>Placeholder</p>',
+				],
+			],
+			'innerContent' => [ '<div>', null, '</div>' ],
+			'innerHTML'    => '<div></div>',
+		];
+
+		$result = Newspack_Newsletters_Renderer::render_mjml_component( $block );
+
+		// The inner paragraph should have its own section/column wrapping from render_mjml_component.
+		// But the RDB container block itself should NOT add additional wrapping.
+		// Count mj-section occurrences - should be 1 (from the inner paragraph), not 2.
+		$section_count = substr_count( $result, '<mj-section' );
+		$this->assertEquals(
+			1,
+			$section_count,
+			'RDB block should not add extra section wrapping beyond what inner blocks need'
+		);
+	}
+
+	/**
+	 * Test RDB block with image binding.
+	 *
+	 * @covers Newspack_Newsletters_Renderer::render_mjml_component
+	 * @covers Newspack_Newsletters_Renderer::resolve_rdb_block_bindings
+	 * @covers Newspack_Newsletters_Renderer::update_block_inner_html
+	 * @covers Newspack_Newsletters_Renderer::update_src_in_html
+	 * @covers Newspack_Newsletters_Renderer::update_alt_in_html
+	 */
+	public function test_render_rdb_block_with_image_binding() {
+		// Reset the mock.
+		\RemoteDataBlocks\Editor\DataBinding\BlockBindings::reset();
+		\RemoteDataBlocks\Editor\DataBinding\BlockBindings::set_stub_values(
+			[
+				'url' => 'https://example.com/image.jpg',
+				'alt' => 'Event Image',
+			]
+		);
+
+		$block = [
+			'blockName'    => 'remote-data-blocks/foundation-event',
+			'attrs'        => [
+				'remoteData' => [
+					'blockName'        => 'remote-data-blocks/foundation-event',
+					'results'          => [ [ 'image' => 'https://example.com/image.jpg' ] ],
+					'enabledOverrides' => [],
+					'queryInputs'      => [],
+				],
+			],
+			'innerBlocks'  => [
+				[
+					'blockName'    => 'core/image',
+					'attrs'        => [
+						'metadata' => [
+							'bindings' => [
+								'url' => [
+									'source' => 'remote-data/binding',
+									'args'   => [ 'field' => 'image_url' ],
+								],
+								'alt' => [
+									'source' => 'remote-data/binding',
+									'args'   => [ 'field' => 'image_alt' ],
+								],
+							],
+						],
+					],
+					'innerBlocks'  => [],
+					'innerContent' => [ '<figure class="wp-block-image"><img src="placeholder.jpg" alt=""/></figure>' ],
+					'innerHTML'    => '<figure class="wp-block-image"><img src="placeholder.jpg" alt=""/></figure>',
+				],
+			],
+			'innerContent' => [ '<div>', null, '</div>' ],
+			'innerHTML'    => '<div></div>',
+		];
+
+		$result = Newspack_Newsletters_Renderer::render_mjml_component( $block );
+
+		// Verify the resolved image URL appears in the output.
+		$this->assertStringContainsString(
+			'https://example.com/image.jpg',
+			$result,
+			'Output should contain the resolved image URL'
+		);
+
+		// Verify the resolved alt text appears in the output.
+		$this->assertStringContainsString(
+			'Event Image',
+			$result,
+			'Output should contain the resolved alt text'
+		);
+
+		// Verify the output contains mj-image.
+		$this->assertStringContainsString(
+			'<mj-image',
+			$result,
+			'Output should contain mj-image element'
+		);
+	}
+
+	/**
+	 * Test RDB block with heading binding.
+	 *
+	 * @covers Newspack_Newsletters_Renderer::render_mjml_component
+	 * @covers Newspack_Newsletters_Renderer::resolve_rdb_block_bindings
+	 * @covers Newspack_Newsletters_Renderer::update_block_inner_html
+	 * @covers Newspack_Newsletters_Renderer::reconstruct_heading_html
+	 * @covers Newspack_Newsletters_Renderer::cleanup_rdb_html
+	 */
+	public function test_render_rdb_block_with_heading_binding() {
+		// Reset the mock.
+		\RemoteDataBlocks\Editor\DataBinding\BlockBindings::reset();
+		\RemoteDataBlocks\Editor\DataBinding\BlockBindings::set_stub_values(
+			[
+				'content' => 'Resolved Heading Text',
+			]
+		);
+
+		$block = [
+			'blockName'    => 'remote-data-blocks/foundation-event',
+			'attrs'        => [
+				'remoteData' => [
+					'blockName'        => 'remote-data-blocks/foundation-event',
+					'results'          => [ [ 'title' => 'Event' ] ],
+					'enabledOverrides' => [],
+					'queryInputs'      => [],
+				],
+			],
+			'innerBlocks'  => [
+				[
+					'blockName'    => 'core/heading',
+					'attrs'        => [
+						'level'    => 2,
+						'metadata' => [
+							'bindings' => [
+								'content' => [
+									'source' => 'remote-data/binding',
+									'args'   => [ 'field' => 'title' ],
+								],
+							],
+						],
+					],
+					'innerBlocks'  => [],
+					'innerContent' => [ '<h2>Placeholder</h2>' ],
+					'innerHTML'    => '<h2>Placeholder</h2>',
+				],
+			],
+			'innerContent' => [ '<div>', null, '</div>' ],
+			'innerHTML'    => '<div></div>',
+		];
+
+		$result = Newspack_Newsletters_Renderer::render_mjml_component( $block );
+
+		// Verify the resolved heading content appears in the output.
+		$this->assertStringContainsString(
+			'Resolved Heading Text',
+			$result,
+			'Output should contain the resolved heading text'
+		);
+
+		// Verify the output contains h2 tag.
+		$this->assertStringContainsString(
+			'<h2>',
+			$result,
+			'Output should preserve the h2 heading tag'
+		);
+	}
+
+	/**
+	 * Test that RDB blocks with no inner blocks don't call BlockBindings.
+	 *
+	 * @covers Newspack_Newsletters_Renderer::render_mjml_component
+	 * @covers Newspack_Newsletters_Renderer::get_rdb_context
+	 * @covers Newspack_Newsletters_Renderer::clone_blocks_with_index
+	 */
+	public function test_rdb_block_with_no_inner_blocks() {
+		// Block without inner blocks (no bindings to resolve).
+		$block = [
+			'blockName'    => 'remote-data-blocks/foundation-event',
+			'attrs'        => [],
+			'innerBlocks'  => [],
+			'innerContent' => [ '<div><p>Static content</p></div>' ],
+			'innerHTML'    => '<div><p>Static content</p></div>',
+		];
+
+		$result = Newspack_Newsletters_Renderer::render_mjml_component( $block );
+
+		// Verify BlockBindings::get_value() was NOT called since there are no inner blocks.
+		$calls = \RemoteDataBlocks\Editor\DataBinding\BlockBindings::$calls;
+		$this->assertEmpty( $calls, 'BlockBindings::get_value() should not be called when there are no inner blocks' );
+	}
+
+	/**
+	 * Test RDB block rendering with nested inner blocks (columns structure).
+	 *
+	 * @covers Newspack_Newsletters_Renderer::render_mjml_component
+	 * @covers Newspack_Newsletters_Renderer::resolve_rdb_block_bindings
+	 * @covers Newspack_Newsletters_Renderer::update_block_inner_html
+	 * @covers Newspack_Newsletters_Renderer::reconstruct_paragraph_html
+	 * @covers Newspack_Newsletters_Renderer::update_src_in_html
+	 */
+	public function test_render_rdb_block_with_nested_structure() {
+		// Reset the mock.
+		\RemoteDataBlocks\Editor\DataBinding\BlockBindings::reset();
+		\RemoteDataBlocks\Editor\DataBinding\BlockBindings::set_stub_values(
+			[
+				'content' => 'Nested Content',
+				'url'     => 'https://example.com/nested.jpg',
+			]
+		);
+
+		$block = [
+			'blockName'    => 'remote-data-blocks/foundation-event',
+			'attrs'        => [
+				'remoteData' => [
+					'blockName'        => 'remote-data-blocks/foundation-event',
+					'results'          => [ [ 'title' => 'Event' ] ],
+					'enabledOverrides' => [],
+					'queryInputs'      => [],
+				],
+			],
+			'innerBlocks'  => [
+				[
+					'blockName'    => 'core/columns',
+					'attrs'        => [],
+					'innerBlocks'  => [
+						[
+							'blockName'    => 'core/column',
+							'attrs'        => [ 'width' => '50%' ],
+							'innerBlocks'  => [
+								[
+									'blockName'    => 'core/paragraph',
+									'attrs'        => [
+										'metadata' => [
+											'bindings' => [
+												'content' => [
+													'source' => 'remote-data/binding',
+													'args' => [ 'field' => 'description' ],
+												],
+											],
+										],
+									],
+									'innerBlocks'  => [],
+									'innerContent' => [ '<p>Placeholder</p>' ],
+									'innerHTML'    => '<p>Placeholder</p>',
+								],
+							],
+							'innerContent' => [ '<div class="wp-block-column">', null, '</div>' ],
+							'innerHTML'    => '<div class="wp-block-column"></div>',
+						],
+						[
+							'blockName'    => 'core/column',
+							'attrs'        => [ 'width' => '50%' ],
+							'innerBlocks'  => [
+								[
+									'blockName'    => 'core/image',
+									'attrs'        => [
+										'metadata' => [
+											'bindings' => [
+												'url' => [
+													'source' => 'remote-data/binding',
+													'args' => [ 'field' => 'image' ],
+												],
+											],
+										],
+									],
+									'innerBlocks'  => [],
+									'innerContent' => [ '<figure><img src="placeholder.jpg"/></figure>' ],
+									'innerHTML'    => '<figure><img src="placeholder.jpg"/></figure>',
+								],
+							],
+							'innerContent' => [ '<div class="wp-block-column">', null, '</div>' ],
+							'innerHTML'    => '<div class="wp-block-column"></div>',
+						],
+					],
+					'innerContent' => [ '<div class="wp-block-columns">', null, null, '</div>' ],
+					'innerHTML'    => '<div class="wp-block-columns"></div>',
+				],
+			],
+			'innerContent' => [ '<div>', null, '</div>' ],
+			'innerHTML'    => '<div></div>',
+		];
+
+		$result = Newspack_Newsletters_Renderer::render_mjml_component( $block );
+
+		// Verify both bindings were resolved.
+		$calls = \RemoteDataBlocks\Editor\DataBinding\BlockBindings::$calls;
+		$this->assertCount( 2, $calls, 'BlockBindings::get_value() should be called for both bindings' );
+
+		// Verify the output contains mj-column elements.
+		$this->assertStringContainsString(
+			'<mj-column',
+			$result,
+			'Output should contain mj-column elements for columns layout'
+		);
+
+		// Verify the resolved content appears.
+		$this->assertStringContainsString(
+			'Nested Content',
+			$result,
+			'Output should contain the resolved paragraph content'
+		);
+
+		$this->assertStringContainsString(
+			'https://example.com/nested.jpg',
+			$result,
+			'Output should contain the resolved image URL'
+		);
+	}
+
+	/**
+	 * Test RDB block with button binding (url and text).
+	 *
+	 * @covers Newspack_Newsletters_Renderer::render_mjml_component
+	 * @covers Newspack_Newsletters_Renderer::resolve_rdb_block_bindings
+	 * @covers Newspack_Newsletters_Renderer::update_block_inner_html
+	 * @covers Newspack_Newsletters_Renderer::update_href_in_html
+	 * @covers Newspack_Newsletters_Renderer::update_link_text_in_html
+	 */
+	public function test_render_rdb_block_with_button_binding() {
+		// Reset the mock.
+		\RemoteDataBlocks\Editor\DataBinding\BlockBindings::reset();
+		\RemoteDataBlocks\Editor\DataBinding\BlockBindings::set_stub_values(
+			[
+				'url'  => 'https://example.com/event-link',
+				'text' => 'Register Now',
+			]
+		);
+
+		$block = [
+			'blockName'    => 'remote-data-blocks/foundation-event',
+			'attrs'        => [
+				'remoteData' => [
+					'blockName'        => 'remote-data-blocks/foundation-event',
+					'results'          => [ [ 'link' => 'https://example.com/event-link' ] ],
+					'enabledOverrides' => [],
+					'queryInputs'      => [],
+				],
+			],
+			'innerBlocks'  => [
+				[
+					'blockName'    => 'core/buttons',
+					'attrs'        => [],
+					'innerBlocks'  => [
+						[
+							'blockName'    => 'core/button',
+							'attrs'        => [
+								'metadata' => [
+									'bindings' => [
+										'url'  => [
+											'source' => 'remote-data/binding',
+											'args'   => [ 'field' => 'event_url' ],
+										],
+										'text' => [
+											'source' => 'remote-data/binding',
+											'args'   => [ 'field' => 'event_cta' ],
+										],
+									],
+								],
+							],
+							'innerBlocks'  => [],
+							'innerContent' => [ '<div class="wp-block-button"><a class="wp-block-button__link" href="https://placeholder.com">Placeholder</a></div>' ],
+							'innerHTML'    => '<div class="wp-block-button"><a class="wp-block-button__link" href="https://placeholder.com">Placeholder</a></div>',
+						],
+					],
+					'innerContent' => [ '<div class="wp-block-buttons">', null, '</div>' ],
+					'innerHTML'    => '<div class="wp-block-buttons"></div>',
+				],
+			],
+			'innerContent' => [ '<div>', null, '</div>' ],
+			'innerHTML'    => '<div></div>',
+		];
+
+		$result = Newspack_Newsletters_Renderer::render_mjml_component( $block );
+
+		// Verify the resolved URL appears in the output.
+		$this->assertStringContainsString(
+			'https://example.com/event-link',
+			$result,
+			'Output should contain the resolved button URL'
+		);
+
+		// Verify the resolved button text appears in the output.
+		$this->assertStringContainsString(
+			'Register Now',
+			$result,
+			'Output should contain the resolved button text'
+		);
+
+		// Verify the output contains mj-button.
+		$this->assertStringContainsString(
+			'<mj-button',
+			$result,
+			'Output should contain mj-button element'
 		);
 	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Recent changes to Remote Data Blocks meant that data from remote bindings were no longer persisted in post content.  Newsletter rendering (but not in-editor preview!) of RDB-derived blocks depended on that behavior, and remote data that depended on those bindings was no longer included on send.

This patch (heavily inspired by the new preview rendering behavior in RDB) uses the new get_value() implementation in RDB to resolve those bindings and populate remote data on send.  This essentially restores the old behavior as far as our newsletters are concerned.

Addresses [NPPM-2483: Continuing problem with trying to add Foundation -- Event block to newsletters](https://linear.app/a8c/issue/NPPM-2483/continuing-problem-with-trying-to-add-foundation-event-block-to).

### How to test the changes in this Pull Request:

1.  Ensure that Newspack Newsletters and Foundation Integration are set up on your test environment.
2.  Pull down the latest version of the [`fix/rdb-rendering` topic branch](https://github.com/Automattic/newspack-newsletters/tree/fix/rdb-rendering).
3.  Create a new newsletter.
4. Add a RDB block (newsletters support `Foundation - Event` or `Foundation - Location` blocks) to the newsletter; select data to display in it; choose a Newsletter pattern.  Verify the remote data shows up in the editor.
5. Hit **Preview Email** button in the upper right.  Verify the remote data shows on the preview popup.
6. **If you're set up to test newsletter sending** hit **Send** in the upper right and kick off a test send.  Verify the recipient sees the remote data.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
