### PR TITLE
fix: iframe Editor Compatibility

### DIFF
--- a/includes/class-newspack-newsletters-blocks.php
+++ b/includes/class-newspack-newsletters-blocks.php
@@ -16,13 +16,16 @@ final class Newspack_Newsletters_Blocks {
 	 */
 	public static function init() {
 		require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/src/blocks/subscribe/index.php';
-		add_action( 'enqueue_block_editor_assets', [ __CLASS__, 'enqueue_block_editor_assets' ] );
+		add_action( 'enqueue_block_assets', [ __CLASS__, 'enqueue_block_assets' ] );
 	}
 
 	/**
 	 * Enqueue blocks scripts and styles for editor.
 	 */
-	public static function enqueue_block_editor_assets() {
+	public static function enqueue_block_assets() {
+		if ( ! is_admin() ) {
+			return;
+		}
 		$handle = 'newspack-newsletters-blocks';
 		wp_enqueue_script(
 			$handle,

--- a/includes/class-newspack-newsletters-editor.php
+++ b/includes/class-newspack-newsletters-editor.php
@@ -186,12 +186,12 @@ final class Newspack_Newsletters_Editor {
 			$allowed_actions
 		);
 
-		$enqueue_block_editor_assets_filters = $GLOBALS['wp_filter']['enqueue_block_editor_assets']->callbacks;
-		foreach ( $enqueue_block_editor_assets_filters as $index => $filter ) {
+		$enqueue_block_assets_filters = $GLOBALS['wp_filter']['enqueue_block_assets']->callbacks;
+		foreach ( $enqueue_block_assets_filters as $index => $filter ) {
 			$action_handlers = array_keys( $filter );
 			foreach ( $action_handlers as $handler ) {
 				if ( ! in_array( $handler, $allowed_actions, true ) ) {
-					remove_action( 'enqueue_block_editor_assets', $handler, $index );
+					remove_action( 'enqueue_block_assets', $handler, $index );
 				}
 			}
 		}

--- a/includes/class-newspack-newsletters-editor.php
+++ b/includes/class-newspack-newsletters-editor.php
@@ -48,7 +48,7 @@ final class Newspack_Newsletters_Editor {
 		add_filter( 'block_editor_settings_all', [ __CLASS__, 'disable_autosave' ], 10, 2 );
 		add_action( 'the_post', [ __CLASS__, 'strip_editor_modifications' ] );
 		add_action( 'after_setup_theme', [ __CLASS__, 'newspack_font_sizes' ], 11 );
-		add_action( 'enqueue_block_editor_assets', [ __CLASS__, 'enqueue_block_editor_assets' ] );
+		add_action( 'enqueue_block_assets', [ __CLASS__, 'enqueue_block_assets' ] );
 		add_filter( 'block_categories_all', [ __CLASS__, 'add_custom_block_category' ] );
 		add_filter( 'allowed_block_types_all', [ __CLASS__, 'newsletters_allowed_block_types' ], 10, 2 );
 		add_action( 'rest_post_query', [ __CLASS__, 'maybe_filter_excerpt_length' ], 10, 2 );
@@ -160,7 +160,7 @@ final class Newspack_Newsletters_Editor {
 		}
 
 		$allowed_actions = [
-			__CLASS__ . '::enqueue_block_editor_assets',
+			__CLASS__ . '::enqueue_block_assets',
 			'newspack_enqueue_scripts',
 			'wp_enqueue_editor_format_library_assets',
 		];
@@ -330,7 +330,10 @@ final class Newspack_Newsletters_Editor {
 	/**
 	 * Load up common JS/CSS for newsletter editor.
 	 */
-	public static function enqueue_block_editor_assets() {
+	public static function enqueue_block_assets() {
+		if ( ! is_admin() ) {
+			return;
+		}
 		// Remove the Ads CPT - it does not need MJML handling since ads
 		// will be injected into email content before it's converted to MJML.
 		$mjml_handling_post_types = array_values( array_diff( self::get_email_editor_cpts(), [ Newspack_Newsletters\Ads::CPT ] ) );

--- a/src/blocks/subscribe/block.json
+++ b/src/blocks/subscribe/block.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
-	"apiVersion": 2,
+	"apiVersion": 3,
 	"name": "newspack-newsletters/subscribe",
 	"title": "Newsletter Subscription Form",
 	"category": "newspack",

--- a/src/editor/blocks/ad/block.json
+++ b/src/editor/blocks/ad/block.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
-	"apiVersion": 2,
+	"apiVersion": 3,
 	"name": "newspack-newsletters/ad",
 	"title": "Newsletter Ad",
 	"category": "newspack",

--- a/src/editor/blocks/posts-inserter/block.json
+++ b/src/editor/blocks/posts-inserter/block.json
@@ -1,4 +1,6 @@
 {
+	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"apiVersion": 3,
 	"name": "newspack-newsletters/posts-inserter",
 	"category": "newspack",
 	"supports": [

--- a/src/editor/blocks/posts-inserter/index.js
+++ b/src/editor/blocks/posts-inserter/index.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { isUndefined, find, pickBy, get } from 'lodash';
+import classnames from 'classnames';
 
 /**
  * WordPress dependencies
@@ -49,7 +50,9 @@ const PostsInserterBlock = ( {
 } ) => {
 	const [ isReady, setIsReady ] = useState( ! attributes.displayFeaturedImage );
 	const blockProps = useBlockProps( {
-		className: `newspack-posts-inserter ${ ! isReady ? 'newspack-posts-inserter--loading' : '' }`,
+		className: classnames( 'newspack-posts-inserter', {
+			'newspack-posts-inserter--loading': ! isReady,
+		} ),
 	} );
 	const stringifiedPostList = JSON.stringify( postList );
 

--- a/src/editor/blocks/posts-inserter/index.js
+++ b/src/editor/blocks/posts-inserter/index.js
@@ -22,7 +22,7 @@ import {
 	Toolbar,
 	ToolbarDropdownMenu,
 } from '@wordpress/components';
-import { InnerBlocks, InspectorControls, BlockControls } from '@wordpress/block-editor';
+import { InnerBlocks, InspectorControls, BlockControls, useBlockProps } from '@wordpress/block-editor';
 import { Fragment, useEffect, useMemo, useState } from '@wordpress/element';
 import { Icon, check, pages } from '@wordpress/icons';
 
@@ -48,6 +48,9 @@ const PostsInserterBlock = ( {
 	blockEditorSettings,
 } ) => {
 	const [ isReady, setIsReady ] = useState( ! attributes.displayFeaturedImage );
+	const blockProps = useBlockProps( {
+		className: `newspack-posts-inserter ${ ! isReady ? 'newspack-posts-inserter--loading' : '' }`,
+	} );
 	const stringifiedPostList = JSON.stringify( postList );
 
 	// Stringify added to minimize flicker.
@@ -276,7 +279,7 @@ const PostsInserterBlock = ( {
 				) }
 			</BlockControls>
 
-			<div className={ `newspack-posts-inserter ${ ! isReady ? 'newspack-posts-inserter--loading' : '' }` }>
+			<div { ...blockProps }>
 				<div className="newspack-posts-inserter__header">
 					<Icon icon={ pages } />
 					<span>{ __( 'Posts Inserter', 'newspack-newsletters' ) }</span>

--- a/src/editor/blocks/share/block.json
+++ b/src/editor/blocks/share/block.json
@@ -1,0 +1,30 @@
+{
+	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"apiVersion": 3,
+	"name": "newspack-newsletters/share",
+	"title": "Share Newsletter",
+	"category": "newspack",
+	"description": "",
+	"textdomain": "newspack-newsletters",
+	"attributes": {
+		"content": {
+			"type": "string",
+			"source": "html",
+			"selector": "p",
+			"default": "Thanks for reading. If you liked it, please send to a friend!",
+			"__experimentalRole": "content"
+		},
+		"shareMessage": {
+			"type": "string",
+			"default": "I'd like to share this newsletter with you: [LINK]"
+		}
+	},
+	"supports": {
+		"className": false,
+		"color": {
+			"link": true
+		},
+		"fontSize": true,
+		"lineHeight": true
+	}
+}

--- a/src/editor/blocks/share/index.js
+++ b/src/editor/blocks/share/index.js
@@ -14,6 +14,8 @@ import { SHARE_BLOCK_NAME } from './consts';
 
 export default () => {
 	registerBlockType( SHARE_BLOCK_NAME, {
+		$schema: 'https://schemas.wp.org/trunk/block.json',
+		apiVersion: 3,
 		title: __( 'Share Newsletter', 'newspack-newsletters' ),
 		category: 'newspack',
 		icon: <Icon icon={ customLink } />,

--- a/src/editor/blocks/share/index.js
+++ b/src/editor/blocks/share/index.js
@@ -2,7 +2,6 @@
  * WordPress dependencies
  */
 import { registerBlockType } from '@wordpress/blocks';
-import { __ } from '@wordpress/i18n';
 import { Icon, customLink } from '@wordpress/icons';
 
 /**
@@ -10,37 +9,18 @@ import { Icon, customLink } from '@wordpress/icons';
  */
 import edit from './edit';
 import save from './save';
-import { SHARE_BLOCK_NAME } from './consts';
+import metadata from './block.json';
+
+const { name } = metadata;
+
+export { metadata, name };
+
+export const settings = {
+	icon: <Icon icon={ customLink } />,
+	edit,
+	save,
+};
 
 export default () => {
-	registerBlockType( SHARE_BLOCK_NAME, {
-		$schema: 'https://schemas.wp.org/trunk/block.json',
-		apiVersion: 3,
-		title: __( 'Share Newsletter', 'newspack-newsletters' ),
-		category: 'newspack',
-		icon: <Icon icon={ customLink } />,
-		attributes: {
-			content: {
-				type: 'string',
-				source: 'html',
-				selector: 'p',
-				default: __( 'Thanks for reading. If you liked it, please send to a friend!', 'newspack-newsletters' ),
-				__experimentalRole: 'content',
-			},
-			shareMessage: {
-				type: 'string',
-				default: __( "I'd like to share this newsletter with you: [LINK]", 'newspack-newsletters' ),
-			},
-		},
-		supports: {
-			className: false,
-			color: {
-				link: true,
-			},
-			fontSize: true,
-			lineHeight: true,
-		},
-		edit,
-		save,
-	} );
+	registerBlockType( { name, ...metadata }, settings );
 };


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes https://linear.app/a8c/issue/NPPM-2586/newspack-newsletters-iframe-editor-compatibility

### How to test the changes in this Pull Request:

1. Ensure ONLY the main plugin, blocks, newsletters, and popups are the only Newspack extensions active and are all on the `fix/iframe-editor-compatibility` branch.
2. Smoke test blocks in the editor + frontend (You can find a list in the linked linear issue)


### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
