### PR TITLE
chore: add new get_fields method to provider abstraction

### DIFF
--- a/includes/class-newspack-newsletters-contacts.php
+++ b/includes/class-newspack-newsletters-contacts.php
@@ -387,4 +387,22 @@ class Newspack_Newsletters_Contacts {
 
 		return $result;
 	}
+
+	/**
+	 * Get the contact fields from the provider.
+	 *
+	 * Used by Newspack integrations sync.
+	 *
+	 * @param string|null $list_id Optional list ID to get the fields for. Needed for Mailchimp.
+	 *
+	 * @return array|WP_Error Array of fields or error if failed.
+	 */
+	public static function get_fields( $list_id = null ) {
+		$provider = Newspack_Newsletters::get_service_provider();
+		if ( empty( $provider ) ) {
+			return new WP_Error( 'newspack_newsletters_invalid_provider', __( 'Provider is not set.' ) );
+		}
+
+		return $provider->get_contact_fields( $list_id );
+	}
 }

--- a/includes/service-providers/active_campaign/class-newspack-newsletters-active-campaign.php
+++ b/includes/service-providers/active_campaign/class-newspack-newsletters-active-campaign.php
@@ -1753,6 +1753,11 @@ final class Newspack_Newsletters_Active_Campaign extends \Newspack_Newsletters_S
 	 * @return array The contact fields for the list. Each field should be an array with 'key' key at least.
 	 */
 	public function get_contact_fields( $list_id = null ) {
+		$cache_key = 'active_campaign_contact_fields';
+		$cached_fields = wp_cache_get( $cache_key );
+		if ( false !== $cached_fields ) {
+			return $cached_fields;
+		}
 		$all_fields = $this->get_all_contact_fields();
 		if ( is_wp_error( $all_fields ) ) {
 			return [];
@@ -1763,6 +1768,7 @@ final class Newspack_Newsletters_Active_Campaign extends \Newspack_Newsletters_S
 				'key' => $field['title'],
 			];
 		}
+		wp_cache_set( $cache_key, $fields, '', 5 * MINUTE_IN_SECONDS );
 		return $fields;
 	}
 }

--- a/includes/service-providers/active_campaign/class-newspack-newsletters-active-campaign.php
+++ b/includes/service-providers/active_campaign/class-newspack-newsletters-active-campaign.php
@@ -1574,7 +1574,7 @@ final class Newspack_Newsletters_Active_Campaign extends \Newspack_Newsletters_S
 	 *
 	 * @param number $offset Offset for pagination.
 	 */
-	private function get_contact_fields( $offset ) {
+	private function fetch_contact_fields( $offset ) {
 		return $this->api_v3_request(
 			'fields',
 			'GET',
@@ -1592,8 +1592,8 @@ final class Newspack_Newsletters_Active_Campaign extends \Newspack_Newsletters_S
 	 *
 	 * @param number $offset Offset for pagination.
 	 */
-	private function get_all_contact_fields( $offset = 0 ) {
-		$response = $this->get_contact_fields( $offset );
+	public function get_all_contact_fields( $offset = 0 ) {
+		$response = $this->fetch_contact_fields( $offset );
 		if ( \is_wp_error( $response ) ) {
 			return $response;
 		}
@@ -1740,5 +1740,29 @@ final class Newspack_Newsletters_Active_Campaign extends \Newspack_Newsletters_S
 	public function get_usage_report() {
 		$ac_usage_reports = new Newspack_Newsletters_Active_Campaign_Usage_Reports();
 		return $ac_usage_reports->get_usage_report();
+	}
+
+	/**
+	 * Get contact fields for a list.
+	 *
+	 * By default, this method returns an empty array, but providers can override it to return the fields available in the ESP for a specific list.
+	 *
+	 * This is used by Newspack integrations to sync contact data.
+	 *
+	 * @param string|null $list_id The List ID. Optional, as some providers might not have different fields per list.
+	 * @return array The contact fields for the list. Each field should be an array with 'key' key at least.
+	 */
+	public function get_contact_fields( $list_id = null ) {
+		$all_fields = $this->get_all_contact_fields();
+		if ( is_wp_error( $all_fields ) ) {
+			return [];
+		}
+		$fields = [];
+		foreach ( $all_fields as $field ) {
+			$fields[] = [
+				'key' => $field['title'],
+			];
+		}
+		return $fields;
 	}
 }

--- a/includes/service-providers/active_campaign/class-newspack-newsletters-active-campaign.php
+++ b/includes/service-providers/active_campaign/class-newspack-newsletters-active-campaign.php
@@ -1592,7 +1592,7 @@ final class Newspack_Newsletters_Active_Campaign extends \Newspack_Newsletters_S
 	 *
 	 * @param number $offset Offset for pagination.
 	 */
-	public function get_all_contact_fields( $offset = 0 ) {
+	private function get_all_contact_fields( $offset = 0 ) {
 		$response = $this->fetch_contact_fields( $offset );
 		if ( \is_wp_error( $response ) ) {
 			return $response;
@@ -1750,7 +1750,7 @@ final class Newspack_Newsletters_Active_Campaign extends \Newspack_Newsletters_S
 	 * This is used by Newspack integrations to sync contact data.
 	 *
 	 * @param string|null $list_id The List ID. Optional, as some providers might not have different fields per list.
-	 * @return array The contact fields for the list. Each field should be an array with 'key' key at least.
+	 * @return array|WP_Error The contact fields for the list. Each field should be an array with 'key' key at least. WP_Error if the request to fetch the fields failed.
 	 */
 	public function get_contact_fields( $list_id = null ) {
 		$cache_key = 'active_campaign_contact_fields';
@@ -1760,7 +1760,7 @@ final class Newspack_Newsletters_Active_Campaign extends \Newspack_Newsletters_S
 		}
 		$all_fields = $this->get_all_contact_fields();
 		if ( is_wp_error( $all_fields ) ) {
-			return [];
+			return $all_fields;
 		}
 		$fields = [];
 		foreach ( $all_fields as $field ) {

--- a/includes/service-providers/class-newspack-newsletters-service-provider.php
+++ b/includes/service-providers/class-newspack-newsletters-service-provider.php
@@ -918,4 +918,18 @@ Error message(s) received:
 	public function get_transient_name( $post_id ) {
 		return sprintf( 'newspack_newsletters_error_%s_%s', $post_id, get_current_user_id() );
 	}
+
+	/**
+	 * Get contact fields for a list.
+	 *
+	 * By default, this method returns an empty array, but providers can override it to return the fields available in the ESP for a specific list.
+	 *
+	 * This is used by Newspack integrations to sync contact data.
+	 *
+	 * @param string|null $list_id The List ID. Optional, as some providers might not have different fields per list.
+	 * @return array The contact fields for the list. Each field should be an array with 'key' key at least.
+	 */
+	public function get_contact_fields( $list_id = null ) {
+		return [];
+	}
 }

--- a/includes/service-providers/class-newspack-newsletters-service-provider.php
+++ b/includes/service-providers/class-newspack-newsletters-service-provider.php
@@ -927,7 +927,7 @@ Error message(s) received:
 	 * This is used by Newspack integrations to sync contact data.
 	 *
 	 * @param string|null $list_id The List ID. Optional, as some providers might not have different fields per list.
-	 * @return array The contact fields for the list. Each field should be an array with 'key' key at least.
+	 * @return array|WP_Error The contact fields for the list. Each field should be an array with 'key' key at least. WP_Error if the request to fetch the fields failed.
 	 */
 	public function get_contact_fields( $list_id = null ) {
 		return [];

--- a/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp.php
+++ b/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp.php
@@ -2254,6 +2254,14 @@ final class Newspack_Newsletters_Mailchimp extends \Newspack_Newsletters_Service
 	 * @return array|WP_Error The contact fields for the list. Each field should be an array with 'key' key at least. WP_Error if the request to fetch the fields failed.
 	 */
 	public function get_contact_fields( $list_id = null ) {
+		// Validate list_id up front.
+		if ( empty( $list_id ) ) {
+			return new WP_Error(
+				'newspack_mailchimp_get_contact_fields_failed',
+				__( 'List ID is required.', 'newspack-newsletters' )
+			);
+		}
+
 		try {
 			$all_fields = Newspack_Newsletters_Mailchimp_Cached_Data::get_merge_fields( $list_id );
 		} catch ( Exception $e ) {
@@ -2262,6 +2270,12 @@ final class Newspack_Newsletters_Mailchimp extends \Newspack_Newsletters_Service
 				$e->getMessage()
 			);
 		}
+
+		// Normalize to array to prevent PHP warnings when iterating.
+		if ( ! is_array( $all_fields ) ) {
+			$all_fields = [];
+		}
+
 		$fields = [];
 		foreach ( $all_fields as $field ) {
 			$fields[] = [

--- a/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp.php
+++ b/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp.php
@@ -2251,13 +2251,16 @@ final class Newspack_Newsletters_Mailchimp extends \Newspack_Newsletters_Service
 	 * This is used by Newspack integrations to sync contact data.
 	 *
 	 * @param string|null $list_id The List ID. Optional, as some providers might not have different fields per list.
-	 * @return array The contact fields for the list. Each field should be an array with 'key' key at least.
+	 * @return array|WP_Error The contact fields for the list. Each field should be an array with 'key' key at least. WP_Error if the request to fetch the fields failed.
 	 */
 	public function get_contact_fields( $list_id = null ) {
 		try {
 			$all_fields = Newspack_Newsletters_Mailchimp_Cached_Data::get_merge_fields( $list_id );
 		} catch ( Exception $e ) {
-			return [];
+			return new WP_Error(
+				'newspack_mailchimp_get_contact_fields_failed',
+				$e->getMessage()
+			);
 		}
 		$fields = [];
 		foreach ( $all_fields as $field ) {

--- a/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp.php
+++ b/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp.php
@@ -2242,4 +2242,29 @@ final class Newspack_Newsletters_Mailchimp extends \Newspack_Newsletters_Service
 	public function get_usage_report() {
 		return Newspack_Newsletters_Mailchimp_Usage_Reports::get_usage_report();
 	}
+
+	/**
+	 * Get contact fields for a list.
+	 *
+	 * By default, this method returns an empty array, but providers can override it to return the fields available in the ESP for a specific list.
+	 *
+	 * This is used by Newspack integrations to sync contact data.
+	 *
+	 * @param string|null $list_id The List ID. Optional, as some providers might not have different fields per list.
+	 * @return array The contact fields for the list. Each field should be an array with 'key' key at least.
+	 */
+	public function get_contact_fields( $list_id = null ) {
+		try {
+			$all_fields = Newspack_Newsletters_Mailchimp_Cached_Data::get_merge_fields( $list_id );
+		} catch ( Exception $e ) {
+			return [];
+		}
+		$fields = [];
+		foreach ( $all_fields as $field ) {
+			$fields[] = [
+				'key' => $field['name'],
+			];
+		}
+		return $fields;
+	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Creates a new method in the ESP abstraction to fetch all available contact fields.

This will be used by Newspack integrations in https://github.com/Automattic/newspack-plugin/pull/4470

### How to test the changes in this Pull Request:

1. Set up Mailchimp as the ESP
2. enter wp shell
3. invoke `Newspack_Newsletters_Contacts::get_fields( $list_id );` informing the Audience ID in $list_id. (you can get it calling `Newspack_Newsletters_Subscription::get_lists()`.
4. Check the output is correct
5. Change the ESP to Active Campaign
6. invoke  `Newspack_Newsletters_Contacts::get_fields();`
7. Check the output is correct

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
