### PR TITLE
fix: improve error handling in upsert contact method

### DIFF
--- a/includes/class-newspack-newsletters-contacts.php
+++ b/includes/class-newspack-newsletters-contacts.php
@@ -248,15 +248,19 @@ class Newspack_Newsletters_Contacts {
 		);
 
 		if ( $errors->has_errors() ) {
-			// Get a reader-friendly error message to show to the user.
-			$reader_error = $provider->get_reader_error_message(
-				[
-					'email' => $contact['email'],
-					'lists' => $lists,
-				],
-				is_wp_error( $result ) ? $result : $errors
+			$error = new WP_Error(
+				'newspack_newsletters_upsert_contact_error',
+				// Get a reader-friendly error message to show to the user.
+				$provider->get_reader_error_message(
+					[
+						'email' => $contact['email'],
+						'lists' => $lists,
+					],
+					is_wp_error( $result ) ? $result : $errors
+				)
 			);
-			return Newspack_Newsletters::debug_mode() ? $errors : new \WP_Error( 'newspack_newsletters_upsert_contact_error', $reader_error );
+			$error->merge_from( $errors );
+			return $error;
 		}
 
 		return $result;
@@ -293,7 +297,7 @@ class Newspack_Newsletters_Contacts {
 					'provider' => $provider->service,
 					'errors'   => is_wp_error( $result ) ? $result->get_error_message() : [],
 				],
-				'user_email' => $user['data']['user_email'],
+				'user_email' => $email,
 				'file'       => 'newspack_esp_sync',
 			]
 		);

--- a/includes/class-newspack-newsletters-contacts.php
+++ b/includes/class-newspack-newsletters-contacts.php
@@ -248,19 +248,7 @@ class Newspack_Newsletters_Contacts {
 		);
 
 		if ( $errors->has_errors() ) {
-			$error = new WP_Error(
-				'newspack_newsletters_upsert_contact_error',
-				// Get a reader-friendly error message to show to the user.
-				$provider->get_reader_error_message(
-					[
-						'email' => $contact['email'],
-						'lists' => $lists,
-					],
-					is_wp_error( $result ) ? $result : $errors
-				)
-			);
-			$error->merge_from( $errors );
-			return $error;
+			return $errors;
 		}
 
 		return $result;

--- a/includes/class-newspack-newsletters-subscription.php
+++ b/includes/class-newspack-newsletters-subscription.php
@@ -1049,7 +1049,18 @@ class Newspack_Newsletters_Subscription {
 				$result        = Newspack_Newsletters_Contacts::update_lists( $email, $lists, 'User updated their subscriptions on My Account page' );
 			}
 			if ( is_wp_error( $result ) ) {
-				wc_add_notice( $result->get_error_message(), 'error' );
+				// Get a reader-friendly error message to show to the user.
+				$provider = Newspack_Newsletters::get_service_provider();
+				$message  = $provider
+					? $provider->get_reader_error_message(
+						[
+							'email' => $email,
+							'lists' => $lists,
+						],
+						$result
+					)
+					: $result->get_error_message();
+				wc_add_notice( $message, 'error' );
 			} elseif ( false === $result ) {
 				wc_add_notice( __( 'You must select newsletters to update.', 'newspack-newsletters' ), 'error' );
 			} else {

--- a/src/blocks/subscribe/index.php
+++ b/src/blocks/subscribe/index.php
@@ -528,6 +528,18 @@ function process_form() {
 	}
 
 	if ( \is_wp_error( $result ) ) {
+		// Get a reader-friendly error message to show to the user.
+		$provider = \Newspack_Newsletters::get_service_provider();
+		if ( $provider ) {
+			$reader_error = $provider->get_reader_error_message(
+				[
+					'email' => $email,
+					'lists' => $lists,
+				],
+				$result
+			);
+			$result = new \WP_Error( $result->get_error_code(), $reader_error );
+		}
 		return send_form_response( $result );
 	}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Refactor the reader-friendly error logic so that the response from the `upsert()` method still contains meaningful information about what happened.

Further details and test instructions at https://github.com/Automattic/newspack-plugin/pull/4488

### How to test the changes in this Pull Request:

Follow the test instructions from #1754 and confirm there are no regressions.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
