### PR TITLE
fix: upload release archive artifact after release build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,12 +23,6 @@ jobs:
       GIT_COMMITTER_TOKEN: ${{ secrets.GIT_COMMITTER_TOKEN }}
       NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
-  build-distributable:
-    needs: release
-    uses: Automattic/newspack-scripts/.github/workflows/reusable-build-distributable.yml@trunk
-    with:
-      archive-name: newspack-newsletters
-
   post-release:
     if: github.ref == 'refs/heads/release'
     needs: release
@@ -40,7 +34,7 @@ jobs:
 
   release-wporg:
     if: github.ref == 'refs/heads/release'
-    needs: [ release, build-distributable ]
+    needs: release
     uses: Automattic/newspack-scripts/.github/workflows/reusable-release-wporg.yml@trunk
     with:
       plugin-name: newspack-newsletters

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,6 +23,12 @@ jobs:
       GIT_COMMITTER_TOKEN: ${{ secrets.GIT_COMMITTER_TOKEN }}
       NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
+  build-distributable:
+    needs: release
+    uses: Automattic/newspack-scripts/.github/workflows/reusable-build-distributable.yml@trunk
+    with:
+      archive-name: newspack-newsletters
+
   post-release:
     if: github.ref == 'refs/heads/release'
     needs: release
@@ -36,6 +42,8 @@ jobs:
     if: github.ref == 'refs/heads/release'
     needs: release
     uses: Automattic/newspack-scripts/.github/workflows/reusable-release-wporg.yml@trunk
+    with:
+      plugin-name: newspack-newsletters
     secrets:
       WP_ORG_USERNAME: ${{ secrets.WP_ORG_USERNAME }}
       WP_ORG_PASSWORD: ${{ secrets.WP_ORG_PASSWORD }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,7 +40,7 @@ jobs:
 
   release-wporg:
     if: github.ref == 'refs/heads/release'
-    needs: release
+    needs: [ release, build-distributable ]
     uses: Automattic/newspack-scripts/.github/workflows/reusable-release-wporg.yml@trunk
     with:
       plugin-name: newspack-newsletters


### PR DESCRIPTION
Attempt to explicitly pass `newspack-newsletters` as an input variable to the `release-wporg` job.