### PR TITLE
fix: no parallel post-release jobs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,7 @@ jobs:
 
   release-wporg:
     if: github.ref == 'refs/heads/release'
-    needs: release
+    needs: post-release
     uses: Automattic/newspack-scripts/.github/workflows/reusable-release-wporg.yml@trunk
     with:
       plugin-name: newspack-newsletters

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
 				"qs": "^6.14.0"
 			},
 			"devDependencies": {
-				"newspack-scripts": "^5.9.3"
+				"newspack-scripts": "^5.9.5"
 			}
 		},
 		"node_modules/@actions/core": {
@@ -25483,9 +25483,9 @@
 			}
 		},
 		"node_modules/newspack-scripts": {
-			"version": "5.9.3",
-			"resolved": "https://registry.npmjs.org/newspack-scripts/-/newspack-scripts-5.9.3.tgz",
-			"integrity": "sha512-gsPcWxsrYteAmnmqAYrLVa4SULbczW4lWI1EymYMnw/JaYGGTsnHG7WUl0piL+s1idZa0Bs2+aKNHCXp4Yr55A==",
+			"version": "5.9.5",
+			"resolved": "https://registry.npmjs.org/newspack-scripts/-/newspack-scripts-5.9.5.tgz",
+			"integrity": "sha512-GtM1x8FiW5HvaW1iJEPBq4x+kmPl19ap+BPFmCMgTdihjny/kdiUnQuM+Lm5hGwbuy3eCihYSHwGPst9m1rTKg==",
 			"dev": true,
 			"license": "ISC",
 			"dependencies": {

--- a/package.json
+++ b/package.json
@@ -47,6 +47,6 @@
 		"qs": "^6.14.0"
 	},
 	"devDependencies": {
-		"newspack-scripts": "^5.9.3"
+		"newspack-scripts": "^5.9.5"
 	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Changes the job dependency for `release-wporg` so that it runs AFTER `post-release` instead of in parallel with it.

### How to test the changes in this Pull Request:

❓ 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
