### PR TITLE
feat(init-modal): apply new modal style to init screen in editor

### DIFF
--- a/src/components/init-modal/index.js
+++ b/src/components/init-modal/index.js
@@ -6,7 +6,6 @@
  * WordPress dependencies
  */
 import { Modal } from '@wordpress/components';
-import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -23,7 +22,7 @@ export default ( { shouldDisplaySettings, onSetupStatus } ) => {
 			overlayClassName="newspack-newsletters-modal__screen-overlay"
 			shouldCloseOnClickOutside={ false }
 			shouldCloseOnEsc={ false }
-			title={ shouldDisplaySettings ? __( 'Configure Plugin', 'newspack-newsletters' ) : __( 'Add New Newsletter', 'newspack-newsletters' ) }
+			size="fill"
 		>
 			{ shouldDisplaySettings ? <APIKeys onSetupStatus={ onSetupStatus } /> : <LayoutPicker /> }
 		</Modal>

--- a/src/components/init-modal/screens/api-keys/index.js
+++ b/src/components/init-modal/screens/api-keys/index.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import apiFetch from '@wordpress/api-fetch';
-import { Button, ExternalLink, SelectControl, Spinner, TextControl } from '@wordpress/components';
+import { Button, ExternalLink, SelectControl, Spinner, TextControl, __experimentalHStack as HStack } from '@wordpress/components'; // eslint-disable-line @wordpress/no-unsafe-wp-apis
 import { Fragment, useEffect, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { ENTER } from '@wordpress/keycodes';
@@ -89,6 +89,7 @@ export default ( { onSetupStatus } ) => {
 			<div className={ classes }>
 				<div className="newspack-newsletters-modal__settings-wrapper">
 					{ inFlight && <Spinner /> }
+					<h1>{ __( 'Configure plugin', 'newspack-newsletters' ) }</h1>
 					<h4>{ __( 'Select your email service provider', 'newspack-newsletters' ) }</h4>
 					<SelectControl
 						label={ __( 'Service Provider', 'newspack-newsletters' ) }
@@ -116,6 +117,7 @@ export default ( { onSetupStatus } ) => {
 							},
 							{ value: 'manual', label: __( 'Manual / Other', 'newspack-newsletters' ) },
 						] }
+						__next40pxDefaultSize
 					/>
 					{ 'mailchimp' === serviceProvider && (
 						<Fragment>
@@ -127,6 +129,7 @@ export default ( { onSetupStatus } ) => {
 								disabled={ inFlight }
 								onKeyDown={ handleKeyDown }
 								className={ errors.newspack_newsletters_invalid_keys && 'has-error' }
+								__next40pxDefaultSize
 							/>
 							{ errors.newspack_newsletters_invalid_keys && <p className="error">{ errors.newspack_newsletters_invalid_keys }</p> }
 
@@ -147,6 +150,7 @@ export default ( { onSetupStatus } ) => {
 								disabled={ inFlight }
 								onKeyDown={ handleKeyDown }
 								className={ errors.newspack_newsletters_invalid_keys && 'has-error' }
+								__next40pxDefaultSize
 							/>
 							<TextControl
 								label={ __( 'Constant Contact API Secret', 'newspack-newsletters' ) }
@@ -155,6 +159,7 @@ export default ( { onSetupStatus } ) => {
 								disabled={ inFlight }
 								onKeyDown={ handleKeyDown }
 								className={ errors.newspack_newsletters_invalid_keys && 'has-error' }
+								__next40pxDefaultSize
 							/>
 							{ errors.newspack_newsletters_invalid_keys && <p className="error">{ errors.newspack_newsletters_invalid_keys }</p> }
 
@@ -179,6 +184,7 @@ export default ( { onSetupStatus } ) => {
 								disabled={ inFlight }
 								onKeyDown={ handleKeyDown }
 								className={ errors.newspack_newsletters_invalid_keys && 'has-error' }
+								__next40pxDefaultSize
 							/>
 							<TextControl
 								label={ __( 'Campaign Monitor Client ID', 'newspack-newsletters' ) }
@@ -187,6 +193,7 @@ export default ( { onSetupStatus } ) => {
 								disabled={ inFlight }
 								onKeyDown={ handleKeyDown }
 								className={ errors.newspack_newsletters_invalid_keys && 'has-error' }
+								__next40pxDefaultSize
 							/>
 							{ errors.newspack_newsletters_invalid_keys && <p className="error">{ errors.newspack_newsletters_invalid_keys }</p> }
 
@@ -207,6 +214,7 @@ export default ( { onSetupStatus } ) => {
 								disabled={ inFlight }
 								onKeyDown={ handleKeyDown }
 								className={ errors.newspack_newsletters_invalid_keys && 'has-error' }
+								__next40pxDefaultSize
 							/>
 							<TextControl
 								label={ __( 'ActiveCampaign API Key', 'newspack-newsletters' ) }
@@ -215,6 +223,7 @@ export default ( { onSetupStatus } ) => {
 								disabled={ inFlight }
 								onKeyDown={ handleKeyDown }
 								className={ errors.newspack_newsletters_invalid_keys && 'has-error' }
+								__next40pxDefaultSize
 							/>
 							{ errors.newspack_newsletters_invalid_keys && <p className="error">{ errors.newspack_newsletters_invalid_keys }</p> }
 
@@ -227,11 +236,11 @@ export default ( { onSetupStatus } ) => {
 					) }
 				</div>
 			</div>
-			<div className="newspack-newsletters-modal__action-buttons">
-				<Button isPrimary onClick={ commitSettings } disabled={ inFlight || ! canSubmit }>
-					{ __( 'Save Settings', 'newspack-newsletter' ) }
+			<HStack align="center" className="newspack-newsletters-modal__action-buttons" justify="end">
+				<Button variant="primary" onClick={ commitSettings } disabled={ inFlight || ! canSubmit }>
+					{ __( 'Save settings', 'newspack-newsletter' ) }
 				</Button>
-			</div>
+			</HStack>
 		</Fragment>
 	);
 };

--- a/src/components/init-modal/screens/layout-picker/index.js
+++ b/src/components/init-modal/screens/layout-picker/index.js
@@ -10,7 +10,7 @@ import { find } from 'lodash';
 import { parse } from '@wordpress/blocks';
 import { useState, useEffect } from '@wordpress/element';
 import { useDispatch } from '@wordpress/data';
-import { Button, Spinner } from '@wordpress/components';
+import { Button, Spinner, __experimentalHStack as HStack } from '@wordpress/components'; // eslint-disable-line @wordpress/no-unsafe-wp-apis
 import { __ } from '@wordpress/i18n';
 
 /**
@@ -121,14 +121,14 @@ export default function LayoutPicker() {
 					) }
 				</div>
 			</div>
-			<div className="newspack-newsletters-modal__action-buttons">
+			<HStack align="center" className="newspack-newsletters-modal__action-buttons" justify="end">
 				<Button variant="secondary" onClick={ () => insertLayout( BLANK_LAYOUT_ID ) }>
 					{ __( 'Blank newsletter', 'newspack-newsletters' ) }
 				</Button>
 				<Button variant="primary" disabled={ isFetchingLayouts || ! selectedLayoutId } onClick={ () => insertLayout( selectedLayoutId ) }>
 					{ __( 'Use selected layout', 'newspack-newsletters' ) }
 				</Button>
-			</div>
+			</HStack>
 		</>
 	);
 }

--- a/src/components/init-modal/style.scss
+++ b/src/components/init-modal/style.scss
@@ -2,117 +2,48 @@
 
 // Modal
 .newspack-newsletters-modal {
-	&__screen-overlay {
-		animation: none;
-		background: white;
-		top: 46px;
-
-		@media only screen and (min-width: 783px) {
-			left: 36px;
-			top: 32px;
-
-			// Fullscreen mode
-			.is-fullscreen-mode & {
-				left: 60px;
-				top: 0;
-			}
-		}
-
-		@media only screen and (min-width: 961px) {
-			// Not folded sidebar
-			body:not(.folded, .is-fullscreen-mode) & {
-				left: 160px;
-			}
-		}
-
+	&__frame {
 		.components-modal__header {
-			border-color: wp-colors.$gray-300;
-			height: 60px;
-			padding: 0 24px;
+			display: none;
 		}
 
 		.components-modal__content {
-			justify-content: start;
-			margin-top: 60px;
-			padding: 0;
+			flex: 1;
+			margin: 0;
+			padding: 0 0 65px;
 
-			@media only screen and (min-width: 783px) {
-				.is-fullscreen-mode & {
-					margin-left: -60px;
-					width: calc(100% + 60px);
+			div:has(.newspack-newsletters-modal__content) {
+				height: auto;
+
+				@media only screen and (min-width: 783px) {
+					height: 100%;
 				}
 			}
 		}
 	}
 
-	&__frame {
-		animation: none;
-		border: 0;
-		box-shadow: none;
-		height: 100%;
-		margin: 0;
-		max-height: 100%;
-		max-width: 100%;
-		min-height: 100%;
-		min-width: 100%;
-		overflow-y: hidden;
-		transform: none;
-		width: 100%;
-		inset: 0;
-
-		@media only screen and (min-width: 783px) {
-			.is-fullscreen-mode & {
-				overflow: visible;
-			}
-		}
-
-		.components-modal__header-heading {
-			display: none;
-			font-size: 0.8rem;
-			line-height: 1.25;
-
-			@media only screen and (min-width: 600px) {
-				display: block;
-			}
-
-			@media only screen and (min-width: 783px) {
-				font-size: 1rem;
-				line-height: 1;
-			}
-		}
-
-		.components-modal__header + div:not([class]) {
-			height: 100%;
-		}
-	}
-
 	&__content {
-		background: white;
 		height: 100%;
-		left: 0;
-		margin: 0;
 		width: 100%;
 
 		@media only screen and (min-width: 783px) {
 			display: grid;
-			gap: 0;
-			grid-template-columns: 280px 1fr;
-			grid-template-rows: 1fr;
+			grid-template-columns: 281px 1fr;
 		}
 
 		&__sidebar {
-			background: wp-colors.$gray-100;
-			border-bottom: 1px solid wp-colors.$gray-300;
-
 			@media only screen and (min-width: 783px) {
-				border-bottom: none;
 				border-right: 1px solid wp-colors.$gray-300;
 			}
 
 			&-wrapper {
-				padding: 24px;
+				padding: 32px 32px 0;
 				position: sticky;
 				top: 0;
+
+				@media only screen and (min-width: 783px) {
+					padding-bottom: 32px;
+				}
 			}
 
 			p {
@@ -122,28 +53,37 @@
 
 		&__layout-buttons {
 			display: grid;
-			grid-gap: 4px;
 			grid-template-columns: repeat(2, 1fr);
-			padding: 24px 0 0;
+			padding: 16px 0 0;
 
 			@media only screen and (min-width: 783px) {
 				grid-template-columns: 1fr;
+				padding-top: 32px;
+			}
+
+			.components-button {
+				height: 40px;
+				justify-content: center;
+
+				@media only screen and (min-width: 783px) {
+					justify-content: flex-start;
+				}
 			}
 		}
 	}
 
 	&__action-buttons {
-		align-items: center;
-		display: flex;
-		flex-wrap: wrap;
-		justify-content: flex-end;
-		position: absolute;
-		right: 24px;
-		top: 12px;
-		z-index: 11;
+		background: wp-colors.$white;
+		border-top: 1px solid wp-colors.$gray-300;
+		bottom: 0;
+		left: 0;
+		padding: 12px 32px;
+		position: fixed;
+		right: 0;
+		z-index: 2;
 
-		.components-button + .components-button {
-			margin-left: 8px;
+		.components-button {
+			height: 40px;
 		}
 	}
 
@@ -158,13 +98,20 @@
 
 		&-wrapper {
 			flex: 0 0 100%;
-			max-width: 600px;
-			padding-left: 24px;
-			padding-right: 24px;
+			max-width: calc(600px + 32px * 2);
+			padding: 0 32px;
 			position: relative;
 
-			@media only screen and (min-width: 648px) {
-				max-width: 648px;
+			h1 {
+				margin-top: 32px;
+			}
+
+			> :last-child {
+				margin-bottom: 32px;
+
+				@media only screen and (min-width: 783px) {
+					margin-bottom: calc(32px + 65px);
+				}
 			}
 		}
 
@@ -206,7 +153,7 @@
 
 	&__layouts {
 		max-height: 100%;
-		padding: 24px;
+		padding: 32px;
 
 		@media only screen and (min-width: 783px) {
 			overflow-y: scroll;
@@ -225,10 +172,6 @@
 			grid-auto-rows: minmax(min-content, max-content);
 			overflow: hidden;
 			padding: 0;
-
-			@media only screen and (min-width: 600px) {
-				grid-template-columns: 1fr;
-			}
 
 			@media only screen and (min-width: 783px) {
 				grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
@@ -268,7 +211,7 @@
 			}
 
 			&__item-preview {
-				background: white;
+				background: wp-colors.$white;
 				border: 1px solid wp-colors.$gray-300;
 				border-radius: 2px;
 				overflow: hidden;
@@ -277,7 +220,7 @@
 				width: 100%;
 
 				&::before {
-					border: 2px solid white;
+					border: 2px solid wp-colors.$white;
 					content: "";
 					display: block;
 					position: absolute;
@@ -337,7 +280,7 @@
 		// stylelint-disable-next-line
 		grid-row-end: 3;
 		align-items: center;
-		background: white;
+		background: wp-colors.$white;
 		border: 1px solid wp-colors.$gray-300;
 		border-top: none;
 		display: none;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

WordPress recently updated the Editor Post Header height from 60px to 64px, which caused the Init modal to appear slightly misaligned. This is not the first time this modal has had issues. It was originally styled to simulate a full-screen experience, making it fragile and prone to breaking when upstream changes occur.

This PR refactors the Init modal to render as a standard "fill" Modal, bringing it in line with conventional modal behaviour. This approach is more resilient to future WordPress Editor changes and reduces the risk of layout regressions.

<img width="3344" height="2536" alt="image" src="https://github.com/user-attachments/assets/caa01b97-853a-4c40-953a-3a21da5335dc" />

### How to test the changes in this Pull Request:

1. Ensure you are on the current trunk branch
2. Confirm the site icon in the newsletter header appears slightly misaligned (this is the pre-fix state)
3. Switch to this branch
4. Add a new newsletter: the layout picker should now appear in a standard modal
5. Remove the newsletter API keys
6. Add a new newsletter again: you should see the "Configure plugin" screen
7. Verify that the settings screen works as expected
8. Verify that the layout picker functions correctly

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
