### PR TITLE
fix: ensure current user lists are initialized as an empty array

### DIFF
--- a/includes/plugins/woocommerce-memberships/class-woocommerce-memberships.php
+++ b/includes/plugins/woocommerce-memberships/class-woocommerce-memberships.php
@@ -337,6 +337,9 @@ class Woocommerce_Memberships {
 
 		// No need to re-add the user to the lists they are already subscribed to.
 		$current_user_lists = \Newspack_Newsletters_Subscription::get_contact_lists( $user_email );
+		if ( ! is_array( $current_user_lists ) ) {
+			$current_user_lists = [];
+		}
 
 		// If a list is shown in the post-checkout newsletter signup modal, we only want to add the reader to membership-tied lists if:
 		// - The membership is going from `paused` to `active` status (when a prior subscription is renewed).


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

`Newspack_Newsletters_Subscription::get_contact_lists( $user_email )` can return a `WP_Error`, which will throw an exception if used as an argument in `array_diff()`.

### How to test the changes in this Pull Request:

Just make sure nothing stands out in the code.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
