### PR TITLE
feat: add test_connection() to newsletter service providers

### DIFF
--- a/includes/class-newspack-newsletters.php
+++ b/includes/class-newspack-newsletters.php
@@ -233,6 +233,19 @@ final class Newspack_Newsletters {
 	}
 
 	/**
+	 * Test the active provider's API connection.
+	 *
+	 * @return true|WP_Error True if the connection is successful, WP_Error otherwise.
+	 */
+	public static function test_connection() {
+		$provider = self::get_service_provider();
+		if ( ! $provider ) {
+			return new \WP_Error( 'newspack_newsletters_no_provider', __( 'No newsletter service provider configured.', 'newspack-newsletters' ) );
+		}
+		return $provider->test_connection();
+	}
+
+	/**
 	 * Register custom fields for use in the editor only.
 	 * These have to be registered so the updates are handles correctly.
 	 */

--- a/includes/service-providers/active_campaign/class-newspack-newsletters-active-campaign.php
+++ b/includes/service-providers/active_campaign/class-newspack-newsletters-active-campaign.php
@@ -88,6 +88,19 @@ final class Newspack_Newsletters_Active_Campaign extends \Newspack_Newsletters_S
 	}
 
 	/**
+	 * Test the ActiveCampaign API connection.
+	 *
+	 * @return true|WP_Error True if the connection is successful, WP_Error otherwise.
+	 */
+	public function test_connection() {
+		$result = $this->api_v3_request( 'users/me' );
+		if ( is_wp_error( $result ) ) {
+			return $result;
+		}
+		return true;
+	}
+
+	/**
 	 * Perform v3 API request.
 	 *
 	 * @param string $resource Resource path.

--- a/includes/service-providers/class-newspack-newsletters-service-provider.php
+++ b/includes/service-providers/class-newspack-newsletters-service-provider.php
@@ -921,6 +921,15 @@ Error message(s) received:
 	}
 
 	/**
+	 * Test the provider's API connection.
+	 *
+	 * @return true|WP_Error True if the connection is successful, WP_Error otherwise.
+	 */
+	public function test_connection() {
+		return true;
+	}
+
+	/**
 	 * Get transient name for async error messages.
 	 *
 	 * @param int $post_id The post ID.

--- a/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp.php
+++ b/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp.php
@@ -98,6 +98,27 @@ final class Newspack_Newsletters_Mailchimp extends \Newspack_Newsletters_Service
 	}
 
 	/**
+	 * Test the Mailchimp API connection.
+	 *
+	 * @return true|WP_Error True if the connection is successful, WP_Error otherwise.
+	 */
+	public function test_connection() {
+		if ( ! $this->has_api_credentials() ) {
+			return new \WP_Error( 'newspack_newsletters_missing_credentials', __( 'Missing Mailchimp API credentials.', 'newspack-newsletters' ) );
+		}
+		try {
+			$mc = new Mailchimp( $this->api_key() );
+			$mc->get( 'ping' );
+		} catch ( \Exception $e ) {
+			return new \WP_Error( 'newspack_newsletters_connection_error', $e->getMessage() );
+		}
+		if ( ! $mc->success() ) {
+			return new \WP_Error( 'newspack_newsletters_connection_error', $mc->getLastError() );
+		}
+		return true;
+	}
+
+	/**
 	 * Check if provider has all necessary credentials set.
 	 *
 	 * @return Boolean Result.

--- a/tests/mocks/class-mailchimp-mock.php
+++ b/tests/mocks/class-mailchimp-mock.php
@@ -36,6 +36,58 @@ class Newspack_Newsletters_Mailchimp_Api {
 	}
 
 	/**
+	 * Whether the last request was successful.
+	 *
+	 * @var bool
+	 */
+	private static $mock_success = true;
+
+	/**
+	 * The last error message.
+	 *
+	 * @var string
+	 */
+	private static $mock_last_error = '';
+
+	/**
+	 * Constructor (no-op for mock).
+	 *
+	 * @param string $api_key      API key.
+	 * @param string $api_endpoint Optional endpoint.
+	 */
+	public function __construct( $api_key = '', $api_endpoint = null ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed, Squiz.Commenting.FunctionComment.Missing
+	}
+
+	/**
+	 * Set mock success state.
+	 *
+	 * @param bool   $success    Whether the request was successful.
+	 * @param string $last_error The error message when not successful.
+	 */
+	public static function set_mock_success( $success, $last_error = '' ) {
+		self::$mock_success    = $success;
+		self::$mock_last_error = $last_error;
+	}
+
+	/**
+	 * Was the last request successful?
+	 *
+	 * @return bool
+	 */
+	public function success() {
+		return self::$mock_success;
+	}
+
+	/**
+	 * Get the last error.
+	 *
+	 * @return string|false
+	 */
+	public function getLastError() { // phpcs:ignore WordPress.NamingConventions.ValidFunctionName.MethodNameInvalid
+		return self::$mock_last_error ? self::$mock_last_error : false;
+	}
+
+	/**
 	 * Can use the mock API?
 	 */
 	public static function is_api_configured() {

--- a/tests/test-test-connection.php
+++ b/tests/test-test-connection.php
@@ -1,0 +1,220 @@
+<?php
+/**
+ * Tests for the test_connection() methods.
+ *
+ * @package Newspack_Newsletters
+ */
+
+/**
+ * Test the test_connection() method on the base class, Mailchimp, ActiveCampaign,
+ * and the static Newspack_Newsletters::test_connection() entry point.
+ */
+class Test_Test_Connection extends WP_UnitTestCase {
+
+	/**
+	 * Stored pre_http_request callback for removal in tear_down.
+	 *
+	 * @var callable|null
+	 */
+	private $http_filter = null;
+
+	/**
+	 * Set up each test.
+	 */
+	public function set_up() {
+		parent::set_up();
+		delete_option( 'newspack_mailchimp_api_key' );
+		delete_option( 'newspack_newsletters_mailchimp_api_key' );
+		delete_option( 'newspack_newsletters_active_campaign_url' );
+		delete_option( 'newspack_newsletters_active_campaign_key' );
+		Newspack_Newsletters_Mailchimp_Api::set_mock_success( true, '' );
+	}
+
+	/**
+	 * Tear down each test.
+	 */
+	public function tear_down() {
+		if ( $this->http_filter ) {
+			remove_filter( 'pre_http_request', $this->http_filter );
+			$this->http_filter = null;
+		}
+		parent::tear_down();
+	}
+
+	/**
+	 * Helper to mock HTTP responses for ActiveCampaign.
+	 *
+	 * @param array|WP_Error $response The mocked response.
+	 */
+	private function mock_http_response( $response ) {
+		$this->http_filter = function () use ( $response ) {
+			return $response;
+		};
+		add_filter( 'pre_http_request', $this->http_filter, 10, 3 );
+	}
+
+	// --- Base class tests ---
+
+	/**
+	 * Test that the base class test_connection() returns true by default.
+	 */
+	public function test_base_class_returns_true() {
+		\Newspack_Newsletters::set_service_provider( 'mailchimp' );
+		// With no API key, has_api_credentials() is false, but the base class method returns true.
+		// We test the base class default by using a provider that doesn't override test_connection().
+		// Since all current providers override it, we test via the static entry point with no provider.
+		$provider = \Newspack_Newsletters::get_service_provider();
+		// The base class method itself returns true, tested indirectly through Constant Contact
+		// which does not override test_connection().
+		$cc = Newspack_Newsletters_Constant_Contact::instance();
+		$result = $cc->test_connection();
+		$this->assertTrue( $result );
+	}
+
+	// --- Mailchimp tests ---
+
+	/**
+	 * Test Mailchimp test_connection() returns WP_Error when credentials are missing.
+	 */
+	public function test_mailchimp_missing_credentials() {
+		\Newspack_Newsletters::set_service_provider( 'mailchimp' );
+		$mc = Newspack_Newsletters_Mailchimp::instance();
+
+		$result = $mc->test_connection();
+
+		$this->assertWPError( $result );
+		$this->assertEquals( 'newspack_newsletters_missing_credentials', $result->get_error_code() );
+	}
+
+	/**
+	 * Test Mailchimp test_connection() returns true on successful ping.
+	 */
+	public function test_mailchimp_successful_connection() {
+		update_option( 'newspack_mailchimp_api_key', 'test-key-us1' );
+		\Newspack_Newsletters::set_service_provider( 'mailchimp' );
+		Newspack_Newsletters_Mailchimp_Api::set_mock_success( true );
+
+		$mc     = Newspack_Newsletters_Mailchimp::instance();
+		$result = $mc->test_connection();
+
+		$this->assertTrue( $result );
+	}
+
+	/**
+	 * Test Mailchimp test_connection() returns WP_Error when API reports failure.
+	 */
+	public function test_mailchimp_api_failure() {
+		update_option( 'newspack_mailchimp_api_key', 'test-key-us1' );
+		\Newspack_Newsletters::set_service_provider( 'mailchimp' );
+		Newspack_Newsletters_Mailchimp_Api::set_mock_success( false, 'API Key Invalid' );
+
+		$mc     = Newspack_Newsletters_Mailchimp::instance();
+		$result = $mc->test_connection();
+
+		$this->assertWPError( $result );
+		$this->assertEquals( 'newspack_newsletters_connection_error', $result->get_error_code() );
+		$this->assertEquals( 'API Key Invalid', $result->get_error_message() );
+	}
+
+	// --- ActiveCampaign tests ---
+
+	/**
+	 * Test ActiveCampaign test_connection() returns WP_Error when credentials are missing.
+	 */
+	public function test_active_campaign_missing_credentials() {
+		\Newspack_Newsletters::set_service_provider( 'active_campaign' );
+		$ac = Newspack_Newsletters_Active_Campaign::instance();
+
+		$result = $ac->test_connection();
+
+		$this->assertWPError( $result );
+	}
+
+	/**
+	 * Test ActiveCampaign test_connection() returns true on success.
+	 */
+	public function test_active_campaign_successful_connection() {
+		update_option( 'newspack_newsletters_active_campaign_url', 'https://test.api-us1.com' );
+		update_option( 'newspack_newsletters_active_campaign_key', 'test-key' );
+		\Newspack_Newsletters::set_service_provider( 'active_campaign' );
+
+		$this->mock_http_response(
+			[
+				'response' => [
+					'code'    => 200,
+					'message' => 'OK',
+				],
+				'body'     => wp_json_encode( [ 'user' => [ 'id' => 1 ] ] ),
+			]
+		);
+
+		$ac     = Newspack_Newsletters_Active_Campaign::instance();
+		$result = $ac->test_connection();
+
+		$this->assertTrue( $result );
+	}
+
+	/**
+	 * Test ActiveCampaign test_connection() returns WP_Error on API failure.
+	 */
+	public function test_active_campaign_api_failure() {
+		update_option( 'newspack_newsletters_active_campaign_url', 'https://test.api-us1.com' );
+		update_option( 'newspack_newsletters_active_campaign_key', 'bad-key' );
+		\Newspack_Newsletters::set_service_provider( 'active_campaign' );
+
+		$this->mock_http_response(
+			[
+				'response' => [
+					'code'    => 403,
+					'message' => 'Forbidden',
+				],
+				'body'     => null,
+			]
+		);
+
+		$ac     = Newspack_Newsletters_Active_Campaign::instance();
+		$result = $ac->test_connection();
+
+		$this->assertWPError( $result );
+	}
+
+	// --- Static entry point tests ---
+
+	/**
+	 * Test Newspack_Newsletters::test_connection() returns WP_Error when no provider is set.
+	 */
+	public function test_static_no_provider() {
+		\Newspack_Newsletters::set_service_provider( '' );
+
+		$result = \Newspack_Newsletters::test_connection();
+
+		$this->assertWPError( $result );
+		$this->assertEquals( 'newspack_newsletters_no_provider', $result->get_error_code() );
+	}
+
+	/**
+	 * Test Newspack_Newsletters::test_connection() delegates to the active provider.
+	 */
+	public function test_static_delegates_to_provider() {
+		update_option( 'newspack_mailchimp_api_key', 'test-key-us1' );
+		\Newspack_Newsletters::set_service_provider( 'mailchimp' );
+		Newspack_Newsletters_Mailchimp_Api::set_mock_success( true );
+
+		$result = \Newspack_Newsletters::test_connection();
+
+		$this->assertTrue( $result );
+	}
+
+	/**
+	 * Test Newspack_Newsletters::test_connection() propagates provider errors.
+	 */
+	public function test_static_propagates_error() {
+		\Newspack_Newsletters::set_service_provider( 'mailchimp' );
+		// No API key set — Mailchimp's test_connection will return missing credentials error.
+
+		$result = \Newspack_Newsletters::test_connection();
+
+		$this->assertWPError( $result );
+		$this->assertEquals( 'newspack_newsletters_missing_credentials', $result->get_error_code() );
+	}
+}


### PR DESCRIPTION
## Summary

- Adds a `test_connection()` method to the service provider base class (returns `true` by default)
- Implements Mailchimp override using the `/ping` API endpoint
- Implements ActiveCampaign override using the `/api/3/users/me` endpoint
- Adds a static `Newspack_Newsletters::test_connection()` entry point that delegates to the active provider

## How to test

### Mailchimp

1. Configure Mailchimp as the newsletter provider with valid API credentials
2. Run:
   ```bash
   docker exec newspack_dev sh -c "wp eval 'var_dump( Newspack_Newsletters::test_connection() );' --allow-root"
   ```
3. Verify the output is `bool(true)`
4. Change the Mailchimp API key to an invalid value (e.g., via `wp option update` or the settings UI)
5. Run the same command again
6. Verify the output is a `WP_Error` with a connection error message
7. Remove the API key entirely
8. Run again and verify the output is a `WP_Error` with "Missing Mailchimp API credentials"

### ActiveCampaign

1. Configure ActiveCampaign as the newsletter provider with valid API URL and key
2. Run:
   ```bash
   docker exec newspack_dev sh -c "wp eval 'var_dump( Newspack_Newsletters::test_connection() );' --allow-root"
   ```
3. Verify the output is `bool(true)`
4. Change the API key to an invalid value
5. Run again and verify the output is a `WP_Error`
6. Remove the API credentials entirely
7. Run again and verify the output is a `WP_Error` with "API credentials are missing"

### No provider configured

1. Deactivate all newsletter provider settings (set the provider option to empty)
2. Run the test command
3. Verify the output is a `WP_Error` with "No newsletter service provider configured"

🤖 Generated with [Claude Code](https://claude.com/claude-code)