### PR TITLE
fix: use URL params to determine email editing context

### DIFF
--- a/includes/class-newspack-newsletters-editor.php
+++ b/includes/class-newspack-newsletters-editor.php
@@ -103,6 +103,24 @@ final class Newspack_Newsletters_Editor {
 	}
 
 	/**
+	 * Is the current request an email editor admin page?
+	 *
+	 * Uses URL params rather than get_the_ID() to avoid false positives when
+	 * setup_postdata() has been called with a newsletter post during block
+	 * rendering on non-newsletter pages (e.g. a Homepage Articles block
+	 * configured to display newsletter posts).
+	 *
+	 * @return bool
+	 */
+	public static function is_email_editor_request() {
+		global $pagenow;
+		$email_editor_cpts = self::get_email_editor_cpts();
+		$is_editing_email  = 'post.php' === $pagenow && isset( $_GET['post'] ) && self::is_editing_email( absint( $_GET['post'] ) ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		$is_creating_email = 'post-new.php' === $pagenow && isset( $_GET['post_type'] ) && in_array( $_GET['post_type'], $email_editor_cpts ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		return $is_editing_email || $is_creating_email;
+	}
+
+	/**
 	 * Get CSS rules for color palette.
 	 *
 	 * @param string $container_selector Optional selector to prefix as a container to every rule.
@@ -155,11 +173,7 @@ final class Newspack_Newsletters_Editor {
 	 * This is to prevent theme styles being loaded in the editor.
 	 */
 	public static function strip_editor_modifications() {
-		global $pagenow;
-		$email_editor_cpts = self::get_email_editor_cpts();
-		$is_editing_email  = 'post.php' === $pagenow && isset( $_GET['post'] ) && self::is_editing_email( absint( $_GET['post'] ) ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
-		$is_creating_email = 'post-new.php' === $pagenow && isset( $_GET['post_type'] ) && in_array( $_GET['post_type'], $email_editor_cpts ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
-		if ( ! $is_editing_email && ! $is_creating_email ) {
+		if ( ! self::is_email_editor_request() ) {
 			return;
 		}
 
@@ -229,11 +243,7 @@ final class Newspack_Newsletters_Editor {
 	 * Define Editor Font Sizes.
 	 */
 	public static function newspack_font_sizes() {
-		global $pagenow;
-		$email_editor_cpts = self::get_email_editor_cpts();
-		$is_editing_email  = 'post.php' === $pagenow && isset( $_GET['post'] ) && self::is_editing_email( absint( $_GET['post'] ) ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
-		$is_creating_email = 'post-new.php' === $pagenow && isset( $_GET['post_type'] ) && in_array( $_GET['post_type'], $email_editor_cpts ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
-		if ( ! $is_editing_email && ! $is_creating_email ) {
+		if ( ! self::is_email_editor_request() ) {
 			return;
 		}
 		add_theme_support(

--- a/includes/class-newspack-newsletters-editor.php
+++ b/includes/class-newspack-newsletters-editor.php
@@ -155,7 +155,11 @@ final class Newspack_Newsletters_Editor {
 	 * This is to prevent theme styles being loaded in the editor.
 	 */
 	public static function strip_editor_modifications() {
-		if ( ! self::is_editing_email() ) {
+		global $pagenow;
+		$email_editor_cpts = self::get_email_editor_cpts();
+		$is_editing_email  = 'post.php' === $pagenow && isset( $_GET['post'] ) && self::is_editing_email( absint( $_GET['post'] ) ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		$is_creating_email = 'post-new.php' === $pagenow && isset( $_GET['post_type'] ) && in_array( $_GET['post_type'], $email_editor_cpts ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		if ( ! $is_editing_email && ! $is_creating_email ) {
 			return;
 		}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR should be tested with https://github.com/Automattic/newspack-blocks/pull/2319 -- that PR reinstates some code that was removed to patch this issue ASAP.

In the Newsletter plugin, `strip_editor_modifications()` was using `get_the_ID()` to figure out whether the current post was in the newsletter editor. `get_the_ID()` reflects the global `$post` object, which is updated by any `setup_postdata()` call, including those made during block rendering.

A Content Loop block configured to display newsletter posts calls `setup_postdata()` for each newsletter post in its loop. This caused `strip_editor_modifications()` to incorrectly fire during non-newsletter editing situations. This was kind of a hidden bug until the Newspack Blocks plugin was switched to `enqueue_block_assets` for WP 7.0 -- now the block's assets will no longer load in an editor where a Content Loop block is displaying a Newsletter CPT.

This PR switches the check used when deciding to strip editor assets to one that relies on the page URL structure, similar to [here](https://github.com/Automattic/newspack-newsletters/blob/089ae803edd39f7f19ae10f3923c10f743a58eab/includes/class-newspack-newsletters-editor.php#L228-L234).

### How to test the changes in this Pull Request:

1. If your site doesn't have one already, create and publish at least one Newsletter (and publish it publicly to the site). 
2. Apply https://github.com/Automattic/newspack-blocks/pull/2319 (reinstates the `enqueue_block_assets` workaround). 
3. Edit a page and add a Content Loop block.
4. Publish and refresh; confirm the editor looks good.
5. Edit the Content Loop block to show a Newsletter CPT. 
6. Publish and refresh; confirm you get errors that the block is no longer loading.

<img width="876" height="304" alt="CleanShot 2026-03-17 at 10 47 44" src="https://github.com/user-attachments/assets/e80c937c-6641-4001-80b8-298c109bc8a8" />

7. Apply this PR. 
8. Confirm that the editor is now fixed. 

**Smoke testing**
1. Confirm editing in the newsletter editor still works as expected (creating new newsletters; trying to add forbidden blocks; creating templates; sending tests and real newsletters). 
2. Confirm editing other pages and posts still works as expected.
3. Repeat the testing steps [here](https://github.com/Automattic/newspack-blocks/pull/2289).

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
