### PR TITLE
feat(access-control): filter the subscription lists available for signup

### DIFF
--- a/includes/class-subscription-lists.php
+++ b/includes/class-subscription-lists.php
@@ -454,11 +454,18 @@ class Subscription_Lists {
 	 * @return Subscription_List[]
 	 */
 	public static function get_configured_for_current_provider() {
-		return self::get_filtered(
+		$lists = self::get_filtered(
 			function ( $list ) {
 				return $list->is_configured_for_current_provider();
 			}
 		);
+
+		/**
+		 * Filters the available lists for the current provider.
+		 *
+		 * @param Subscription_List[] $lists The lists that are available for the current provider.
+		 */
+		return apply_filters( 'newspack_newsletters_subscription_lists', $lists );
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Adds a filter callback for the available reader-facing subscription lists. Required for access control functionality in https://github.com/Automattic/newspack-plugin/pull/4589.

### How to test the changes in this Pull Request:

See https://github.com/Automattic/newspack-plugin/pull/4589.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
