### PR TITLE
fix: share block registration

### DIFF
--- a/includes/class-newspack-newsletters.php
+++ b/includes/class-newspack-newsletters.php
@@ -654,8 +654,8 @@ final class Newspack_Newsletters {
 				'supports'        => $block_definition['supports'],
 			]
 		);
-		register_block_type(
-			'newspack-newsletters/share',
+		register_block_type_from_metadata(
+			__DIR__ . '/../src/editor/blocks/share/block.json',
 			[
 				'render_callback' => [ __CLASS__, 'render_share_block' ],
 			]

--- a/src/editor/blocks/share/block.json
+++ b/src/editor/blocks/share/block.json
@@ -17,6 +17,10 @@
 		"shareMessage": {
 			"type": "string",
 			"default": "I'd like to share this newsletter with you: [LINK]"
+		},
+		"href": {
+			"type": "string",
+			"default": ""
 		}
 	},
 	"supports": {

--- a/src/editor/blocks/share/block.json
+++ b/src/editor/blocks/share/block.json
@@ -12,7 +12,7 @@
 			"source": "html",
 			"selector": "p",
 			"default": "Thanks for reading. If you liked it, please send to a friend!",
-			"__experimentalRole": "content"
+			"role": "content"
 		},
 		"shareMessage": {
 			"type": "string",

--- a/src/editor/blocks/share/block.json
+++ b/src/editor/blocks/share/block.json
@@ -12,6 +12,7 @@
 			"source": "html",
 			"selector": "p",
 			"default": "Thanks for reading. If you liked it, please send to a friend!",
+			"__experimentalRole": "content",
 			"role": "content"
 		},
 		"shareMessage": {

--- a/src/editor/blocks/share/edit.js
+++ b/src/editor/blocks/share/edit.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { find } from 'lodash';
+import { stringify } from 'qs';
 
 /**
  * WordPress dependencies
@@ -9,8 +10,7 @@ import { find } from 'lodash';
 import { __ } from '@wordpress/i18n';
 import { RichText, useBlockProps, InspectorControls } from '@wordpress/block-editor';
 import { PanelBody, TextareaControl } from '@wordpress/components';
-import { withSelect, withDispatch } from '@wordpress/data';
-import { compose } from '@wordpress/compose';
+import { useSelect, useDispatch } from '@wordpress/data';
 import { useEffect } from '@wordpress/element';
 
 /**
@@ -19,13 +19,52 @@ import { useEffect } from '@wordpress/element';
 import { SHARE_BLOCK_NOTICE_ID } from './consts';
 import './style.scss';
 
-const ShareBlock = ( { createTheNotice, removeNotice, is_public, attributes, setAttributes } ) => {
-	const { content } = attributes;
+export default function ShareBlockEdit( { attributes, setAttributes } ) {
+	const { content, shareMessage } = attributes;
+	const blockProps = useBlockProps( { className: 'newspack-newsletters-share-block' } );
+
+	const { is_public, permalink, postTitle, hasNotice } = useSelect( select => {
+		const { getEditedPostAttribute, getPermalink } = select( 'core/editor' );
+		const meta = getEditedPostAttribute( 'meta' ) || {};
+		return {
+			is_public: meta.is_public,
+			permalink: getPermalink() || '',
+			postTitle: getEditedPostAttribute( 'title' ) || '',
+			hasNotice: Boolean( find( select( 'core/notices' ).getNotices(), [ 'id', SHARE_BLOCK_NOTICE_ID ] ) ),
+		};
+	}, [] );
+
+	const { createWarningNotice, removeNotice } = useDispatch( 'core/notices' );
+	const { editPost } = useDispatch( 'core/editor' );
+
 	useEffect( () => {
-		// eslint-disable-next-line no-unused-expressions
-		is_public ? removeNotice() : createTheNotice();
-		return removeNotice;
+		if ( is_public ) {
+			removeNotice( SHARE_BLOCK_NOTICE_ID );
+		} else if ( ! hasNotice ) {
+			createWarningNotice(
+				__( 'This post is not public - the share block will not be displayed, since there is no post to link to.', 'newspack-newsletters' ),
+				{
+					id: SHARE_BLOCK_NOTICE_ID,
+					isDismissible: false,
+					actions: [
+						{
+							label: __( 'Make public', 'newspack-newsletters' ),
+							onClick: () => editPost( { meta: { is_public: true } } ),
+						},
+					],
+				}
+			);
+		}
+		return () => removeNotice( SHARE_BLOCK_NOTICE_ID );
 	}, [ is_public ] );
+
+	useEffect( () => {
+		const href = `mailto:?${ stringify( {
+			body: shareMessage.replace( '[LINK]', permalink ),
+			subject: 'Fwd: ' + postTitle,
+		} ) }`;
+		setAttributes( { href } );
+	}, [ shareMessage, permalink, postTitle ] );
 
 	return (
 		<>
@@ -37,7 +76,7 @@ const ShareBlock = ( { createTheNotice, removeNotice, is_public, attributes, set
 							'Content of the email that will be pre-filled when a reader clicks this link in their email client. Use the "[LINK]" placeholder where the link to the public post should be placed.',
 							'newspack-newsletters'
 						) }
-						value={ attributes.shareMessage }
+						value={ shareMessage }
 						onChange={ value => setAttributes( { shareMessage: value } ) }
 					/>
 				</PanelBody>
@@ -45,7 +84,7 @@ const ShareBlock = ( { createTheNotice, removeNotice, is_public, attributes, set
 			<RichText
 				identifier="content"
 				tagName="a"
-				{ ...useBlockProps( { className: 'newspack-newsletters-share-block' } ) }
+				{ ...blockProps }
 				value={ content }
 				allowedFormats={ [ 'core/bold', 'core/italic', 'core/text-color' ] }
 				onChange={ newContent => setAttributes( { content: newContent } ) }
@@ -54,44 +93,4 @@ const ShareBlock = ( { createTheNotice, removeNotice, is_public, attributes, set
 			/>
 		</>
 	);
-};
-
-const ShareBlockWithData = compose(
-	withSelect( select => {
-		const { getEditedPostAttribute } = select( 'core/editor' );
-		const { getNotices } = select( 'core/notices' );
-		const { is_public } = getEditedPostAttribute( 'meta' );
-		return {
-			is_public,
-			getNotices,
-		};
-	} ),
-	withDispatch( ( dispatch, { getNotices } ) => {
-		const { createWarningNotice, removeNotice } = dispatch( 'core/notices' );
-		const hasNotice = Boolean( find( getNotices(), [ 'id', SHARE_BLOCK_NOTICE_ID ] ) );
-		const { editPost } = dispatch( 'core/editor' );
-
-		const createTheNotice = hasNotice
-			? () => {}
-			: () =>
-					createWarningNotice(
-						__(
-							'This post is not public - the share block will not be displayed, since there is no post to link to.',
-							'newspack-newsletters'
-						),
-						{
-							id: SHARE_BLOCK_NOTICE_ID,
-							isDismissible: false,
-							actions: [
-								{
-									label: __( 'Make public', 'newspack-newsletters' ),
-									onClick: () => editPost( { meta: { is_public: true } } ),
-								},
-							],
-						}
-					);
-		return { createTheNotice, removeNotice: () => removeNotice( SHARE_BLOCK_NOTICE_ID ) };
-	} )
-)( ShareBlock );
-
-export default ShareBlockWithData;
+}

--- a/src/editor/blocks/share/index.js
+++ b/src/editor/blocks/share/index.js
@@ -11,11 +11,12 @@ import edit from './edit';
 import save from './save';
 import metadata from './block.json';
 
-const { name } = metadata;
+const { name, title } = metadata;
 
 export { metadata, name };
 
 export const settings = {
+	title,
 	icon: <Icon icon={ customLink } />,
 	edit,
 	save,

--- a/src/editor/blocks/share/save.js
+++ b/src/editor/blocks/share/save.js
@@ -1,24 +1,10 @@
 /**
- * External dependencies
- */
-import { stringify } from 'qs';
-
-/**
  * WordPress dependencies
  */
 import { RichText, useBlockProps } from '@wordpress/block-editor';
-import { select } from '@wordpress/data';
 
 export default ( { attributes } ) => {
-	let { content, shareMessage } = attributes;
-	const { getEditedPostAttribute, getPermalink } = select( 'core/editor' );
-
-	const href = `mailto:?${ stringify( {
-		// It'd be cool to include a HTML link in the email body, but that's not possible - https://stackoverflow.com/a/13415988/3772847.
-		body: shareMessage.replace( '[LINK]', getPermalink() || '' ),
-		// Not really a forwarded email, since the body is a link to the site, but in principle it's a forward.
-		subject: 'Fwd: ' + getEditedPostAttribute( 'title' ),
-	} ) }`;
+	let { content, href } = attributes;
 
 	// HACK: The block content contains the anchor element after saving,
 	// but not when first inserted in the editor. So here the wrapping anchor


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes https://linear.app/a8c/issue/NPPM-2693/newslettersshare-block-is-missing

This PR makes some tweaks to the share block registration to ensure it loads in the new iframe editor.

![Screenshot 2026-03-23 at 17 42 05](https://github.com/user-attachments/assets/7db032d9-ddf5-441a-b509-7c1d748a87a2)

### How to test the changes in this Pull Request:

1. Create a new newsletter
2. Ensure you are able to add the newsletters share block
3. Ensure the block renders in preview and clicking the link generates a draft email
4. Send a test email
5. Ensure the sent email contains the newsletter share block content and clicking the link generates a draft email
6. In the newsletter editor, make changes to the newsletter share block content as well as the email content in the sidebar
7. Repeat steps 3-6

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
