### PR TITLE
fix: update block support declaration

### DIFF
--- a/src/editor/blocks/share/block.json
+++ b/src/editor/blocks/share/block.json
@@ -29,7 +29,9 @@
 		"color": {
 			"link": true
 		},
-		"fontSize": true,
-		"lineHeight": true
+		"typography": {
+			"lineHeight": true,
+			"fontSize": true
+		}
 	}
 }


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

This fixes some notices about share block typography support declarations.

```
[26-Mar-2026 15:26:40 UTC] PHP Notice:  Function register_block_type_from_metadata() was called <strong>incorrectly</strong>. Block "newspack-newsletters/share" is declaring <code>lineHeight</code> support in <code>block.json</code> file under <code>supports.lineHeight</code>. <code>lineHeight</code> support is now declared under <code>supports.typography.lineHeight</code>. Please see <a href="https://developer.wordpress.org/advanced-administration/debug/debug-wordpress/">Debugging in WordPress</a> for more information. (This message was added in version 5.8.0.) in /var/www/html/wp-includes/functions.php on line 6170
[26-Mar-2026 15:28:40 UTC] PHP Notice:  Function register_block_type_from_metadata() was called <strong>incorrectly</strong>. Block "newspack-newsletters/share" is declaring <code>fontSize</code> support in <code>block.json</code> file under <code>supports.fontSize</code>. <code>fontSize</code> support is now declared under <code>supports.typography.fontSize</code>. Please see <a href="https://developer.wordpress.org/advanced-administration/debug/debug-wordpress/">Debugging in WordPress</a> for more information. (This message was added in version 5.8.0.) in /var/www/html/wp-includes/functions.php on line 6170
```

### How to test the changes in this Pull Request:

1. Create a new newsletter in WP Admin
2. Smoke test the share block
3. Verify no notices appear in the logs

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
