### PR TITLE
feat: add newsletter editor check regression testing

### DIFF
--- a/tests/test-email-editor-request.php
+++ b/tests/test-email-editor-request.php
@@ -1,0 +1,193 @@
+<?php
+/**
+ * Class Test_Email_Editor_Request
+ *
+ * @package Newspack_Newsletters
+ */
+
+/**
+ * Tests for Newspack_Newsletters_Editor::is_email_editor_request().
+ *
+ * Regression coverage for: using URL params instead of get_the_ID() to
+ * determine whether the current request is the newsletter editor. The
+ * old approach produced false positives when setup_postdata() was called
+ * with a newsletter post during block rendering on non-newsletter pages
+ * (e.g. a Content Loop block configured to display newsletter posts).
+ */
+class Test_Email_Editor_Request extends WP_UnitTestCase {
+
+	/**
+	 * A newsletter post ID created for testing.
+	 *
+	 * @var int
+	 */
+	private static $newsletter_post_id;
+
+	/**
+	 * A regular post ID created for testing.
+	 *
+	 * @var int
+	 */
+	private static $regular_post_id;
+
+	/**
+	 * Original value of $pagenow.
+	 *
+	 * @var string
+	 */
+	private $original_pagenow;
+
+	/**
+	 * Original $_GET values.
+	 *
+	 * @var array
+	 */
+	private $original_get;
+
+	/**
+	 * Set up test fixtures.
+	 */
+	public static function set_up_before_class() {
+		parent::set_up_before_class();
+
+		self::$newsletter_post_id = self::factory()->post->create(
+			[
+				'post_type'   => \Newspack_Newsletters::NEWSPACK_NEWSLETTERS_CPT,
+				'post_status' => 'draft',
+			]
+		);
+
+		self::$regular_post_id = self::factory()->post->create(
+			[
+				'post_type'   => 'post',
+				'post_status' => 'publish',
+			]
+		);
+	}
+
+	/**
+	 * Save and reset global state before each test.
+	 */
+	public function set_up() {
+		global $pagenow;
+		$this->original_pagenow = $pagenow;
+		$this->original_get     = $_GET; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		$_GET                   = []; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+	}
+
+	/**
+	 * Restore global state after each test.
+	 */
+	public function tear_down() {
+		global $pagenow;
+		$pagenow = $this->original_pagenow;
+		$_GET    = $this->original_get; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+	}
+
+	/**
+	 * Returns true when editing an existing newsletter post (post.php + ?post=<newsletter_id>).
+	 */
+	public function test_returns_true_when_editing_newsletter_post() {
+		global $pagenow;
+		$pagenow          = 'post.php';
+		$_GET['post']     = self::$newsletter_post_id; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+
+		$this->assertTrue( Newspack_Newsletters_Editor::is_email_editor_request() );
+	}
+
+	/**
+	 * Returns true when creating a new newsletter (post-new.php + ?post_type=<newsletter_cpt>).
+	 */
+	public function test_returns_true_when_creating_newsletter() {
+		global $pagenow;
+		$pagenow              = 'post-new.php';
+		$_GET['post_type']    = \Newspack_Newsletters::NEWSPACK_NEWSLETTERS_CPT; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+
+		$this->assertTrue( Newspack_Newsletters_Editor::is_email_editor_request() );
+	}
+
+	/**
+	 * Returns false when editing a regular post — even if get_the_ID() would
+	 * return a newsletter post ID (the regression case: setup_postdata() called
+	 * with a newsletter post during block rendering on a non-newsletter page).
+	 */
+	public function test_returns_false_for_regular_post_with_newsletter_in_loop() {
+		global $pagenow, $post;
+		$pagenow      = 'post.php';
+		$_GET['post'] = self::$regular_post_id; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+
+		// Simulate what a Content Loop block does: call setup_postdata() with a
+		// newsletter post, making get_the_ID() return the newsletter's ID.
+		$newsletter_post = get_post( self::$newsletter_post_id );
+		setup_postdata( $newsletter_post );
+
+		$result = Newspack_Newsletters_Editor::is_email_editor_request();
+
+		wp_reset_postdata();
+
+		$this->assertFalse( $result );
+	}
+
+	/**
+	 * Returns false when on post.php with no ?post param.
+	 */
+	public function test_returns_false_when_no_post_param() {
+		global $pagenow;
+		$pagenow = 'post.php';
+
+		$this->assertFalse( Newspack_Newsletters_Editor::is_email_editor_request() );
+	}
+
+	/**
+	 * Returns false when on post-new.php with no ?post_type param.
+	 */
+	public function test_returns_false_when_no_post_type_param() {
+		global $pagenow;
+		$pagenow = 'post-new.php';
+
+		$this->assertFalse( Newspack_Newsletters_Editor::is_email_editor_request() );
+	}
+
+	/**
+	 * Returns false when on an unrelated admin page.
+	 */
+	public function test_returns_false_on_non_editor_page() {
+		global $pagenow;
+		$pagenow = 'edit.php';
+
+		$this->assertFalse( Newspack_Newsletters_Editor::is_email_editor_request() );
+	}
+
+	/**
+	 * Returns false when post.php is used but the post is a regular post type.
+	 */
+	public function test_returns_false_when_editing_non_newsletter_post() {
+		global $pagenow;
+		$pagenow      = 'post.php';
+		$_GET['post'] = self::$regular_post_id; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+
+		$this->assertFalse( Newspack_Newsletters_Editor::is_email_editor_request() );
+	}
+
+	/**
+	 * Returns false when post-new.php is used with a non-newsletter post type.
+	 */
+	public function test_returns_false_when_creating_non_newsletter_post() {
+		global $pagenow;
+		$pagenow           = 'post-new.php';
+		$_GET['post_type'] = 'post'; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+
+		$this->assertFalse( Newspack_Newsletters_Editor::is_email_editor_request() );
+	}
+
+	/**
+	 * Returns true when creating a new newsletter ad.
+	 */
+	public function test_returns_true_when_creating_newsletter_ad() {
+		global $pagenow;
+		$pagenow           = 'post-new.php';
+		$_GET['post_type'] = \Newspack_Newsletters\Ads::CPT; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+
+		$this->assertTrue( Newspack_Newsletters_Editor::is_email_editor_request() );
+	}
+}

--- a/tests/test-email-editor-request.php
+++ b/tests/test-email-editor-request.php
@@ -24,6 +24,13 @@ class Test_Email_Editor_Request extends WP_UnitTestCase {
 	private static $newsletter_post_id;
 
 	/**
+	 * A newsletter ad post ID created for testing.
+	 *
+	 * @var int
+	 */
+	private static $newsletter_ad_post_id;
+
+	/**
 	 * A regular post ID created for testing.
 	 *
 	 * @var int
@@ -57,6 +64,13 @@ class Test_Email_Editor_Request extends WP_UnitTestCase {
 			]
 		);
 
+		self::$newsletter_ad_post_id = self::factory()->post->create(
+			[
+				'post_type'   => \Newspack_Newsletters\Ads::CPT,
+				'post_status' => 'draft',
+			]
+		);
+
 		self::$regular_post_id = self::factory()->post->create(
 			[
 				'post_type'   => 'post',
@@ -69,6 +83,7 @@ class Test_Email_Editor_Request extends WP_UnitTestCase {
 	 * Save and reset global state before each test.
 	 */
 	public function set_up() {
+		parent::set_up();
 		global $pagenow;
 		$this->original_pagenow = $pagenow;
 		$this->original_get     = $_GET; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
@@ -82,6 +97,7 @@ class Test_Email_Editor_Request extends WP_UnitTestCase {
 		global $pagenow;
 		$pagenow = $this->original_pagenow;
 		$_GET    = $this->original_get; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		parent::tear_down();
 	}
 
 	/**
@@ -178,6 +194,17 @@ class Test_Email_Editor_Request extends WP_UnitTestCase {
 		$_GET['post_type'] = 'post'; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 
 		$this->assertFalse( Newspack_Newsletters_Editor::is_email_editor_request() );
+	}
+
+	/**
+	 * Returns true when editing an existing newsletter ad (post.php + ad post ID).
+	 */
+	public function test_returns_true_when_editing_newsletter_ad() {
+		global $pagenow;
+		$pagenow      = 'post.php';
+		$_GET['post'] = self::$newsletter_ad_post_id; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+
+		$this->assertTrue( Newspack_Newsletters_Editor::is_email_editor_request() );
 	}
 
 	/**

--- a/tests/test-email-editor-request.php
+++ b/tests/test-email-editor-request.php
@@ -84,8 +84,7 @@ class Test_Email_Editor_Request extends WP_UnitTestCase {
 	 */
 	public function set_up() {
 		parent::set_up();
-		global $pagenow;
-		$this->original_pagenow = $pagenow;
+		$this->original_pagenow = $GLOBALS['pagenow'] ?? null;
 		$this->original_get     = $_GET; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 		$_GET                   = []; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 	}
@@ -94,9 +93,12 @@ class Test_Email_Editor_Request extends WP_UnitTestCase {
 	 * Restore global state after each test.
 	 */
 	public function tear_down() {
-		global $pagenow;
-		$pagenow = $this->original_pagenow;
-		$_GET    = $this->original_get; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		if ( null === $this->original_pagenow ) {
+			unset( $GLOBALS['pagenow'] );
+		} else {
+			$GLOBALS['pagenow'] = $this->original_pagenow;
+		}
+		$_GET = $this->original_get; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 		parent::tear_down();
 	}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR adds a set of regression testing around our checks for the Newsletter editor. This change is related to this hotfix: https://github.com/Automattic/newspack-newsletters/pull/2051 which switches the check for the editor to use the URL.

### How to test the changes in this Pull Request:

1. Run `n test-php --filter Test_Email_Editor_Request` from within the newspack-newsletters directory, and confirm all the tests pass.
2. Review the tests and confirm they make sense and are comprehensive - they include checks for these different cases:

* `editing newsletter` - A user opens an existing newsletter draft in the block editor: wp-admin/post.php?post=123
* `creating newsletter` - A user creates a new newsletter via "Add New Newsletter": wp-admin/post-new.php?post_type=newspack_nl_cpt
* content loop regression - A user is editing a regular page that contains a Content Loop (or Homepage Articles) block configured to display newsletter posts. During block rendering in the editor, that block calls `setup_postdata()` for each newsletter post in its query, which previously caused `get_the_ID()` to return a newsletter post ID and trick the check into thinking it was inside the newsletter editor.
*  no `?post `param on `post.php` - Covers any hook or action that runs with `$pagenow === 'post.php'` but without a post ID in the URL. This shouldn't happen in normal use (WordPress itself would show an error), but hooks registered on after_setup_theme or similar fire very early, before WordPress validates the URL - so it's there just in case.
* no `?post_type` param on `post-new.php` - The standard "Add New Post" flow. When you click "Add New" for regular posts, WordPress uses `post-new.php` with no `post_type` param and defaults to the post type.
* non-editor page - Any other admin screen: the post list (edit.php), dashboard, settings pages, etc. All of these fire the same early hooks, so the function needs to return false for them.
* editing a non-newsletter post - Editing a regular post, page, or any other CPT in the block editor: `wp-admin/post.php?post=456` where `456` is not a newsletter.
* creating a non-newsletter post - `post-new.php?post_type=post` (or page, or any other CPT). Explicit to make sure `post-new.php` alone doesn't trigger it.
* creating a newsletter ad - Newsletter ads are a second email editor CPT (`Newspack_Newsletters\Ads::CPT`). Confirms both CPTs registered via the `newspack_newsletters_email_editor_cpts` filter are covered, not just the primary newsletter CPT.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
