### PR TITLE
fix: render synced patterns inside Group blocks in newsletters

### DIFF
--- a/includes/class-newspack-newsletters-renderer.php
+++ b/includes/class-newspack-newsletters-renderer.php
@@ -466,6 +466,7 @@ final class Newspack_Newsletters_Renderer {
 	 */
 	public static function is_empty_block( $block ) {
 		$blocks_without_inner_html = [
+			'core/block',
 			'core/site-logo',
 			'core/site-title',
 			'core/site-tagline',
@@ -1436,6 +1437,28 @@ final class Newspack_Newsletters_Renderer {
 					$block_mjml_markup .= '</mj-text>';
 				}
 
+				break;
+
+			/**
+			 * Reusable block (synced pattern).
+			 * Resolve the referenced wp_block post and render as a group block.
+			 */
+			case 'core/block':
+				if ( isset( $attrs['ref'] ) ) {
+					$reusable_block_post = get_post( $attrs['ref'] );
+					if ( ! empty( $reusable_block_post ) ) {
+						$block['blockName']    = 'core/group';
+						$block['innerBlocks']  = array_filter(
+							parse_blocks( $reusable_block_post->post_content ),
+							function ( $b ) {
+								return null !== $b['blockName'];
+							}
+						);
+						$block['innerHTML']    = $reusable_block_post->post_content;
+						$block['innerContent'] = [ $reusable_block_post->post_content ];
+						return self::render_mjml_component( $block, $is_in_column, $is_in_group, $default_attrs );
+					}
+				}
 				break;
 
 			/**

--- a/includes/class-newspack-newsletters-renderer.php
+++ b/includes/class-newspack-newsletters-renderer.php
@@ -1837,7 +1837,8 @@ final class Newspack_Newsletters_Renderer {
 	 * @return string MJML markup.
 	 */
 	public static function render_post_to_mjml( $post ) {
-		self::$newsletter_id = $post->ID;
+		self::$rendering_refs = [];
+		self::$newsletter_id  = $post->ID;
 		self::$color_palette = json_decode( get_option( Newspack_Newsletters::NEWSPACK_NEWSLETTERS_PALETTE_META, false ), true );
 		self::$font_header   = get_post_meta( $post->ID, 'font_header', true );
 		self::$font_body     = get_post_meta( $post->ID, 'font_body', true );

--- a/includes/class-newspack-newsletters-renderer.php
+++ b/includes/class-newspack-newsletters-renderer.php
@@ -1792,6 +1792,11 @@ final class Newspack_Newsletters_Renderer {
 			if ( null !== $resolved ) {
 				$block           = $resolved;
 				$is_resolved_ref = true;
+			} elseif ( 'core/block' === $block['blockName'] ) {
+				// Unresolvable reusable block (stale or circular ref). Skip rather
+				// than falling through to render_mjml_component, which would attempt
+				// the same resolution again.
+				continue;
 			}
 
 			if ( 'core/group' === $block['blockName'] ) {

--- a/includes/class-newspack-newsletters-renderer.php
+++ b/includes/class-newspack-newsletters-renderer.php
@@ -1456,7 +1456,7 @@ final class Newspack_Newsletters_Renderer {
 				if ( null === $resolved ) {
 					return '';
 				}
-				$block_mjml_markup = self::render_mjml_component( $resolved, $is_in_column, $is_in_group, $default_attrs );
+				$block_mjml_markup = self::render_mjml_component( $resolved, $is_in_column, $is_in_group, $default_attrs, $is_in_list_or_quote );
 				self::release_reusable_block_ref();
 				return $block_mjml_markup;
 

--- a/includes/class-newspack-newsletters-renderer.php
+++ b/includes/class-newspack-newsletters-renderer.php
@@ -1704,7 +1704,7 @@ final class Newspack_Newsletters_Renderer {
 	 * @param array $block The core/block block array.
 	 * @return array|null The resolved group block, or null if unresolvable.
 	 */
-	private static function resolve_reusable_block( $block ) {
+	private static function resolve_reusable_block( array $block ): ?array {
 		if ( 'core/block' !== $block['blockName'] || ! isset( $block['attrs']['ref'] ) ) {
 			return null;
 		}
@@ -1744,7 +1744,7 @@ final class Newspack_Newsletters_Renderer {
 	 *
 	 * Must be called after rendering a block resolved by resolve_reusable_block().
 	 */
-	private static function release_reusable_block_ref() {
+	private static function release_reusable_block_ref(): void {
 		array_pop( self::$rendering_refs );
 	}
 

--- a/includes/class-newspack-newsletters-renderer.php
+++ b/includes/class-newspack-newsletters-renderer.php
@@ -54,6 +54,14 @@ final class Newspack_Newsletters_Renderer {
 	protected static $post_permalink = null;
 
 	/**
+	 * Stack of reusable block ref IDs currently being rendered,
+	 * used to detect and prevent circular references.
+	 *
+	 * @var int[]
+	 */
+	private static $rendering_refs = [];
+
+	/**
 	 * Inline tags that are allowed to be rendered in a text block.
 	 *
 	 * @var bool[]|array[] Associative array of tag names to allowed attributes.
@@ -1444,22 +1452,13 @@ final class Newspack_Newsletters_Renderer {
 			 * Resolve the referenced wp_block post and render as a group block.
 			 */
 			case 'core/block':
-				if ( isset( $attrs['ref'] ) ) {
-					$reusable_block_post = get_post( $attrs['ref'] );
-					if ( ! empty( $reusable_block_post ) ) {
-						$block['blockName']    = 'core/group';
-						$block['innerBlocks']  = array_filter(
-							parse_blocks( $reusable_block_post->post_content ),
-							function ( $b ) {
-								return null !== $b['blockName'];
-							}
-						);
-						$block['innerHTML']    = $reusable_block_post->post_content;
-						$block['innerContent'] = [ $reusable_block_post->post_content ];
-						return self::render_mjml_component( $block, $is_in_column, $is_in_group, $default_attrs );
-					}
+				$resolved = self::resolve_reusable_block( $block );
+				if ( null === $resolved ) {
+					return '';
 				}
-				break;
+				$block_mjml_markup = self::render_mjml_component( $resolved, $is_in_column, $is_in_group, $default_attrs );
+				self::release_reusable_block_ref();
+				return $block_mjml_markup;
 
 			/**
 			 * Group block.
@@ -1695,6 +1694,60 @@ final class Newspack_Newsletters_Renderer {
 		return $block_mjml_markup;
 	}
 
+	/**
+	 * Resolve a core/block (synced pattern / reusable block) into a core/group block.
+	 *
+	 * Fetches the referenced wp_block post, validates it, guards against circular
+	 * references, and returns a block array with blockName changed to core/group
+	 * and innerBlocks populated from the reusable block's content.
+	 *
+	 * @param array $block The core/block block array.
+	 * @return array|null The resolved group block, or null if unresolvable.
+	 */
+	private static function resolve_reusable_block( $block ) {
+		if ( 'core/block' !== $block['blockName'] || ! isset( $block['attrs']['ref'] ) ) {
+			return null;
+		}
+
+		$ref = (int) $block['attrs']['ref'];
+
+		// Guard against circular references.
+		if ( in_array( $ref, self::$rendering_refs, true ) ) {
+			return null;
+		}
+
+		$reusable_block_post = get_post( $ref );
+
+		// Validate post type and status.
+		if (
+			empty( $reusable_block_post )
+			|| 'wp_block' !== $reusable_block_post->post_type
+			|| 'publish' !== $reusable_block_post->post_status
+		) {
+			return null;
+		}
+
+		// Push ref onto the stack. Callers must call release_reusable_block_ref()
+		// after they are done rendering the resolved block.
+		self::$rendering_refs[] = $ref;
+
+		$block['blockName']    = 'core/group';
+		$block['innerBlocks']  = self::get_valid_post_blocks( $reusable_block_post );
+		$block['innerHTML']    = $reusable_block_post->post_content;
+		$block['innerContent'] = [ $reusable_block_post->post_content ];
+
+		return $block;
+	}
+
+	/**
+	 * Release a reusable block ref from the rendering stack.
+	 *
+	 * Must be called after rendering a block resolved by resolve_reusable_block().
+	 */
+	private static function release_reusable_block_ref() {
+		array_pop( self::$rendering_refs );
+	}
+
 	/** Convert a WP post to an array of non-empty blocks.
 	 *
 	 * @param WP_Post $post The post.
@@ -1734,15 +1787,11 @@ final class Newspack_Newsletters_Renderer {
 			$block_content = '';
 
 			// Convert reusable block to group block.
-			// Reusable blocks are CPTs, where the block's ref attribute is the post ID.
-			if ( 'core/block' === $block['blockName'] && isset( $block['attrs']['ref'] ) ) {
-				$reusable_block_post = get_post( $block['attrs']['ref'] );
-				if ( ! empty( $reusable_block_post ) ) {
-					$block['blockName']    = 'core/group';
-					$block['innerBlocks']  = self::get_valid_post_blocks( $reusable_block_post );
-					$block['innerHTML']    = $reusable_block_post->post_content;
-					$block['innerContent'] = $reusable_block_post->post_content;
-				}
+			$is_resolved_ref = false;
+			$resolved        = self::resolve_reusable_block( $block );
+			if ( null !== $resolved ) {
+				$block           = $resolved;
+				$is_resolved_ref = true;
 			}
 
 			if ( 'core/group' === $block['blockName'] ) {
@@ -1769,6 +1818,10 @@ final class Newspack_Newsletters_Renderer {
 				}
 			} else {
 				$block_content = self::render_mjml_component( $block );
+			}
+
+			if ( $is_resolved_ref ) {
+				self::release_reusable_block_ref();
 			}
 
 			$body .= $block_content;

--- a/src/editor/blocks-validation/blocks-filters.js
+++ b/src/editor/blocks-validation/blocks-filters.js
@@ -120,7 +120,7 @@ const withUnsupportedFeaturesNotices = createHigherOrderComponent( BlockListBloc
 			<BlockListBlock { ...props } />
 		);
 	};
-}, 'withInspectorControl' );
+}, 'withUnsupportedFeaturesNotices' );
 
 export const addBlocksValidationFilter = () => {
 	addFilter( 'editor.BlockListBlock', 'newspack-newsletters/unsupported-features-notices', withUnsupportedFeaturesNotices );

--- a/src/editor/blocks-validation/blocks-filters.js
+++ b/src/editor/blocks-validation/blocks-filters.js
@@ -9,7 +9,7 @@ import { every, some } from 'lodash';
 import { __ } from '@wordpress/i18n';
 import { addFilter } from '@wordpress/hooks';
 import { createHigherOrderComponent } from '@wordpress/compose';
-import { select } from '@wordpress/data';
+import { select, useSelect } from '@wordpress/data';
 
 const handleSideAlignment = ( warnings, props ) => {
 	if ( props.attributes.align === 'left' || props.attributes.align === 'right' ) {
@@ -75,9 +75,34 @@ const getWarnings = props => {
 	return warnings;
 };
 
+/**
+ * Reactive check for `core/block` (synced pattern) references whose target
+ * `wp_block` post is not published. The server-side MJML renderer omits these
+ * from the preview and sent email, so surface a warning in the editor to match.
+ */
+const useUnpublishedReusableBlockWarning = ( name, attributes ) => {
+	return useSelect(
+		selectData => {
+			if ( 'core/block' !== name || ! attributes?.ref ) {
+				return null;
+			}
+			const post = selectData( 'core' ).getEntityRecord( 'postType', 'wp_block', attributes.ref );
+			if ( post && 'publish' !== post.status ) {
+				return __( 'Unpublished synced pattern', 'newspack-newsletters' );
+			}
+			return null;
+		},
+		[ name, attributes?.ref ]
+	);
+};
+
 const withUnsupportedFeaturesNotices = createHigherOrderComponent( BlockListBlock => {
 	return props => {
 		const warnings = getWarnings( props );
+		const unpublishedRefWarning = useUnpublishedReusableBlockWarning( props.name, props.attributes );
+		if ( unpublishedRefWarning ) {
+			warnings.push( unpublishedRefWarning );
+		}
 		return warnings.length ? (
 			<div className="newspack-newsletters__editor-block">
 				<div className="newspack-newsletters__editor-block__warning components-notice is-error">

--- a/tests/test-renderer.php
+++ b/tests/test-renderer.php
@@ -436,6 +436,34 @@ class Newsletters_Renderer_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Rendering a reusable block nested inside a group block.
+	 */
+	public function test_reusable_block_in_group() {
+		$reusable_block_post_id = self::factory()->post->create(
+			[
+				'post_type'    => 'wp_block',
+				'post_title'   => 'Reusable block in group.',
+				'post_content' => "<!-- wp:paragraph -->\n<p>Nested Hello</p>\n<!-- /wp:paragraph -->",
+			]
+		);
+		$newsletter_post        = self::factory()->post->create(
+			[
+				'post_type'    => Newspack_Newsletters::NEWSPACK_NEWSLETTERS_CPT,
+				'post_title'   => 'A newsletter with a reusable block inside a group.',
+				'post_content' => '<!-- wp:group --><div class="wp-block-group"><!-- wp:block {"ref":' . $reusable_block_post_id . '} /--></div><!-- /wp:group -->',
+			]
+		);
+		$result = Newspack_Newsletters_Renderer::post_to_mjml_components(
+			get_post( $newsletter_post )
+		);
+		$this->assertStringContainsString(
+			'Nested Hello',
+			$result,
+			'Reusable block content inside a group block is rendered'
+		);
+	}
+
+	/**
 	 * Rendering with custom CSS.
 	 */
 	public function test_custom_css() {

--- a/tests/test-renderer.php
+++ b/tests/test-renderer.php
@@ -464,6 +464,67 @@ class Newsletters_Renderer_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * A stale reusable block reference (deleted post) should not emit empty markup.
+	 */
+	public function test_stale_reusable_block_ref() {
+		$newsletter_post = self::factory()->post->create(
+			[
+				'post_type'    => Newspack_Newsletters::NEWSPACK_NEWSLETTERS_CPT,
+				'post_title'   => 'A newsletter with a stale reusable block ref.',
+				'post_content' => '<!-- wp:block {"ref":999999} /-->',
+			]
+		);
+		$result = Newspack_Newsletters_Renderer::post_to_mjml_components(
+			get_post( $newsletter_post )
+		);
+		$this->assertEmpty(
+			$result,
+			'Stale reusable block reference produces no output'
+		);
+	}
+
+	/**
+	 * Circular reusable block references should not cause infinite recursion.
+	 */
+	public function test_circular_reusable_block_ref() {
+		// Create two wp_block posts that reference each other.
+		$block_a_id = self::factory()->post->create(
+			[
+				'post_type'    => 'wp_block',
+				'post_title'   => 'Block A',
+				'post_content' => '<!-- wp:paragraph --><p>A</p><!-- /wp:paragraph -->',
+			]
+		);
+		$block_b_id = self::factory()->post->create(
+			[
+				'post_type'    => 'wp_block',
+				'post_title'   => 'Block B',
+				'post_content' => '<!-- wp:block {"ref":' . $block_a_id . '} /-->',
+			]
+		);
+		// Update Block A to reference Block B, creating a cycle.
+		wp_update_post(
+			[
+				'ID'           => $block_a_id,
+				'post_content' => '<!-- wp:block {"ref":' . $block_b_id . '} /-->',
+			]
+		);
+
+		$newsletter_post = self::factory()->post->create(
+			[
+				'post_type'    => Newspack_Newsletters::NEWSPACK_NEWSLETTERS_CPT,
+				'post_title'   => 'A newsletter with circular reusable blocks.',
+				'post_content' => '<!-- wp:block {"ref":' . $block_a_id . '} /-->',
+			]
+		);
+		// Should not fatal — the circular ref is silently dropped.
+		$result = Newspack_Newsletters_Renderer::post_to_mjml_components(
+			get_post( $newsletter_post )
+		);
+		$this->assertIsString( $result, 'Circular reusable block references do not cause fatal errors' );
+	}
+
+	/**
 	 * Rendering with custom CSS.
 	 */
 	public function test_custom_css() {

--- a/tests/test-renderer.php
+++ b/tests/test-renderer.php
@@ -522,6 +522,8 @@ class Newsletters_Renderer_Test extends WP_UnitTestCase {
 			get_post( $newsletter_post )
 		);
 		$this->assertIsString( $result, 'Circular reusable block references do not cause fatal errors' );
+		// The cycle is broken: output contains only empty wrapper shells, not unbounded content.
+		$this->assertLessThan( 200, strlen( $result ), 'Circular reusable block output is bounded' );
 	}
 
 	/**


### PR DESCRIPTION
## Changes proposed

Synced patterns (reusable blocks / `core/block`) placed inside Group blocks were silently stripped from newsletter email output. This happened because:

1. `is_empty_block()` treated `core/block` as empty (it has no `innerHTML` — content lives in a referenced `wp_block` post).  This is similar to a pattern that prevented Remote Data Blocks from rendering on send.
2. `render_mjml_component()` had no handler for `core/block` — resolution only happened at the top level in `post_to_mjml_components()`

This PR extracts the reusable block resolution into a shared `resolve_reusable_block()` method used by both code paths, with additional hardening:

- **Post validation** — checks `post_type === 'wp_block'` and `post_status === 'publish'` (previously unchecked)
- **Circular reference guard** — static stack prevents infinite recursion if patterns reference each other
- **Filter consistency** — uses `get_valid_post_blocks()` so the `newspack_newsletters_newsletter_content` filter is applied to nested patterns, matching top-level behavior
- **Stale ref handling** — deleted/invalid refs return empty instead of rendering empty wrapper markup

Resolves [NPPM-2610: Bug: Some Patterns don't display in sent Newsletters when placed inside of a "Group" block](https://linear.app/a8c/issue/NPPM-2610)

## How to test

1. Create a synced pattern containing a Heading and a Paragraph block
2. Create a newsletter, add a Group block, insert the synced pattern inside it
3. Preview the newsletter — the pattern content should appear in the email output
4. Also verify: a top-level synced pattern (not in a group) still renders correctly