### PR TITLE
fix: use active campaign saved segments summary endpoint

### DIFF
--- a/includes/service-providers/active_campaign/class-newspack-newsletters-active-campaign.php
+++ b/includes/service-providers/active_campaign/class-newspack-newsletters-active-campaign.php
@@ -667,8 +667,8 @@ final class Newspack_Newsletters_Active_Campaign extends \Newspack_Newsletters_S
 				return $segments;
 			}
 			foreach ( $segments as $segment ) {
-				$segment_name = ! empty( $segment['name'] ) ?
-					$segment['name'] . ' (ID ' . $segment['id'] . ')' :
+				$segment_name = ! empty( $segment['attributes']['name'] ) ?
+					$segment['attributes']['name'] :
 					sprintf(
 						// Translators: %s is the segment ID.
 						__( 'Untitled %s', 'newspack-newsletters' ),
@@ -682,7 +682,7 @@ final class Newspack_Newsletters_Active_Campaign extends \Newspack_Newsletters_S
 						'parent_id'   => $args['parent_id'] ?? null,
 						'name'        => $segment_name,
 						'entity_type' => 'segment',
-						'count'       => $segment['subscriber_count'] ?? null,
+						'count'       => $segment['attributes']['counts']['last_active_total']['count'] ?? null,
 					]
 				);
 			}
@@ -725,7 +725,7 @@ final class Newspack_Newsletters_Active_Campaign extends \Newspack_Newsletters_S
 					array_filter(
 						$this->segments,
 						function ( $segment ) use ( $args ) {
-							return Send_Lists::matches_search( $args['search'], [ $segment['name'] ] );
+							return Send_Lists::matches_search( $args['search'], [ $segment['attributes']['name'] ] );
 						}
 					)
 				);
@@ -734,11 +734,11 @@ final class Newspack_Newsletters_Active_Campaign extends \Newspack_Newsletters_S
 			return $this->segments;
 		}
 
-		$query_args           = $args;
-		$query_args['limit']  = $args['limit'] ?? 100;
-		$query_args['offset'] = 0;
+		$query_args               = $args;
+		$query_args['page_size']  = $args['limit'] ?? 500;
+		$query_args['page']       = 1;
 		$result = $this->api_v3_request(
-			'segments',
+			'audiences',
 			'GET',
 			[
 				'query' => $query_args,
@@ -747,17 +747,17 @@ final class Newspack_Newsletters_Active_Campaign extends \Newspack_Newsletters_S
 		if ( is_wp_error( $result ) ) {
 			return $result;
 		}
-		$segments = $result['segments'];
+		$segments = $result['data'];
 		if ( isset( $args['limit'] ) ) {
 			return $segments;
 		}
 
 		// If not passed a limit, get all the segments.
-		$total = $result['meta']['total'];
-		while ( $total > $query_args['offset'] + $query_args['limit'] ) {
-			$query_args['offset'] = $query_args['offset'] + $query_args['limit'];
+		$total = $result['meta']['page']['total'];
+		while ( $total > $query_args['page_size'] * $query_args['page'] ) {
+			$query_args['page'] = $query_args['page'] + 1;
 			$result = $this->api_v3_request(
-				'segments',
+				'audiences',
 				'GET',
 				[
 					'query' => $query_args,
@@ -766,7 +766,7 @@ final class Newspack_Newsletters_Active_Campaign extends \Newspack_Newsletters_S
 			if ( is_wp_error( $result ) ) {
 				return $result;
 			}
-			$segments = array_merge( $segments, $result['segments'] );
+			$segments = array_merge( $segments, $result['data'] );
 		}
 
 		$this->segments = $segments;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes the Active Campaign provider by using the [saved segments summary endpoint](https://developers.activecampaign.com/reference/get_saved_segment_summaries) instead of the generic segments endpoint.

This is the endpoint that reflects what people see in the Segments dashboard in AC.

### How to test the changes in this Pull Request:

1. Make sure setting a segment to send the newsletter to shows the right segments with their data (subscriber count, name, id)
2. Make sure when you send a newsletter it goes to the right segment and the campaign created in AC is tied to the correct segment
3. Test the `get_segments` method on WP Shell and see if it works as expected. Manually edit the code and change the default `page_size` to 1 to check if pagination is working.
4. During the same session on CLI, call get_segments passing a search or ids to check that the method behaves correctly with the meomized result.
5. Double check things :) 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
