### PR TITLE
feat(esp): enrich contact field schema for integrations

### DIFF
--- a/includes/class-newspack-newsletters-contacts.php
+++ b/includes/class-newspack-newsletters-contacts.php
@@ -408,6 +408,6 @@ class Newspack_Newsletters_Contacts {
 			return new WP_Error( 'newspack_newsletters_invalid_provider', __( 'Provider is not set.' ) );
 		}
 
-		return $provider->get_contact_fields( $list_id );
+		return $provider->get_contact_fields_for_integrations( $list_id );
 	}
 }

--- a/includes/service-providers/active_campaign/class-newspack-newsletters-active-campaign.php
+++ b/includes/service-providers/active_campaign/class-newspack-newsletters-active-campaign.php
@@ -1780,14 +1780,19 @@ final class Newspack_Newsletters_Active_Campaign extends \Newspack_Newsletters_S
 	}
 
 	/**
+	 * Object cache group for the integrations field schema and per-field option lists.
+	 */
+	const INTEGRATIONS_CACHE_GROUP = 'newspack_newsletters_active_campaign';
+
+	/**
 	 * Get contact fields for Newspack integrations.
 	 *
 	 * @param string|null $list_id The List ID (unused — ActiveCampaign contact fields are global).
 	 * @return array|WP_Error
 	 */
 	public function get_contact_fields_for_integrations( $list_id = null ) {
-		$cache_key     = 'active_campaign_contact_fields_for_integrations';
-		$cached_fields = wp_cache_get( $cache_key );
+		$cache_key     = $this->integrations_cache_key( 'fields' );
+		$cached_fields = wp_cache_get( $cache_key, self::INTEGRATIONS_CACHE_GROUP );
 		if ( false !== $cached_fields ) {
 			return $cached_fields;
 		}
@@ -1802,17 +1807,44 @@ final class Newspack_Newsletters_Active_Campaign extends \Newspack_Newsletters_S
 				$fields[] = $mapped;
 			}
 		}
-		wp_cache_set( $cache_key, $fields, '', 5 * MINUTE_IN_SECONDS );
+		wp_cache_set( $cache_key, $fields, self::INTEGRATIONS_CACHE_GROUP, 5 * MINUTE_IN_SECONDS );
 		return $fields;
+	}
+
+	/**
+	 * Build a cache key for integrations data, namespaced by the configured AC account URL.
+	 *
+	 * Two sites sharing an object cache backend can be configured against different AC accounts;
+	 * a flat global key would let one site's cached schema leak into the other.
+	 *
+	 * @param string $suffix Per-call key suffix (e.g. 'fields', 'options:34').
+	 * @return string
+	 */
+	private function integrations_cache_key( $suffix ) {
+		$credentials = $this->api_credentials();
+		if ( ! empty( $credentials['url'] ) ) {
+			$account_hash = substr( md5( (string) $credentials['url'] ), 0, 12 );
+		} else {
+			// Defensive fallback for a code path that bypasses credential checks; salt with
+			// the blog id so two unconfigured sites sharing an object cache don't collide.
+			$account_hash = 'noaccount-' . get_current_blog_id();
+		}
+		return $account_hash . ':' . $suffix;
 	}
 
 	/**
 	 * Map an ActiveCampaign contact field to the Newspack integrations schema.
 	 *
 	 * AC types eligible for access-rule / segmentation defaults: text, textarea, date, datetime,
-	 * dropdown, radio, listbox, checkbox. Hidden and NULL-typed fields are exposed but not
-	 * promoted by default. All fields use the 'default' matching function — AC stores dropdown
-	 * selections as a single string value, so exact-equality matching against a chosen option works.
+	 * dropdown, radio, listbox, checkbox, multiselect. Hidden and NULL-typed fields are exposed
+	 * but not promoted by default.
+	 *
+	 * Matching function depends on selection cardinality. Per AC's Contact Custom Fields API
+	 * Guide, dropdown / radio / listbox are single-selection types (their stored value is the
+	 * raw chosen option), so 'default' (strict equality) matching is correct. Checkbox and
+	 * multiselect are multi-selection types: AC stores the chosen options with a `||` delimiter
+	 * (e.g. `||Option A||Option C||`), which `default` matching cannot resolve — those types
+	 * use 'list__in', and the consumer's parse_list_value() recognizes the delimiter.
 	 *
 	 * @param array $field Raw field from the ActiveCampaign v3 /fields endpoint.
 	 * @return array|null Mapped field, or null if no usable identifier is available.
@@ -1823,10 +1855,13 @@ final class Newspack_Newsletters_Active_Campaign extends \Newspack_Newsletters_S
 			return null;
 		}
 
-		$type                   = isset( $field['type'] ) ? $field['type'] : 'text';
-		$enumerated_types       = [ 'dropdown', 'radio', 'listbox', 'checkbox' ];
-		$eligible_types         = array_merge( [ 'text', 'textarea', 'date', 'datetime' ], $enumerated_types );
-		$is_promoted_by_default = in_array( $type, $eligible_types, true );
+		$type                       = isset( $field['type'] ) ? $field['type'] : 'text';
+		$single_select_enum_types   = [ 'dropdown', 'radio', 'listbox' ];
+		$multi_select_enum_types    = [ 'checkbox', 'multiselect' ];
+		$enumerated_types           = array_merge( $single_select_enum_types, $multi_select_enum_types );
+		$eligible_types             = array_merge( [ 'text', 'textarea', 'date', 'datetime' ], $enumerated_types );
+		$is_promoted_by_default     = in_array( $type, $eligible_types, true );
+		$is_multi_select            = in_array( $type, $multi_select_enum_types, true );
 
 		$options = [];
 		if ( in_array( $type, $enumerated_types, true ) && ! empty( $field['id'] ) ) {
@@ -1837,7 +1872,7 @@ final class Newspack_Newsletters_Active_Campaign extends \Newspack_Newsletters_S
 			'key'                 => $perstag,
 			'name'                => ! empty( $field['title'] ) ? $field['title'] : $perstag,
 			'value_type'          => 'string',
-			'matching_function'   => 'default',
+			'matching_function'   => $is_multi_select ? 'list__in' : 'default',
 			'options'             => $options,
 			'description'         => ! empty( $field['descript'] ) ? $field['descript'] : '',
 			'is_access_rule'      => $is_promoted_by_default,
@@ -1848,12 +1883,33 @@ final class Newspack_Newsletters_Active_Campaign extends \Newspack_Newsletters_S
 	/**
 	 * Fetch the option list for an enumerated ActiveCampaign field.
 	 *
+	 * Cached per field with a longer TTL than the parent schema (1h vs 5min). Option lists
+	 * change much less often than the field roster, and a misaligned TTL means the parent
+	 * cache miss only re-fetches options for fields whose own per-field cache has lapsed.
+	 * Tradeoff: an option-label edit in AC can take up to 1h to surface in the admin UI.
+	 *
 	 * @param int|string $field_id The AC field ID.
 	 * @return array Array of [ 'value' => ..., 'label' => ... ] pairs (empty on failure).
 	 */
 	private function fetch_field_options( $field_id ) {
+		$cache_key = $this->integrations_cache_key( 'options:' . $field_id );
+		$cached    = wp_cache_get( $cache_key, self::INTEGRATIONS_CACHE_GROUP );
+		if ( false !== $cached ) {
+			return $cached;
+		}
 		$response = $this->api_v3_request( 'fields/' . rawurlencode( (string) $field_id ) . '/options', 'GET' );
-		if ( is_wp_error( $response ) || empty( $response['fieldOptions'] ) ) {
+		if ( is_wp_error( $response ) ) {
+			Newspack_Newsletters_Logger::log(
+				sprintf(
+					'ActiveCampaign: failed to fetch options for field %s: %s',
+					$field_id,
+					$response->get_error_message()
+				)
+			);
+			return [];
+		}
+		if ( empty( $response['fieldOptions'] ) ) {
+			wp_cache_set( $cache_key, [], self::INTEGRATIONS_CACHE_GROUP, HOUR_IN_SECONDS );
 			return [];
 		}
 		$options = [];
@@ -1866,6 +1922,7 @@ final class Newspack_Newsletters_Active_Campaign extends \Newspack_Newsletters_S
 				'label' => isset( $option['label'] ) ? $option['label'] : $option['value'],
 			];
 		}
+		wp_cache_set( $cache_key, $options, self::INTEGRATIONS_CACHE_GROUP, HOUR_IN_SECONDS );
 		return $options;
 	}
 }

--- a/includes/service-providers/active_campaign/class-newspack-newsletters-active-campaign.php
+++ b/includes/service-providers/active_campaign/class-newspack-newsletters-active-campaign.php
@@ -1797,7 +1797,10 @@ final class Newspack_Newsletters_Active_Campaign extends \Newspack_Newsletters_S
 		}
 		$fields = [];
 		foreach ( $all_fields as $field ) {
-			$fields[] = $this->map_contact_field_to_integration_schema( $field );
+			$mapped = $this->map_contact_field_to_integration_schema( $field );
+			if ( null !== $mapped ) {
+				$fields[] = $mapped;
+			}
 		}
 		wp_cache_set( $cache_key, $fields, '', 5 * MINUTE_IN_SECONDS );
 		return $fields;
@@ -1812,9 +1815,14 @@ final class Newspack_Newsletters_Active_Campaign extends \Newspack_Newsletters_S
 	 * selections as a single string value, so exact-equality matching against a chosen option works.
 	 *
 	 * @param array $field Raw field from the ActiveCampaign v3 /fields endpoint.
-	 * @return array
+	 * @return array|null Mapped field, or null if no usable identifier is available.
 	 */
 	private function map_contact_field_to_integration_schema( $field ) {
+		$perstag = isset( $field['perstag'] ) ? (string) $field['perstag'] : '';
+		if ( '' === $perstag ) {
+			return null;
+		}
+
 		$type                   = isset( $field['type'] ) ? $field['type'] : 'text';
 		$enumerated_types       = [ 'dropdown', 'radio', 'listbox', 'checkbox' ];
 		$eligible_types         = array_merge( [ 'text', 'textarea', 'date', 'datetime' ], $enumerated_types );
@@ -1825,11 +1833,9 @@ final class Newspack_Newsletters_Active_Campaign extends \Newspack_Newsletters_S
 			$options = $this->fetch_field_options( $field['id'] );
 		}
 
-		$name = ! empty( $field['title'] ) ? $field['title'] : ( $field['perstag'] ?? '' );
-
 		return [
-			'key'                 => $field['title'],
-			'name'                => $name,
+			'key'                 => $perstag,
+			'name'                => ! empty( $field['title'] ) ? $field['title'] : $perstag,
 			'value_type'          => 'string',
 			'matching_function'   => 'default',
 			'options'             => $options,

--- a/includes/service-providers/active_campaign/class-newspack-newsletters-active-campaign.php
+++ b/includes/service-providers/active_campaign/class-newspack-newsletters-active-campaign.php
@@ -1780,17 +1780,13 @@ final class Newspack_Newsletters_Active_Campaign extends \Newspack_Newsletters_S
 	}
 
 	/**
-	 * Get contact fields for a list.
+	 * Get contact fields for Newspack integrations.
 	 *
-	 * By default, this method returns an empty array, but providers can override it to return the fields available in the ESP for a specific list.
-	 *
-	 * This is used by Newspack integrations to sync contact data.
-	 *
-	 * @param string|null $list_id The List ID. Optional, as some providers might not have different fields per list.
-	 * @return array|WP_Error The contact fields for the list. Each field should be an array with 'key' key at least. WP_Error if the request to fetch the fields failed.
+	 * @param string|null $list_id The List ID (unused — ActiveCampaign contact fields are global).
+	 * @return array|WP_Error
 	 */
-	public function get_contact_fields( $list_id = null ) {
-		$cache_key = 'active_campaign_contact_fields';
+	public function get_contact_fields_for_integrations( $list_id = null ) {
+		$cache_key     = 'active_campaign_contact_fields_for_integrations';
 		$cached_fields = wp_cache_get( $cache_key );
 		if ( false !== $cached_fields ) {
 			return $cached_fields;
@@ -1801,11 +1797,69 @@ final class Newspack_Newsletters_Active_Campaign extends \Newspack_Newsletters_S
 		}
 		$fields = [];
 		foreach ( $all_fields as $field ) {
-			$fields[] = [
-				'key' => $field['title'],
-			];
+			$fields[] = $this->map_contact_field_to_integration_schema( $field );
 		}
 		wp_cache_set( $cache_key, $fields, '', 5 * MINUTE_IN_SECONDS );
 		return $fields;
+	}
+
+	/**
+	 * Map an ActiveCampaign contact field to the Newspack integrations schema.
+	 *
+	 * AC types eligible for access-rule / segmentation defaults: text, textarea, date, datetime,
+	 * dropdown, radio, listbox, checkbox. Hidden and NULL-typed fields are exposed but not
+	 * promoted by default. All fields use the 'default' matching function — AC stores dropdown
+	 * selections as a single string value, so exact-equality matching against a chosen option works.
+	 *
+	 * @param array $field Raw field from the ActiveCampaign v3 /fields endpoint.
+	 * @return array
+	 */
+	private function map_contact_field_to_integration_schema( $field ) {
+		$type                   = isset( $field['type'] ) ? $field['type'] : 'text';
+		$enumerated_types       = [ 'dropdown', 'radio', 'listbox', 'checkbox' ];
+		$eligible_types         = array_merge( [ 'text', 'textarea', 'date', 'datetime' ], $enumerated_types );
+		$is_promoted_by_default = in_array( $type, $eligible_types, true );
+
+		$options = [];
+		if ( in_array( $type, $enumerated_types, true ) && ! empty( $field['id'] ) ) {
+			$options = $this->fetch_field_options( $field['id'] );
+		}
+
+		$name = ! empty( $field['title'] ) ? $field['title'] : ( $field['perstag'] ?? '' );
+
+		return [
+			'key'                 => $field['title'],
+			'name'                => $name,
+			'value_type'          => 'string',
+			'matching_function'   => 'default',
+			'options'             => $options,
+			'description'         => ! empty( $field['descript'] ) ? $field['descript'] : '',
+			'is_access_rule'      => $is_promoted_by_default,
+			'is_segment_criteria' => $is_promoted_by_default,
+		];
+	}
+
+	/**
+	 * Fetch the option list for an enumerated ActiveCampaign field.
+	 *
+	 * @param int|string $field_id The AC field ID.
+	 * @return array Array of [ 'value' => ..., 'label' => ... ] pairs (empty on failure).
+	 */
+	private function fetch_field_options( $field_id ) {
+		$response = $this->api_v3_request( 'fields/' . rawurlencode( (string) $field_id ) . '/options', 'GET' );
+		if ( is_wp_error( $response ) || empty( $response['fieldOptions'] ) ) {
+			return [];
+		}
+		$options = [];
+		foreach ( $response['fieldOptions'] as $option ) {
+			if ( ! isset( $option['value'] ) ) {
+				continue;
+			}
+			$options[] = [
+				'value' => $option['value'],
+				'label' => isset( $option['label'] ) ? $option['label'] : $option['value'],
+			];
+		}
+		return $options;
 	}
 }

--- a/includes/service-providers/class-newspack-newsletters-service-provider.php
+++ b/includes/service-providers/class-newspack-newsletters-service-provider.php
@@ -952,8 +952,11 @@ Error message(s) received:
 	 *
 	 *   - key (string, required): Machine key for the field. Used as the Incoming_Field key.
 	 *   - name (string): Human-readable label. Defaults to the key.
-	 *   - value_type (string): 'string' or 'boolean'. Defaults to 'string'.
-	 *   - matching_function (string): 'default' | 'list__in' | 'list__not_in' | 'range'. Defaults to 'default'.
+	 *   - value_type (string): Defaults to 'string'. The Incoming_Field setter accepts other values
+	 *       (e.g. 'boolean'); current providers only emit 'string'.
+	 *   - matching_function (string): Defaults to 'default' (strict equality). Use 'list__in' for
+	 *       multi-select fields whose stored value is a delimited list. The consumer also
+	 *       recognizes 'list__not_in' and 'range', though no current provider emits them.
 	 *   - options (array): List of [ 'value' => ..., 'label' => ... ] pairs for enumerated fields.
 	 *   - description (string): Optional help text surfaced in the admin UI.
 	 *   - is_access_rule (bool): Whether the field is eligible as a content-gate access rule by default.

--- a/includes/service-providers/class-newspack-newsletters-service-provider.php
+++ b/includes/service-providers/class-newspack-newsletters-service-provider.php
@@ -941,16 +941,28 @@ Error message(s) received:
 	}
 
 	/**
-	 * Get contact fields for a list.
+	 * Get contact fields for Newspack integrations.
 	 *
-	 * By default, this method returns an empty array, but providers can override it to return the fields available in the ESP for a specific list.
+	 * By default, this method returns an empty array. Providers should override it to return the fields
+	 * available in the ESP in a shape that can be consumed by the Newspack ESP integration to configure
+	 * Reader Activation incoming fields (content gate access rules and popups segmentation criteria).
 	 *
-	 * This is used by Newspack integrations to sync contact data.
+	 * Each returned entry is an associative array with the following keys. All keys except 'key' are
+	 * optional — defaults kick in from the Incoming_Field class when a key is missing.
+	 *
+	 *   - key (string, required): Machine key for the field. Used as the Incoming_Field key.
+	 *   - name (string): Human-readable label. Defaults to the key.
+	 *   - value_type (string): 'string' or 'boolean'. Defaults to 'string'.
+	 *   - matching_function (string): 'default' | 'list__in' | 'list__not_in' | 'range'. Defaults to 'default'.
+	 *   - options (array): List of [ 'value' => ..., 'label' => ... ] pairs for enumerated fields.
+	 *   - description (string): Optional help text surfaced in the admin UI.
+	 *   - is_access_rule (bool): Whether the field is eligible as a content-gate access rule by default.
+	 *   - is_segment_criteria (bool): Whether the field is eligible as a popups segmentation criterion by default.
 	 *
 	 * @param string|null $list_id The List ID. Optional, as some providers might not have different fields per list.
-	 * @return array|WP_Error The contact fields for the list. Each field should be an array with 'key' key at least. WP_Error if the request to fetch the fields failed.
+	 * @return array|WP_Error The contact fields for the list, or WP_Error if the request failed.
 	 */
-	public function get_contact_fields( $list_id = null ) {
+	public function get_contact_fields_for_integrations( $list_id = null ) {
 		return [];
 	}
 }

--- a/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp.php
+++ b/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp.php
@@ -2265,17 +2265,12 @@ final class Newspack_Newsletters_Mailchimp extends \Newspack_Newsletters_Service
 	}
 
 	/**
-	 * Get contact fields for a list.
+	 * Get contact fields for Newspack integrations.
 	 *
-	 * By default, this method returns an empty array, but providers can override it to return the fields available in the ESP for a specific list.
-	 *
-	 * This is used by Newspack integrations to sync contact data.
-	 *
-	 * @param string|null $list_id The List ID. Optional, as some providers might not have different fields per list.
-	 * @return array|WP_Error The contact fields for the list. Each field should be an array with 'key' key at least. WP_Error if the request to fetch the fields failed.
+	 * @param string|null $list_id The List ID.
+	 * @return array|WP_Error
 	 */
-	public function get_contact_fields( $list_id = null ) {
-		// Validate list_id up front.
+	public function get_contact_fields_for_integrations( $list_id = null ) {
 		if ( empty( $list_id ) ) {
 			return new WP_Error(
 				'newspack_mailchimp_get_contact_fields_failed',
@@ -2292,17 +2287,50 @@ final class Newspack_Newsletters_Mailchimp extends \Newspack_Newsletters_Service
 			);
 		}
 
-		// Normalize to array to prevent PHP warnings when iterating.
 		if ( ! is_array( $all_fields ) ) {
 			$all_fields = [];
 		}
 
 		$fields = [];
 		foreach ( $all_fields as $field ) {
-			$fields[] = [
-				'key' => $field['name'],
-			];
+			$fields[] = self::map_merge_field_to_integration_schema( $field );
 		}
 		return $fields;
+	}
+
+	/**
+	 * Map a Mailchimp merge field to the Newspack integrations schema.
+	 *
+	 * Mailchimp types eligible for access-rule / segmentation defaults: text, number, date, radio, dropdown.
+	 * Other types (phone, url, imageurl, birthday, zip, address) are exposed but not promoted by default.
+	 *
+	 * @param array $field Raw merge field from the Mailchimp API.
+	 * @return array
+	 */
+	private static function map_merge_field_to_integration_schema( $field ) {
+		$type                 = isset( $field['type'] ) ? $field['type'] : 'text';
+		$eligible_types       = [ 'text', 'number', 'date', 'radio', 'dropdown' ];
+		$is_promoted_by_default = in_array( $type, $eligible_types, true );
+
+		$options = [];
+		if ( in_array( $type, [ 'radio', 'dropdown' ], true ) && ! empty( $field['options']['choices'] ) ) {
+			foreach ( (array) $field['options']['choices'] as $choice ) {
+				$options[] = [
+					'value' => $choice,
+					'label' => $choice,
+				];
+			}
+		}
+
+		return [
+			'key'                 => $field['name'],
+			'name'                => ! empty( $field['name'] ) ? $field['name'] : $field['tag'],
+			'value_type'          => 'string',
+			'matching_function'   => 'default',
+			'options'             => $options,
+			'description'         => isset( $field['help_text'] ) ? $field['help_text'] : '',
+			'is_access_rule'      => $is_promoted_by_default,
+			'is_segment_criteria' => $is_promoted_by_default,
+		];
 	}
 }

--- a/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp.php
+++ b/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp.php
@@ -2293,7 +2293,10 @@ final class Newspack_Newsletters_Mailchimp extends \Newspack_Newsletters_Service
 
 		$fields = [];
 		foreach ( $all_fields as $field ) {
-			$fields[] = self::map_merge_field_to_integration_schema( $field );
+			$mapped = self::map_merge_field_to_integration_schema( $field );
+			if ( null !== $mapped ) {
+				$fields[] = $mapped;
+			}
 		}
 		return $fields;
 	}
@@ -2305,9 +2308,14 @@ final class Newspack_Newsletters_Mailchimp extends \Newspack_Newsletters_Service
 	 * Other types (phone, url, imageurl, birthday, zip, address) are exposed but not promoted by default.
 	 *
 	 * @param array $field Raw merge field from the Mailchimp API.
-	 * @return array
+	 * @return array|null Mapped field, or null if no usable identifier is available.
 	 */
 	private static function map_merge_field_to_integration_schema( $field ) {
+		$tag = isset( $field['tag'] ) ? (string) $field['tag'] : '';
+		if ( '' === $tag ) {
+			return null;
+		}
+
 		$type                 = isset( $field['type'] ) ? $field['type'] : 'text';
 		$eligible_types       = [ 'text', 'number', 'date', 'radio', 'dropdown' ];
 		$is_promoted_by_default = in_array( $type, $eligible_types, true );
@@ -2323,8 +2331,8 @@ final class Newspack_Newsletters_Mailchimp extends \Newspack_Newsletters_Service
 		}
 
 		return [
-			'key'                 => $field['name'],
-			'name'                => ! empty( $field['name'] ) ? $field['name'] : $field['tag'],
+			'key'                 => $tag,
+			'name'                => ! empty( $field['name'] ) ? $field['name'] : $tag,
 			'value_type'          => 'string',
 			'matching_function'   => 'default',
 			'options'             => $options,

--- a/tests/test-active-campaign-integrations-schema.php
+++ b/tests/test-active-campaign-integrations-schema.php
@@ -1,0 +1,145 @@
+<?php
+/**
+ * Tests for the ActiveCampaign → Newspack integrations schema mapper.
+ *
+ * @package Newspack_Newsletters
+ */
+
+/**
+ * Lock in which AC field types get auto-promoted, what `matching_function` the
+ * mapper emits per type (single-select → 'default', multi-select → 'list__in'),
+ * and the full schema shape.
+ *
+ * AC's per-field options API is not exercised here — the eligibility matrix and
+ * matching-function selection are pure logic.
+ */
+class ActiveCampaignIntegrationsSchemaTest extends WP_UnitTestCase {
+
+	/**
+	 * Invoke the private AC mapper via reflection.
+	 *
+	 * The class is `final`, so we can't subclass to bypass HTTP. The mapper itself
+	 * doesn't read instance state for the branches under test (no `id` ⇒ no
+	 * `fetch_field_options()` call), so we instantiate without running the
+	 * constructor — that avoids the parent class's hook registrations from firing
+	 * once per test invocation in the test process.
+	 *
+	 * @param array $field Raw AC field.
+	 * @return array|null
+	 */
+	private function map_field( $field ) {
+		$reflection                = new ReflectionClass( 'Newspack_Newsletters_Active_Campaign' );
+		$provider                  = $reflection->newInstanceWithoutConstructor();
+		$map_contact_field_method  = $reflection->getMethod( 'map_contact_field_to_integration_schema' );
+		$map_contact_field_method->setAccessible( true );
+		return $map_contact_field_method->invoke( $provider, $field );
+	}
+
+	/**
+	 * Without a `perstag`, AC fields lack a stable machine identifier — must be skipped.
+	 */
+	public function test_skip_when_perstag_missing() {
+		$this->assertNull( $this->map_field( [] ) );
+		$this->assertNull( $this->map_field( [ 'perstag' => '' ] ) );
+	}
+
+	/**
+	 * Single-selection enumerated types use 'default' matching (strict equality
+	 * against the chosen option). Per AC's Contact Custom Fields API Guide:
+	 * dropdown / radio / listbox are single selection.
+	 */
+	public function test_single_select_types_use_default_matching() {
+		foreach ( [ 'dropdown', 'radio', 'listbox' ] as $type ) {
+			$mapped = $this->map_field(
+				[
+					'perstag' => 'X',
+					'type'    => $type,
+				]
+			);
+			$this->assertSame( 'default', $mapped['matching_function'], "$type should use 'default' matching" );
+		}
+	}
+
+	/**
+	 * Multi-selection enumerated types use 'list__in'. AC stores their value
+	 * with `||` delimiters; the consumer's parse_list_value() recognizes that
+	 * format. Strict equality cannot match `||A||B||` against `'A'`.
+	 */
+	public function test_multi_select_types_use_list_in_matching() {
+		foreach ( [ 'checkbox', 'multiselect' ] as $type ) {
+			$mapped = $this->map_field(
+				[
+					'perstag' => 'X',
+					'type'    => $type,
+				]
+			);
+			$this->assertSame( 'list__in', $mapped['matching_function'], "$type should use 'list__in' matching" );
+		}
+	}
+
+	/**
+	 * Promotion eligibility — the eligible set drives the `is_access_rule` /
+	 * `is_segment_criteria` defaults the consumer applies to fresh fields. Both
+	 * flags are derived from the same internal predicate today, but assert each
+	 * one independently so a future split (e.g. adding a segment-only type)
+	 * can't pass silently.
+	 */
+	public function test_promotion_eligibility_matrix() {
+		$promoted     = [ 'text', 'textarea', 'date', 'datetime', 'dropdown', 'radio', 'listbox', 'checkbox', 'multiselect' ];
+		$not_promoted = [ 'hidden', 'NULL', 'made-up-future-type' ];
+
+		foreach ( $promoted as $type ) {
+			$mapped = $this->map_field(
+				[
+					'perstag' => 'X',
+					'type'    => $type,
+				]
+			);
+			$this->assertTrue( $mapped['is_access_rule'], "$type should be promoted as access rule" );
+			$this->assertTrue( $mapped['is_segment_criteria'], "$type should be promoted as segment criteria" );
+		}
+		foreach ( $not_promoted as $type ) {
+			$mapped = $this->map_field(
+				[
+					'perstag' => 'X',
+					'type'    => $type,
+				]
+			);
+			$this->assertFalse( $mapped['is_access_rule'], "$type should NOT be promoted as access rule" );
+			$this->assertFalse( $mapped['is_segment_criteria'], "$type should NOT be promoted as segment criteria" );
+		}
+	}
+
+	/**
+	 * Schema shape — every key the consumer reads must be present.
+	 */
+	public function test_returned_schema_shape() {
+		$mapped = $this->map_field(
+			[
+				'perstag'  => 'FAVCOLOR',
+				'type'     => 'dropdown',
+				'title'    => 'Favorite Color',
+				'descript' => 'Picked at signup',
+			]
+		);
+		foreach ( [ 'key', 'name', 'value_type', 'matching_function', 'options', 'description', 'is_access_rule', 'is_segment_criteria' ] as $key ) {
+			$this->assertArrayHasKey( $key, $mapped );
+		}
+		$this->assertSame( 'FAVCOLOR', $mapped['key'] );
+		$this->assertSame( 'Favorite Color', $mapped['name'] );
+		$this->assertSame( 'Picked at signup', $mapped['description'] );
+	}
+
+	/**
+	 * `name` falls back to `perstag` when AC's `title` is missing.
+	 */
+	public function test_name_falls_back_to_perstag() {
+		$mapped = $this->map_field(
+			[
+				'perstag' => 'PHONE_NUM',
+				'type'    => 'text',
+			]
+		);
+		$this->assertSame( 'PHONE_NUM', $mapped['name'] );
+	}
+}

--- a/tests/test-mailchimp-integrations-schema.php
+++ b/tests/test-mailchimp-integrations-schema.php
@@ -1,0 +1,187 @@
+<?php
+/**
+ * Tests for the Mailchimp → Newspack integrations schema mapper.
+ *
+ * @package Newspack_Newsletters
+ */
+
+/**
+ * Lock in which Mailchimp merge-field types get auto-promoted, and the shape
+ * `Newspack_Newsletters_Mailchimp::map_merge_field_to_integration_schema()`
+ * returns. The mapper is the cross-repo contract between this plugin and
+ * newspack-plugin's ESP integration; treat it as a self-proving spec.
+ */
+class MailchimpIntegrationsSchemaTest extends WP_UnitTestCase {
+
+	/**
+	 * Invoke the private static mapper via reflection.
+	 *
+	 * @param array $field Raw merge field input.
+	 * @return array|null
+	 */
+	private function map_field( $field ) {
+		$reflection         = new ReflectionClass( 'Newspack_Newsletters_Mailchimp' );
+		$map_field_method   = $reflection->getMethod( 'map_merge_field_to_integration_schema' );
+		$map_field_method->setAccessible( true );
+		return $map_field_method->invoke( null, $field );
+	}
+
+	/**
+	 * A field without a `tag` has no usable machine key — must be skipped.
+	 */
+	public function test_skip_when_tag_missing() {
+		$this->assertNull( $this->map_field( [] ) );
+		$this->assertNull( $this->map_field( [ 'tag' => '' ] ) );
+		$this->assertNull(
+			$this->map_field(
+				[
+					'tag'  => null,
+					'name' => 'No Tag',
+				] 
+			) 
+		);
+	}
+
+	/**
+	 * Promotion eligibility matrix. Keep this in sync with the implementation.
+	 */
+	public function test_promotion_eligibility_by_type() {
+		$promoted_types  = [ 'text', 'number', 'date', 'radio', 'dropdown' ];
+		$exposed_only    = [ 'phone', 'url', 'imageurl', 'birthday', 'zip', 'address' ];
+
+		foreach ( $promoted_types as $type ) {
+			$mapped = $this->map_field(
+				[
+					'tag'  => 'T',
+					'type' => $type,
+				] 
+			);
+			$this->assertTrue( $mapped['is_access_rule'], "$type should be promoted as access rule" );
+			$this->assertTrue( $mapped['is_segment_criteria'], "$type should be promoted as segment criteria" );
+		}
+		foreach ( $exposed_only as $type ) {
+			$mapped = $this->map_field(
+				[
+					'tag'  => 'T',
+					'type' => $type,
+				] 
+			);
+			$this->assertFalse( $mapped['is_access_rule'], "$type should NOT be promoted as access rule" );
+			$this->assertFalse( $mapped['is_segment_criteria'], "$type should NOT be promoted as segment criteria" );
+		}
+	}
+
+	/**
+	 * Enumerated types (radio / dropdown) expose their inline choices as options.
+	 */
+	public function test_options_built_from_choices_for_enumerated_types() {
+		$dropdown_mapped = $this->map_field(
+			[
+				'tag'     => 'COLOR',
+				'type'    => 'dropdown',
+				'options' => [ 'choices' => [ 'Red', 'Green', 'Blue' ] ],
+			]
+		);
+		$this->assertSame(
+			[
+				[
+					'value' => 'Red',
+					'label' => 'Red',
+				],
+				[
+					'value' => 'Green',
+					'label' => 'Green',
+				],
+				[
+					'value' => 'Blue',
+					'label' => 'Blue',
+				],
+			],
+			$dropdown_mapped['options']
+		);
+
+		$text_mapped = $this->map_field(
+			[
+				'tag'  => 'NAME',
+				'type' => 'text',
+			] 
+		);
+		$this->assertSame( [], $text_mapped['options'], 'text fields have no options array' );
+
+		$dropdown_no_choices = $this->map_field(
+			[
+				'tag'  => 'EMPTY',
+				'type' => 'dropdown',
+			] 
+		);
+		$this->assertSame( [], $dropdown_no_choices['options'], 'dropdown without choices yields []' );
+	}
+
+	/**
+	 * Schema shape — every key the consumer (newspack-plugin) reads must be present.
+	 */
+	public function test_returned_schema_shape() {
+		$mapped = $this->map_field(
+			[
+				'tag'       => 'FAVCOLOR',
+				'type'      => 'dropdown',
+				'name'      => 'Favorite Color',
+				'help_text' => 'Picked at signup',
+				'options'   => [ 'choices' => [ 'Red' ] ],
+			]
+		);
+
+		$expected_keys = [
+			'key',
+			'name',
+			'value_type',
+			'matching_function',
+			'options',
+			'description',
+			'is_access_rule',
+			'is_segment_criteria',
+		];
+		foreach ( $expected_keys as $key ) {
+			$this->assertArrayHasKey( $key, $mapped, "Mapped schema must include '$key'" );
+		}
+
+		$this->assertSame( 'FAVCOLOR', $mapped['key'] );
+		$this->assertSame( 'Favorite Color', $mapped['name'] );
+		$this->assertSame( 'string', $mapped['value_type'] );
+		$this->assertSame( 'default', $mapped['matching_function'] );
+		$this->assertSame( 'Picked at signup', $mapped['description'] );
+	}
+
+	/**
+	 * `name` falls back to `tag` when missing or empty so the consumer never
+	 * has to render a blank label.
+	 */
+	public function test_name_falls_back_to_tag() {
+		$no_name = $this->map_field(
+			[
+				'tag'  => 'PHONE_NUM',
+				'type' => 'phone',
+			] 
+		);
+		$this->assertSame( 'PHONE_NUM', $no_name['name'] );
+
+		$empty_name = $this->map_field(
+			[
+				'tag'  => 'PHONE_NUM',
+				'type' => 'phone',
+				'name' => '',
+			] 
+		);
+		$this->assertSame( 'PHONE_NUM', $empty_name['name'] );
+	}
+
+	/**
+	 * Missing `type` defaults to 'text', which is in the promoted set — keep this
+	 * test so a future refactor of the default doesn't silently change promotion.
+	 */
+	public function test_missing_type_defaults_to_text_and_is_promoted() {
+		$mapped = $this->map_field( [ 'tag' => 'FOO' ] );
+		$this->assertTrue( $mapped['is_access_rule'] );
+		$this->assertTrue( $mapped['is_segment_criteria'] );
+	}
+}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-newsletters/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Rework the ESP service provider's contact-field method so the Newspack Reader Activation ESP integration can auto-configure incoming fields (access rules / segmentation criteria) based on the ESP-reported field type, and so enumerated fields (dropdown / radio / listbox / checkbox) expose their option lists in the admin UI.

- Rename `get_contact_fields()` → `get_contact_fields_for_integrations()` on the ESP service-provider base class to make the method's purpose explicit.
- Expand the returned schema from `{ key }` to a structured payload whose keys mirror Newspack `Incoming_Field` setters: `key`, `name`, `value_type`, `matching_function`, `options`, `description`, `is_access_rule`, `is_segment_criteria`.
- Mailchimp override: inspect merge-field `type` and auto-promote `text / number / date / radio / dropdown`; build `options` from the inline `options.choices` payload for `radio / dropdown`.
- ActiveCampaign override: promote `text / textarea / date / datetime / dropdown / radio / listbox / checkbox`; fetch option lists for enumerated fields via `GET /fields/{id}/options`; keep the existing 5-minute cache; all AC fields use `default` matching.
- Remove stale `var_dump()` calls from both provider overrides.

### Related PR

Paired with [Automattic/newspack-plugin#4676](https://github.com/Automattic/newspack-plugin/pull/4676), which consumes this schema in the ESP integration's `configure_incoming_field()` hook. That PR depends on this one — trunk of newspack-plugin will break against trunk of newspack-newsletters only during the window where one is merged without the other, so please coordinate merges.

### How to test the changes in this Pull Request:

1. Start the workspace, `n setup --yes`, and check out this branch.
2. Configure **Mailchimp** as the ESP with a list containing a mix of merge-field types (including a dropdown with choices).
3. Run `n wp eval 'print_r( Newspack_Newsletters_Contacts::get_fields( "<list_id>" ) );'` and verify:
   - Every entry has the new schema keys (`name`, `value_type`, `matching_function`, `options`, `is_access_rule`, `is_segment_criteria`).
   - `dropdown` / `radio` fields return a populated `options` array; other types return `options = []`.
   - `text`, `number`, `date`, `radio`, `dropdown` return both promotion flags `true`; `phone`, `url`, `imageurl`, `birthday`, `zip`, `address` return both `false`.
4. Switch the ESP to **ActiveCampaign** and rerun `n wp eval 'print_r( Newspack_Newsletters_Contacts::get_fields() );'`:
   - `text / textarea / date / datetime / dropdown / radio / listbox / checkbox` fields return both promotion flags `true`; `hidden` and NULL-typed fields return both `false`.
   - Enumerated fields have their `options` array populated from the `/v3/fields/{id}/options` endpoint.
5. With the paired newspack-plugin PR applied, verify that **Audience → Content Gates** surfaces promoted ESP fields as access rules with the right option lists, and that popups segmentation picks up the same options.
6. Confirm `get_contact_fields()` no longer exists on the provider classes (calling it directly now throws a fatal). The only callers (this repo's `Newspack_Newsletters_Contacts::get_fields()` and `newspack-plugin`'s ESP integration) have been updated.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?