### PR TITLE
docs(modernisation): record phased rollout and agent contract

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,8 +51,10 @@ Requires PHP, JS, and registration. See Constant Contact or ActiveCampaign for s
 
 <!--
 =====================================================================
-Epic branch addendum — REMOVE before merging epic/newsletters-modernisation back into trunk.
-See docs/newsletter-modernisation/CONTEXT.md "Decisions log" for context.
+Epic branch addendum — REMOVE this entire section (and apply the
+pre-merge checklist below) before merging epic/newsletters-modernisation
+back into trunk. See docs/newsletter-modernisation/CONTEXT.md
+"Decisions log" for context.
 =====================================================================
 -->
 
@@ -62,3 +64,12 @@ If you are on `epic/newsletters-modernisation` (or any feature branch off it):
 
 1. **Read `docs/newsletter-modernisation/CONTEXT.md` in full at the start of the session.** It is the authoritative record of decisions, rationale, constraints, and open questions for this work.
 2. **Treat the contract in that file's "How to use this doc" section as binding** — including the rule that PRs into the epic update the Decisions log when they introduce a decision, gotcha, learning, or shift in scope (or explicitly state "No context change." in the PR description if not).
+
+### Pre-merge checklist (epic → trunk)
+
+When merging `epic/newsletters-modernisation` back to trunk, do the following before completing the merge:
+
+1. **Remove this entire "Working on `epic/newsletters-modernisation`" section** from `AGENTS.md` (including the HTML comment marker above and this checklist). It is epic-only scaffolding.
+2. **Restore `.github/CODEOWNERS`** to its trunk content (a single line: `* @Automattic/newspack-product`). The file on this branch is currently a comment-only stub that disables auto-review requests during epic iteration.
+
+See `docs/newsletter-modernisation/CONTEXT.md` "Decisions log" for the rationale behind both items.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,3 +48,17 @@ Requires PHP, JS, and registration. See Constant Contact or ActiveCampaign for s
 4. Add provider-specific UI in `src/service-providers/<name>/`. Export an object matching the shape in `src/service-providers/index.js` (`ProviderSidebar`, `renderPreSendInfo`, `isCampaignSent`), and add it to the `SERVICE_PROVIDERS` map.
 5. Run `composer dump-autoload`.
 6. Rebuild: `n build`.
+
+<!--
+=====================================================================
+Epic branch addendum — REMOVE before merging epic/newsletters-modernisation back into trunk.
+See docs/newsletter-modernisation/CONTEXT.md "Decisions log" for context.
+=====================================================================
+-->
+
+## Working on `epic/newsletters-modernisation`
+
+If you are on `epic/newsletters-modernisation` (or any feature branch off it):
+
+1. **Read `docs/newsletter-modernisation/CONTEXT.md` in full at the start of the session.** It is the authoritative record of decisions, rationale, constraints, and open questions for this work.
+2. **Treat the contract in that file's "How to use this doc" section as binding** — including the rule that PRs into the epic update the Decisions log when they introduce a decision, gotcha, learning, or shift in scope (or explicitly state "No context change." in the PR description if not).

--- a/docs/newsletter-modernisation/CONTEXT.md
+++ b/docs/newsletter-modernisation/CONTEXT.md
@@ -4,9 +4,11 @@ This document captures the *why* behind decisions for the newsletter modernisati
 
 ## How to use this doc
 
-- Read at the start of any session on this project.
-- Every PR into `epic/newsletters-modernisation` should consider whether it introduces a decision, gotcha, learning, or shift in scope worth capturing here. If yes, update the relevant section in the same PR. If purely additive (a new gotcha, a closed open question), append to the **Decisions log** with a date prefix.
-- Tone: terse but explanatory. Future readers won't have the conversation that produced each decision — they need the reasoning, not just the conclusion.
+This is the contract for anyone — human or AI agent — working on `epic/newsletters-modernisation`:
+
+1. **Before starting a session** on this branch (or any feature branch off it): read this doc in full. It tells you what's been decided and why, and which open questions still bind.
+2. **Before opening a PR** into `epic/newsletters-modernisation`: decide whether your work introduces a decision, gotcha, learning, or shift in scope. If yes, update the relevant section and append a dated entry to the **Decisions log** in the same PR. If no context change applies, say so explicitly in the PR description (e.g. "No context change.").
+3. **Tone:** terse but explanatory. Future readers won't have the conversation that produced each decision — they need the reasoning, not just the conclusion.
 
 ## Strategy
 
@@ -32,7 +34,12 @@ class Column extends WC_Column {
 }
 ```
 
-**Hard constraint:** existing in-flight newsletters must keep rendering through MJML during migration. Drafts cannot be broken. Migration runs behind a feature flag with a dual-pipeline period.
+**Rollout: dual pipelines behind a feature flag, not a big-bang switch.** Newsletters are brittle and critical — a phased rollout is the safe path. Both pipelines coexist for a soak period:
+
+- New newsletters created post-flag opt into the WC pipeline.
+- Existing in-flight newsletters and drafts continue rendering through MJML and must not break.
+- A documented migration path lets publishers switch deliberately when ready.
+- The flag stays in place until block-by-block QA and email-client testing pass; only then is MJML removed.
 
 **Parallel decision (not solved by replacing the PHP path):** the JS-side `mjml-browser` editor preview in `src/editor/mjml/index.js` also needs to be replaced — either with `@woocommerce/email-editor` JS, a server round-trip, or a hybrid.
 
@@ -48,6 +55,8 @@ Three workstreams running in parallel:
 
 A running list of decisions made as the project progresses. Newest entries at the top.
 
+- **2026-04-28** — Confirmed phased rollout via dual pipelines + feature flag, not a big-bang cutover. New newsletters created post-flag opt into the WC pipeline; existing drafts continue rendering through MJML; the flag stays until block-by-block QA and email-client testing pass. The rollout work is captured as a dedicated work item in the Editor refactor backlog.
+- **2026-04-28** — Added an epic-only addendum to `AGENTS.md` pointing agents at this doc as the authoritative contract for sessions on `epic/newsletters-modernisation`. **When merging epic → trunk, remove the addendum** — see the inline marker in `AGENTS.md` ("Epic branch addendum").
 - **2026-04-27** — Project kick-off. WC email-editor confirmed as the replacement for MJML, with the downstream override pattern for impedance mismatches.
 - **2026-04-27** — Overrode `.github/CODEOWNERS` on this branch (emptied to a comment-only file) to skip auto-review requests from `@Automattic/newspack-product` during long-running iteration on the epic. **When merging epic → trunk, restore the original rule (`* @Automattic/newspack-product`)** — the `.github/CODEOWNERS` file on this branch carries an inline reminder for whoever performs the merge.
 


### PR DESCRIPTION
## Summary

- Promotes the dual-pipeline rollout from a buried "Hard constraint" line into its own paragraph in the Strategy section, with phased-rollout language (new newsletters opt into the WC pipeline behind the flag; existing drafts keep rendering through MJML; flag stays until QA and email-client testing pass).
- Rewrites the "How to use this doc" section as an explicit contract for humans and AI agents — read in full at session start; update the Decisions log on PRs into the epic, or explicitly note "No context change." in the PR body.
- Adds an epic-only addendum to `AGENTS.md` pointing agents at `docs/newsletter-modernisation/CONTEXT.md` as the authoritative contract when working on `epic/newsletters-modernisation`. The addendum has a clear "REMOVE before merging epic → trunk" marker and a matching entry in the Decisions log alongside the existing CODEOWNERS reminder.

## Decisions log

Two new entries dated 2026-04-28: one confirming the phased-rollout direction, one flagging the AGENTS.md addendum for removal at the eventual epic → trunk merge.

## Test plan

- [ ] Skim `docs/newsletter-modernisation/CONTEXT.md` end-to-end and check the Strategy section reads as a phased rollout, not a hard cutover.
- [ ] Confirm `AGENTS.md` builds on the existing structure and the "Epic branch addendum" marker is unmissable for whoever merges epic to trunk.