### PR TITLE
docs(modernisation): clarify rollout wording and bracket epic addendum

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -73,3 +73,9 @@ When merging `epic/newsletters-modernisation` back to trunk, do the following be
 2. **Restore `.github/CODEOWNERS`** to its trunk content (a single line: `* @Automattic/newspack-product`). The file on this branch is currently a comment-only stub that disables auto-review requests during epic iteration.
 
 See `docs/newsletter-modernisation/CONTEXT.md` "Decisions log" for the rationale behind both items.
+
+<!--
+=====================================================================
+END epic branch addendum — anything below this marker is shared with trunk.
+=====================================================================
+-->

--- a/docs/newsletter-modernisation/CONTEXT.md
+++ b/docs/newsletter-modernisation/CONTEXT.md
@@ -36,7 +36,7 @@ class Column extends WC_Column {
 
 **Rollout: dual pipelines behind a feature flag, not a big-bang switch.** Newsletters are brittle and critical — a phased rollout is the safe path. Both pipelines coexist for a soak period:
 
-- New newsletters created post-flag opt into the WC pipeline.
+- New newsletters created with the flag enabled opt into the WC pipeline.
 - Existing in-flight newsletters and drafts continue rendering through MJML and must not break.
 - A documented migration path lets publishers switch deliberately when ready.
 - The flag stays in place until block-by-block QA and email-client testing pass; only then is MJML removed.
@@ -55,7 +55,7 @@ Three workstreams running in parallel:
 
 A running list of decisions made as the project progresses. Newest entries at the top.
 
-- **2026-04-28** — Confirmed phased rollout via dual pipelines + feature flag, not a big-bang cutover. New newsletters created post-flag opt into the WC pipeline; existing drafts continue rendering through MJML; the flag stays until block-by-block QA and email-client testing pass. The rollout work is captured as a dedicated work item in the Editor refactor backlog.
+- **2026-04-28** — Confirmed phased rollout via dual pipelines + feature flag, not a big-bang cutover. New newsletters created with the flag enabled opt into the WC pipeline; existing drafts continue rendering through MJML; the flag stays until block-by-block QA and email-client testing pass. The rollout work is captured as a dedicated work item in the Editor refactor backlog.
 - **2026-04-28** — Added an epic-only addendum to `AGENTS.md` pointing agents at this doc as the authoritative contract for sessions on `epic/newsletters-modernisation`. **When merging epic → trunk, remove the addendum** — see the inline marker in `AGENTS.md` ("Epic branch addendum").
 - **2026-04-27** — Project kick-off. WC email-editor confirmed as the replacement for MJML, with the downstream override pattern for impedance mismatches.
 - **2026-04-27** — Overrode `.github/CODEOWNERS` on this branch (emptied to a comment-only file) to skip auto-review requests from `@Automattic/newspack-product` during long-running iteration on the epic. **When merging epic → trunk, restore the original rule (`* @Automattic/newspack-product`)** — the `.github/CODEOWNERS` file on this branch carries an inline reminder for whoever performs the merge.


### PR DESCRIPTION
## Summary

Addresses Copilot feedback from #2088 (already merged):

- **CONTEXT.md** — replaces the ambiguous "post-flag" phrasing in the Strategy bullet and the matching Decisions log entry with "with the flag enabled". "Post-flag" could be misread as "after the flag is removed", which is the opposite of the intended meaning.
- **AGENTS.md** — adds a closing `END epic branch addendum` HTML comment so the section is bracketed top and bottom. Makes mechanical removal at the eventual epic → trunk merge safer (no risk of leaving a stray paragraph behind).

No context change. The decision and rollout direction remain identical; this PR is a clarity / safety pass on the wording.

## Test plan

- [ ] CONTEXT.md Strategy and Decisions log read unambiguously now.
- [ ] AGENTS.md addendum has matching START and END markers, and the END marker explicitly notes that anything below it is shared with trunk.