### PR TITLE
docs(modernisation): adopt three-tier milestone branching

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,10 +60,11 @@ back into trunk. See docs/newsletter-modernisation/CONTEXT.md
 
 ## Working on `epic/newsletters-modernisation`
 
-If you are on `epic/newsletters-modernisation` (or any feature branch off it):
+If you are on `epic/newsletters-modernisation`, on a milestone integration branch (`epic/<milestone>`, e.g. `epic/admin-ux-modernisation`), or on a per-ticket branch off either:
 
-1. **Read `docs/newsletter-modernisation/CONTEXT.md` in full at the start of the session.** It is the authoritative record of decisions, rationale, constraints, and open questions for this work.
-2. **Treat the contract in that file's "How to use this doc" section as binding** — including the rule that PRs into the epic update the Decisions log when they introduce a decision, gotcha, learning, or shift in scope (or explicitly state "No context change." in the PR description if not).
+1. **Read `docs/newsletter-modernisation/CONTEXT.md` in full at the start of the session.** It is the authoritative record of decisions, rationale, constraints, and open questions for this work — including the *Branch structure* section that defines which base branch your PR should target.
+2. **Treat the contract in that file's "How to use this doc" section as binding.** Per-ticket PRs target their milestone integration branch (`epic/<milestone>`), not the project epic directly. PRs into either branch update the Decisions log when they introduce a decision, gotcha, learning, or shift in scope (or explicitly state "No context change." in the PR description if not).
+3. **When in doubt about which milestone branch is yours**, look up the Linear ticket's milestone and kebab-case the milestone name (e.g. "Admin UX modernisation" → `epic/admin-ux-modernisation`). Cut the per-ticket branch from there and target the same branch with your PR.
 
 ### Pre-merge checklist (epic → trunk)
 

--- a/docs/newsletter-modernisation/CONTEXT.md
+++ b/docs/newsletter-modernisation/CONTEXT.md
@@ -4,11 +4,25 @@ This document captures the *why* behind decisions for the newsletter modernisati
 
 ## How to use this doc
 
-This is the contract for anyone — human or AI agent — working on `epic/newsletters-modernisation`:
+This is the contract for anyone — human or AI agent — working on this project:
 
-1. **Before starting a session** on this branch (or any feature branch off it): read this doc in full. It tells you what's been decided and why, and which open questions still bind.
-2. **Before opening a PR** into `epic/newsletters-modernisation`: decide whether your work introduces a decision, gotcha, learning, or shift in scope. If yes, update the relevant section and append a dated entry to the **Decisions log** in the same PR. If no context change applies, say so explicitly in the PR description (e.g. "No context change.").
+1. **Before starting a session** on any branch in this project (the project epic, a milestone integration branch, or a per-ticket branch off either): read this doc in full. It tells you what's been decided and why, and which open questions still bind.
+2. **Before opening a PR**: identify the right base branch (see *Branch structure* below — per-ticket PRs target their milestone branch, not the project epic). Decide whether your work introduces a decision, gotcha, learning, or shift in scope. If yes, update the relevant section and append a dated entry to the **Decisions log** in the same PR. If no context change applies, say so explicitly in the PR description (e.g. "No context change.").
 3. **Tone:** terse but explanatory. Future readers won't have the conversation that produced each decision — they need the reasoning, not just the conclusion.
+
+## Branch structure
+
+Three tiers:
+
+- **`epic/newsletters-modernisation`** — the project epic. Receives only milestone-integration merges. Ultimately merges to `trunk`.
+- **`epic/<milestone>`** — one integration branch per Linear milestone (e.g. `epic/admin-ux-modernisation`, `epic/editor-refactor`, `epic/beehiiv`, `epic/de-risk`, `epic/validate`). Receives per-ticket PRs and is QA'd as a coherent unit before promoting to the project epic. Naming: kebab-case version of the Linear milestone name.
+- **`news-<id>-<slug>`** — per-ticket branch cut from its milestone integration branch. PRs target the milestone branch.
+
+**Why three tiers.** Newsletters are critical and the modernisation is wide-ranging. We want each milestone to land on the project epic only after it's been tested as a unit (cross-ticket integration, regression sweep, manual UAT). Per-ticket review still happens via individual PRs into the milestone branch — Copilot review, lint, tests — so nothing skips the per-ticket gate.
+
+**Promoting a milestone:** once a milestone branch is fully QA'd, open a single PR `epic/<milestone>` → `epic/newsletters-modernisation`. Treat that PR as the integration-test gate.
+
+**Promoting the project:** once the project epic is ready, open a final PR `epic/newsletters-modernisation` → `trunk`. The pre-merge checklist for that step lives in `AGENTS.md`.
 
 ## Strategy
 
@@ -55,6 +69,7 @@ Three workstreams running in parallel:
 
 A running list of decisions made as the project progresses. Newest entries at the top.
 
+- **2026-04-29** — **Adopted three-tier branching as a project-wide convention.** Each Linear milestone gets its own `epic/<milestone>` integration branch (kebab-case) cut from `epic/newsletters-modernisation`; per-ticket branches target the milestone branch; a single promotion PR moves a fully-QA'd milestone up to the project epic. First instance: `epic/admin-ux-modernisation`. Reasoning: per-ticket gates (Copilot review, lint, tests) still happen at PR time, but the project epic only sees integration-tested units, which is what we need given how brittle the newsletter pipeline is. See *Branch structure* above for the full mechanics.
 - **2026-04-29** — Expanded the UX workstream from "Layouts UX rework" to **Admin UX modernisation**. Scope is now the entire Newsletters admin in React (DataViews + React shells), aligned with `newspack-plugin`'s pattern. Layouts becomes a first-class section nested inside the broader migration with its own admin menu and DataView. Standalone-vs-bundled parity is called out explicitly so design accounts for both deployment modes from the start.
 - **2026-04-28** — Confirmed phased rollout via dual pipelines + feature flag, not a big-bang cutover. New newsletters created with the flag enabled opt into the WC pipeline; existing drafts continue rendering through MJML; the flag stays until block-by-block QA and email-client testing pass. The rollout work is captured as a dedicated work item in the Editor refactor backlog.
 - **2026-04-28** — Added an epic-only addendum to `AGENTS.md` pointing agents at this doc as the authoritative contract for sessions on `epic/newsletters-modernisation`. **When merging epic → trunk, remove the addendum** — see the inline marker in `AGENTS.md` ("Epic branch addendum").


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Documents the layered branch convention we're adopting for the modernisation project: each Linear milestone gets its own integration branch (`epic/<milestone>`) cut from the project epic; per-ticket PRs target the milestone branch; and a single promotion PR moves a fully-QA'd milestone up to `epic/newsletters-modernisation`. The project epic only sees integration-tested units, not individual tickets.

Per-ticket gates (Copilot review, lint, tests) still happen at PR time — nothing skips the per-ticket review. The new layer adds a deliberate integration-test gate before anything reaches the project epic, which matters given how brittle the newsletter pipeline is.

Updates `docs/newsletter-modernisation/CONTEXT.md` with a new *Branch structure* section, refreshes the *How to use this doc* contract, and appends the decision to the log. Updates `AGENTS.md` so AI agents working on any milestone branch (or per-ticket branch off one) know to use the layered structure and identify the correct base branch from the ticket's Linear milestone.

The first instance of this pattern is `epic/admin-ux-modernisation`, which is already in flight (PR #2091 retargeted to it earlier today).

No code changes; documentation only.

### How to test the changes in this Pull Request:

1. Read the updated `docs/newsletter-modernisation/CONTEXT.md` *Branch structure* section &mdash; confirm the three-tier hierarchy is clearly explained (project epic / milestone branch / per-ticket).
2. Read the updated `AGENTS.md` *Working on `epic/newsletters-modernisation`* section &mdash; confirm an agent landing on a milestone branch (or per-ticket branch off one) would correctly identify the right base branch for their PR.
3. Sanity-check the kebab-case mapping rule by mentally translating each existing Linear milestone name to a branch name (Admin UX modernisation, Editor refactor, beehiiv, De-risk, Validate).
4. Confirm the *Pre-merge checklist (epic &rarr; trunk)* in `AGENTS.md` is left intact &mdash; the CODEOWNERS / addendum restoration only happens at the final epic &rarr; trunk merge, not at intermediate milestone &rarr; epic merges.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable? &mdash; documentation only, no tests.
* [x] Have you successfully ran tests with your changes locally?