### PR TITLE
docs(modernisation): require branch-protection waiver for milestone branches

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,6 +65,7 @@ If you are on `epic/newsletters-modernisation`, on a milestone integration branc
 1. **Read `docs/newsletter-modernisation/CONTEXT.md` in full at the start of the session.** It is the authoritative record of decisions, rationale, constraints, and open questions for this work — including the *Branch structure* section that defines which base branch your PR should target.
 2. **Treat the contract in that file's "How to use this doc" section as binding.** Per-ticket PRs target their milestone integration branch (`epic/<milestone>`), not the project epic directly. PRs into either branch update the Decisions log when they introduce a decision, gotcha, learning, or shift in scope (or explicitly state "No context change." in the PR description if not).
 3. **When in doubt about which milestone branch is yours**, look up the Linear ticket's milestone and kebab-case the milestone name (e.g. "Admin UX modernisation" → `epic/admin-ux-modernisation`). Cut the per-ticket branch from there and target the same branch with your PR.
+4. **When creating a fresh milestone integration branch**, after pushing it to origin ask the project owner to extend the project epic's branch-protection waiver to the new branch (or use a glob like `epic/*` so it inherits automatically). Without it, PRs targeting the new milestone branch are `BLOCKED` by the org-default review-required rule even though Copilot review passes. CODEOWNERS inherits via branching; branch-protection does not. See *Branch structure* in CONTEXT.md.
 
 ### Pre-merge checklist (epic → trunk)
 

--- a/docs/newsletter-modernisation/CONTEXT.md
+++ b/docs/newsletter-modernisation/CONTEXT.md
@@ -24,6 +24,13 @@ Three tiers:
 
 **Promoting the project:** once the project epic is ready, open a final PR `epic/newsletters-modernisation` → `trunk`. The pre-merge checklist for that step lives in `AGENTS.md`.
 
+**Creating a new milestone integration branch.** When you cut a fresh `epic/<milestone>` from the project epic, also configure repo settings so PRs into it follow the same convention as the project epic:
+
+- **Branch protection:** waive the review-required rule for `epic/<milestone>` (or use a glob pattern like `epic/*` so all integration branches inherit the waiver). Without this, PRs into the new milestone branch are `BLOCKED` by the org-default review-required rule even though Copilot review passes — the per-ticket gate is the Copilot pass at PR time, not a CODEOWNERS approval.
+- **CODEOWNERS:** the empty stub on the project epic is inherited automatically when you branch, so no separate action is needed.
+
+Reasoning: long-running integration branches (the project epic and milestone branches alike) intentionally accumulate per-ticket PRs without per-PR human approval. The integration-test gate is the *promotion* PR (milestone → epic, then epic → trunk), not the individual tickets. See the `2026-04-27` Decisions log entry for the original rationale on the project epic.
+
 ## Strategy
 
 Replace the MJML rendering pipeline with [`woocommerce/email-editor`](https://packagist.org/packages/woocommerce/email-editor) — an actively maintained PHP package; the same engine MailPoet uses.
@@ -69,6 +76,7 @@ Three workstreams running in parallel:
 
 A running list of decisions made as the project progresses. Newest entries at the top.
 
+- **2026-04-29** — **Milestone integration branches need their own branch-protection waiver.** Discovered when trying to merge PR #2091 into the freshly-created `epic/admin-ux-modernisation`: the merge was `BLOCKED` by the org-default review-required rule because the project epic's review waiver doesn't propagate to new branches. CODEOWNERS does inherit (the empty stub is a file on the branch) but branch-protection rules are repo-config, set per branch or via a glob pattern. Documented the configuration step in *Branch structure* and mirrored the reminder in `AGENTS.md` so future milestone branches are set up at creation time. Recommendation: configure the rule once with a glob like `epic/*` so all integration branches inherit the waiver automatically.
 - **2026-04-29** — **Adopted three-tier branching as a project-wide convention.** Each Linear milestone gets its own `epic/<milestone>` integration branch (kebab-case) cut from `epic/newsletters-modernisation`; per-ticket branches target the milestone branch; a single promotion PR moves a fully-QA'd milestone up to the project epic. First instance: `epic/admin-ux-modernisation`. Reasoning: per-ticket gates (Copilot review, lint, tests) still happen at PR time, but the project epic only sees integration-tested units, which is what we need given how brittle the newsletter pipeline is. See *Branch structure* above for the full mechanics.
 - **2026-04-29** — Expanded the UX workstream from "Layouts UX rework" to **Admin UX modernisation**. Scope is now the entire Newsletters admin in React (DataViews + React shells), aligned with `newspack-plugin`'s pattern. Layouts becomes a first-class section nested inside the broader migration with its own admin menu and DataView. Standalone-vs-bundled parity is called out explicitly so design accounts for both deployment modes from the start.
 - **2026-04-28** — Confirmed phased rollout via dual pipelines + feature flag, not a big-bang cutover. New newsletters created with the flag enabled opt into the WC pipeline; existing drafts continue rendering through MJML; the flag stays until block-by-block QA and email-client testing pass. The rollout work is captured as a dedicated work item in the Editor refactor backlog.


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Documents the operational step missing from the three-tier branching convention: when a fresh `epic/<milestone>` branch is cut from the project epic, the repo's branch-protection rule must be extended to it (either explicitly or via a glob like `epic/*`). Without this, PRs targeting the new milestone branch are `BLOCKED` by the org-default review-required rule even when Copilot review passes &mdash; observed first-hand attempting to merge PR #2091 into the freshly-created `epic/admin-ux-modernisation`.

CODEOWNERS inherits when branching (the empty stub is a file on the branch), but branch-protection rules are repo-config and don't propagate &mdash; that's the gap we missed. The doc now spells out the configuration step in the *Branch structure* section, mirrors a reminder in `AGENTS.md` so any human or agent creating a new milestone branch knows to do it, and recommends a glob pattern as the long-term solution.

No code changes; documentation only.

### How to test the changes in this Pull Request:

1. Read the updated `docs/newsletter-modernisation/CONTEXT.md` *Branch structure* section &mdash; confirm the *Creating a new milestone integration branch* subsection clearly explains the branch-protection step and the inheritance gotcha.
2. Read the updated `AGENTS.md` *Working on epic/newsletters-modernisation* section &mdash; confirm the new bullet 4 reminds whoever creates a milestone branch to ask for the waiver.
3. Confirm the Decisions log entry references the discovery context (PR #2091 hitting `BLOCKED`) so the rationale is preserved.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable? &mdash; documentation only, no tests.
* [x] Have you successfully ran tests with your changes locally?