### PR TITLE
chore: forward-merge epic/newsletters-modernisation into epic/admin-ux-modernisation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,6 +65,7 @@ If you are on `epic/newsletters-modernisation`, on a milestone integration branc
 1. **Read `docs/newsletter-modernisation/CONTEXT.md` in full at the start of the session.** It is the authoritative record of decisions, rationale, constraints, and open questions for this work — including the *Branch structure* section that defines which base branch your PR should target.
 2. **Treat the contract in that file's "How to use this doc" section as binding.** Per-ticket PRs target their milestone integration branch (`epic/<milestone>`), not the project epic directly. PRs into either branch update the Decisions log when they introduce a decision, gotcha, learning, or shift in scope (or explicitly state "No context change." in the PR description if not).
 3. **When in doubt about which milestone branch is yours**, look up the Linear ticket's milestone and kebab-case the milestone name (e.g. "Admin UX modernisation" → `epic/admin-ux-modernisation`). Cut the per-ticket branch from there and target the same branch with your PR.
+4. **When creating a fresh milestone integration branch**, after pushing it to origin ask the project owner to extend the project epic's branch-protection waiver to the new branch (or use a glob like `epic/*` so it inherits automatically). Without it, PRs targeting the new milestone branch are `BLOCKED` by the org-default review-required rule even though Copilot review passes. CODEOWNERS inherits via branching; branch-protection does not. See *Branch structure* in CONTEXT.md.
 
 ### Pre-merge checklist (epic → trunk)
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,10 +60,11 @@ back into trunk. See docs/newsletter-modernisation/CONTEXT.md
 
 ## Working on `epic/newsletters-modernisation`
 
-If you are on `epic/newsletters-modernisation` (or any feature branch off it):
+If you are on `epic/newsletters-modernisation`, on a milestone integration branch (`epic/<milestone>`, e.g. `epic/admin-ux-modernisation`), or on a per-ticket branch off either:
 
-1. **Read `docs/newsletter-modernisation/CONTEXT.md` in full at the start of the session.** It is the authoritative record of decisions, rationale, constraints, and open questions for this work.
-2. **Treat the contract in that file's "How to use this doc" section as binding** — including the rule that PRs into the epic update the Decisions log when they introduce a decision, gotcha, learning, or shift in scope (or explicitly state "No context change." in the PR description if not).
+1. **Read `docs/newsletter-modernisation/CONTEXT.md` in full at the start of the session.** It is the authoritative record of decisions, rationale, constraints, and open questions for this work — including the *Branch structure* section that defines which base branch your PR should target.
+2. **Treat the contract in that file's "How to use this doc" section as binding.** Per-ticket PRs target their milestone integration branch (`epic/<milestone>`), not the project epic directly. PRs into either branch update the Decisions log when they introduce a decision, gotcha, learning, or shift in scope (or explicitly state "No context change." in the PR description if not).
+3. **When in doubt about which milestone branch is yours**, look up the Linear ticket's milestone and kebab-case the milestone name (e.g. "Admin UX modernisation" → `epic/admin-ux-modernisation`). Cut the per-ticket branch from there and target the same branch with your PR.
 
 ### Pre-merge checklist (epic → trunk)
 

--- a/docs/newsletter-modernisation/CONTEXT.md
+++ b/docs/newsletter-modernisation/CONTEXT.md
@@ -24,6 +24,13 @@ Three tiers:
 
 **Promoting the project:** once the project epic is ready, open a final PR `epic/newsletters-modernisation` → `trunk`. The pre-merge checklist for that step lives in `AGENTS.md`.
 
+**Creating a new milestone integration branch.** When you cut a fresh `epic/<milestone>` from the project epic, also configure repo settings so PRs into it follow the same convention as the project epic:
+
+- **Branch protection:** waive the review-required rule for `epic/<milestone>` (or use a glob pattern like `epic/*` so all integration branches inherit the waiver). Without this, PRs into the new milestone branch are `BLOCKED` by the org-default review-required rule even though Copilot review passes — the per-ticket gate is the Copilot pass at PR time, not a CODEOWNERS approval.
+- **CODEOWNERS:** the empty stub on the project epic is inherited automatically when you branch, so no separate action is needed.
+
+Reasoning: long-running integration branches (the project epic and milestone branches alike) intentionally accumulate per-ticket PRs without per-PR human approval. The integration-test gate is the *promotion* PR (milestone → epic, then epic → trunk), not the individual tickets. See the `2026-04-27` Decisions log entry for the original rationale on the project epic.
+
 ## Strategy
 
 Replace the MJML rendering pipeline with [`woocommerce/email-editor`](https://packagist.org/packages/woocommerce/email-editor) — an actively maintained PHP package; the same engine MailPoet uses.
@@ -69,6 +76,7 @@ Three workstreams running in parallel:
 
 A running list of decisions made as the project progresses. Newest entries at the top.
 
+- **2026-04-29** — **Milestone integration branches need their own branch-protection waiver.** Discovered when trying to merge PR #2091 into the freshly-created `epic/admin-ux-modernisation`: the merge was `BLOCKED` by the org-default review-required rule because the project epic's review waiver doesn't propagate to new branches. CODEOWNERS does inherit (the empty stub is a file on the branch) but branch-protection rules are repo-config, set per branch or via a glob pattern. Documented the configuration step in *Branch structure* and mirrored the reminder in `AGENTS.md` so future milestone branches are set up at creation time. Recommendation: configure the rule once with a glob like `epic/*` so all integration branches inherit the waiver automatically.
 - **2026-04-29** — **Adopted three-tier branching as a project-wide convention.** Each Linear milestone gets its own `epic/<milestone>` integration branch (kebab-case) cut from `epic/newsletters-modernisation`; per-ticket branches target the milestone branch; a single promotion PR moves a fully-QA'd milestone up to the project epic. First instance: `epic/admin-ux-modernisation`. Reasoning: per-ticket gates (Copilot review, lint, tests) still happen at PR time, but the project epic only sees integration-tested units, which is what we need given how brittle the newsletter pipeline is. See *Branch structure* above for the full mechanics.
 - **2026-04-29** — Expanded the UX workstream from "Layouts UX rework" to **Admin UX modernisation**. Scope is now the entire Newsletters admin in React (DataViews + React shells), aligned with `newspack-plugin`'s pattern. Layouts becomes a first-class section nested inside the broader migration with its own admin menu and DataView. Standalone-vs-bundled parity is called out explicitly so design accounts for both deployment modes from the start.
 - **2026-04-28** — Confirmed phased rollout via dual pipelines + feature flag, not a big-bang cutover. New newsletters created with the flag enabled opt into the WC pipeline; existing drafts continue rendering through MJML; the flag stays until block-by-block QA and email-client testing pass. The rollout work is captured as a dedicated work item in the Editor refactor backlog.

--- a/docs/newsletter-modernisation/CONTEXT.md
+++ b/docs/newsletter-modernisation/CONTEXT.md
@@ -4,11 +4,25 @@ This document captures the *why* behind decisions for the newsletter modernisati
 
 ## How to use this doc
 
-This is the contract for anyone — human or AI agent — working on `epic/newsletters-modernisation`:
+This is the contract for anyone — human or AI agent — working on this project:
 
-1. **Before starting a session** on this branch (or any feature branch off it): read this doc in full. It tells you what's been decided and why, and which open questions still bind.
-2. **Before opening a PR** into `epic/newsletters-modernisation`: decide whether your work introduces a decision, gotcha, learning, or shift in scope. If yes, update the relevant section and append a dated entry to the **Decisions log** in the same PR. If no context change applies, say so explicitly in the PR description (e.g. "No context change.").
+1. **Before starting a session** on any branch in this project (the project epic, a milestone integration branch, or a per-ticket branch off either): read this doc in full. It tells you what's been decided and why, and which open questions still bind.
+2. **Before opening a PR**: identify the right base branch (see *Branch structure* below — per-ticket PRs target their milestone branch, not the project epic). Decide whether your work introduces a decision, gotcha, learning, or shift in scope. If yes, update the relevant section and append a dated entry to the **Decisions log** in the same PR. If no context change applies, say so explicitly in the PR description (e.g. "No context change.").
 3. **Tone:** terse but explanatory. Future readers won't have the conversation that produced each decision — they need the reasoning, not just the conclusion.
+
+## Branch structure
+
+Three tiers:
+
+- **`epic/newsletters-modernisation`** — the project epic. Receives only milestone-integration merges. Ultimately merges to `trunk`.
+- **`epic/<milestone>`** — one integration branch per Linear milestone (e.g. `epic/admin-ux-modernisation`, `epic/editor-refactor`, `epic/beehiiv`, `epic/de-risk`, `epic/validate`). Receives per-ticket PRs and is QA'd as a coherent unit before promoting to the project epic. Naming: kebab-case version of the Linear milestone name.
+- **`news-<id>-<slug>`** — per-ticket branch cut from its milestone integration branch. PRs target the milestone branch.
+
+**Why three tiers.** Newsletters are critical and the modernisation is wide-ranging. We want each milestone to land on the project epic only after it's been tested as a unit (cross-ticket integration, regression sweep, manual UAT). Per-ticket review still happens via individual PRs into the milestone branch — Copilot review, lint, tests — so nothing skips the per-ticket gate.
+
+**Promoting a milestone:** once a milestone branch is fully QA'd, open a single PR `epic/<milestone>` → `epic/newsletters-modernisation`. Treat that PR as the integration-test gate.
+
+**Promoting the project:** once the project epic is ready, open a final PR `epic/newsletters-modernisation` → `trunk`. The pre-merge checklist for that step lives in `AGENTS.md`.
 
 ## Strategy
 
@@ -55,6 +69,7 @@ Three workstreams running in parallel:
 
 A running list of decisions made as the project progresses. Newest entries at the top.
 
+- **2026-04-29** — **Adopted three-tier branching as a project-wide convention.** Each Linear milestone gets its own `epic/<milestone>` integration branch (kebab-case) cut from `epic/newsletters-modernisation`; per-ticket branches target the milestone branch; a single promotion PR moves a fully-QA'd milestone up to the project epic. First instance: `epic/admin-ux-modernisation`. Reasoning: per-ticket gates (Copilot review, lint, tests) still happen at PR time, but the project epic only sees integration-tested units, which is what we need given how brittle the newsletter pipeline is. See *Branch structure* above for the full mechanics.
 - **2026-04-29** — Expanded the UX workstream from "Layouts UX rework" to **Admin UX modernisation**. Scope is now the entire Newsletters admin in React (DataViews + React shells), aligned with `newspack-plugin`'s pattern. Layouts becomes a first-class section nested inside the broader migration with its own admin menu and DataView. Standalone-vs-bundled parity is called out explicitly so design accounts for both deployment modes from the start.
 - **2026-04-28** — Confirmed phased rollout via dual pipelines + feature flag, not a big-bang cutover. New newsletters created with the flag enabled opt into the WC pipeline; existing drafts continue rendering through MJML; the flag stays until block-by-block QA and email-client testing pass. The rollout work is captured as a dedicated work item in the Editor refactor backlog.
 - **2026-04-28** — Added an epic-only addendum to `AGENTS.md` pointing agents at this doc as the authoritative contract for sessions on `epic/newsletters-modernisation`. **When merging epic → trunk, remove the addendum** — see the inline marker in `AGENTS.md` ("Epic branch addendum").


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Forward-merges `epic/newsletters-modernisation` into `epic/admin-ux-modernisation` so the milestone integration branch picks up the docs updates that landed on the project epic while the chassis was in flight (PR #2092 three-tier branching, PR #2093 milestone branch-protection waiver).

This is the first instance of the propagation step the new convention requires &mdash; whenever the project epic accumulates changes that should be visible to milestone branches, a forward-merge keeps them in sync. Done as a regular merge (not squash) to preserve history on both sides.

A merge conflict on the CONTEXT.md decisions log was expected (both sides added 2026-04-29 entries) and resolved additively: kept all entries from both branches, ordered newest-first into a single chronological narrative.

No code changes; documentation propagation only.

### How to test the changes in this Pull Request:

1. Confirm the PR diff against `epic/admin-ux-modernisation` shows the *Branch structure* / *Creating a new milestone integration branch* additions in CONTEXT.md and the bullet 4 addition in AGENTS.md.
2. Confirm the CONTEXT.md decisions log on this branch lists, top-to-bottom: branch-protection waiver, three-tier branching, NEWS-1927 chassis correction, NEWS-1927 chassis ships, workstream expansion, and the older entries unchanged.
3. Confirm the merge graph (`git log --graph`) shows the two histories joining at the merge commit, with the chassis (#2091) commit on the milestone side and the docs (#2092, #2093) commits on the project-epic side both reachable.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable? &mdash; documentation propagation only, no tests.
* [x] Have you successfully ran tests with your changes locally?