### PR TITLE
fix: hide font family option from newsletter

### DIFF
--- a/includes/class-newspack-newsletters-editor.php
+++ b/includes/class-newspack-newsletters-editor.php
@@ -198,6 +198,12 @@ final class Newspack_Newsletters_Editor {
 			$editor_settings['__experimentalFeatures']['layout']['wideSize']    = $email_width;
 		}
 
+		// Hide the font-family picker — registered fonts (including those added
+		// via Appearance > Fonts) cannot be relied on to render in email clients.
+		if ( isset( $editor_settings['__experimentalFeatures']['typography'] ) ) {
+			$editor_settings['__experimentalFeatures']['typography']['fontFamilies'] = [];
+		}
+
 		return $editor_settings;
 	}
 

--- a/includes/class-newspack-newsletters-editor.php
+++ b/includes/class-newspack-newsletters-editor.php
@@ -46,7 +46,7 @@ final class Newspack_Newsletters_Editor {
 	public function __construct() {
 		add_action( 'init', [ __CLASS__, 'register_meta' ] );
 		add_filter( 'block_editor_settings_all', [ __CLASS__, 'disable_autosave' ], 10, 2 );
-		add_filter( 'block_editor_settings_all', [ __CLASS__, 'override_editor_layout' ], 10, 2 );
+		add_filter( 'block_editor_settings_all', [ __CLASS__, 'override_email_editor_settings' ], 10, 2 );
 		add_action( 'the_post', [ __CLASS__, 'strip_editor_modifications' ] );
 		add_action( 'after_setup_theme', [ __CLASS__, 'newspack_font_sizes' ], 11 );
 		add_filter( 'wp_theme_json_data_theme', [ __CLASS__, 'override_theme_json_for_email_editor' ] );
@@ -171,18 +171,20 @@ final class Newspack_Newsletters_Editor {
 	}
 
 	/**
-	 * Override the editor layout settings for the newsletter editor.
+	 * Override the editor settings and width for the newsletter editor.
 	 *
 	 * Block themes provide layout settings (contentSize, wideSize) via
 	 * block_editor_settings_all that control block widths in the editor.
 	 * For the newsletter editor, all blocks should use the email max-width.
+	 *
+	 * This function also hides the 'font' family option from the Typography panel.
 	 *
 	 * @param array                   $editor_settings      Default editor settings.
 	 * @param WP_Block_Editor_Context $block_editor_context The current block editor context.
 	 *
 	 * @return array
 	 */
-	public static function override_editor_layout( $editor_settings, $block_editor_context ) {
+	public static function override_email_editor_settings( $editor_settings, $block_editor_context ) {
 		if (
 			! isset( $block_editor_context->post->post_type ) ||
 			! in_array( $block_editor_context->post->post_type, self::get_email_editor_cpts(), true )


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

WordPress 7.0 introduces an Appearance > Fonts page. While this is somewhat redundant to the font options in the Newspack theme, it has a couple nice benefits:

* It can be used to upload font files, which then preview in the editor. We previously did this by SFTPing fonts and using Custom CSS, which doesn't preview in the editor.
* It adds an option to change the font face on a per-block basis, which can be nice. 

There's some risks but on the whole it seems like a net positive... one issue is that the font family absolutely will not work in the Newsletter, so this PR removes it. It also renames an editor function to capture that it's now doing more than changing the layout width.

Closes NEWS-1625

### How to test the changes in this Pull Request:

1. On a site running the latest WordPress RC, navigate to Appearance > Fonts.
2. Click Install Fonts, allow Google Fonts, pick at least one font and install a variant by checking at least one weight/style, and clicking 'Install':

<img width="877" height="544" alt="CleanShot 2026-05-01 at 15 57 30" src="https://github.com/user-attachments/assets/b67a8ce4-c342-4d36-be65-8e70ab446a1d" />

3. Go to a regular post/page, and add a block like a paragraph or heading. When the block is selected, click the kebab (`...` menu next to the Typography header in the sidebar, and confirm one of the options you can add to the panel is 'Font':

<img width="546" height="574" alt="CleanShot 2026-05-01 at 15 58 26" src="https://github.com/user-attachments/assets/89a450c8-b576-48bb-9658-9b5c57b82eac" />

4. Apply this PR.
5. Repeat step 3 with a post/page and confirm you can still add a 'Font' option via the Typography panel to change the font face.
6. Repeat step 3 with a newsletter post and confirm you CAN'T add a 'Font' option via the Typography panel -- it shouldn't show up as an option at all.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
