### PR TITLE
fix: skip and remove malformed subscription intents

### DIFF
--- a/includes/class-newspack-newsletters-subscription.php
+++ b/includes/class-newspack-newsletters-subscription.php
@@ -472,6 +472,17 @@ class Newspack_Newsletters_Subscription {
 			if ( is_object( $intent ) || is_numeric( $intent ) ) {
 				$intent = self::get_subscription_intent( $intent );
 			}
+			// An intent's `contact` meta can be missing or corrupted (e.g. cleared by
+			// a third party, or never written due to a wp_insert_post race). Without a
+			// valid contact array we have nothing to subscribe; remove the intent so
+			// it doesn't keep fataling on every cron tick.
+			if ( ! is_array( $intent ) || ! isset( $intent['id'] ) || ! is_array( $intent['contact'] ) || empty( $intent['contact']['email'] ) ) {
+				if ( is_array( $intent ) && ! empty( $intent['id'] ) ) {
+					Newspack_Newsletters_Logger::log( 'Removing malformed subscription intent ' . $intent['id'] . ' (missing or invalid contact data).' );
+					self::remove_subscription_intent( $intent['id'] );
+				}
+				continue;
+			}
 			if ( is_array( $intent['errors'] ) && count( $intent['errors'] ) > 3 ) {
 				Newspack_Newsletters_Logger::log( 'Too many errors for contact ' . $intent['contact']['email'] . '. Removing intent.' );
 				self::remove_subscription_intent( $intent['id'] );

--- a/includes/class-newspack-newsletters-subscription.php
+++ b/includes/class-newspack-newsletters-subscription.php
@@ -462,9 +462,6 @@ class Newspack_Newsletters_Subscription {
 		}
 
 		$provider = Newspack_Newsletters::get_service_provider();
-		if ( empty( $provider ) ) {
-			return;
-		}
 		foreach ( $intents as $intent ) {
 			if ( empty( $intent ) ) {
 				continue;
@@ -475,12 +472,17 @@ class Newspack_Newsletters_Subscription {
 			// An intent's `contact` meta can be missing or corrupted (e.g. cleared by
 			// a third party, or never written due to a wp_insert_post race). Without a
 			// valid contact array we have nothing to subscribe; remove the intent so
-			// it doesn't keep fataling on every cron tick.
+			// it doesn't keep throwing on every cron tick. Done regardless of provider
+			// availability so a missing provider can't strand bad intents in the queue.
 			if ( ! is_array( $intent ) || ! isset( $intent['id'] ) || ! is_array( $intent['contact'] ) || empty( $intent['contact']['email'] ) ) {
 				if ( is_array( $intent ) && ! empty( $intent['id'] ) ) {
 					Newspack_Newsletters_Logger::log( 'Removing malformed subscription intent ' . $intent['id'] . ' (missing or invalid contact data).' );
 					self::remove_subscription_intent( $intent['id'] );
 				}
+				continue;
+			}
+			// No provider configured: leave valid intents queued for a later cron run.
+			if ( empty( $provider ) ) {
 				continue;
 			}
 			if ( is_array( $intent['errors'] ) && count( $intent['errors'] ) > 3 ) {

--- a/tests/test-subscription-intents.php
+++ b/tests/test-subscription-intents.php
@@ -1,0 +1,78 @@
+<?php
+/**
+ * Class Newsletters Test Subscription_Intents
+ *
+ * @package Newspack_Newsletters
+ */
+
+/**
+ * Tests Newspack_Newsletters_Subscription::process_subscription_intents.
+ */
+class Subscription_Intents_Test extends WP_UnitTestCase {
+	/**
+	 * Make sure the intent CPT is registered for tests.
+	 */
+	public function set_up() {
+		parent::set_up();
+		Newspack_Newsletters_Subscription::register_subscription_intents();
+	}
+
+	/**
+	 * An intent post whose `contact` meta is missing or non-array previously
+	 * fataled with "Cannot access offset of type string on string" when the
+	 * cron tried to read `$intent['contact']['email']`. The processor must
+	 * tolerate that state and remove the malformed intent so the cron stops
+	 * looping on it.
+	 */
+	public function test_process_subscription_intents_removes_intent_with_missing_contact() {
+		$intent_id = wp_insert_post(
+			[
+				'post_type'   => Newspack_Newsletters_Subscription::SUBSCRIPTION_INTENT_CPT,
+				'post_status' => 'publish',
+				'meta_input'  => [
+					// Simulates a corrupted intent: `contact` was cleared and
+					// now reads as an empty string via get_post_meta.
+					'contact' => '',
+					'lists'   => [ 'list1' ],
+					'errors'  => [],
+					'context' => 'test',
+				],
+			]
+		);
+
+		$this->assertIsInt( $intent_id );
+
+		Newspack_Newsletters_Subscription::process_subscription_intents( $intent_id );
+
+		$this->assertNull(
+			get_post( $intent_id ),
+			'Malformed intent is removed so it does not keep fataling on every cron tick.'
+		);
+	}
+
+	/**
+	 * Sanity check: when the contact array is missing the `email` key, the
+	 * intent is also treated as malformed and removed.
+	 */
+	public function test_process_subscription_intents_removes_intent_with_emailless_contact() {
+		$intent_id = wp_insert_post(
+			[
+				'post_type'   => Newspack_Newsletters_Subscription::SUBSCRIPTION_INTENT_CPT,
+				'post_status' => 'publish',
+				'meta_input'  => [
+					'contact' => [ 'name' => 'Contact without email' ],
+					'lists'   => [ 'list1' ],
+					'errors'  => [],
+					'context' => 'test',
+				],
+			]
+		);
+
+		Newspack_Newsletters_Subscription::process_subscription_intents( $intent_id );
+
+		$this->assertNull(
+			get_post( $intent_id ),
+			'Intent with no contact email is removed.'
+		);
+	}
+}

--- a/tests/test-subscription-intents.php
+++ b/tests/test-subscription-intents.php
@@ -18,11 +18,13 @@ class Subscription_Intents_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * An intent post whose `contact` meta is missing or non-array previously
-	 * fataled with "Cannot access offset of type string on string" when the
-	 * cron tried to read `$intent['contact']['email']`. The processor must
-	 * tolerate that state and remove the malformed intent so the cron stops
-	 * looping on it.
+	 * A malformed intent (contact meta missing or non-array) is skipped and
+	 * removed by the cron. Without this, `$intent['contact']['email']` throws
+	 * "Cannot access offset of type string on string" and the bad intent stays
+	 * in the queue, re-firing the same fatal on every tick.
+	 *
+	 * Cleanup runs regardless of whether a service provider is configured, so a
+	 * missing provider can't strand bad intents.
 	 */
 	public function test_process_subscription_intents_removes_intent_with_missing_contact() {
 		$intent_id = wp_insert_post(
@@ -46,7 +48,7 @@ class Subscription_Intents_Test extends WP_UnitTestCase {
 
 		$this->assertNull(
 			get_post( $intent_id ),
-			'Malformed intent is removed so it does not keep fataling on every cron tick.'
+			'Malformed intent is removed so the cron does not loop on it.'
 		);
 	}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Production fatals from `class-newspack-newsletters-subscription.php:482`. A single malformed intent on a busy site can produce thousands of fatals because the cron rerun keeps re-firing on it.

```
PHP Fatal error: Uncaught TypeError: Cannot access offset of type string on string
in includes/class-newspack-newsletters-subscription.php:482
Stack trace:
#0 .../class-wp-hook.php(341): Newspack_Newsletters_Subscription::process_subscription_intents()
#1 .../class-wp-hook.php(365): WP_Hook->apply_filters('', Array)
#2 .../plugin.php(570): WP_Hook->do_action(Array)
#3 .../wp-cron.php(191): do_action_ref_array('newspack_newsle...', Array)
```

In `process_subscription_intents` the body of the loop trusts that `$intent['contact']` is always an array:

```php
$contact = $intent['contact'];
$email   = $contact['email'];   // ← line 482, fatals when $contact is ''
```

But `get_subscription_intent` builds the intent array from `get_post_meta`:

```php
return [
    'id'      => $intent->ID,
    'contact' => get_post_meta( $intent->ID, 'contact', true ),
    ...
];
```

If the `contact` meta is missing (cleared by a third party, or never written due to a `wp_insert_post` race), `get_post_meta` returns `''` and `$contact['email']` fatals. The malformed intent stays in the CPT queue, so every cron tick re-fires the same fatal.

This PR validates the intent shape after narrowing to an array:

- `$intent` is an array
- `$intent['id']` is set
- `$intent['contact']` is an array with a non-empty `email`

Anything else: log and remove the intent so the cron stops looping on it.

### How to test the changes in this Pull Request:

1. Apply the patch on a site running the newsletters plugin.
2. Insert a malformed intent post directly: `wp post create --post_type=np_nl_sub_intent --post_status=publish --meta_input='{"contact":"","lists":["list1"],"errors":[],"context":"manual"}'`.
3. Trigger the cron: `wp cron event run newspack_newsletters_process_subscription_intents`.
4. Confirm no PHP fatal is logged and the intent post is gone (`wp post list --post_type=np_nl_sub_intent`).
5. Run `phpunit tests/test-subscription-intents.php` and confirm both cases pass.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?