### PR TITLE
fix: ensure editor preview and front end match for default subscripti…

### DIFF
--- a/src/blocks/subscribe/editor.scss
+++ b/src/blocks/subscribe/editor.scss
@@ -8,6 +8,7 @@
 			border: solid 1px #ddd;
 			box-sizing: border-box;
 			outline: none;
+			line-height: 2;
 			padding: 0.36rem 0.66rem;
 			appearance: none;
 			outline-offset: 0;


### PR DESCRIPTION
…on block style

### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This is super minor, but in WP 7.0, the input line height has been increased in the editor, and this is bleeding into the Default style for the Subscription block. This PR just reinstates the WP 6.9.4 line height for the block.

Closes NEWS-1743

### How to test the changes in this Pull Request:

1. On a site running the latest WP 7.0 RC, insert a subscription block into the editor. Publish and compare to the front end; the one in the editor is noticeably taller:

<img width="835" height="208" alt="CleanShot 2026-05-06 at 11 08 23" src="https://github.com/user-attachments/assets/82d332ce-1a51-4130-8395-163999f55280" />

2. Apply this PR and run `npm run build`.
3. Refresh the editor and confirm it looks closer to how it looks on the front-end:

<img width="849" height="187" alt="CleanShot 2026-05-06 at 11 03 30" src="https://github.com/user-attachments/assets/feded1a2-a2df-4817-8990-4a38b5fe1ccc" />

4. Test the other styles and confirm they look okay.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
