### PR TITLE
fix: remove block-level CSS field from Newsletter editor

### DIFF
--- a/src/editor/index.js
+++ b/src/editor/index.js
@@ -64,7 +64,9 @@ addFilter( 'blocks.registerBlockType', 'newspack-newsletters/core-blocks', ( set
 		settings.supports = { ...settings.supports, align: [ 'full' ] };
 	}
 
-	/* Remove 'Hide' and 'Custom CSS' options for all blocks for Newsletters CPTs, Newsletter Ads */
+	/* This bundle is only enqueued in the email editor (see
+	 * Newspack_Newsletters_Editor::enqueue_block_editor_assets), so disabling
+	 * these block supports applies to the newsletter and newsletter-ad CPTs only. */
 	settings.supports = { ...settings.supports, customCSS: false, visibility: false };
 
 	return settings;

--- a/src/editor/index.js
+++ b/src/editor/index.js
@@ -66,6 +66,9 @@ addFilter( 'blocks.registerBlockType', 'newspack-newsletters/core-blocks', ( set
 		settings.supports = { ...settings.supports, align: [ 'full' ] };
 	}
 
+	/* Remove block-level Custom CSS field; CSS added there does not work in sent newsletters. */
+	settings.supports = { ...settings.supports, customCSS: false };
+
 	/* Remove 'Hide' option only for the newsletter CPT. */
 	if ( isEditingNewsletterCpt ) {
 		settings.supports = { ...settings.supports, visibility: false };

--- a/src/editor/index.js
+++ b/src/editor/index.js
@@ -23,8 +23,6 @@ import { addBlocksValidationFilter } from './blocks-validation/blocks-filters';
 import { NestedColumnsDetection } from './blocks-validation/nesting-detection';
 import MJML from './mjml';
 
-const isEditingNewsletterCpt = newspack_email_editor_data.newsletter_post_type === newspack_email_editor_data.current_post_type;
-
 addBlocksValidationFilter();
 registerAdBlock();
 registerPostsInserterBlock();
@@ -66,13 +64,8 @@ addFilter( 'blocks.registerBlockType', 'newspack-newsletters/core-blocks', ( set
 		settings.supports = { ...settings.supports, align: [ 'full' ] };
 	}
 
-	/* Remove block-level Custom CSS field; CSS added there does not work in sent newsletters. */
-	settings.supports = { ...settings.supports, customCSS: false };
-
-	/* Remove 'Hide' option only for the newsletter CPT. */
-	if ( isEditingNewsletterCpt ) {
-		settings.supports = { ...settings.supports, visibility: false };
-	}
+	/* Remove 'Hide' and 'Custom CSS' options for all blocks for Newsletters CPTs, Newsletter Ads */
+	settings.supports = { ...settings.supports, customCSS: false, visibility: false };
 
 	return settings;
 } );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

WordPress 7.0 introduces a block-level CSS field under the 'Advanced' panel in the block editor. This CSS seems to be stripped out on sent emails, so this hotfix removes it from the newsletter editor. 

It also updates the code removing the 'Hide' option from newsletters so it's blocked from the Newsletter Ads CPT, too.

Closes NEWS-2203

### How to test the changes in this Pull Request:

1. Apply this PR to a test site running the latest version of the WP 7.0 RC.
2. Create a newsletter, and add some blocks.
3. Click on a block, and then open the 'Advanced' panel in the right sidebar. Confirm that there isn't a "Additional CSS" text field.
4. Using the block toolbar, click the `...` menu item, and confirm that 'Hide' is not available as an option.
5. Repeat steps 2-4 with a Newsletter Ads post type.
6. Repeat step 2-4 on a regular post or page; confirm that there is still an "Additional CSS" text field in the Advanced panel in other CPTs, and that blocks still have the 'Hide' option.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
