### PR TITLE
feat(admin): author avatars + status icons on admin lists

### DIFF
--- a/src/admin-shell/screens/ads-list/fields.js
+++ b/src/admin-shell/screens/ads-list/fields.js
@@ -12,11 +12,21 @@
  * `post_status` plus the matching date-driven SQL bucket.
  */
 
+import { Icon } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
+import { drafts, notAllowed, published, scheduled, trash } from '@wordpress/icons';
 import { dateI18n, getDate, getSettings as getDateSettings } from '@wordpress/date';
 
 import { getAdminUrl } from '../../admin-globals';
 import { statusKindLabel, STATUS_KIND_LABELS } from './status-label';
+
+const STATUS_KIND_ICONS = {
+	active: published,
+	scheduled,
+	expired: notAllowed,
+	draft: drafts,
+	trash,
+};
 
 const formatTimestampAsDate = timestamp => {
 	if ( ! timestamp ) {
@@ -67,24 +77,31 @@ const renderTitle = ( { item } ) => {
 const renderStatus = ( { item } ) => {
 	const status = item?.newspack_newsletters_ad_status || {};
 	const kind = status.kind || 'draft';
+	const icon = STATUS_KIND_ICONS[ kind ] || STATUS_KIND_ICONS.draft;
 
+	let label;
 	if ( 'expired' === kind && status.expires_at ) {
-		return sprintf(
+		label = sprintf(
 			/* translators: %s: formatted expiry date */
 			__( 'Expired %s', 'newspack-newsletters' ),
 			formatTimestampAsDate( status.expires_at )
 		);
-	}
-
-	if ( 'scheduled' === kind && status.starts_at ) {
-		return sprintf(
+	} else if ( 'scheduled' === kind && status.starts_at ) {
+		label = sprintf(
 			/* translators: %s: formatted start date */
 			__( 'Starts %s', 'newspack-newsletters' ),
 			formatTimestampAsDate( status.starts_at )
 		);
+	} else {
+		label = statusKindLabel( kind );
 	}
 
-	return statusKindLabel( kind );
+	return (
+		<span className="newspack-newsletters-list__status">
+			<Icon className="newspack-newsletters-list__status-icon" icon={ icon } size={ 24 } />
+			<span>{ label }</span>
+		</span>
+	);
 };
 
 const renderTerms =

--- a/src/admin-shell/screens/layouts-list/fields.js
+++ b/src/admin-shell/screens/layouts-list/fields.js
@@ -136,10 +136,21 @@ export function getFields( { renamingId = null, onRenameCommit, onRenameCancel, 
 			return null;
 		}
 		const isPrebuilt = !! item?.is_prebuilt;
-		const icon = isPrebuilt ? plugins : commentAuthorAvatar;
+		// Prefer the 48px source so the 16px display stays crisp on hi-DPI screens.
+		const avatarUrl = ! isPrebuilt && ( author.avatar_urls?.[ 48 ] || author.avatar_urls?.[ 24 ] );
 		return (
 			<span className="newspack-newsletters-layouts-list__author">
-				<Icon className="newspack-newsletters-layouts-list__author-icon" icon={ icon } size={ 24 } />
+				{ avatarUrl ? (
+					<span className="newspack-newsletters-layouts-list__author-avatar">
+						<img src={ avatarUrl } width={ 16 } height={ 16 } alt="" />
+					</span>
+				) : (
+					<Icon
+						className="newspack-newsletters-layouts-list__author-icon"
+						icon={ isPrebuilt ? plugins : commentAuthorAvatar }
+						size={ 24 }
+					/>
+				) }
 				<span>{ author.name || '' }</span>
 			</span>
 		);

--- a/src/admin-shell/screens/layouts-list/fields.js
+++ b/src/admin-shell/screens/layouts-list/fields.js
@@ -139,17 +139,13 @@ export function getFields( { renamingId = null, onRenameCommit, onRenameCancel, 
 		// Prefer the 48px source so the 16px display stays crisp on hi-DPI screens.
 		const avatarUrl = ! isPrebuilt && ( author.avatar_urls?.[ 48 ] || author.avatar_urls?.[ 24 ] );
 		return (
-			<span className="newspack-newsletters-layouts-list__author">
+			<span className="newspack-newsletters-list__author">
 				{ avatarUrl ? (
-					<span className="newspack-newsletters-layouts-list__author-avatar">
+					<span className="newspack-newsletters-list__author-avatar">
 						<img src={ avatarUrl } width={ 16 } height={ 16 } alt="" />
 					</span>
 				) : (
-					<Icon
-						className="newspack-newsletters-layouts-list__author-icon"
-						icon={ isPrebuilt ? plugins : commentAuthorAvatar }
-						size={ 24 }
-					/>
+					<Icon className="newspack-newsletters-list__author-icon" icon={ isPrebuilt ? plugins : commentAuthorAvatar } size={ 24 } />
 				) }
 				<span>{ author.name || '' }</span>
 			</span>

--- a/src/admin-shell/screens/newsletters-list/fields.js
+++ b/src/admin-shell/screens/newsletters-list/fields.js
@@ -8,11 +8,20 @@
  * client-side. Server-side sort / filter — see build-query.
  */
 
+import { Icon } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
+import { commentAuthorAvatar, drafts, published, scheduled, trash } from '@wordpress/icons';
 import { dateI18n, getDate, getSettings as getDateSettings } from '@wordpress/date';
 
 import { getAdminUrl } from '../../admin-globals';
 import { statusKindLabel, STATUS_KIND_LABELS } from './status-label';
+
+const STATUS_KIND_ICONS = {
+	sent: published,
+	scheduled,
+	draft: drafts,
+	trash,
+};
 
 const formatDate = timestamp => {
 	if ( ! timestamp ) {
@@ -44,24 +53,31 @@ const renderTitle = ( { item } ) => {
 const renderStatus = ( { item } ) => {
 	const status = item?.newspack_newsletters_status || {};
 	const kind = status.kind || 'draft';
+	const icon = STATUS_KIND_ICONS[ kind ] || STATUS_KIND_ICONS.draft;
 
+	let label;
 	if ( 'sent' === kind && status.sent_at ) {
-		return sprintf(
+		label = sprintf(
 			/* translators: %s: formatted send date */
 			__( 'Sent %s', 'newspack-newsletters' ),
 			formatDate( status.sent_at )
 		);
-	}
-
-	if ( 'scheduled' === kind && status.scheduled_at ) {
-		return sprintf(
+	} else if ( 'scheduled' === kind && status.scheduled_at ) {
+		label = sprintf(
 			/* translators: %s: formatted scheduled date */
 			__( 'Scheduled for %s', 'newspack-newsletters' ),
 			formatDate( status.scheduled_at )
 		);
+	} else {
+		label = statusKindLabel( kind );
 	}
 
-	return statusKindLabel( kind );
+	return (
+		<span className="newspack-newsletters-list__status">
+			<Icon className="newspack-newsletters-list__status-icon" icon={ icon } size={ 24 } />
+			<span>{ label }</span>
+		</span>
+	);
 };
 
 const renderSendDate = ( { item } ) => {
@@ -81,7 +97,22 @@ const renderSendList = ( { item } ) => {
 
 const renderAuthor = ( { item } ) => {
 	const author = item?._embedded?.author?.[ 0 ];
-	return author?.name || '';
+	if ( ! author ) {
+		return '';
+	}
+	const avatarUrl = author.avatar_urls?.[ 48 ] || author.avatar_urls?.[ 24 ];
+	return (
+		<span className="newspack-newsletters-list__author">
+			{ avatarUrl ? (
+				<span className="newspack-newsletters-list__author-avatar">
+					<img src={ avatarUrl } width={ 16 } height={ 16 } alt="" />
+				</span>
+			) : (
+				<Icon className="newspack-newsletters-list__author-icon" icon={ commentAuthorAvatar } size={ 24 } />
+			) }
+			<span>{ author.name || '' }</span>
+		</span>
+	);
 };
 
 // Look up embedded terms by `taxonomy` — positional indexing is unsafe across post types.

--- a/src/admin-shell/style.scss
+++ b/src/admin-shell/style.scss
@@ -198,6 +198,48 @@ body.newspack-newsletters-admin-screen--bundled .newspack-newsletters-admin-moun
 	box-shadow: none;
 }
 
+.newspack-newsletters-list {
+	&__author,
+	&__status {
+		align-items: center;
+		display: inline-flex;
+		gap: wp-vars.$grid-unit-10;
+	}
+
+	&__author-icon,
+	&__status-icon {
+		fill: currentcolor;
+		flex-shrink: 0;
+	}
+
+	&__author-avatar {
+		align-items: center;
+		display: inline-flex;
+		flex-shrink: 0;
+		height: 24px;
+		justify-content: center;
+		width: 24px;
+
+		img {
+			border-radius: 50%;
+			display: block;
+		}
+	}
+}
+
+// WP icons have a 24px viewBox with 4px padding — negative margin pulls neighbours in to the visible 16px footprint without changing the icon's draw.
+.dataviews-view-table {
+	.newspack-newsletters-list__author-icon,
+	.newspack-newsletters-list__status-icon {
+		margin: -4px;
+	}
+
+	.newspack-newsletters-list__author-avatar {
+		height: 16px;
+		width: 16px;
+	}
+}
+
 .newspack-newsletters-layouts-list {
 	&__preview {
 		background: wp-colors.$white;
@@ -257,6 +299,20 @@ body.newspack-newsletters-admin-screen--bundled .newspack-newsletters-admin-moun
 	&__author-icon {
 		fill: currentcolor;
 		flex-shrink: 0;
+	}
+
+	&__author-avatar {
+		align-items: center;
+		display: inline-flex;
+		flex-shrink: 0;
+		height: 24px;
+		justify-content: center;
+		width: 24px;
+
+		img {
+			border-radius: 50%;
+			display: block;
+		}
 	}
 }
 

--- a/src/admin-shell/style.scss
+++ b/src/admin-shell/style.scss
@@ -289,30 +289,5 @@ body.newspack-newsletters-admin-screen--bundled .newspack-newsletters-admin-moun
 			flex: 1;
 		}
 	}
-
-	&__author {
-		align-items: center;
-		display: inline-flex;
-		gap: wp-vars.$grid-unit-10;
-	}
-
-	&__author-icon {
-		fill: currentcolor;
-		flex-shrink: 0;
-	}
-
-	&__author-avatar {
-		align-items: center;
-		display: inline-flex;
-		flex-shrink: 0;
-		height: 24px;
-		justify-content: center;
-		width: 24px;
-
-		img {
-			border-radius: 50%;
-			display: block;
-		}
-	}
 }
 


### PR DESCRIPTION
## Summary

Polish on the admin shell list surfaces, in two parts plus a table-view refinement.

### Author avatars (layouts + newsletters lists)

When the embedded author carries an `avatar_urls` map (i.e. a real WP user), render their Gravatar in place of the existing affordance:

- **Layouts list** — replaces the generic `commentAuthorAvatar` person icon. Prebuilts keep the `plugins` icon (no real user behind them).
- **Newsletters list** — replaces the plain-text-only author cell. Falls back to the `commentAuthorAvatar` icon when `avatar_urls` is absent.

Default shape: 24×24 container, avatar at 16×16 centred inside with `border-radius: 50%`. Pulls the 48px Gravatar URL so the downscale stays sharp on hi-DPI displays.

### Status icons (newsletters + ads lists)

Mirror the site-editor pages list — render the WP status icons next to the label in the Status column:

- **Newsletters list**: `sent` → `published`, `scheduled` → `scheduled`, `draft` → `drafts`, `trash` → `trash`.
- **Ads list**: `active` → `published`, `scheduled` → `scheduled`, `expired` → `notAllowed`, `draft` → `drafts`, `trash` → `trash`.

Same 24px slot as the author affordance.

### Table-view compaction

The default 24px container leaves too much breathing room around the 16px visible content in dense table rows. Under `.dataviews-view-table` only:

- Icons get a `margin: -4px` (icons sit inside a 24px viewBox with 4px padding, so this pulls neighbours in to the visible 16px footprint without changing the icon's draw).
- The author avatar wrapper drops to 16×16, no inner centring needed.

Grid view keeps the airy 24px slot.

Author / status / avatar / icon styles all hoisted to the shared `.newspack-newsletters-list` SCSS block so future lists pick them up.

No Linear ticket — small polish picked up immediately after NEWS-2199 merged. Linked from NEWS-2037 (main QA ticket).

## Test plan

- [ ] **Layouts list**, Grid view: rows authored by a user with a Gravatar show the avatar; rows by a user without one fall back to the icon. Prebuilts still show the `plugins` icon.
- [ ] **Newsletters list**, Grid + Table views: avatar when present, icon when absent. Status column shows the correct icon per kind (sent / scheduled / draft / trash).
- [ ] **Ads list**, Grid + Table views: Status column shows the correct icon per kind (active / scheduled / expired / draft / trash).
- [ ] **Table view density**: icons + avatars in table view sit at a 16px footprint with no extra horizontal padding around them; row heights unchanged.
- [ ] **Grid view**: 24px slot preserved on author and status — visual rhythm untouched.