### PR TITLE
fix(esp): abort send when configured segment cannot be resolved

### DIFF
--- a/includes/service-providers/active_campaign/class-newspack-newsletters-active-campaign.php
+++ b/includes/service-providers/active_campaign/class-newspack-newsletters-active-campaign.php
@@ -1181,6 +1181,37 @@ final class Newspack_Newsletters_Active_Campaign extends \Newspack_Newsletters_S
 		$send_list_id    = get_post_meta( $post->ID, 'send_list_id', true );
 		$send_sublist_id = get_post_meta( $post->ID, 'send_sublist_id', true );
 
+		// A configured-but-unresolvable segment must NOT silently fall through
+		// to "no segment" — AC interprets segmentid=0 as "send to the entire
+		// parent audience", and sent email cannot be unsent. Verify the segment
+		// resolves before submitting; only an explicitly empty send_sublist_id
+		// (no segment ever picked) is treated as an intentional whole-list send.
+		if ( ! empty( $send_sublist_id ) ) {
+			$segment_check = $this->get_send_lists(
+				[
+					'type'      => 'sublist',
+					'ids'       => [ $send_sublist_id ],
+					'parent_id' => $send_list_id,
+				]
+			);
+			if ( is_wp_error( $segment_check ) ) {
+				return new \WP_Error(
+					'newspack_newsletters_active_campaign_segment_lookup_failed',
+					sprintf(
+						// Translators: %s is the upstream error message from ActiveCampaign.
+						__( 'Could not verify the selected segment with ActiveCampaign (%s). Sending was aborted to avoid sending to the entire audience.', 'newspack-newsletters' ),
+						$segment_check->get_error_message()
+					)
+				);
+			}
+			if ( empty( $segment_check ) ) {
+				return new \WP_Error(
+					'newspack_newsletters_active_campaign_segment_not_found',
+					__( 'The selected segment could not be found in ActiveCampaign. Sending was aborted to avoid sending to the entire audience. Please re-select a segment and try again.', 'newspack-newsletters' )
+				);
+			}
+		}
+
 		$is_public = get_post_meta( $post->ID, 'is_public', true );
 		if ( empty( $campaign_name ) ) {
 			$campaign_name = $this->get_campaign_name( $post );
@@ -1192,7 +1223,7 @@ final class Newspack_Newsletters_Active_Campaign extends \Newspack_Newsletters_S
 			'name'                                  => $campaign_name,
 			'fromname'                              => $from_name,
 			'fromemail'                             => $from_email,
-			'segmentid'                             => $send_sublist_id ?? 0, // 0 = No segment.
+			'segmentid'                             => ! empty( $send_sublist_id ) ? $send_sublist_id : 0, // 0 = No segment.
 			'p[' . $send_list_id . ']'              => $send_list_id,
 			'm[' . $sync_result['message_id'] . ']' => 100, // 100 = 100% of contacts will receive this.
 			'addressid'                             => $this->get_address_id(),

--- a/includes/service-providers/active_campaign/class-newspack-newsletters-active-campaign.php
+++ b/includes/service-providers/active_campaign/class-newspack-newsletters-active-campaign.php
@@ -998,7 +998,7 @@ final class Newspack_Newsletters_Active_Campaign extends \Newspack_Newsletters_S
 		}
 		/** Create disposable campaign for sending a test. */
 		$campaign_name = sprintf( 'Test for %s', $this->get_campaign_name( $post ) );
-		$campaign      = $this->create_campaign( get_post( $post_id ), $campaign_name );
+		$campaign      = $this->create_campaign( get_post( $post_id ), $campaign_name, true );
 		if ( is_wp_error( $campaign ) ) {
 			return $campaign;
 		}
@@ -1156,10 +1156,11 @@ final class Newspack_Newsletters_Active_Campaign extends \Newspack_Newsletters_S
 	 *
 	 * @param WP_Post $post          Post to create campaign for.
 	 * @param string  $campaign_name Optional custom title for this campaign.
+	 * @param bool    $is_test       Whether this campaign is a disposable test send. Test sends deliver via `action=test` with explicit recipient emails, so the campaign's segmentid is never used — segment validation is skipped to let publishers test newsletters that reference a deleted-but-still-saved segment.
 	 *
 	 * @return array|WP_Error Campaign data or error.
 	 */
-	private function create_campaign( $post, $campaign_name = '' ) {
+	private function create_campaign( $post, $campaign_name = '', $is_test = false ) {
 		$sync_result = $this->sync( $post );
 		if ( is_wp_error( $sync_result ) ) {
 			return $sync_result;
@@ -1184,9 +1185,20 @@ final class Newspack_Newsletters_Active_Campaign extends \Newspack_Newsletters_S
 		// A configured-but-unresolvable segment must NOT silently fall through
 		// to "no segment" — AC interprets segmentid=0 as "send to the entire
 		// parent audience", and sent email cannot be unsent. Verify the segment
-		// resolves before submitting; only an explicitly empty send_sublist_id
-		// (no segment ever picked) is treated as an intentional whole-list send.
-		if ( ! empty( $send_sublist_id ) ) {
+		// resolves before submitting; only an explicitly unset send_sublist_id
+		// (null or '' — no segment ever picked) is treated as an intentional
+		// whole-list send. A literal "0" is treated as configured-but-invalid
+		// rather than as "no segment", since AC segment IDs are positive
+		// integers and zero is the sentinel for the whole-audience case.
+		$has_configured_segment = ! $is_test && null !== $send_sublist_id && '' !== $send_sublist_id;
+		if ( $has_configured_segment ) {
+			// Note: AC segments are global per account, not scoped to a parent
+			// list. `get_send_lists()` accepts `parent_id` but only echoes it
+			// back on the returned `Send_List` — it does NOT filter the AC
+			// `audiences` lookup. A segment that belongs to a different list
+			// will therefore still resolve here. Cross-list mismatches are an
+			// inherent AC limitation rather than something this guard can
+			// catch.
 			$segment_check = $this->get_send_lists(
 				[
 					'type'      => 'sublist',
@@ -1223,7 +1235,7 @@ final class Newspack_Newsletters_Active_Campaign extends \Newspack_Newsletters_S
 			'name'                                  => $campaign_name,
 			'fromname'                              => $from_name,
 			'fromemail'                             => $from_email,
-			'segmentid'                             => ! empty( $send_sublist_id ) ? $send_sublist_id : 0, // 0 = No segment.
+			'segmentid'                             => $has_configured_segment ? $send_sublist_id : 0, // 0 = No segment (intentional whole-list send, or a test send where the segment is irrelevant because delivery is via `action=test` with explicit recipients).
 			'p[' . $send_list_id . ']'              => $send_list_id,
 			'm[' . $sync_result['message_id'] . ']' => 100, // 100 = 100% of contacts will receive this.
 			'addressid'                             => $this->get_address_id(),

--- a/includes/service-providers/constant_contact/class-newspack-newsletters-constant-contact.php
+++ b/includes/service-providers/constant_contact/class-newspack-newsletters-constant-contact.php
@@ -782,16 +782,53 @@ final class Newspack_Newsletters_Constant_Contact extends \Newspack_Newsletters_
 		}
 
 		// Sync send-to selections.
-		$send_lists = $this->get_send_lists( [ 'ids' => get_post_meta( $post->ID, 'send_list_id', true ) ] );
-		if ( is_wp_error( $send_lists ) ) {
-			return $send_lists;
-		}
-		if ( ! empty( $send_lists[0] ) ) {
-			$send_list = $send_lists[0];
-			if ( 'list' === $send_list->get_entity_type() ) {
+		$send_list_id = get_post_meta( $post->ID, 'send_list_id', true );
+		// Only an explicitly unset send_list_id (null or '' — no list/segment
+		// ever picked) is treated as "no recipient configured" and left for
+		// CC's API to reject downstream. Any other value, including a literal
+		// "0", is treated as configured-and-must-resolve so a garbage value
+		// can't quietly produce an upstream error that's harder to debug than
+		// a clear, local abort.
+		if ( null !== $send_list_id && '' !== $send_list_id ) {
+			$send_lists = $this->get_send_lists( [ 'ids' => $send_list_id ] );
+			// CC's recipient selector requires a non-empty `contact_list_ids`
+			// or `segment_ids` array; if neither is set, the upstream
+			// `create_campaign` call rejects the payload. So the silent
+			// whole-list failure mode that hit AC and MC does not apply here.
+			// This guard exists for parity with the other providers — it
+			// converts an opaque upstream rejection into a clear, local
+			// abort that names the actual cause.
+			if ( is_wp_error( $send_lists ) ) {
+				return new WP_Error(
+					'newspack_newsletters_constant_contact_send_list_lookup_failed',
+					sprintf(
+						// Translators: %s is the upstream error message from Constant Contact.
+						__( 'Could not verify the selected list or segment with Constant Contact (%s). Sending was aborted; please re-select a list or segment and try again.', 'newspack-newsletters' ),
+						$send_lists->get_error_message()
+					)
+				);
+			}
+			if ( empty( $send_lists[0] ) ) {
+				return new WP_Error(
+					'newspack_newsletters_constant_contact_send_list_not_found',
+					__( 'The selected list or segment could not be found in Constant Contact. Sending was aborted; please re-select a list or segment and try again.', 'newspack-newsletters' )
+				);
+			}
+			$send_list   = $send_lists[0];
+			$entity_type = $send_list->get_entity_type();
+			if ( 'list' === $entity_type ) {
 				$payload['contact_list_ids'] = [ $send_list->get_id() ];
-			} elseif ( 'segment' === $send_list->get_entity_type() ) {
+			} elseif ( 'segment' === $entity_type ) {
 				$payload['segment_ids'] = [ $send_list->get_id() ];
+			} else {
+				return new WP_Error(
+					'newspack_newsletters_constant_contact_send_list_unknown_type',
+					sprintf(
+						// Translators: %s is the unrecognized recipient entity type.
+						__( 'Unrecognized Constant Contact recipient type "%s". Sending was aborted; please re-select a list or segment and try again.', 'newspack-newsletters' ),
+						$entity_type
+					)
+				);
 			}
 		}
 

--- a/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp.php
+++ b/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp.php
@@ -1054,7 +1054,20 @@ final class Newspack_Newsletters_Mailchimp extends \Newspack_Newsletters_Service
 				'list_id' => $send_list_id,
 			];
 			$send_sublist_id = get_post_meta( $post->ID, 'send_sublist_id', true );
-			if ( ! empty( $send_sublist_id ) ) {
+			// Only an explicitly unset send_sublist_id (null or '' — no sublist
+			// ever picked) is treated as an intentional whole-list send. Any
+			// other value, including a literal "0", is treated as
+			// configured-and-must-resolve so a garbage value can't quietly fall
+			// through to the whole audience.
+			if ( null !== $send_sublist_id && '' !== $send_sublist_id ) {
+				// Note: Mailchimp groups and tags are looked up via
+				// Newspack_Newsletters_Mailchimp_Cached_Data, which refreshes
+				// asynchronously (~10-minute TTL). A group or tag that was
+				// deleted upstream within that window can still resolve from
+				// stale cache and pass this check. Saved segments are looked
+				// up live via `fetch_segment()` further down and don't have
+				// this gap. Closing the group/tag gap would mean a live
+				// lookup at send time — tracked as follow-up.
 				$sublist = $this->get_send_lists(
 					[
 						'ids'       => [ $send_sublist_id ],
@@ -1434,6 +1447,16 @@ final class Newspack_Newsletters_Mailchimp extends \Newspack_Newsletters_Service
 				];
 			} elseif ( $segment_id ) {
 				$segment_data = $mc->get( "lists/$list_id/segments/$segment_id" );
+				// A configured-but-unresolvable saved segment must NOT silently
+				// fall through to an empty segment_opts payload — Mailchimp
+				// would PATCH the campaign to "send to the entire audience",
+				// and a subsequent send would mail the full list.
+				if ( empty( $segment_data ) || empty( $segment_data['type'] ) ) {
+					return new WP_Error(
+						'newspack_newsletters_mailchimp_segment_not_found',
+						__( 'The selected segment could not be found in Mailchimp. The audience was not updated to avoid sending to the entire list.', 'newspack-newsletters' )
+					);
+				}
 				if ( 'static' === $segment_data['type'] ) {
 					// Handle static segments (tags).
 					$segment_opts = [
@@ -1450,6 +1473,15 @@ final class Newspack_Newsletters_Mailchimp extends \Newspack_Newsletters_Service
 				} elseif ( 'saved' === $segment_data['type'] ) {
 					// Handle saved segments.
 					$segment_opts = $segment_data['options'];
+				} else {
+					return new WP_Error(
+						'newspack_newsletters_mailchimp_segment_unknown_type',
+						sprintf(
+							// Translators: %s is the unrecognized segment type returned by Mailchimp.
+							__( 'Unrecognized Mailchimp segment type "%s". The audience was not updated to avoid sending to the entire list.', 'newspack-newsletters' ),
+							$segment_data['type']
+						)
+					);
 				}
 			}
 

--- a/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp.php
+++ b/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp.php
@@ -1063,47 +1063,74 @@ final class Newspack_Newsletters_Mailchimp extends \Newspack_Newsletters_Service
 						'type'      => 'sublist',
 					]
 				);
-				if ( ! empty( $sublist ) && ! empty( $sublist[0]->get_entity_type() ) ) {
-					$sublist_type = $sublist[0]->get_entity_type();
-					switch ( $sublist_type ) {
-						case 'group':
-							$payload['recipients']['segment_opts'] = [
-								'match'      => 'all',
-								'conditions' => [
-									[
-										'condition_type' => 'Interests',
-										'field'          => 'interests-' . $send_sublist_id,
-										'op'             => 'interestcontains',
-										'value'          => [ $send_sublist_id ],
-									],
+				// A configured-but-unresolvable sublist must NOT silently fall
+				// through to a list-only payload — Mailchimp would treat the
+				// missing segment_opts as "send to the entire audience", and
+				// sent email cannot be unsent.
+				if ( is_wp_error( $sublist ) ) {
+					return new WP_Error(
+						'newspack_newsletters_mailchimp_sublist_lookup_failed',
+						sprintf(
+							// Translators: %s is the upstream error message from Mailchimp.
+							__( 'Could not verify the selected sublist with Mailchimp (%s). Sending was aborted to avoid sending to the entire audience.', 'newspack-newsletters' ),
+							$sublist->get_error_message()
+						)
+					);
+				}
+				if ( empty( $sublist ) || empty( $sublist[0]->get_entity_type() ) ) {
+					return new WP_Error(
+						'newspack_newsletters_mailchimp_sublist_not_found',
+						__( 'The selected sublist could not be found in Mailchimp. Sending was aborted to avoid sending to the entire audience. Please re-select a sublist and try again.', 'newspack-newsletters' )
+					);
+				}
+				$sublist_type = $sublist[0]->get_entity_type();
+				switch ( $sublist_type ) {
+					case 'group':
+						$payload['recipients']['segment_opts'] = [
+							'match'      => 'all',
+							'conditions' => [
+								[
+									'condition_type' => 'Interests',
+									'field'          => 'interests-' . $send_sublist_id,
+									'op'             => 'interestcontains',
+									'value'          => [ $send_sublist_id ],
 								],
-							];
-							break;
-						case 'tag':
-							$payload['recipients']['segment_opts'] = [
-								'match'      => 'all',
-								'conditions' => [
-									[
-										'condition_type' => 'StaticSegment',
-										'field'          => 'static_segment',
-										'op'             => 'static_is',
-										'value'          => $send_sublist_id,
-									],
+							],
+						];
+						break;
+					case 'tag':
+						$payload['recipients']['segment_opts'] = [
+							'match'      => 'all',
+							'conditions' => [
+								[
+									'condition_type' => 'StaticSegment',
+									'field'          => 'static_segment',
+									'op'             => 'static_is',
+									'value'          => $send_sublist_id,
 								],
-							];
-							break;
-						case 'segment':
-							$segment_data = Newspack_Newsletters_Mailchimp_Cached_Data::fetch_segment( $send_sublist_id, $send_list_id );
-							if ( is_wp_error( $segment_data ) ) {
-								return $segment_data;
-							}
-							if ( ! empty( $segment_data['options'] ) ) {
-								$payload['recipients']['segment_opts'] = $segment_data['options'];
-							} else {
-								return new WP_Error( 'newspack_newsletters_mailchimp_error', __( 'Could not fetch segment criteria for segment ', 'newspack-newsletters' ) . $sublist['name'] );
-							}
-							break;
-					}
+							],
+						];
+						break;
+					case 'segment':
+						$segment_data = Newspack_Newsletters_Mailchimp_Cached_Data::fetch_segment( $send_sublist_id, $send_list_id );
+						if ( is_wp_error( $segment_data ) ) {
+							return $segment_data;
+						}
+						if ( ! empty( $segment_data['options'] ) ) {
+							$payload['recipients']['segment_opts'] = $segment_data['options'];
+						} else {
+							return new WP_Error( 'newspack_newsletters_mailchimp_error', __( 'Could not fetch segment criteria for segment ', 'newspack-newsletters' ) . $sublist['name'] );
+						}
+						break;
+					default:
+						return new WP_Error(
+							'newspack_newsletters_mailchimp_sublist_unknown_type',
+							sprintf(
+								// Translators: %s is the unrecognized sublist entity type.
+								__( 'Unrecognized Mailchimp sublist type "%s". Sending was aborted to avoid sending to the entire audience.', 'newspack-newsletters' ),
+								$sublist_type
+							)
+						);
 				}
 			} else {
 				$payload['recipients']['segment_opts'] = (object) [];

--- a/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp.php
+++ b/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp.php
@@ -1017,7 +1017,7 @@ final class Newspack_Newsletters_Mailchimp extends \Newspack_Newsletters_Service
 	 * Get a payload for syncing post data to the ESP campaign.
 	 *
 	 * @param WP_Post|int $post Post object or ID.
-	 * @return object Payload for syncing.
+	 * @return array|WP_Error Payload for syncing, or WP_Error if the payload cannot be safely built (e.g. an unverified sender domain, or a configured sublist that cannot be resolved against Mailchimp).
 	 */
 	public function get_sync_payload( $post ) {
 		if ( is_int( $post ) ) {
@@ -1119,7 +1119,14 @@ final class Newspack_Newsletters_Mailchimp extends \Newspack_Newsletters_Service
 						if ( ! empty( $segment_data['options'] ) ) {
 							$payload['recipients']['segment_opts'] = $segment_data['options'];
 						} else {
-							return new WP_Error( 'newspack_newsletters_mailchimp_error', __( 'Could not fetch segment criteria for segment ', 'newspack-newsletters' ) . $sublist['name'] );
+							return new WP_Error(
+								'newspack_newsletters_mailchimp_error',
+								sprintf(
+									// Translators: %s is the name of the Mailchimp segment.
+									__( 'Could not fetch segment criteria for segment %s.', 'newspack-newsletters' ),
+									$sublist[0]->get_name()
+								)
+							);
 						}
 						break;
 					default:
@@ -1171,6 +1178,14 @@ final class Newspack_Newsletters_Mailchimp extends \Newspack_Newsletters_Service
 			$mc_campaign_id = get_post_meta( $post->ID, 'mc_campaign_id', true );
 			$payload        = $this->get_sync_payload( $post );
 
+			// Short-circuit on a WP_Error payload before reaching the filter
+			// below — its contract is an array, and passing a WP_Error through
+			// would fatal any third-party callback that assumes the documented
+			// shape.
+			if ( is_wp_error( $payload ) ) {
+				throw new Exception( esc_html( $payload->get_error_message() ) );
+			}
+
 			/**
 			 * Filter the metadata payload sent to Mailchimp when syncing.
 			 *
@@ -1181,11 +1196,6 @@ final class Newspack_Newsletters_Mailchimp extends \Newspack_Newsletters_Service
 			 * @param string $mc_campaign_id Mailchimp campaign ID, if defined.
 			 */
 			$payload = apply_filters( 'newspack_newsletters_mc_payload_sync', $payload, $post, $mc_campaign_id );
-
-			// If we have any errors in the payload, throw an exception.
-			if ( is_wp_error( $payload ) ) {
-				throw new Exception( esc_html( $payload->get_error_message() ) );
-			}
 
 			if ( $mc_campaign_id ) {
 				$campaign_result = $this->validate(


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Closes the catastrophic-by-default failure mode that turned the recent #2079 hotfix regression into a downstream incident.

When a newsletter post had `send_sublist_id` set but the saved segment/sublist could no longer be resolved against the ESP (e.g. after an endpoint change, a deleted segment, or a transient API error), both providers silently fell through to a list-only payload:

- **ActiveCampaign**: `'segmentid' => $send_sublist_id ?? 0` passed an unresolvable ID straight through, and AC interprets `segmentid=0` as "send to the entire parent audience."
- **Mailchimp**: when the sublist lookup returned empty / no entity_type, the switch in `get_sync_payload()` was silently skipped, leaving `recipients = { list_id }` with no `segment_opts` (also "send to entire list").

Combined with the irreversibility of email sends, a routine upstream regression was enough to mail an entire audience by accident.

This PR validates the configured segment/sublist before the campaign is submitted and aborts with `WP_Error` if the lookup errors or returns empty. An *explicitly* empty `send_sublist_id` (no segment was ever picked) is still treated as an intentional whole-list send, so existing whole-list workflows are unaffected.

Error codes added:

- `newspack_newsletters_active_campaign_segment_lookup_failed`
- `newspack_newsletters_active_campaign_segment_not_found`
- `newspack_newsletters_mailchimp_sublist_lookup_failed`
- `newspack_newsletters_mailchimp_sublist_not_found`
- `newspack_newsletters_mailchimp_sublist_unknown_type` (defensive: covers unexpected entity_type values returned by the lookup)

The `WP_Error` propagates through the existing `send()` → `send_newsletter()` flow, so failures land in the `newsletter_send_errors` meta, trigger the admin failure email, and `wp_die` the editor request (or trigger the scheduled-send retry with exponential backoff). No new wiring.

### How to test the changes in this Pull Request:

Prereqs: ActiveCampaign and/or Mailchimp credentials configured for the active provider, with at least one list/audience and at least one segment/sublist available.

**ActiveCampaign — abort path:**

1. Switch the active provider to ActiveCampaign.
2. Create a draft newsletter post; in the editor pick a list and a segment, save.
3. Via WP-CLI: `wp post meta update <ID> send_sublist_id 99999999` (overwrite with a bogus ID).
4. Attempt to publish (status → `private` or `publish`).
5. Expected: send is aborted, no campaign is created in AC, the failure surfaces in the editor with the message "The selected segment could not be found in ActiveCampaign. Sending was aborted to avoid sending to the entire audience. Please re-select a segment and try again." For scheduled sends the post drops back to `future` with exponential backoff (existing behavior).

**ActiveCampaign — happy paths:**

6. With a real segment ID set as `send_sublist_id`, publish. Expected: campaign is created in AC with the segment applied, no abort.
7. With `send_sublist_id` empty / absent, publish. Expected: campaign is created with `segmentid=0` (intentional whole-list send), no abort.

**Mailchimp — abort path:**

8. Switch the active provider to Mailchimp.
9. Create a draft newsletter post; pick a list and a group/tag/segment, save.
10. Via WP-CLI: `wp post meta update <ID> send_sublist_id BOGUS_ID`.
11. Trigger sync (e.g. open the editor or call `get_sync_payload` via `wp eval`). Expected: sync errors with "The selected sublist could not be found in Mailchimp. Sending was aborted to avoid sending to the entire audience..." surfaced via the existing sync-error transient.

**Mailchimp — happy paths:**

12. With a real group ID as `send_sublist_id`, sync. Expected: `recipients.segment_opts.conditions` contains the `Interests` condition.
13. With a real tag ID as `send_sublist_id`, sync. Expected: `recipients.segment_opts.conditions` contains the `StaticSegment` condition.
14. With a real saved-segment ID as `send_sublist_id`, sync. Expected: `recipients.segment_opts` is populated from `fetch_segment( ... )['options']`.
15. With no `send_sublist_id`, sync. Expected: `recipients = { list_id, segment_opts: {} }` (intentional whole-list send), no abort.

**Regression:**

16. `npm run lint:php` and `n test-php` from the plugin directory should pass (no test changes; verifying the existing 198-test suite is unaffected).

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable? — Existing PHPUnit suite continues to pass. The new code paths were validated end-to-end against real AC and MC sandboxes (both providers, abort + happy paths) on a staging site; a dedicated PHPUnit test for the abort path would require mocking `get_send_lists` and is left as a follow-up if desired.
* [x] Have you successfully ran tests with your changes locally?