### PR TITLE
fix(editor): keep legacy CSS vars in sync with newsletters-prefixed ones

### DIFF
--- a/src/editor/style.scss
+++ b/src/editor/style.scss
@@ -2,9 +2,9 @@
 	--newspack-newsletters-header-font: arial, sans-serif;
 	--newspack-newsletters-body-font: georgia, serif;
 	--newspack-newsletters-max-width: 600px;
-	--newspack-header-font: arial, sans-serif;
-	--newspack-body-font: georgia, serif;
-	--newspack-max-width: 600px;
+	--newspack-header-font: var(--newspack-newsletters-header-font);
+	--newspack-body-font: var(--newspack-newsletters-body-font);
+	--newspack-max-width: var(--newspack-newsletters-max-width);
 	--wp--style--global--content-size: 600px;
 	--wp--style--global--wide-size: 600px;
 }
@@ -20,7 +20,7 @@
 // Override block theme layout constraints — all newsletter blocks
 // should use the same max-width (600px) regardless of theme settings.
 .is-layout-constrained > * {
-	max-width: var(--newspack-max-width) !important;
+	max-width: var(--newspack-newsletters-max-width) !important;
 }
 
 // Override block theme global-padding layout rule that sets negative


### PR DESCRIPTION
## Why

Follow-up to [@Copilot's review comment on #2136](https://github.com/Automattic/newspack-newsletters/pull/2136#discussion_r3260729080).

`src/editor/style.scss` declares both the canonical `--newspack-newsletters-*` variables and the legacy `--newspack-*` ones with independent literal values. The runtime layout JS only updates the prefixed variants, so:

- `.wp-block` (reads `--newspack-newsletters-max-width`) tracks runtime changes
- `.is-layout-constrained > *` (reads `--newspack-max-width`) was pinned to the static 600px and would silently desync

## What

- Alias the three legacy variables (`--newspack-header-font`, `--newspack-body-font`, `--newspack-max-width`) to their `--newspack-newsletters-*` counterparts in `:root`. External consumers keep working and pick up runtime updates for free.
- Update `.is-layout-constrained > *` to read `--newspack-newsletters-max-width` directly — internal styles should reference the canonical name.

## Test plan

- [x] Open the newsletter editor and confirm 600px constraint still applies to blocks under `.is-layout-constrained` parents
- [x] Confirm header/body font tokens still resolve in the editor