### PR TITLE
fix: read editor script deps from .asset.php for WP 7.0

### DIFF
--- a/includes/class-newspack-newsletters-blocks.php
+++ b/includes/class-newspack-newsletters-blocks.php
@@ -27,10 +27,11 @@ final class Newspack_Newsletters_Blocks {
 			return;
 		}
 		$handle = 'newspack-newsletters-blocks';
+		$asset  = include NEWSPACK_NEWSLETTERS_PLUGIN_FILE . 'dist/blocks.asset.php';
 		wp_enqueue_script(
 			$handle,
 			plugins_url( '../dist/blocks.js', __FILE__ ),
-			[],
+			$asset['dependencies'],
 			filemtime( NEWSPACK_NEWSLETTERS_PLUGIN_FILE . 'dist/blocks.js' ),
 			true
 		);

--- a/includes/class-newspack-newsletters-editor.php
+++ b/includes/class-newspack-newsletters-editor.php
@@ -555,10 +555,11 @@ final class Newspack_Newsletters_Editor {
 
 			wp_add_inline_style( 'newspack-newsletters', self::get_color_palette_css( '.editor-styles-wrapper' ) );
 
+			$editor_asset = include NEWSPACK_NEWSLETTERS_PLUGIN_FILE . 'dist/editor.asset.php';
 			\wp_enqueue_script(
 				'newspack-newsletters-editor',
 				plugins_url( '../dist/editor.js', __FILE__ ),
-				[ 'lodash' ],
+				$editor_asset['dependencies'],
 				filemtime( NEWSPACK_NEWSLETTERS_PLUGIN_FILE . 'dist/editor.js' ),
 				true
 			);
@@ -567,10 +568,11 @@ final class Newspack_Newsletters_Editor {
 		}
 
 		if ( self::is_editing_newsletter_ad() ) {
+			$ads_page_asset = include NEWSPACK_NEWSLETTERS_PLUGIN_FILE . 'dist/adsEditor.asset.php';
 			\wp_enqueue_script(
 				'newspack-newsletters-ads-page',
 				plugins_url( '../dist/adsEditor.js', __FILE__ ),
-				[ 'wp-components', 'wp-api-fetch' ],
+				$ads_page_asset['dependencies'],
 				filemtime( NEWSPACK_NEWSLETTERS_PLUGIN_FILE . 'dist/adsEditor.js' ),
 				true
 			);
@@ -595,10 +597,11 @@ final class Newspack_Newsletters_Editor {
 			);
 			wp_style_add_data( 'newspack-newsletters-newsletter-editor', 'rtl', 'replace' );
 			wp_enqueue_style( 'newspack-newsletters-newsletter-editor' );
+			$newsletter_editor_asset = include NEWSPACK_NEWSLETTERS_PLUGIN_FILE . 'dist/newsletterEditor.asset.php';
 			\wp_enqueue_script(
 				'newspack-newsletters-newsletter-editor',
 				plugins_url( '../dist/newsletterEditor.js', __FILE__ ),
-				[],
+				$newsletter_editor_asset['dependencies'],
 				filemtime( NEWSPACK_NEWSLETTERS_PLUGIN_FILE . 'dist/newsletterEditor.js' ),
 				true
 			);
@@ -611,10 +614,11 @@ final class Newspack_Newsletters_Editor {
 					]
 				);
 			}
+			$ads_editor_asset = include NEWSPACK_NEWSLETTERS_PLUGIN_FILE . 'dist/newsletterAdsEditor.asset.php';
 			\wp_enqueue_script(
 				'newspack-newsletters-ads-editor',
 				plugins_url( '../dist/newsletterAdsEditor.js', __FILE__ ),
-				[ 'wp-components', 'wp-api-fetch' ],
+				$ads_editor_asset['dependencies'],
 				filemtime( NEWSPACK_NEWSLETTERS_PLUGIN_FILE . 'dist/newsletterAdsEditor.js' ),
 				true
 			);
@@ -622,10 +626,11 @@ final class Newspack_Newsletters_Editor {
 
 		// If it's a reusable block, register this plugin's blocks.
 		if ( 'wp_block' === get_post_type() ) {
+			$editor_blocks_asset = include NEWSPACK_NEWSLETTERS_PLUGIN_FILE . 'dist/editorBlocks.asset.php';
 			\wp_enqueue_script(
 				'newspack-newsletters-editor-blocks',
 				plugins_url( '../dist/editorBlocks.js', __FILE__ ),
-				[],
+				$editor_blocks_asset['dependencies'],
 				filemtime( NEWSPACK_NEWSLETTERS_PLUGIN_FILE . 'dist/editorBlocks.js' ),
 				true
 			);


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

As of WP 7.0, editor.js, newsletterEditor.js, and newsletterAdsEditor.js all throw `window.wp is undefined` errors. This is because enqueue calls in class-newspack-newsletters-editor.php and class-newspack-newsletters-blocks.php have hardcoded incomplete dependency arrays (e.g. `['lodash']`, `[]`, `['wp-components', 'wp-api-fetch']`).

Compiled bundles use `window.wp.*` as webpack externals - they need those core scripts loaded first. 

For some reason, prior to WP 7.0, those scripts were enqueued on the block editor screens anyway, masking the issue. As of WP 7.0, they're not. 

This hotfix replaces the hardcoded arrays with the dependency list from each script's generated .asset.php file, following the same pattern used in newspack-plugin. It also applies the same fix to blocks.js, since it has the same dependency issue.

### How to test the changes in this Pull Request:

Test the following on WP 7.0 and WP 6.9.4 just in case (this will probably land after the 7.0 release but it'd be good not to break sites still running 6.9.x 😅 )

1. Create or open an existing newsletter
2. Open the browser console. Confirm no `window.wp is undefined` / `Cannot access property "blocks"/"i18n"/"plugins"` errors.
3. Confirm the editor loads fully: blocks insert, sidebar panels render, the Newsletters sidebar plugin shows up.
4. Test the styles (fonts, colours, CSS) and just ensure all of those styles are still loaded into the editor. 
5. Save a draft. Confirm no JS errors during save.
6. Go to Newsletters > Advertising and open or create a newsletter ad.
7. Confirm the editor loads with no console errors and the ad-specific UI renders.
8. Open a regular post or page just to smoke test - the newsletter enqueues shouldn't run there, but just in case. 
9. Preview an editor, and send a test just to smoke test normal functionality

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
