### PR TITLE
refactor(admin): extract shared utils for list-screen DRY (newsletters/ads/advertisers/layouts)

### DIFF
--- a/src/admin-shell/components/confirm-modal/index.js
+++ b/src/admin-shell/components/confirm-modal/index.js
@@ -1,0 +1,56 @@
+/**
+ * Shared confirmation modal body used by destructive DataView actions
+ * across the list screens (newsletters, ads, advertisers, layouts).
+ *
+ * DataViews mounts the modal chrome; this component renders only the
+ * question + Cancel/Confirm buttons. The async `onConfirm` is invoked
+ * with the modal's pre-filtered item list and resolves before the modal
+ * closes; on rejection the Confirm button is re-enabled so the user can
+ * retry without losing the modal.
+ */
+
+import { Button } from '@wordpress/components';
+import { useState } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * @param {Object}                                       props
+ * @param {Array<Object>}                                props.items           Items DataViews passed into the action.
+ * @param {() => void}                                   props.closeModal      Close handler supplied by DataViews.
+ * @param {string}                                       props.confirmLabel    Label for the confirm button at rest.
+ * @param {string}                                       props.confirmingLabel Label shown while the confirm action is in flight.
+ * @param {string|import('react').ReactNode}             props.question        Body content rendered above the buttons.
+ * @param {boolean}                                      [props.isDestructive] Apply destructive styling to the confirm button.
+ * @param {( items: Array<Object> ) => Promise<unknown>} props.onConfirm       Async handler invoked with `items`.
+ * @return {import('react').ReactElement} Modal body element.
+ */
+export default function ConfirmModal( { items, closeModal, confirmLabel, confirmingLabel, question, isDestructive, onConfirm } ) {
+	const [ isBusy, setIsBusy ] = useState( false );
+	return (
+		<div>
+			<p>{ question }</p>
+			<div style={ { display: 'flex', gap: '8px', justifyContent: 'flex-end' } }>
+				<Button variant="tertiary" onClick={ closeModal } disabled={ isBusy }>
+					{ __( 'Cancel', 'newspack-newsletters' ) }
+				</Button>
+				<Button
+					variant="primary"
+					isDestructive={ isDestructive }
+					isBusy={ isBusy }
+					disabled={ isBusy }
+					onClick={ async () => {
+						setIsBusy( true );
+						try {
+							await onConfirm( items );
+							closeModal();
+						} catch ( error ) {
+							setIsBusy( false );
+						}
+					} }
+				>
+					{ isBusy ? confirmingLabel : confirmLabel }
+				</Button>
+			</div>
+		</div>
+	);
+}

--- a/src/admin-shell/components/confirm-modal/index.js
+++ b/src/admin-shell/components/confirm-modal/index.js
@@ -1,14 +1,3 @@
-/**
- * Shared confirmation modal body used by destructive DataView actions
- * across the list screens (newsletters, ads, advertisers, layouts).
- *
- * DataViews mounts the modal chrome; this component renders only the
- * question + Cancel/Confirm buttons. The async `onConfirm` is invoked
- * with the modal's pre-filtered item list and resolves before the modal
- * closes; on rejection the Confirm button is re-enabled so the user can
- * retry without losing the modal.
- */
-
 import { Button } from '@wordpress/components';
 import { useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';

--- a/src/admin-shell/components/confirm-modal/index.js
+++ b/src/admin-shell/components/confirm-modal/index.js
@@ -17,7 +17,8 @@ export default function ConfirmModal( { items, closeModal, confirmLabel, confirm
 	const [ isBusy, setIsBusy ] = useState( false );
 	return (
 		<div>
-			<p>{ question }</p>
+			{ /* Wrap raw strings in a <p>; pass ReactNodes through to avoid nested-paragraph markup. */ }
+			{ 'string' === typeof question ? <p>{ question }</p> : question }
 			<div style={ { display: 'flex', gap: '8px', justifyContent: 'flex-end' } }>
 				<Button variant="tertiary" onClick={ closeModal } disabled={ isBusy }>
 					{ __( 'Cancel', 'newspack-newsletters' ) }

--- a/src/admin-shell/hooks/use-collection-data.js
+++ b/src/admin-shell/hooks/use-collection-data.js
@@ -1,0 +1,112 @@
+import apiFetch from '@wordpress/api-fetch';
+import { useCallback, useEffect, useState } from '@wordpress/element';
+
+import { notifyError } from '../notices';
+
+function parseHeaderInt( value ) {
+	const parsed = parseInt( value, 10 );
+	return Number.isNaN( parsed ) ? 0 : parsed;
+}
+
+function readPaginationInfo( response ) {
+	return {
+		totalItems: parseHeaderInt( response.headers.get( 'X-WP-Total' ) ),
+		totalPages: parseHeaderInt( response.headers.get( 'X-WP-TotalPages' ) ),
+	};
+}
+
+/**
+ * Server-side paginated fetch hook for DataView list screens.
+ *
+ * A falsy `path` defers the main fetch (used by layouts during the
+ * parent's `view === null` latch). A falsy `trashCountPath` skips the
+ * trash sub-fetch — `hasResolved` flips solely on the main resolution.
+ *
+ * @param {Object} options
+ * @param {string} options.path             Pre-computed REST path. Falsy ⇒ defer.
+ * @param {string} [options.trashCountPath] When set, sub-fetch for the trash banner.
+ * @param {number} [options.mutationKey]    Bump externally to refetch (alongside internal refresh).
+ * @param {string} [options.errorMessage]   notifyError message on fetch failure.
+ * @param {string} [options.errorNoticeId]  notifyError dedupe id.
+ * @return {{ data: Array, paginationInfo: Object, isLoading: boolean, hasResolved: boolean, hasLoadedOnce: boolean, trashCount: number|null, refresh: () => void }} Hook state.
+ */
+export default function useCollectionData( { path, trashCountPath = null, mutationKey = 0, errorMessage, errorNoticeId } ) {
+	const [ data, setData ] = useState( [] );
+	const [ paginationInfo, setPaginationInfo ] = useState( { totalItems: 0, totalPages: 0 } );
+	const [ isLoading, setIsLoading ] = useState( true );
+	const [ refreshKey, setRefreshKey ] = useState( 0 );
+	const [ mainResolved, setMainResolved ] = useState( false );
+	const [ trashResolved, setTrashResolved ] = useState( ! trashCountPath );
+	const [ hasLoadedOnce, setHasLoadedOnce ] = useState( false );
+	// `null` ⇒ unknown; failed trash fetch stays `null` so `=== 0` stays false and the banner stays hidden.
+	const [ trashCount, setTrashCount ] = useState( null );
+
+	const refresh = useCallback( () => setRefreshKey( key => key + 1 ), [] );
+
+	useEffect( () => {
+		if ( ! path ) {
+			setData( [] );
+			setPaginationInfo( { totalItems: 0, totalPages: 0 } );
+			setIsLoading( false );
+			return undefined;
+		}
+		let cancelled = false;
+		setIsLoading( true );
+
+		apiFetch( { path, parse: false } )
+			.then( async response => {
+				const items = await response.json();
+				if ( cancelled ) {
+					return;
+				}
+				setData( Array.isArray( items ) ? items : [] );
+				setPaginationInfo( readPaginationInfo( response ) );
+				setHasLoadedOnce( true );
+			} )
+			.catch( () => {
+				if ( cancelled || ! errorMessage ) {
+					return;
+				}
+				// Keep last-good data so a refetch error doesn't trip the strict-empty banner.
+				notifyError( errorMessage, errorNoticeId ? { id: errorNoticeId } : undefined );
+			} )
+			.finally( () => {
+				if ( ! cancelled ) {
+					setIsLoading( false );
+					setMainResolved( true );
+				}
+			} );
+
+		return () => {
+			cancelled = true;
+		};
+	}, [ path, mutationKey, refreshKey, errorMessage, errorNoticeId ] );
+
+	useEffect( () => {
+		if ( ! trashCountPath ) {
+			return undefined;
+		}
+		let cancelled = false;
+		// Back to "unknown" while the new count is in flight, or a freshly-trashed last item flashes EmptyState.
+		setTrashCount( null );
+		apiFetch( { path: trashCountPath, parse: false } )
+			.then( response => {
+				if ( ! cancelled ) {
+					setTrashCount( parseHeaderInt( response.headers.get( 'X-WP-Total' ) ) );
+				}
+			} )
+			.catch( () => {} )
+			.finally( () => {
+				if ( ! cancelled ) {
+					setTrashResolved( true );
+				}
+			} );
+		return () => {
+			cancelled = true;
+		};
+	}, [ trashCountPath, mutationKey, refreshKey ] );
+
+	const hasResolved = mainResolved && trashResolved;
+
+	return { data, paginationInfo, isLoading, hasResolved, hasLoadedOnce, trashCount, refresh };
+}

--- a/src/admin-shell/screens/ads-list/actions.js
+++ b/src/admin-shell/screens/ads-list/actions.js
@@ -9,14 +9,13 @@
  */
 
 import apiFetch from '@wordpress/api-fetch';
-import { Button } from '@wordpress/components';
-import { useState } from '@wordpress/element';
 import { __, _n, sprintf } from '@wordpress/i18n';
 import { edit, trash } from '@wordpress/icons';
 
 import { getAdminUrl } from '../../admin-globals';
+import ConfirmModal from '../../components/confirm-modal';
 import RenameForm from '../../components/rename-form';
-import { notifyError, notifySuccess } from '../../notices';
+import { runBulk } from '../../utils/bulk-action';
 import { isTrashed } from './status-label';
 
 const POSTS_PATH = '/wp/v2/newspack_nl_ads_cpt';
@@ -36,37 +35,6 @@ const restoreOne = id =>
 	} );
 
 const deleteOne = id => apiFetch( { path: `${ POSTS_PATH }/${ id }?force=true`, method: 'DELETE' } );
-
-function ConfirmModal( { items, closeModal, confirmLabel, confirmingLabel, question, isDestructive, onConfirm } ) {
-	const [ isBusy, setIsBusy ] = useState( false );
-	return (
-		<div>
-			<p>{ question }</p>
-			<div style={ { display: 'flex', gap: '8px', justifyContent: 'flex-end' } }>
-				<Button variant="tertiary" onClick={ closeModal } disabled={ isBusy }>
-					{ __( 'Cancel', 'newspack-newsletters' ) }
-				</Button>
-				<Button
-					variant="primary"
-					isDestructive={ isDestructive }
-					isBusy={ isBusy }
-					disabled={ isBusy }
-					onClick={ async () => {
-						setIsBusy( true );
-						try {
-							await onConfirm( items );
-							closeModal();
-						} catch ( error ) {
-							setIsBusy( false );
-						}
-					} }
-				>
-					{ isBusy ? confirmingLabel : confirmLabel }
-				</Button>
-			</div>
-		</div>
-	);
-}
 
 export function getActions( { refresh, openQuickEdit } ) {
 	const editAction = {
@@ -140,28 +108,23 @@ export function getActions( { refresh, openQuickEdit } ) {
 					items.length
 				) }
 				isDestructive
-				onConfirm={ async list => {
-					const failed = [];
-					await Promise.all(
-						list.map( item =>
-							trashOne( item.id ).catch( () => {
-								failed.push( item );
-							} )
-						)
-					);
-					refresh();
-					if ( failed.length === 0 ) {
-						notifySuccess( _n( 'Ad moved to trash.', 'Ads moved to trash.', list.length, 'newspack-newsletters' ) );
-					} else {
-						notifyError(
+				onConfirm={ list =>
+					runBulk( list, item => trashOne( item.id ), {
+						refresh,
+						successPlural: n => _n( 'Ad moved to trash.', 'Ads moved to trash.', n, 'newspack-newsletters' ),
+						failurePlural: n =>
 							sprintf(
 								/* translators: %d: number that failed */
-								__( 'Failed to trash %d ad(s). Please try again.', 'newspack-newsletters' ),
-								failed.length
-							)
-						);
-					}
-				} }
+								_n(
+									'Failed to trash %d ad. Please try again.',
+									'Failed to trash %d ads. Please try again.',
+									n,
+									'newspack-newsletters'
+								),
+								n
+							),
+					} )
+				}
 			/>
 		),
 	};
@@ -176,26 +139,16 @@ export function getActions( { refresh, openQuickEdit } ) {
 			if ( eligible.length === 0 ) {
 				return;
 			}
-			const failed = [];
-			await Promise.all(
-				eligible.map( item =>
-					restoreOne( item.id ).catch( () => {
-						failed.push( item );
-					} )
-				)
-			);
-			refresh();
-			if ( failed.length === 0 ) {
-				notifySuccess( _n( 'Ad restored.', 'Ads restored.', eligible.length, 'newspack-newsletters' ) );
-			} else {
-				notifyError(
+			await runBulk( eligible, item => restoreOne( item.id ), {
+				refresh,
+				successPlural: n => _n( 'Ad restored.', 'Ads restored.', n, 'newspack-newsletters' ),
+				failurePlural: n =>
 					sprintf(
 						/* translators: %d: number that failed */
-						__( 'Failed to restore %d ad(s).', 'newspack-newsletters' ),
-						failed.length
-					)
-				);
-			}
+						_n( 'Failed to restore %d ad.', 'Failed to restore %d ads.', n, 'newspack-newsletters' ),
+						n
+					),
+			} );
 		},
 	};
 
@@ -222,28 +175,18 @@ export function getActions( { refresh, openQuickEdit } ) {
 					items.length
 				) }
 				isDestructive
-				onConfirm={ async list => {
-					const failed = [];
-					await Promise.all(
-						list.map( item =>
-							deleteOne( item.id ).catch( () => {
-								failed.push( item );
-							} )
-						)
-					);
-					refresh();
-					if ( failed.length === 0 ) {
-						notifySuccess( _n( 'Ad deleted.', 'Ads deleted.', list.length, 'newspack-newsletters' ) );
-					} else {
-						notifyError(
+				onConfirm={ list =>
+					runBulk( list, item => deleteOne( item.id ), {
+						refresh,
+						successPlural: n => _n( 'Ad deleted.', 'Ads deleted.', n, 'newspack-newsletters' ),
+						failurePlural: n =>
 							sprintf(
 								/* translators: %d: number that failed */
-								__( 'Failed to delete %d ad(s).', 'newspack-newsletters' ),
-								failed.length
-							)
-						);
-					}
-				} }
+								_n( 'Failed to delete %d ad.', 'Failed to delete %d ads.', n, 'newspack-newsletters' ),
+								n
+							),
+					} )
+				}
 			/>
 		),
 	};

--- a/src/admin-shell/screens/ads-list/build-query.js
+++ b/src/admin-shell/screens/ads-list/build-query.js
@@ -14,13 +14,15 @@
  *   same set the publisher previously saw on the classic CPT list.
  */
 
+import { buildQueryParams as baseBuildQueryParams, toQueryString } from '../../utils/build-query';
+
 // `future` covers WP-scheduled ads (the standard Publish-Schedule UI) —
 // the React Ads list and the consolidated status payload both treat
 // these as `kind=scheduled` regardless of `start_date` meta. Without
 // `future` in the default set, WP-scheduled rows would silently
 // disappear from the list (the classic CPT list showed them).
 // `auto-draft` keeps an abandoned "Add new" visible.
-const DEFAULT_STATUSES = [ 'publish', 'private', 'future', 'draft', 'pending', 'auto-draft' ];
+const DEFAULT_STATUSES = 'publish,private,future,draft,pending,auto-draft';
 
 // Each value is the WP REST taxonomy filter param — i.e. the
 // taxonomy's `rest_base`, which defaults to the taxonomy slug when
@@ -45,81 +47,16 @@ const SORT_FIELD_TO_ORDERBY = {
 	clicks: 'clicks',
 };
 
-function asArray( value ) {
-	if ( Array.isArray( value ) ) {
-		return value;
-	}
-	if ( value === undefined || value === null || value === '' ) {
-		return [];
-	}
-	return [ value ];
-}
-
 export function buildQueryParams( view = {} ) {
-	const params = {
-		page: view.page || 1,
-		per_page: view.perPage || 25,
-		_embed: 'wp:term',
-		context: 'edit',
-	};
-
-	if ( view.search ) {
-		params.search = view.search;
-	}
-
-	if ( view.sort?.field && SORT_FIELD_TO_ORDERBY[ view.sort.field ] ) {
-		params.orderby = SORT_FIELD_TO_ORDERBY[ view.sort.field ];
-		params.order = view.sort.direction === 'asc' ? 'asc' : 'desc';
-	}
-
-	const filters = Array.isArray( view.filters ) ? view.filters : [];
-	const statusFilter = filters.find( filter => filter.field === 'status' );
-
-	if ( statusFilter ) {
-		const kinds = asArray( statusFilter.value );
-		if ( kinds.length > 0 ) {
-			params.newspack_newsletters_ad_status = kinds.join( ',' );
-		}
-	} else {
-		// No kind filter: hand WP a post_status default that matches the
-		// writable statuses publishers see today on the classic list.
-		// Trash is excluded by default — selecting Trash in the filter
-		// flips into the kind path which sets `post_status=trash`
-		// server-side.
-		params.status = DEFAULT_STATUSES.join( ',' );
-	}
-
-	for ( const filter of filters ) {
-		if ( filter.field === 'status' ) {
-			continue;
-		}
-		const param = FIELD_TO_QUERY_PARAM[ filter.field ];
-		if ( ! param ) {
-			continue;
-		}
-		const values = asArray( filter.value );
-		if ( values.length === 0 ) {
-			continue;
-		}
-		params[ param ] = values.join( ',' );
-	}
-
-	return params;
-}
-
-/**
- * Serialise params object into a query string suitable for apiFetch's `path`.
- *
- * @param {Object} params Query params from buildQueryParams.
- * @return {string} Query string starting with `?`.
- */
-export function toQueryString( params ) {
-	const search = new URLSearchParams();
-	Object.entries( params ).forEach( ( [ key, value ] ) => {
-		if ( value === undefined || value === null || value === '' ) {
-			return;
-		}
-		search.append( key, String( value ) );
+	return baseBuildQueryParams( view, {
+		fieldToQueryParam: FIELD_TO_QUERY_PARAM,
+		sortFieldToOrderby: SORT_FIELD_TO_ORDERBY,
+		defaultStatuses: DEFAULT_STATUSES,
+		// Active kind filter → custom REST param; no filter → wide post_status default.
+		statusFilterParam: 'newspack_newsletters_ad_status',
+		defaultStatusParam: 'status',
+		extraParams: { _embed: 'wp:term' },
 	} );
-	return `?${ search.toString() }`;
 }
+
+export { toQueryString };

--- a/src/admin-shell/screens/ads-list/initial-filters.js
+++ b/src/admin-shell/screens/ads-list/initial-filters.js
@@ -10,6 +10,8 @@
  * Pure module so it stays trivial to unit-test.
  */
 
+import { makeGetInitialView } from '../../utils/initial-view';
+
 // Map legacy post_status values onto a kind-based filter value. The
 // classic ads list only meaningfully exposes draft / trash via this
 // query arg; "publish" rows split across active / scheduled / expired
@@ -38,61 +40,7 @@ const ORDERBY_TO_SORT_FIELD = {
 	clicks: 'clicks',
 };
 
-/**
- * Read the current document URL and return DataViews-compatible
- * filters seeded from `post_status`. Returns `[]` when no recognised
- * value is present.
- *
- * @param {string} [search] URL search string (defaults to `window.location.search`).
- * @return {Array<{ field: string, operator: string, value: Array<string> }>} DataViews-shaped initial filters.
- */
-export function getInitialFilters( search = typeof window === 'undefined' ? '' : window.location.search ) {
-	const params = new URLSearchParams( search );
-	const postStatus = params.get( 'post_status' );
-	if ( ! postStatus ) {
-		return [];
-	}
-
-	const kind = POST_STATUS_TO_KIND[ postStatus ];
-	if ( ! kind ) {
-		return [];
-	}
-
-	return [ { field: 'status', operator: 'isAny', value: [ kind ] } ];
-}
-
-/**
- * Read the current document URL and return a partial DataView `view`
- * patch (filters / search / sort) seeded from forwarded legacy args.
- * Anything not present in the URL is omitted so callers can spread
- * the result over their `DEFAULT_VIEW` without clobbering keys.
- *
- * @param {string} [search] URL search string (defaults to `window.location.search`).
- * @return {Object} Partial view object.
- */
-export function getInitialView( search = typeof window === 'undefined' ? '' : window.location.search ) {
-	const params = new URLSearchParams( search );
-	const patch = {};
-
-	const filters = getInitialFilters( search );
-	if ( filters.length > 0 ) {
-		patch.filters = filters;
-	}
-
-	const term = params.get( 's' );
-	if ( term ) {
-		patch.search = term;
-	}
-
-	const orderby = params.get( 'orderby' );
-	const order = params.get( 'order' );
-	const sortField = orderby && ORDERBY_TO_SORT_FIELD[ orderby ];
-	if ( sortField ) {
-		patch.sort = {
-			field: sortField,
-			direction: 'asc' === ( order || '' ).toLowerCase() ? 'asc' : 'desc',
-		};
-	}
-
-	return patch;
-}
+export const { getInitialFilters, getInitialView } = makeGetInitialView( {
+	orderbyMap: ORDERBY_TO_SORT_FIELD,
+	postStatusMap: POST_STATUS_TO_KIND,
+} );

--- a/src/admin-shell/screens/ads-list/status-label.js
+++ b/src/admin-shell/screens/ads-list/status-label.js
@@ -8,33 +8,14 @@
 
 import { __ } from '@wordpress/i18n';
 
-let cachedLabels = null;
+import { createStatusLabelModule } from '../../utils/status-label';
 
-export function STATUS_KIND_LABELS() {
-	if ( null === cachedLabels ) {
-		cachedLabels = {
-			active: __( 'Active', 'newspack-newsletters' ),
-			scheduled: __( 'Scheduled', 'newspack-newsletters' ),
-			expired: __( 'Expired', 'newspack-newsletters' ),
-			draft: __( 'Draft', 'newspack-newsletters' ),
-			trash: __( 'Trash', 'newspack-newsletters' ),
-		};
-	}
-	return cachedLabels;
-}
+export const { STATUS_KIND_LABELS, statusKindLabel } = createStatusLabelModule( () => ( {
+	active: __( 'Active', 'newspack-newsletters' ),
+	scheduled: __( 'Scheduled', 'newspack-newsletters' ),
+	expired: __( 'Expired', 'newspack-newsletters' ),
+	draft: __( 'Draft', 'newspack-newsletters' ),
+	trash: __( 'Trash', 'newspack-newsletters' ),
+} ) );
 
-export function statusKindLabel( kind ) {
-	const labels = STATUS_KIND_LABELS();
-	return labels[ kind ] || labels.draft;
-}
-
-/**
- * Returns true if a row item is currently in the trash. The DataViews
- * actions read this to gate destructive vs restorative buttons.
- *
- * @param {Object} item Post object from REST.
- * @return {boolean} True when the row is trashed.
- */
-export function isTrashed( item ) {
-	return 'trash' === item?.status;
-}
+export { isTrashed } from '../../utils/status-label';

--- a/src/admin-shell/screens/ads-list/use-ads-data.js
+++ b/src/admin-shell/screens/ads-list/use-ads-data.js
@@ -1,112 +1,16 @@
-/**
- * Server-side paginated data hook for the Ads list DataView.
- */
-
-import apiFetch from '@wordpress/api-fetch';
-import { useCallback, useEffect, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 
-import { notifyError } from '../../notices';
+import useCollectionData from '../../hooks/use-collection-data';
 import { buildQueryParams, toQueryString } from './build-query';
 
 const POSTS_PATH = '/wp/v2/newspack_nl_ads_cpt';
-
-// Fall back to 0 so a missing or non-numeric header doesn't propagate NaN into DataViews pagination.
-function parseHeaderInt( value ) {
-	const parsed = parseInt( value, 10 );
-	return Number.isNaN( parsed ) ? 0 : parsed;
-}
-
-function readPaginationInfo( response ) {
-	return {
-		totalItems: parseHeaderInt( response.headers.get( 'X-WP-Total' ) ),
-		totalPages: parseHeaderInt( response.headers.get( 'X-WP-TotalPages' ) ),
-	};
-}
+const TRASH_COUNT_PATH = `${ POSTS_PATH }?status=trash&per_page=1&context=edit`;
 
 export default function useAdsData( view ) {
-	const [ data, setData ] = useState( [] );
-	const [ paginationInfo, setPaginationInfo ] = useState( { totalItems: 0, totalPages: 0 } );
-	const [ isLoading, setIsLoading ] = useState( true );
-	const [ refreshKey, setRefreshKey ] = useState( 0 );
-	// `*Resolved` flips on success OR failure (drives the spinner gate); `hasLoadedOnce` only on success
-	// (gates the strict-empty banner so a transient error doesn't flash onboarding).
-	const [ mainResolved, setMainResolved ] = useState( false );
-	const [ trashResolved, setTrashResolved ] = useState( false );
-	const [ hasLoadedOnce, setHasLoadedOnce ] = useState( false );
-	// `null` = unknown; a failed trash fetch stays `null` so `=== 0` stays false and the banner stays hidden.
-	const [ trashCount, setTrashCount ] = useState( null );
-
-	const refresh = useCallback( () => setRefreshKey( key => key + 1 ), [] );
-
-	useEffect( () => {
-		let cancelled = false;
-		setIsLoading( true );
-
-		const path = `${ POSTS_PATH }${ toQueryString( buildQueryParams( view ) ) }`;
-
-		apiFetch( { path, parse: false } )
-			.then( async response => {
-				const items = await response.json();
-				if ( cancelled ) {
-					return;
-				}
-				setData( Array.isArray( items ) ? items : [] );
-				setPaginationInfo( readPaginationInfo( response ) );
-				setHasLoadedOnce( true );
-			} )
-			.catch( () => {
-				if ( cancelled ) {
-					return;
-				}
-				// Keep last-good data so a refetch error doesn't trip the strict-empty banner.
-				notifyError( __( 'Failed to load ads. Please refresh the page.', 'newspack-newsletters' ), {
-					id: 'newspack-newsletters-ads-list-fetch-error',
-				} );
-			} )
-			.finally( () => {
-				if ( ! cancelled ) {
-					setIsLoading( false );
-					setMainResolved( true );
-				}
-			} );
-
-		return () => {
-			cancelled = true;
-		};
-	}, [
-		view.page,
-		view.perPage,
-		view.search,
-		view.sort?.field,
-		view.sort?.direction,
-		// Filters are arrays of objects; serialise for referential equality.
-		JSON.stringify( view.filters || [] ),
-		refreshKey,
-	] );
-
-	useEffect( () => {
-		let cancelled = false;
-		// Back to "unknown" while the new count is in flight, or a freshly-trashed last item flashes EmptyState.
-		setTrashCount( null );
-		apiFetch( { path: `${ POSTS_PATH }?status=trash&per_page=1&context=edit`, parse: false } )
-			.then( response => {
-				if ( ! cancelled ) {
-					setTrashCount( parseHeaderInt( response.headers.get( 'X-WP-Total' ) ) );
-				}
-			} )
-			.catch( () => {} )
-			.finally( () => {
-				if ( ! cancelled ) {
-					setTrashResolved( true );
-				}
-			} );
-		return () => {
-			cancelled = true;
-		};
-	}, [ refreshKey ] );
-
-	const hasResolved = mainResolved && trashResolved;
-
-	return { data, paginationInfo, isLoading, hasResolved, hasLoadedOnce, trashCount, refresh };
+	return useCollectionData( {
+		path: `${ POSTS_PATH }${ toQueryString( buildQueryParams( view ) ) }`,
+		trashCountPath: TRASH_COUNT_PATH,
+		errorMessage: __( 'Failed to load ads. Please refresh the page.', 'newspack-newsletters' ),
+		errorNoticeId: 'newspack-newsletters-ads-list-fetch-error',
+	} );
 }

--- a/src/admin-shell/screens/advertisers-list/actions.js
+++ b/src/admin-shell/screens/advertisers-list/actions.js
@@ -9,57 +9,14 @@
  */
 
 import apiFetch from '@wordpress/api-fetch';
-import { Button } from '@wordpress/components';
-import { useState } from '@wordpress/element';
 import { __, _n, sprintf } from '@wordpress/i18n';
 
-import { notifyError, notifySuccess } from '../../notices';
+import ConfirmModal from '../../components/confirm-modal';
+import { runBulk } from '../../utils/bulk-action';
 
 const TAXONOMY_PATH = '/wp/v2/newspack_nl_advertiser';
 
 const deleteOne = id => apiFetch( { path: `${ TAXONOMY_PATH }/${ id }?force=true`, method: 'DELETE' } );
-
-function ConfirmDeleteModal( { items, closeModal, onConfirm } ) {
-	const [ isBusy, setIsBusy ] = useState( false );
-	const question = sprintf(
-		/* translators: %d: number of advertisers */
-		_n(
-			'Permanently delete %d advertiser? Ads referencing it will lose the assignment. This cannot be undone.',
-			'Permanently delete %d advertisers? Ads referencing them will lose the assignment. This cannot be undone.',
-			items.length,
-			'newspack-newsletters'
-		),
-		items.length
-	);
-
-	return (
-		<div>
-			<p>{ question }</p>
-			<div style={ { display: 'flex', gap: '8px', justifyContent: 'flex-end' } }>
-				<Button variant="tertiary" onClick={ closeModal } disabled={ isBusy }>
-					{ __( 'Cancel', 'newspack-newsletters' ) }
-				</Button>
-				<Button
-					variant="primary"
-					isDestructive
-					isBusy={ isBusy }
-					disabled={ isBusy }
-					onClick={ async () => {
-						setIsBusy( true );
-						try {
-							await onConfirm( items );
-							closeModal();
-						} catch ( error ) {
-							setIsBusy( false );
-						}
-					} }
-				>
-					{ isBusy ? __( 'Deleting…', 'newspack-newsletters' ) : __( 'Delete permanently', 'newspack-newsletters' ) }
-				</Button>
-			</div>
-		</div>
-	);
-}
 
 export function getActions( { onEdit, onMutated } ) {
 	const editAction = {
@@ -81,36 +38,44 @@ export function getActions( { onEdit, onMutated } ) {
 		isDestructive: true,
 		supportsBulk: true,
 		RenderModal: ( { items, closeModal } ) => (
-			<ConfirmDeleteModal
+			<ConfirmModal
 				items={ items }
 				closeModal={ closeModal }
-				onConfirm={ async list => {
-					const failed = [];
-					await Promise.all(
-						list.map( item =>
-							deleteOne( item.id ).catch( () => {
-								failed.push( item );
-							} )
-						)
-					);
-					// `onMutated` refetches both the paginated list and
-					// the all-advertisers cache that powers the parent
-					// picker — without the second refetch, a deleted
-					// term would linger in the modal's TreeSelect and
-					// fail server-side if picked as a parent.
-					onMutated();
-					if ( failed.length === 0 ) {
-						notifySuccess( _n( 'Advertiser deleted.', 'Advertisers deleted.', list.length, 'newspack-newsletters' ) );
-					} else {
-						notifyError(
+				confirmLabel={ __( 'Delete permanently', 'newspack-newsletters' ) }
+				confirmingLabel={ __( 'Deleting…', 'newspack-newsletters' ) }
+				question={ sprintf(
+					/* translators: %d: number of advertisers */
+					_n(
+						'Permanently delete %d advertiser? Ads referencing it will lose the assignment. This cannot be undone.',
+						'Permanently delete %d advertisers? Ads referencing them will lose the assignment. This cannot be undone.',
+						items.length,
+						'newspack-newsletters'
+					),
+					items.length
+				) }
+				isDestructive
+				onConfirm={ list =>
+					runBulk( list, item => deleteOne( item.id ), {
+						// `onMutated` refetches both the paginated list and
+						// the all-advertisers cache that powers the parent
+						// picker — without the second refetch, a deleted
+						// term would linger in the modal's TreeSelect and
+						// fail server-side if picked as a parent.
+						refresh: onMutated,
+						successPlural: n => _n( 'Advertiser deleted.', 'Advertisers deleted.', n, 'newspack-newsletters' ),
+						failurePlural: n =>
 							sprintf(
 								/* translators: %d: number that failed */
-								__( 'Failed to delete %d advertiser(s). Please try again.', 'newspack-newsletters' ),
-								failed.length
-							)
-						);
-					}
-				} }
+								_n(
+									'Failed to delete %d advertiser. Please try again.',
+									'Failed to delete %d advertisers. Please try again.',
+									n,
+									'newspack-newsletters'
+								),
+								n
+							),
+					} )
+				}
 			/>
 		),
 	};

--- a/src/admin-shell/screens/advertisers-list/initial-filters.js
+++ b/src/admin-shell/screens/advertisers-list/initial-filters.js
@@ -11,6 +11,8 @@
  * Pure module so it stays trivial to unit-test.
  */
 
+import { makeGetInitialView } from '../../utils/initial-view';
+
 // Map the WP REST terms controller `orderby` values that the React
 // DataView fields here also expose. `id` / `include` / `term_group`
 // are accepted by REST but the DataView has no field for them, so a
@@ -22,33 +24,9 @@ const ORDERBY_TO_SORT_FIELD = {
 	count: 'count',
 };
 
-/**
- * Read the current document URL and return a partial DataView `view`
- * patch (search / sort) seeded from forwarded legacy args. Anything
- * not present in the URL is omitted so callers can spread the result
- * over their `DEFAULT_VIEW` without clobbering keys.
- *
- * @param {string} [search] URL search string (defaults to `window.location.search`).
- * @return {Object} Partial view object.
- */
-export function getInitialView( search = typeof window === 'undefined' ? '' : window.location.search ) {
-	const params = new URLSearchParams( search );
-	const patch = {};
-
-	const term = params.get( 's' );
-	if ( term ) {
-		patch.search = term;
-	}
-
-	const orderby = params.get( 'orderby' );
-	const order = params.get( 'order' );
-	const sortField = orderby && ORDERBY_TO_SORT_FIELD[ orderby ];
-	if ( sortField ) {
-		patch.sort = {
-			field: sortField,
-			direction: 'desc' === ( order || '' ).toLowerCase() ? 'desc' : 'asc',
-		};
-	}
-
-	return patch;
-}
+// Alphabetical lists default to ascending; everywhere else the default
+// is descending.
+export const { getInitialView } = makeGetInitialView( {
+	orderbyMap: ORDERBY_TO_SORT_FIELD,
+	defaultSortDirection: 'asc',
+} );

--- a/src/admin-shell/screens/advertisers-list/use-advertisers-data.js
+++ b/src/admin-shell/screens/advertisers-list/use-advertisers-data.js
@@ -1,111 +1,21 @@
-/**
- * Server-side paginated data hook for the Advertisers list DataView.
- *
- * Wraps `apiFetch` against `/wp/v2/newspack_nl_advertiser` and reads
- * `X-WP-Total` / `X-WP-TotalPages` from the response headers. Mutations
- * are driven from the screen via the `mutationKey` argument — bumping
- * it from the parent triggers a refetch so the action handlers don't
- * have to thread a refresh callback through props.
- *
- * Mirrors the ads list `use-ads-data` shape — kept screen-local rather
- * than promoted to a shared hook because the search-arg shapes diverge
- * across surfaces and the savings would be trivial.
- */
-
-import apiFetch from '@wordpress/api-fetch';
-import { useEffect, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 
+import useCollectionData from '../../hooks/use-collection-data';
 import { buildQueryParams, toQueryString } from '../../utils/build-query';
-import { notifyError } from '../../notices';
 
 const TAXONOMY_PATH = '/wp/v2/newspack_nl_advertiser';
 
-function parseHeaderInt( value ) {
-	const parsed = parseInt( value, 10 );
-	return Number.isNaN( parsed ) ? 0 : parsed;
-}
-
-function readPaginationInfo( response ) {
-	return {
-		totalItems: parseHeaderInt( response.headers.get( 'X-WP-Total' ) ),
-		totalPages: parseHeaderInt( response.headers.get( 'X-WP-TotalPages' ) ),
-	};
-}
-
-function buildPath( view ) {
-	return `${ TAXONOMY_PATH }${ toQueryString( buildQueryParams( view ) ) }`;
-}
-
 /**
  * @param {Object} view          DataViews view state.
- * @param {number} [mutationKey] Increment from the parent to force a
- *                               refetch after a mutation (Modal save,
- *                               per-row / bulk Delete). Shared with
- *                               `useAllAdvertisers` so both datasets
- *                               refetch in lockstep.
- * @return {{ data: Array, paginationInfo: Object, isLoading: boolean, hasLoadedOnce: boolean }} The current data, pagination info, and loading flags.
+ * @param {number} [mutationKey] Bump from the parent (Modal save / Delete) to force a refetch.
+ *                               Shared with `useAllAdvertisers` so both datasets refetch in lockstep.
+ * @return {ReturnType<typeof useCollectionData>} Hook state.
  */
 export default function useAdvertisersData( view, mutationKey = 0 ) {
-	const [ data, setData ] = useState( [] );
-	const [ paginationInfo, setPaginationInfo ] = useState( { totalItems: 0, totalPages: 0 } );
-	const [ isLoading, setIsLoading ] = useState( true );
-	// `hasResolved` flips on either success or failure of the first fetch — drives the spinner gate so a first-load
-	// error doesn't leave the screen stuck on the placeholder. `hasLoadedOnce` only flips on a successful response —
-	// drives the strict-empty check so a transient fetch failure doesn't trigger the onboarding banner.
-	const [ hasResolved, setHasResolved ] = useState( false );
-	const [ hasLoadedOnce, setHasLoadedOnce ] = useState( false );
-
-	useEffect( () => {
-		let cancelled = false;
-		setIsLoading( true );
-
-		apiFetch( { path: buildPath( view ), parse: false } )
-			.then( async response => {
-				const items = await response.json();
-				if ( cancelled ) {
-					return;
-				}
-				setData( Array.isArray( items ) ? items : [] );
-				setPaginationInfo( readPaginationInfo( response ) );
-				// Only flip `hasLoadedOnce` after a successful response.
-				// On error the catch path resets `paginationInfo` to
-				// `{ totalItems: 0, totalPages: 0 }`; if the flag also
-				// flipped here, the screen's `isStrictEmpty` check would
-				// render the onboarding EmptyState for a failed load —
-				// misleading (the list may be non-empty, it just
-				// couldn't be fetched). Keeping the flag tied to a
-				// confirmed totalItems read keeps the empty state honest.
-				setHasLoadedOnce( true );
-			} )
-			.catch( () => {
-				if ( cancelled ) {
-					return;
-				}
-				// Don't clobber `data` or `paginationInfo` on failure.
-				// Two reasons: (1) on first-load failure they're still
-				// at their initial empty values, so resetting is a
-				// no-op; (2) on a later-refresh failure (page change,
-				// filter change, post-mutation refetch), preserving
-				// the last good data keeps the DataView populated and
-				// prevents `isStrictEmpty` from spuriously rendering
-				// the onboarding EmptyState — the failure surfaces via
-				// the error notice instead.
-				notifyError( __( 'Failed to load advertisers. Please refresh the page.', 'newspack-newsletters' ), {
-					id: 'newspack-newsletters-advertisers-list-fetch-error',
-				} );
-			} )
-			.finally( () => {
-				if ( ! cancelled ) {
-					setIsLoading( false );
-					setHasResolved( true );
-				}
-			} );
-
-		return () => {
-			cancelled = true;
-		};
-	}, [ view.page, view.perPage, view.search, view.sort?.field, view.sort?.direction, mutationKey ] );
-
-	return { data, paginationInfo, isLoading, hasResolved, hasLoadedOnce };
+	return useCollectionData( {
+		path: `${ TAXONOMY_PATH }${ toQueryString( buildQueryParams( view ) ) }`,
+		mutationKey,
+		errorMessage: __( 'Failed to load advertisers. Please refresh the page.', 'newspack-newsletters' ),
+		errorNoticeId: 'newspack-newsletters-advertisers-list-fetch-error',
+	} );
 }

--- a/src/admin-shell/screens/advertisers-list/use-advertisers-data.js
+++ b/src/admin-shell/screens/advertisers-list/use-advertisers-data.js
@@ -16,6 +16,7 @@ import apiFetch from '@wordpress/api-fetch';
 import { useEffect, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 
+import { buildQueryParams, toQueryString } from '../../utils/build-query';
 import { notifyError } from '../../notices';
 
 const TAXONOMY_PATH = '/wp/v2/newspack_nl_advertiser';
@@ -33,18 +34,7 @@ function readPaginationInfo( response ) {
 }
 
 function buildPath( view ) {
-	const params = new URLSearchParams();
-	params.set( 'page', String( view.page || 1 ) );
-	params.set( 'per_page', String( view.perPage || 25 ) );
-	params.set( 'context', 'edit' );
-	if ( view.search ) {
-		params.set( 'search', view.search );
-	}
-	if ( view.sort?.field ) {
-		params.set( 'orderby', view.sort.field );
-		params.set( 'order', view.sort.direction === 'asc' ? 'asc' : 'desc' );
-	}
-	return `${ TAXONOMY_PATH }?${ params.toString() }`;
+	return `${ TAXONOMY_PATH }${ toQueryString( buildQueryParams( view ) ) }`;
 }
 
 /**

--- a/src/admin-shell/screens/layouts-list/actions.js
+++ b/src/admin-shell/screens/layouts-list/actions.js
@@ -3,16 +3,12 @@
  */
 
 import apiFetch from '@wordpress/api-fetch';
-import {
-	Button,
-	__experimentalHStack as HStack, // eslint-disable-line @wordpress/no-unsafe-wp-apis
-	__experimentalVStack as VStack, // eslint-disable-line @wordpress/no-unsafe-wp-apis
-} from '@wordpress/components';
-import { useState } from '@wordpress/element';
 import { __, _n, sprintf } from '@wordpress/i18n';
 
 import { LAYOUT_CPT_SLUG } from '../../../utils/consts';
+import ConfirmModal from '../../components/confirm-modal';
 import { notifyError, notifySuccess } from '../../notices';
+import { runBulk } from '../../utils/bulk-action';
 
 const COLLECTION_PATH = `/wp/v2/${ LAYOUT_CPT_SLUG }`;
 
@@ -75,48 +71,6 @@ async function duplicateSaved( item ) {
 
 const duplicateOne = item => ( item?.is_prebuilt ? duplicatePrebuilt( item ) : duplicateSaved( item ) );
 
-function ConfirmDeleteModal( { items, closeModal, onConfirm } ) {
-	const [ isBusy, setIsBusy ] = useState( false );
-	const question = sprintf(
-		/* translators: %d: number of layouts */
-		_n(
-			'Permanently delete %d layout? Newsletters created from it keep their content; only the saved layout entry is removed. This cannot be undone.',
-			'Permanently delete %d layouts? Newsletters created from them keep their content; only the saved layout entries are removed. This cannot be undone.',
-			items.length,
-			'newspack-newsletters'
-		),
-		items.length
-	);
-
-	return (
-		<VStack spacing={ 4 }>
-			<p style={ { margin: 0 } }>{ question }</p>
-			<HStack justify="flex-end" spacing={ 2 }>
-				<Button variant="tertiary" onClick={ closeModal } disabled={ isBusy }>
-					{ __( 'Cancel', 'newspack-newsletters' ) }
-				</Button>
-				<Button
-					variant="primary"
-					isDestructive
-					isBusy={ isBusy }
-					disabled={ isBusy }
-					onClick={ async () => {
-						setIsBusy( true );
-						try {
-							await onConfirm( items );
-							closeModal();
-						} catch ( error ) {
-							setIsBusy( false );
-						}
-					} }
-				>
-					{ isBusy ? __( 'Deleting…', 'newspack-newsletters' ) : __( 'Delete permanently', 'newspack-newsletters' ) }
-				</Button>
-			</HStack>
-		</VStack>
-	);
-}
-
 // Prebuilts are bundled JSON, shared across every site, and locked from
 // every mutating action in this view.
 const isUserOwned = item => ! item?.is_prebuilt;
@@ -175,31 +129,39 @@ export function getActions( { onRenameStart, onMutated } ) {
 		isEligible: isUserOwned,
 		modalSize: 'small',
 		RenderModal: ( { items, closeModal } ) => (
-			<ConfirmDeleteModal
+			<ConfirmModal
 				items={ items }
 				closeModal={ closeModal }
-				onConfirm={ async list => {
-					const failed = [];
-					await Promise.all(
-						list.map( item =>
-							deleteOne( item.id ).catch( () => {
-								failed.push( item );
-							} )
-						)
-					);
-					onMutated();
-					if ( failed.length === 0 ) {
-						notifySuccess( _n( 'Layout deleted.', 'Layouts deleted.', list.length, 'newspack-newsletters' ) );
-					} else {
-						notifyError(
+				confirmLabel={ __( 'Delete permanently', 'newspack-newsletters' ) }
+				confirmingLabel={ __( 'Deleting…', 'newspack-newsletters' ) }
+				question={ sprintf(
+					/* translators: %d: number of layouts */
+					_n(
+						'Permanently delete %d layout? Newsletters created from it keep their content; only the saved layout entry is removed. This cannot be undone.',
+						'Permanently delete %d layouts? Newsletters created from them keep their content; only the saved layout entries are removed. This cannot be undone.',
+						items.length,
+						'newspack-newsletters'
+					),
+					items.length
+				) }
+				isDestructive
+				onConfirm={ list =>
+					runBulk( list, item => deleteOne( item.id ), {
+						refresh: onMutated,
+						successPlural: n => _n( 'Layout deleted.', 'Layouts deleted.', n, 'newspack-newsletters' ),
+						failurePlural: n =>
 							sprintf(
 								/* translators: %d: number that failed */
-								__( 'Failed to delete %d layout(s). Please try again.', 'newspack-newsletters' ),
-								failed.length
-							)
-						);
-					}
-				} }
+								_n(
+									'Failed to delete %d layout. Please try again.',
+									'Failed to delete %d layouts. Please try again.',
+									n,
+									'newspack-newsletters'
+								),
+								n
+							),
+					} )
+				}
 			/>
 		),
 	};

--- a/src/admin-shell/screens/layouts-list/initial-filters.js
+++ b/src/admin-shell/screens/layouts-list/initial-filters.js
@@ -9,39 +9,14 @@
  * URL-shareable filter / sort state is supported day-one.
  */
 
+import { makeGetInitialView } from '../../utils/initial-view';
+
 const ORDERBY_TO_SORT_FIELD = {
 	title: 'title',
 	modified: 'modified',
 	date: 'date',
 };
 
-/**
- * Read the document URL and return a partial DataView `view` patch
- * (search / sort) seeded from the query string. Anything not present
- * is omitted so the caller can spread the result over its
- * `DEFAULT_VIEW` without clobbering keys.
- *
- * @param {string} [search] URL search string (defaults to `window.location.search`).
- * @return {Object} Partial view object.
- */
-export function getInitialView( search = typeof window === 'undefined' ? '' : window.location.search ) {
-	const params = new URLSearchParams( search );
-	const patch = {};
-
-	const term = params.get( 's' );
-	if ( term ) {
-		patch.search = term;
-	}
-
-	const orderby = params.get( 'orderby' );
-	const order = params.get( 'order' );
-	const sortField = orderby && ORDERBY_TO_SORT_FIELD[ orderby ];
-	if ( sortField ) {
-		patch.sort = {
-			field: sortField,
-			direction: 'asc' === ( order || '' ).toLowerCase() ? 'asc' : 'desc',
-		};
-	}
-
-	return patch;
-}
+export const { getInitialView } = makeGetInitialView( {
+	orderbyMap: ORDERBY_TO_SORT_FIELD,
+} );

--- a/src/admin-shell/screens/layouts-list/use-layouts-data.js
+++ b/src/admin-shell/screens/layouts-list/use-layouts-data.js
@@ -1,43 +1,23 @@
-/**
- * Server-side paginated data hook for the Layouts list DataView.
- * Mirrors the ads list / advertisers list shape.
- */
-
-import apiFetch from '@wordpress/api-fetch';
-import { useEffect, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 
 import { LAYOUT_CPT_SLUG } from '../../../utils/consts';
+import useCollectionData from '../../hooks/use-collection-data';
 import { buildQueryParams, toQueryString } from '../../utils/build-query';
-import { notifyError } from '../../notices';
 
 const COLLECTION_PATH = `/wp/v2/${ LAYOUT_CPT_SLUG }`;
-
-// `auto-draft` keeps an abandoned "Add new" visible. `future` is excluded
-// — layouts don't surface scheduling.
+// `future` is excluded — layouts don't surface scheduling. `auto-draft` keeps "Add new" + back visible.
 const DEFAULT_STATUSES = 'publish,private,draft,pending,auto-draft';
 
-function parseHeaderInt( value ) {
-	const parsed = parseInt( value, 10 );
-	return Number.isNaN( parsed ) ? 0 : parsed;
-}
-
-function readPaginationInfo( response ) {
-	return {
-		totalItems: parseHeaderInt( response.headers.get( 'X-WP-Total' ) ),
-		totalPages: parseHeaderInt( response.headers.get( 'X-WP-TotalPages' ) ),
-	};
-}
-
 function buildPath( view ) {
+	if ( ! view ) {
+		return '';
+	}
 	const params = buildQueryParams( view, {
 		defaultPerPage: 12,
 		defaultStatuses: DEFAULT_STATUSES,
-		// `offset` overrides `page` so page 1 can reserve slots for prebuilts
-		// and subsequent pages start mid-collection.
+		// `offset` overrides `page` so page 1 can reserve slots for prebuilts.
 		supportsOffset: true,
-		// Legacy `_embed=1` form — layouts pull author + taxonomy + revisions
-		// in one request for the grid preview tooltip.
+		// Legacy `_embed=1` returns author + taxonomy in one go for grid tooltips.
 		extraParams: { _embed: '1' },
 		arrayParams: [ { viewKey: 'author', param: 'author' } ],
 	} );
@@ -45,72 +25,15 @@ function buildPath( view ) {
 }
 
 /**
- * @param {Object} view          DataViews view state.
- * @param {number} [mutationKey] Increment from the parent to force a refetch after a mutation.
- * @return {{ data: Array, paginationInfo: Object, isLoading: boolean, hasResolved: boolean, hasLoadedOnce: boolean }} The current data, pagination info, and loading flags.
+ * @param {Object|null} view          DataViews view state, or `null` to defer the fetch.
+ * @param {number}      [mutationKey] Bump from the parent to force a refetch after a mutation.
+ * @return {ReturnType<typeof useCollectionData>} Hook state.
  */
 export default function useLayoutsData( view, mutationKey = 0 ) {
-	const [ data, setData ] = useState( [] );
-	const [ paginationInfo, setPaginationInfo ] = useState( { totalItems: 0, totalPages: 0 } );
-	const [ isLoading, setIsLoading ] = useState( true );
-	// `hasResolved` flips on success or failure of the first real fetch
-	// (deliberately stays false while `view === null` — flipping there
-	// races the parent latch on null → non-null transitions).
-	// `hasLoadedOnce` only flips on success.
-	const [ hasResolved, setHasResolved ] = useState( false );
-	const [ hasLoadedOnce, setHasLoadedOnce ] = useState( false );
-
-	useEffect( () => {
-		if ( ! view ) {
-			setData( [] );
-			setPaginationInfo( { totalItems: 0, totalPages: 0 } );
-			setIsLoading( false );
-			return undefined;
-		}
-		let cancelled = false;
-		setIsLoading( true );
-
-		apiFetch( { path: buildPath( view ), parse: false } )
-			.then( async response => {
-				const items = await response.json();
-				if ( cancelled ) {
-					return;
-				}
-				setData( Array.isArray( items ) ? items : [] );
-				setPaginationInfo( readPaginationInfo( response ) );
-				setHasLoadedOnce( true );
-			} )
-			.catch( () => {
-				if ( cancelled ) {
-					return;
-				}
-				// Preserve the last good page on failure — a transient
-				// network error shouldn't blank the screen.
-				notifyError( __( 'Failed to load layouts. Please refresh the page.', 'newspack-newsletters' ), {
-					id: 'newspack-newsletters-layouts-list-fetch-error',
-				} );
-			} )
-			.finally( () => {
-				if ( ! cancelled ) {
-					setIsLoading( false );
-					setHasResolved( true );
-				}
-			} );
-
-		return () => {
-			cancelled = true;
-		};
-	}, [
-		view?.page,
-		view?.perPage,
-		view?.offset,
-		view?.search,
-		view?.sort?.field,
-		view?.sort?.direction,
-		// Stringify so reference-only changes to the array don't refetch.
-		Array.isArray( view?.author ) ? view.author.join( ',' ) : '',
+	return useCollectionData( {
+		path: buildPath( view ),
 		mutationKey,
-	] );
-
-	return { data, paginationInfo, isLoading, hasResolved, hasLoadedOnce };
+		errorMessage: __( 'Failed to load layouts. Please refresh the page.', 'newspack-newsletters' ),
+		errorNoticeId: 'newspack-newsletters-layouts-list-fetch-error',
+	} );
 }

--- a/src/admin-shell/screens/layouts-list/use-layouts-data.js
+++ b/src/admin-shell/screens/layouts-list/use-layouts-data.js
@@ -8,9 +8,14 @@ import { useEffect, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 
 import { LAYOUT_CPT_SLUG } from '../../../utils/consts';
+import { buildQueryParams, toQueryString } from '../../utils/build-query';
 import { notifyError } from '../../notices';
 
 const COLLECTION_PATH = `/wp/v2/${ LAYOUT_CPT_SLUG }`;
+
+// `auto-draft` keeps an abandoned "Add new" visible. `future` is excluded
+// — layouts don't surface scheduling.
+const DEFAULT_STATUSES = 'publish,private,draft,pending,auto-draft';
 
 function parseHeaderInt( value ) {
 	const parsed = parseInt( value, 10 );
@@ -25,31 +30,18 @@ function readPaginationInfo( response ) {
 }
 
 function buildPath( view ) {
-	const params = new URLSearchParams();
-	// `offset` overrides `page` so page 1 can reserve slots for prebuilts
-	// and subsequent pages start mid-collection.
-	if ( typeof view.offset === 'number' ) {
-		params.set( 'offset', String( view.offset ) );
-	} else {
-		params.set( 'page', String( view.page || 1 ) );
-	}
-	params.set( 'per_page', String( view.perPage || 12 ) );
-	params.set( 'context', 'edit' );
-	if ( view.search ) {
-		params.set( 'search', view.search );
-	}
-	if ( view.sort?.field ) {
-		params.set( 'orderby', view.sort.field );
-		params.set( 'order', view.sort.direction === 'asc' ? 'asc' : 'desc' );
-	}
-	// `auto-draft` keeps an abandoned "Add new" visible. `future` is excluded
-	// — layouts don't surface scheduling.
-	params.set( 'status', 'publish,private,draft,pending,auto-draft' );
-	params.set( '_embed', '1' );
-	if ( Array.isArray( view.author ) && view.author.length > 0 ) {
-		params.set( 'author', view.author.join( ',' ) );
-	}
-	return `${ COLLECTION_PATH }?${ params.toString() }`;
+	const params = buildQueryParams( view, {
+		defaultPerPage: 12,
+		defaultStatuses: DEFAULT_STATUSES,
+		// `offset` overrides `page` so page 1 can reserve slots for prebuilts
+		// and subsequent pages start mid-collection.
+		supportsOffset: true,
+		// Legacy `_embed=1` form — layouts pull author + taxonomy + revisions
+		// in one request for the grid preview tooltip.
+		extraParams: { _embed: '1' },
+		arrayParams: [ { viewKey: 'author', param: 'author' } ],
+	} );
+	return `${ COLLECTION_PATH }${ toQueryString( params ) }`;
 }
 
 /**

--- a/src/admin-shell/screens/newsletters-list/actions.js
+++ b/src/admin-shell/screens/newsletters-list/actions.js
@@ -9,14 +9,13 @@
  */
 
 import apiFetch from '@wordpress/api-fetch';
-import { Button } from '@wordpress/components';
-import { useState } from '@wordpress/element';
 import { __, _n, sprintf } from '@wordpress/i18n';
 import { edit, trash } from '@wordpress/icons';
 
 import { getAdminUrl } from '../../admin-globals';
+import ConfirmModal from '../../components/confirm-modal';
 import RenameForm from '../../components/rename-form';
-import { notifyError, notifySuccess } from '../../notices';
+import { runBulk } from '../../utils/bulk-action';
 import { isTrashed } from './status-label';
 
 const POSTS_PATH = '/wp/v2/newspack_nl_cpt';
@@ -61,37 +60,6 @@ const setIsPublic = ( id, isPublic ) =>
 		data: { meta: { is_public: !! isPublic } },
 	} );
 
-function ConfirmModal( { items, closeModal, confirmLabel, confirmingLabel, question, isDestructive, onConfirm } ) {
-	const [ isBusy, setIsBusy ] = useState( false );
-	return (
-		<div>
-			<p>{ question }</p>
-			<div style={ { display: 'flex', gap: '8px', justifyContent: 'flex-end' } }>
-				<Button variant="tertiary" onClick={ closeModal } disabled={ isBusy }>
-					{ __( 'Cancel', 'newspack-newsletters' ) }
-				</Button>
-				<Button
-					variant="primary"
-					isDestructive={ isDestructive }
-					isBusy={ isBusy }
-					disabled={ isBusy }
-					onClick={ async () => {
-						setIsBusy( true );
-						try {
-							await onConfirm( items );
-							closeModal();
-						} catch ( error ) {
-							setIsBusy( false );
-						}
-					} }
-				>
-					{ isBusy ? confirmingLabel : confirmLabel }
-				</Button>
-			</div>
-		</div>
-	);
-}
-
 // Eligibility predicates extracted to constants so each non-modal bulk
 // callback can re-apply them to the selection. DataViews only filters
 // by `isEligible` automatically for **modal** bulk actions; plain
@@ -100,6 +68,20 @@ function ConfirmModal( { items, closeModal, confirmLabel, confirmingLabel, quest
 // the latter when they hit "Restore".
 const isMakePublicEligible = item => ! isTrashed( item ) && ! item?.meta?.is_public;
 const isMakeNonPublicEligible = item => ! isTrashed( item ) && !! item?.meta?.is_public;
+
+const visibilitySuccess = n =>
+	sprintf(
+		/* translators: %d: number of newsletters updated */
+		_n( 'Visibility updated for %d newsletter.', 'Visibility updated for %d newsletters.', n, 'newspack-newsletters' ),
+		n
+	);
+
+const visibilityFailure = n =>
+	sprintf(
+		/* translators: %d: number of newsletters that failed */
+		_n( 'Failed to update visibility for %d newsletter.', 'Failed to update visibility for %d newsletters.', n, 'newspack-newsletters' ),
+		n
+	);
 
 export function getActions( { refresh, openQuickEdit } ) {
 	const editAction = {
@@ -175,42 +157,11 @@ export function getActions( { refresh, openQuickEdit } ) {
 			if ( eligible.length === 0 ) {
 				return;
 			}
-			const failed = [];
-			await Promise.all(
-				eligible.map( item =>
-					setIsPublic( item.id, true ).catch( () => {
-						failed.push( item );
-					} )
-				)
-			);
-			refresh();
-			if ( failed.length === 0 ) {
-				notifySuccess(
-					sprintf(
-						/* translators: %d: number of newsletters updated */
-						_n(
-							'Visibility updated for %d newsletter.',
-							'Visibility updated for %d newsletters.',
-							eligible.length,
-							'newspack-newsletters'
-						),
-						eligible.length
-					)
-				);
-			} else {
-				notifyError(
-					sprintf(
-						/* translators: %d: number of newsletters that failed */
-						_n(
-							'Failed to update visibility for %d newsletter.',
-							'Failed to update visibility for %d newsletters.',
-							failed.length,
-							'newspack-newsletters'
-						),
-						failed.length
-					)
-				);
-			}
+			await runBulk( eligible, item => setIsPublic( item.id, true ), {
+				refresh,
+				successPlural: visibilitySuccess,
+				failurePlural: visibilityFailure,
+			} );
 		},
 	};
 
@@ -224,42 +175,11 @@ export function getActions( { refresh, openQuickEdit } ) {
 			if ( eligible.length === 0 ) {
 				return;
 			}
-			const failed = [];
-			await Promise.all(
-				eligible.map( item =>
-					setIsPublic( item.id, false ).catch( () => {
-						failed.push( item );
-					} )
-				)
-			);
-			refresh();
-			if ( failed.length === 0 ) {
-				notifySuccess(
-					sprintf(
-						/* translators: %d: number of newsletters updated */
-						_n(
-							'Visibility updated for %d newsletter.',
-							'Visibility updated for %d newsletters.',
-							eligible.length,
-							'newspack-newsletters'
-						),
-						eligible.length
-					)
-				);
-			} else {
-				notifyError(
-					sprintf(
-						/* translators: %d: number of newsletters that failed */
-						_n(
-							'Failed to update visibility for %d newsletter.',
-							'Failed to update visibility for %d newsletters.',
-							failed.length,
-							'newspack-newsletters'
-						),
-						failed.length
-					)
-				);
-			}
+			await runBulk( eligible, item => setIsPublic( item.id, false ), {
+				refresh,
+				successPlural: visibilitySuccess,
+				failurePlural: visibilityFailure,
+			} );
 		},
 	};
 
@@ -289,28 +209,23 @@ export function getActions( { refresh, openQuickEdit } ) {
 					items.length
 				) }
 				isDestructive
-				onConfirm={ async list => {
-					const failed = [];
-					await Promise.all(
-						list.map( item =>
-							trashOne( item.id ).catch( () => {
-								failed.push( item );
-							} )
-						)
-					);
-					refresh();
-					if ( failed.length === 0 ) {
-						notifySuccess( _n( 'Newsletter moved to trash.', 'Newsletters moved to trash.', list.length, 'newspack-newsletters' ) );
-					} else {
-						notifyError(
+				onConfirm={ list =>
+					runBulk( list, item => trashOne( item.id ), {
+						refresh,
+						successPlural: n => _n( 'Newsletter moved to trash.', 'Newsletters moved to trash.', n, 'newspack-newsletters' ),
+						failurePlural: n =>
 							sprintf(
 								/* translators: %d: number that failed */
-								__( 'Failed to trash %d newsletter(s). Please try again.', 'newspack-newsletters' ),
-								failed.length
-							)
-						);
-					}
-				} }
+								_n(
+									'Failed to trash %d newsletter. Please try again.',
+									'Failed to trash %d newsletters. Please try again.',
+									n,
+									'newspack-newsletters'
+								),
+								n
+							),
+					} )
+				}
 			/>
 		),
 	};
@@ -325,26 +240,16 @@ export function getActions( { refresh, openQuickEdit } ) {
 			if ( eligible.length === 0 ) {
 				return;
 			}
-			const failed = [];
-			await Promise.all(
-				eligible.map( item =>
-					restoreOne( item.id ).catch( () => {
-						failed.push( item );
-					} )
-				)
-			);
-			refresh();
-			if ( failed.length === 0 ) {
-				notifySuccess( _n( 'Newsletter restored.', 'Newsletters restored.', eligible.length, 'newspack-newsletters' ) );
-			} else {
-				notifyError(
+			await runBulk( eligible, item => restoreOne( item.id ), {
+				refresh,
+				successPlural: n => _n( 'Newsletter restored.', 'Newsletters restored.', n, 'newspack-newsletters' ),
+				failurePlural: n =>
 					sprintf(
 						/* translators: %d: number that failed */
-						__( 'Failed to restore %d newsletter(s).', 'newspack-newsletters' ),
-						failed.length
-					)
-				);
-			}
+						_n( 'Failed to restore %d newsletter.', 'Failed to restore %d newsletters.', n, 'newspack-newsletters' ),
+						n
+					),
+			} );
 		},
 	};
 
@@ -371,28 +276,18 @@ export function getActions( { refresh, openQuickEdit } ) {
 					items.length
 				) }
 				isDestructive
-				onConfirm={ async list => {
-					const failed = [];
-					await Promise.all(
-						list.map( item =>
-							deleteOne( item.id ).catch( () => {
-								failed.push( item );
-							} )
-						)
-					);
-					refresh();
-					if ( failed.length === 0 ) {
-						notifySuccess( _n( 'Newsletter deleted.', 'Newsletters deleted.', list.length, 'newspack-newsletters' ) );
-					} else {
-						notifyError(
+				onConfirm={ list =>
+					runBulk( list, item => deleteOne( item.id ), {
+						refresh,
+						successPlural: n => _n( 'Newsletter deleted.', 'Newsletters deleted.', n, 'newspack-newsletters' ),
+						failurePlural: n =>
 							sprintf(
 								/* translators: %d: number that failed */
-								__( 'Failed to delete %d newsletter(s).', 'newspack-newsletters' ),
-								failed.length
-							)
-						);
-					}
-				} }
+								_n( 'Failed to delete %d newsletter.', 'Failed to delete %d newsletters.', n, 'newspack-newsletters' ),
+								n
+							),
+					} )
+				}
 			/>
 		),
 	};

--- a/src/admin-shell/screens/newsletters-list/build-query.js
+++ b/src/admin-shell/screens/newsletters-list/build-query.js
@@ -19,8 +19,8 @@ import { buildQueryParams as baseBuildQueryParams, toQueryString } from '../../u
 // `auto-draft` so an abandoned "Add new" still shows in the list.
 const DEFAULT_STATUSES = 'publish,private,future,draft,pending,auto-draft';
 
+// `status` is handled separately by the shared util's status-filter branch, not here.
 const FIELD_TO_QUERY_PARAM = {
-	status: 'status',
 	author: 'author',
 	categories: 'categories',
 	tags: 'tags',

--- a/src/admin-shell/screens/newsletters-list/build-query.js
+++ b/src/admin-shell/screens/newsletters-list/build-query.js
@@ -14,8 +14,10 @@
  *   common writable statuses when no status filter is set.
  */
 
+import { buildQueryParams as baseBuildQueryParams, toQueryString } from '../../utils/build-query';
+
 // `auto-draft` so an abandoned "Add new" still shows in the list.
-const DEFAULT_STATUSES = [ 'publish', 'private', 'future', 'draft', 'pending', 'auto-draft' ];
+const DEFAULT_STATUSES = 'publish,private,future,draft,pending,auto-draft';
 
 const FIELD_TO_QUERY_PARAM = {
 	status: 'status',
@@ -36,73 +38,13 @@ const SORT_FIELD_TO_ORDERBY = {
 	author: 'author',
 };
 
-function asArray( value ) {
-	if ( Array.isArray( value ) ) {
-		return value;
-	}
-	if ( value === undefined || value === null || value === '' ) {
-		return [];
-	}
-	return [ value ];
-}
-
 export function buildQueryParams( view = {} ) {
-	const params = {
-		page: view.page || 1,
-		per_page: view.perPage || 25,
-		_embed: 'author,wp:term',
-		context: 'edit',
-	};
-
-	if ( view.search ) {
-		params.search = view.search;
-	}
-
-	if ( view.sort?.field && SORT_FIELD_TO_ORDERBY[ view.sort.field ] ) {
-		params.orderby = SORT_FIELD_TO_ORDERBY[ view.sort.field ];
-		params.order = view.sort.direction === 'asc' ? 'asc' : 'desc';
-	}
-
-	const filters = Array.isArray( view.filters ) ? view.filters : [];
-	const statusFilter = filters.find( filter => filter.field === 'status' );
-
-	if ( statusFilter ) {
-		params.status = asArray( statusFilter.value ).join( ',' );
-	} else {
-		params.status = DEFAULT_STATUSES.join( ',' );
-	}
-
-	for ( const filter of filters ) {
-		if ( filter.field === 'status' ) {
-			continue;
-		}
-		const param = FIELD_TO_QUERY_PARAM[ filter.field ];
-		if ( ! param ) {
-			continue;
-		}
-		const values = asArray( filter.value );
-		if ( values.length === 0 ) {
-			continue;
-		}
-		params[ param ] = values.join( ',' );
-	}
-
-	return params;
-}
-
-/**
- * Serialise params object into a query string suitable for apiFetch's `path`.
- *
- * @param {Object} params Query params from buildQueryParams.
- * @return {string} Query string starting with `?`.
- */
-export function toQueryString( params ) {
-	const search = new URLSearchParams();
-	Object.entries( params ).forEach( ( [ key, value ] ) => {
-		if ( value === undefined || value === null || value === '' ) {
-			return;
-		}
-		search.append( key, String( value ) );
+	return baseBuildQueryParams( view, {
+		fieldToQueryParam: FIELD_TO_QUERY_PARAM,
+		sortFieldToOrderby: SORT_FIELD_TO_ORDERBY,
+		defaultStatuses: DEFAULT_STATUSES,
+		extraParams: { _embed: 'author,wp:term' },
 	} );
-	return `?${ search.toString() }`;
 }
+
+export { toQueryString };

--- a/src/admin-shell/screens/newsletters-list/initial-filters.js
+++ b/src/admin-shell/screens/newsletters-list/initial-filters.js
@@ -9,6 +9,8 @@
  * Pure module so it stays trivial to unit-test.
  */
 
+import { makeGetInitialView } from '../../utils/initial-view';
+
 const POST_STATUS_TO_FILTER_VALUE = {
 	trash: 'trash',
 	draft: 'draft,pending,auto-draft',
@@ -36,75 +38,8 @@ const URL_PARAM_TO_FILTER_FIELD = {
 	newspack_newsletters_send_list_id: 'send_list',
 };
 
-/**
- * Read the current document URL and return DataViews-compatible
- * filters seeded from `post_status`. Returns `[]` when no recognised
- * value is present.
- *
- * @param {string} [search] URL search string (defaults to `window.location.search`).
- * @return {Array<{ field: string, operator: string, value: Array<string> }>} DataViews-shaped initial filters.
- */
-export function getInitialFilters( search = typeof window === 'undefined' ? '' : window.location.search ) {
-	const params = new URLSearchParams( search );
-	const filters = [];
-
-	const postStatus = params.get( 'post_status' );
-	if ( postStatus ) {
-		const value = POST_STATUS_TO_FILTER_VALUE[ postStatus ];
-		if ( value ) {
-			filters.push( { field: 'status', operator: 'isAny', value: [ value ] } );
-		}
-	}
-
-	for ( const [ urlParam, fieldId ] of Object.entries( URL_PARAM_TO_FILTER_FIELD ) ) {
-		const raw = params.get( urlParam );
-		if ( ! raw ) {
-			continue;
-		}
-		const values = raw
-			.split( ',' )
-			.map( v => v.trim() )
-			.filter( Boolean );
-		if ( values.length > 0 ) {
-			filters.push( { field: fieldId, operator: 'isAny', value: values } );
-		}
-	}
-
-	return filters;
-}
-
-/**
- * Read the current document URL and return a partial DataView `view`
- * patch (filters / search / sort) seeded from forwarded legacy args.
- * Anything not present in the URL is omitted so callers can spread
- * the result over their `DEFAULT_VIEW` without clobbering keys.
- *
- * @param {string} [search] URL search string (defaults to `window.location.search`).
- * @return {Object} Partial view object.
- */
-export function getInitialView( search = typeof window === 'undefined' ? '' : window.location.search ) {
-	const params = new URLSearchParams( search );
-	const patch = {};
-
-	const filters = getInitialFilters( search );
-	if ( filters.length > 0 ) {
-		patch.filters = filters;
-	}
-
-	const term = params.get( 's' );
-	if ( term ) {
-		patch.search = term;
-	}
-
-	const orderby = params.get( 'orderby' );
-	const order = params.get( 'order' );
-	const sortField = orderby && ORDERBY_TO_SORT_FIELD[ orderby ];
-	if ( sortField ) {
-		patch.sort = {
-			field: sortField,
-			direction: 'asc' === ( order || '' ).toLowerCase() ? 'asc' : 'desc',
-		};
-	}
-
-	return patch;
-}
+export const { getInitialFilters, getInitialView } = makeGetInitialView( {
+	orderbyMap: ORDERBY_TO_SORT_FIELD,
+	postStatusMap: POST_STATUS_TO_FILTER_VALUE,
+	urlParamToFilterField: URL_PARAM_TO_FILTER_FIELD,
+} );

--- a/src/admin-shell/screens/newsletters-list/status-label.js
+++ b/src/admin-shell/screens/newsletters-list/status-label.js
@@ -7,37 +7,13 @@
 
 import { __ } from '@wordpress/i18n';
 
-// Lazy-memoised module-level cache. Building the map runs `__()` once
-// per key, and the function is called per row during DataView rendering
-// — without caching, every row re-allocates the object and re-runs the
-// translation lookups. We populate on first call (rather than at module
-// load) so i18n data has time to register.
-let cachedLabels = null;
+import { createStatusLabelModule } from '../../utils/status-label';
 
-export function STATUS_KIND_LABELS() {
-	if ( null === cachedLabels ) {
-		cachedLabels = {
-			sent: __( 'Sent', 'newspack-newsletters' ),
-			scheduled: __( 'Scheduled', 'newspack-newsletters' ),
-			draft: __( 'Draft', 'newspack-newsletters' ),
-			trash: __( 'Trash', 'newspack-newsletters' ),
-		};
-	}
-	return cachedLabels;
-}
+export const { STATUS_KIND_LABELS, statusKindLabel } = createStatusLabelModule( () => ( {
+	sent: __( 'Sent', 'newspack-newsletters' ),
+	scheduled: __( 'Scheduled', 'newspack-newsletters' ),
+	draft: __( 'Draft', 'newspack-newsletters' ),
+	trash: __( 'Trash', 'newspack-newsletters' ),
+} ) );
 
-export function statusKindLabel( kind ) {
-	const labels = STATUS_KIND_LABELS();
-	return labels[ kind ] || labels.draft;
-}
-
-/**
- * Returns true if a row item is currently in the trash. The DataViews
- * actions read this to gate destructive vs restorative buttons.
- *
- * @param {Object} item Post object from REST.
- * @return {boolean} True when the row is trashed.
- */
-export function isTrashed( item ) {
-	return 'trash' === item?.status;
-}
+export { isTrashed } from '../../utils/status-label';

--- a/src/admin-shell/screens/newsletters-list/use-newsletters-data.js
+++ b/src/admin-shell/screens/newsletters-list/use-newsletters-data.js
@@ -1,112 +1,16 @@
-/**
- * Server-side paginated data hook for the Newsletters list DataView.
- */
-
-import apiFetch from '@wordpress/api-fetch';
-import { useCallback, useEffect, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 
-import { notifyError } from '../../notices';
+import useCollectionData from '../../hooks/use-collection-data';
 import { buildQueryParams, toQueryString } from './build-query';
 
 const POSTS_PATH = '/wp/v2/newspack_nl_cpt';
-
-// Fall back to 0 so a missing or non-numeric header doesn't propagate NaN into DataViews pagination.
-function parseHeaderInt( value ) {
-	const parsed = parseInt( value, 10 );
-	return Number.isNaN( parsed ) ? 0 : parsed;
-}
-
-function readPaginationInfo( response ) {
-	return {
-		totalItems: parseHeaderInt( response.headers.get( 'X-WP-Total' ) ),
-		totalPages: parseHeaderInt( response.headers.get( 'X-WP-TotalPages' ) ),
-	};
-}
+const TRASH_COUNT_PATH = `${ POSTS_PATH }?status=trash&per_page=1&context=edit`;
 
 export default function useNewslettersData( view ) {
-	const [ data, setData ] = useState( [] );
-	const [ paginationInfo, setPaginationInfo ] = useState( { totalItems: 0, totalPages: 0 } );
-	const [ isLoading, setIsLoading ] = useState( true );
-	const [ refreshKey, setRefreshKey ] = useState( 0 );
-	// `*Resolved` flips on success OR failure (drives the spinner gate); `hasLoadedOnce` only on success
-	// (gates the strict-empty banner so a transient error doesn't flash onboarding).
-	const [ mainResolved, setMainResolved ] = useState( false );
-	const [ trashResolved, setTrashResolved ] = useState( false );
-	const [ hasLoadedOnce, setHasLoadedOnce ] = useState( false );
-	// `null` = unknown; a failed trash fetch stays `null` so `=== 0` stays false and the banner stays hidden.
-	const [ trashCount, setTrashCount ] = useState( null );
-
-	const refresh = useCallback( () => setRefreshKey( key => key + 1 ), [] );
-
-	useEffect( () => {
-		let cancelled = false;
-		setIsLoading( true );
-
-		const path = `${ POSTS_PATH }${ toQueryString( buildQueryParams( view ) ) }`;
-
-		apiFetch( { path, parse: false } )
-			.then( async response => {
-				const items = await response.json();
-				if ( cancelled ) {
-					return;
-				}
-				setData( Array.isArray( items ) ? items : [] );
-				setPaginationInfo( readPaginationInfo( response ) );
-				setHasLoadedOnce( true );
-			} )
-			.catch( () => {
-				if ( cancelled ) {
-					return;
-				}
-				// Keep last-good data so a refetch error doesn't trip the strict-empty banner.
-				notifyError( __( 'Failed to load newsletters. Please refresh the page.', 'newspack-newsletters' ), {
-					id: 'newspack-newsletters-list-fetch-error',
-				} );
-			} )
-			.finally( () => {
-				if ( ! cancelled ) {
-					setIsLoading( false );
-					setMainResolved( true );
-				}
-			} );
-
-		return () => {
-			cancelled = true;
-		};
-	}, [
-		view.page,
-		view.perPage,
-		view.search,
-		view.sort?.field,
-		view.sort?.direction,
-		// Filters are arrays of objects; serialise for referential equality.
-		JSON.stringify( view.filters || [] ),
-		refreshKey,
-	] );
-
-	useEffect( () => {
-		let cancelled = false;
-		// Back to "unknown" while the new count is in flight, or a freshly-trashed last item flashes EmptyState.
-		setTrashCount( null );
-		apiFetch( { path: `${ POSTS_PATH }?status=trash&per_page=1&context=edit`, parse: false } )
-			.then( response => {
-				if ( ! cancelled ) {
-					setTrashCount( parseHeaderInt( response.headers.get( 'X-WP-Total' ) ) );
-				}
-			} )
-			.catch( () => {} )
-			.finally( () => {
-				if ( ! cancelled ) {
-					setTrashResolved( true );
-				}
-			} );
-		return () => {
-			cancelled = true;
-		};
-	}, [ refreshKey ] );
-
-	const hasResolved = mainResolved && trashResolved;
-
-	return { data, paginationInfo, isLoading, hasResolved, hasLoadedOnce, trashCount, refresh };
+	return useCollectionData( {
+		path: `${ POSTS_PATH }${ toQueryString( buildQueryParams( view ) ) }`,
+		trashCountPath: TRASH_COUNT_PATH,
+		errorMessage: __( 'Failed to load newsletters. Please refresh the page.', 'newspack-newsletters' ),
+		errorNoticeId: 'newspack-newsletters-list-fetch-error',
+	} );
 }

--- a/src/admin-shell/utils/build-query.js
+++ b/src/admin-shell/utils/build-query.js
@@ -1,12 +1,3 @@
-/**
- * Shared DataViews-`view` → REST-query translation for list screens.
- *
- * Each screen contributes its own filter-field-to-REST-param map, its
- * own sort-field-to-orderby map, and (where applicable) its
- * status-filter conventions. The core shape — page / per_page / search /
- * sort / extra embeds — is uniform and lives here.
- */
-
 function asArray( value ) {
 	if ( Array.isArray( value ) ) {
 		return value;
@@ -19,9 +10,6 @@ function asArray( value ) {
 
 /**
  * Translate a DataViews `view` into a flat REST params object.
- *
- * `view` shape (subset we read):
- *   { page, perPage, offset?, sort?: { field, direction }, search?, filters?: [{ field, operator, value }], [arrayParam]?: Array }
  *
  * @param {Object}                                    view                         DataViews view state.
  * @param {Object}                                    options                      Screen-specific bindings.

--- a/src/admin-shell/utils/build-query.js
+++ b/src/admin-shell/utils/build-query.js
@@ -1,0 +1,130 @@
+/**
+ * Shared DataViews-`view` → REST-query translation for list screens.
+ *
+ * Each screen contributes its own filter-field-to-REST-param map, its
+ * own sort-field-to-orderby map, and (where applicable) its
+ * status-filter conventions. The core shape — page / per_page / search /
+ * sort / extra embeds — is uniform and lives here.
+ */
+
+function asArray( value ) {
+	if ( Array.isArray( value ) ) {
+		return value;
+	}
+	if ( value === undefined || value === null || value === '' ) {
+		return [];
+	}
+	return [ value ];
+}
+
+/**
+ * Translate a DataViews `view` into a flat REST params object.
+ *
+ * `view` shape (subset we read):
+ *   { page, perPage, offset?, sort?: { field, direction }, search?, filters?: [{ field, operator, value }], [arrayParam]?: Array }
+ *
+ * @param {Object}                                    view                         DataViews view state.
+ * @param {Object}                                    options                      Screen-specific bindings.
+ * @param {Object}                                    [options.fieldToQueryParam]  Map of non-status filter fields → REST query params.
+ * @param {Object}                                    [options.sortFieldToOrderby] Map of view.sort.field → REST `orderby`. When omitted, sort is pass-through.
+ * @param {number}                                    [options.defaultPerPage]     Default `per_page` when `view.perPage` is missing. Defaults to 25.
+ * @param {string}                                    [options.defaultStatuses]    Comma-joined statuses to use when no status filter is active.
+ * @param {string}                                    [options.statusFilterParam]  REST param to receive status-filter values. When omitted, `status` is used.
+ * @param {string}                                    [options.defaultStatusParam] REST param to receive `defaultStatuses`. Defaults to `'status'`.
+ * @param {Object}                                    [options.extraParams]        Fixed params merged into the result (e.g. `{ _embed: 'author,wp:term' }`).
+ * @param {boolean}                                   [options.supportsOffset]     When `true`, `view.offset` overrides `page` so callers can address mid-collection windows.
+ * @param {Array<{ viewKey: string, param: string }>} [options.arrayParams]        Pass-through bindings for array-valued view fields (e.g. `view.author`).
+ * @return {Object} Flat REST query params.
+ */
+export function buildQueryParams( view = {}, options = {} ) {
+	const {
+		fieldToQueryParam = {},
+		sortFieldToOrderby = null,
+		defaultPerPage = 25,
+		defaultStatuses = null,
+		statusFilterParam = null,
+		defaultStatusParam = 'status',
+		extraParams = {},
+		supportsOffset = false,
+		arrayParams = [],
+	} = options;
+
+	const params = {
+		per_page: view.perPage || defaultPerPage,
+		context: 'edit',
+		...extraParams,
+	};
+
+	if ( supportsOffset && typeof view.offset === 'number' ) {
+		params.offset = view.offset;
+	} else {
+		params.page = view.page || 1;
+	}
+
+	if ( view.search ) {
+		params.search = view.search;
+	}
+
+	if ( view.sort?.field ) {
+		const orderby = sortFieldToOrderby ? sortFieldToOrderby[ view.sort.field ] : view.sort.field;
+		if ( orderby ) {
+			params.orderby = orderby;
+			params.order = view.sort.direction === 'asc' ? 'asc' : 'desc';
+		}
+	}
+
+	const filters = Array.isArray( view.filters ) ? view.filters : [];
+	const statusFilter = filters.find( filter => filter.field === 'status' );
+
+	if ( statusFilter ) {
+		const values = asArray( statusFilter.value );
+		if ( values.length > 0 ) {
+			params[ statusFilterParam || 'status' ] = values.join( ',' );
+		} else if ( defaultStatuses ) {
+			params[ defaultStatusParam ] = defaultStatuses;
+		}
+	} else if ( defaultStatuses ) {
+		params[ defaultStatusParam ] = defaultStatuses;
+	}
+
+	for ( const filter of filters ) {
+		if ( filter.field === 'status' ) {
+			continue;
+		}
+		const param = fieldToQueryParam[ filter.field ];
+		if ( ! param ) {
+			continue;
+		}
+		const values = asArray( filter.value );
+		if ( values.length === 0 ) {
+			continue;
+		}
+		params[ param ] = values.join( ',' );
+	}
+
+	for ( const { viewKey, param } of arrayParams ) {
+		const value = view[ viewKey ];
+		if ( Array.isArray( value ) && value.length > 0 ) {
+			params[ param ] = value.join( ',' );
+		}
+	}
+
+	return params;
+}
+
+/**
+ * Serialise a params object into a query string suitable for apiFetch's `path`.
+ *
+ * @param {Object} params Flat key/value params.
+ * @return {string} Query string starting with `?`.
+ */
+export function toQueryString( params ) {
+	const search = new URLSearchParams();
+	Object.entries( params ).forEach( ( [ key, value ] ) => {
+		if ( value === undefined || value === null || value === '' ) {
+			return;
+		}
+		search.append( key, String( value ) );
+	} );
+	return `?${ search.toString() }`;
+}

--- a/src/admin-shell/utils/bulk-action.js
+++ b/src/admin-shell/utils/bulk-action.js
@@ -16,10 +16,14 @@ import { notifyError, notifySuccess } from '../notices';
 export async function runBulk( items, op, { refresh, successPlural, failurePlural } ) {
 	const failed = [];
 	await Promise.all(
+		// `Promise.resolve().then(() => op(item))` adapts a possibly-sync
+		// throw or non-Promise return into a rejection so .catch() always sees it.
 		items.map( item =>
-			op( item ).catch( () => {
-				failed.push( item );
-			} )
+			Promise.resolve()
+				.then( () => op( item ) )
+				.catch( () => {
+					failed.push( item );
+				} )
 		)
 	);
 	if ( typeof refresh === 'function' ) {

--- a/src/admin-shell/utils/bulk-action.js
+++ b/src/admin-shell/utils/bulk-action.js
@@ -1,0 +1,50 @@
+/**
+ * Shared scaffolding for parallel per-item mutations behind a single
+ * row/bulk action callback. Captures the `failed = []; Promise.all(... catch)`
+ * pattern + the success / partial-failure notice dispatch.
+ *
+ * Callers supply the pre-translated singular/plural strings via
+ * `successPlural` and `failurePlural` callbacks so each screen can use
+ * the right noun and `_n` form. The helper itself stays i18n-agnostic.
+ */
+
+import { notifyError, notifySuccess } from '../notices';
+
+/**
+ * Run an async `op( item )` against every item in parallel, swallowing
+ * per-item rejections, then dispatch a single aggregated notice.
+ *
+ * `refresh` runs once all ops have settled (success or failure) so the
+ * list reflects whatever state the server actually arrived at. The
+ * caller is responsible for pre-filtering `items` against any
+ * `isEligible` predicate — non-modal bulk callbacks receive the full
+ * DataViews selection.
+ *
+ * @param {Array<Object>}                        items
+ * @param {( item: Object ) => Promise<unknown>} op
+ * @param {Object}                               options
+ * @param {() => void}                           options.refresh       Invoked after all ops settle.
+ * @param {( successCount: number ) => string}   options.successPlural Pre-rendered success notice.
+ * @param {( failedCount: number ) => string}    options.failurePlural Pre-rendered failure notice.
+ * @return {Promise<{ failed: Array<Object>, succeeded: number }>} Outcome counts.
+ */
+export async function runBulk( items, op, { refresh, successPlural, failurePlural } ) {
+	const failed = [];
+	await Promise.all(
+		items.map( item =>
+			op( item ).catch( () => {
+				failed.push( item );
+			} )
+		)
+	);
+	if ( typeof refresh === 'function' ) {
+		refresh();
+	}
+	const succeeded = items.length - failed.length;
+	if ( failed.length === 0 ) {
+		notifySuccess( successPlural( succeeded ) );
+	} else {
+		notifyError( failurePlural( failed.length ) );
+	}
+	return { failed, succeeded };
+}

--- a/src/admin-shell/utils/bulk-action.js
+++ b/src/admin-shell/utils/bulk-action.js
@@ -1,24 +1,9 @@
-/**
- * Shared scaffolding for parallel per-item mutations behind a single
- * row/bulk action callback. Captures the `failed = []; Promise.all(... catch)`
- * pattern + the success / partial-failure notice dispatch.
- *
- * Callers supply the pre-translated singular/plural strings via
- * `successPlural` and `failurePlural` callbacks so each screen can use
- * the right noun and `_n` form. The helper itself stays i18n-agnostic.
- */
-
 import { notifyError, notifySuccess } from '../notices';
 
 /**
- * Run an async `op( item )` against every item in parallel, swallowing
- * per-item rejections, then dispatch a single aggregated notice.
- *
- * `refresh` runs once all ops have settled (success or failure) so the
- * list reflects whatever state the server actually arrived at. The
- * caller is responsible for pre-filtering `items` against any
- * `isEligible` predicate — non-modal bulk callbacks receive the full
- * DataViews selection.
+ * Run `op( item )` in parallel against each item, swallow per-item
+ * rejections, then dispatch a single aggregated success/failure notice.
+ * Callers must pre-filter against any `isEligible` predicate.
  *
  * @param {Array<Object>}                        items
  * @param {( item: Object ) => Promise<unknown>} op

--- a/src/admin-shell/utils/initial-view.js
+++ b/src/admin-shell/utils/initial-view.js
@@ -1,26 +1,7 @@
-/**
- * Shared factory for translating forwarded legacy admin URL args into
- * DataViews `view` patches (filters / search / sort).
- *
- * Each list screen receives forwarded query args from
- * `Admin_Shell::maybe_redirect_legacy_list` and seeds its initial view
- * from them. The translation shape is uniform: a `post_status` →
- * filter-value map, an `orderby` → DataView field map, and optional
- * extra URL-param → filter-field bindings. The factory captures that
- * shape so each screen contributes only its lookup tables.
- */
-
-const EMPTY_SEARCH = '';
-
-const readSearch = search => search ?? ( typeof window === 'undefined' ? EMPTY_SEARCH : window.location.search );
+const readSearch = search => search ?? ( typeof window === 'undefined' ? '' : window.location.search );
 
 /**
- * Build a `{ getInitialFilters, getInitialView }` pair for a list screen.
- *
- * `defaultSortDirection` controls fallback direction when the URL has an
- * `orderby` without an `order` (or with an unrecognised one). Advertisers
- * use `'asc'` because alphabetical defaults to ascending; everywhere else
- * the default is `'desc'`.
+ * Build a `{ getInitialFilters, getInitialView }` pair from URL → view bindings.
  *
  * @param {Object} config                         Screen configuration.
  * @param {Object} config.orderbyMap              Map of REST `orderby` values to DataView field IDs.

--- a/src/admin-shell/utils/initial-view.js
+++ b/src/admin-shell/utils/initial-view.js
@@ -1,0 +1,107 @@
+/**
+ * Shared factory for translating forwarded legacy admin URL args into
+ * DataViews `view` patches (filters / search / sort).
+ *
+ * Each list screen receives forwarded query args from
+ * `Admin_Shell::maybe_redirect_legacy_list` and seeds its initial view
+ * from them. The translation shape is uniform: a `post_status` →
+ * filter-value map, an `orderby` → DataView field map, and optional
+ * extra URL-param → filter-field bindings. The factory captures that
+ * shape so each screen contributes only its lookup tables.
+ */
+
+const EMPTY_SEARCH = '';
+
+const readSearch = search => search ?? ( typeof window === 'undefined' ? EMPTY_SEARCH : window.location.search );
+
+/**
+ * Build a `{ getInitialFilters, getInitialView }` pair for a list screen.
+ *
+ * `defaultSortDirection` controls fallback direction when the URL has an
+ * `orderby` without an `order` (or with an unrecognised one). Advertisers
+ * use `'asc'` because alphabetical defaults to ascending; everywhere else
+ * the default is `'desc'`.
+ *
+ * @param {Object} config                         Screen configuration.
+ * @param {Object} config.orderbyMap              Map of REST `orderby` values to DataView field IDs.
+ * @param {Object} [config.postStatusMap]         Map of `post_status` values to status-filter values.
+ * @param {Object} [config.urlParamToFilterField] Map of URL params to DataView filter field IDs.
+ * @param {string} [config.statusFilterField]     DataView field ID for the status filter. Defaults to `'status'`.
+ * @param {string} [config.defaultSortDirection]  `'asc'` or `'desc'`. Defaults to `'desc'`.
+ * @return {{ getInitialFilters: ( search?: string ) => Array, getInitialView: ( search?: string ) => Object }} URL-driven view accessors.
+ */
+export function makeGetInitialView( {
+	orderbyMap = {},
+	postStatusMap = null,
+	urlParamToFilterField = null,
+	statusFilterField = 'status',
+	defaultSortDirection = 'desc',
+} = {} ) {
+	const defaultIsAsc = 'asc' === defaultSortDirection;
+
+	function getInitialFilters( search ) {
+		const params = new URLSearchParams( readSearch( search ) );
+		const filters = [];
+
+		if ( postStatusMap ) {
+			const postStatus = params.get( 'post_status' );
+			if ( postStatus ) {
+				const value = postStatusMap[ postStatus ];
+				if ( value ) {
+					filters.push( { field: statusFilterField, operator: 'isAny', value: [ value ] } );
+				}
+			}
+		}
+
+		if ( urlParamToFilterField ) {
+			for ( const [ urlParam, fieldId ] of Object.entries( urlParamToFilterField ) ) {
+				const raw = params.get( urlParam );
+				if ( ! raw ) {
+					continue;
+				}
+				const values = raw
+					.split( ',' )
+					.map( v => v.trim() )
+					.filter( Boolean );
+				if ( values.length > 0 ) {
+					filters.push( { field: fieldId, operator: 'isAny', value: values } );
+				}
+			}
+		}
+
+		return filters;
+	}
+
+	function getInitialView( search ) {
+		const resolved = readSearch( search );
+		const params = new URLSearchParams( resolved );
+		const patch = {};
+
+		const filters = getInitialFilters( resolved );
+		if ( filters.length > 0 ) {
+			patch.filters = filters;
+		}
+
+		const term = params.get( 's' );
+		if ( term ) {
+			patch.search = term;
+		}
+
+		const orderby = params.get( 'orderby' );
+		const sortField = orderby && orderbyMap[ orderby ];
+		if ( sortField ) {
+			const order = ( params.get( 'order' ) || '' ).toLowerCase();
+			let direction;
+			if ( defaultIsAsc ) {
+				direction = 'desc' === order ? 'desc' : 'asc';
+			} else {
+				direction = 'asc' === order ? 'asc' : 'desc';
+			}
+			patch.sort = { field: sortField, direction };
+		}
+
+		return patch;
+	}
+
+	return { getInitialFilters, getInitialView };
+}

--- a/src/admin-shell/utils/status-label.js
+++ b/src/admin-shell/utils/status-label.js
@@ -1,18 +1,6 @@
 /**
- * Shared status-label factory for DataView list screens.
- *
- * Each screen registers a `newspack_newsletters_*_status` REST field whose
- * `kind` enum maps to a translated label. The factory captures the lazy-
- * memoised lookup so the per-row `getValue`/`render` paths can call
- * `statusKindLabel( kind )` without re-allocating the labels map or
- * re-running `__()` for every row.
- */
-
-/**
- * Build a `{ STATUS_KIND_LABELS, statusKindLabel }` pair for a screen.
- *
- * `buildLabels` is invoked lazily on first call so i18n data has had a
- * chance to register before any `__()` lookups run.
+ * Build a `{ STATUS_KIND_LABELS, statusKindLabel }` pair. `buildLabels` is
+ * invoked lazily so i18n data has time to register before any `__()` runs.
  *
  * @param {() => Object} buildLabels Factory returning the `{kind: label}` map.
  * @return {{ STATUS_KIND_LABELS: () => Object, statusKindLabel: ( kind: string ) => string }} Memoised accessors.
@@ -36,9 +24,6 @@ export function createStatusLabelModule( buildLabels ) {
 }
 
 /**
- * Returns true if a row item is currently in the trash. DataView actions
- * read this to gate destructive vs restorative buttons.
- *
  * @param {Object} item Post object from REST.
  * @return {boolean} True when the row is trashed.
  */

--- a/src/admin-shell/utils/status-label.js
+++ b/src/admin-shell/utils/status-label.js
@@ -1,0 +1,47 @@
+/**
+ * Shared status-label factory for DataView list screens.
+ *
+ * Each screen registers a `newspack_newsletters_*_status` REST field whose
+ * `kind` enum maps to a translated label. The factory captures the lazy-
+ * memoised lookup so the per-row `getValue`/`render` paths can call
+ * `statusKindLabel( kind )` without re-allocating the labels map or
+ * re-running `__()` for every row.
+ */
+
+/**
+ * Build a `{ STATUS_KIND_LABELS, statusKindLabel }` pair for a screen.
+ *
+ * `buildLabels` is invoked lazily on first call so i18n data has had a
+ * chance to register before any `__()` lookups run.
+ *
+ * @param {() => Object} buildLabels Factory returning the `{kind: label}` map.
+ * @return {{ STATUS_KIND_LABELS: () => Object, statusKindLabel: ( kind: string ) => string }} Memoised accessors.
+ */
+export function createStatusLabelModule( buildLabels ) {
+	let cached = null;
+
+	const STATUS_KIND_LABELS = () => {
+		if ( null === cached ) {
+			cached = buildLabels();
+		}
+		return cached;
+	};
+
+	const statusKindLabel = kind => {
+		const labels = STATUS_KIND_LABELS();
+		return labels[ kind ] || labels.draft;
+	};
+
+	return { STATUS_KIND_LABELS, statusKindLabel };
+}
+
+/**
+ * Returns true if a row item is currently in the trash. DataView actions
+ * read this to gate destructive vs restorative buttons.
+ *
+ * @param {Object} item Post object from REST.
+ * @return {boolean} True when the row is trashed.
+ */
+export function isTrashed( item ) {
+	return 'trash' === item?.status;
+}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Targets `epic/admin-ux-modernisation` so it can land before #2141 and be reviewed independently of the milestone roll-up.

Lifts five clusters of repetition out of the four admin-shell list screens (newsletters / ads / advertisers / layouts) into shared modules under `src/admin-shell/{utils,hooks,components}/`. Net diff: **-1218 / +708 = ~510 LoC removed across 22 files**, six new shared modules.

#### Extractions

1. **`utils/status-label.js`** — `createStatusLabelModule( buildLabels )` factory captures the lazy-memoised `__()` lookup. Both screen `status-label.js` files now contribute only their `{kind: label}` map. `isTrashed` moves to the shared module.
2. **`utils/initial-view.js`** — `makeGetInitialView({ orderbyMap, postStatusMap?, urlParamToFilterField?, statusFilterField?, defaultSortDirection? })`. Each `initial-filters.js` now contributes only its lookup tables. Advertisers keeps its alphabetical `asc` default; the other three keep `desc`.
3. **`components/confirm-modal/`** + **`utils/bulk-action.js`** — single `ConfirmModal` replaces three verbatim copies plus the layouts VStack/HStack variant. `runBulk( items, op, { refresh, successPlural, failurePlural } )` collapses the six `Promise.all(... .catch); refresh(); notify…` blocks. Each caller supplies pre-rendered `_n` plural strings.
4. **`utils/build-query.js`** — shared `buildQueryParams( view, options )` + `toQueryString( params )`. The newsletters and ads `build-query.js` files (~80% identical) become per-screen lookup-table wrappers; the inlined `buildPath` in advertisers and layouts data hooks now delegate too. `supportsOffset` and `arrayParams` handle the layouts shape (offset-overrides-page, `view.author` array, `_embed=1`).
5. **`hooks/use-collection-data.js`** — the four `use-*-data.js` hooks were ~120 LoC of byte-identical scaffolding (apiFetch + `X-WP-Total` parsing + cancellation flag + `mainResolved` / `hasLoadedOnce` split + optional trash sub-fetch + optional external `mutationKey` + internal `refresh()` bump). Each screen's hook is now a thin wrapper that supplies its path + notice text + optional `trashCountPath` / `mutationKey`.

#### Behavioural fixes folded in

- Replaced eight `Failed to … %d <noun>(s). Please try again.` strings (parenthesised plural — untranslatable per locale) with proper `_n` singular/plural pairs.

No other behavioural changes. Inconsistencies caught in code review (advertisers/layouts "Delete" vs modal "Delete permanently", missing `.catch` on three filter-option hooks, etc.) are deliberately **not** folded in — they belong in follow-up tickets so this stays a low-risk pure refactor.

No context change.

### How to test the changes in this Pull Request:

1. Pull this branch, run `n ci-build`, and load the Newsletters admin.
2. Open each of the four DataView screens and confirm the list renders, filters apply, sort works, and the spinner gate behaves the same as before (no flash of empty state on refetch).
3. Trigger Trash / Restore / Delete permanently on Newsletters and Ads — confirm success and partial-failure notices both read correctly in singular and plural forms.
4. Trigger Delete on Advertisers and Layouts — same singular/plural check.
5. Toggle `Set visibility to Email and web` / `Email only` on a Newsletter — confirm success notice and refresh.
6. Confirm the URL-driven initial view still works: `?post_status=trash`, `?orderby=title&order=asc`, `?author=42` on the Newsletters list; `?orderby=name&order=desc` on the Advertisers list (default direction stays `asc`).
7. JS tests: `n test-js` (195 tests, all green).

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?