### PR TITLE
fix(admin): Tier-1 bug fixes (layouts guard, posts_where race, transactional Settings switch)

### DIFF
--- a/includes/admin/class-ads-list-rest.php
+++ b/includes/admin/class-ads-list-rest.php
@@ -217,11 +217,9 @@ class Ads_List_REST {
 
 		$args['post_status'] = array_values( array_unique( $post_status_set ) );
 
-		// Per-request token scopes the closure to this specific WP_Query.
-		// Without it, `posts_where` fires for every nested WP_Query in the
-		// same request and the closure would both corrupt those unrelated
-		// queries and `remove_filter` itself before the intended WP_Query
-		// reached `posts_where`.
+		// Token-scope the closure: `posts_where` fires for every WP_Query in the request, so
+		// without this gate a nested query corrupts the WHERE and self-removes the filter
+		// before our intended query runs.
 		$token                              = uniqid( 'newspack_ads_bucket_', true );
 		$args['_newspack_ads_bucket_token'] = $token;
 

--- a/includes/admin/class-ads-list-rest.php
+++ b/includes/admin/class-ads-list-rest.php
@@ -217,12 +217,23 @@ class Ads_List_REST {
 
 		$args['post_status'] = array_values( array_unique( $post_status_set ) );
 
-		$callback = static function ( $where ) use ( &$callback, $bucket_clauses ) {
+		// Per-request token scopes the closure to this specific WP_Query.
+		// Without it, `posts_where` fires for every nested WP_Query in the
+		// same request and the closure would both corrupt those unrelated
+		// queries and `remove_filter` itself before the intended WP_Query
+		// reached `posts_where`.
+		$token                              = uniqid( 'newspack_ads_bucket_', true );
+		$args['_newspack_ads_bucket_token'] = $token;
+
+		$callback = static function ( $where, $wp_query ) use ( &$callback, $token, $bucket_clauses ) {
+			if ( ! is_object( $wp_query ) || $wp_query->get( '_newspack_ads_bucket_token' ) !== $token ) {
+				return $where;
+			}
 			$where .= ' AND ( ' . implode( ' OR ', $bucket_clauses ) . ' )';
 			remove_filter( 'posts_where', $callback, 10 );
 			return $where;
 		};
-		add_filter( 'posts_where', $callback, 10, 1 );
+		add_filter( 'posts_where', $callback, 10, 2 );
 
 		return $args;
 	}

--- a/includes/admin/class-newsletters-list-rest.php
+++ b/includes/admin/class-newsletters-list-rest.php
@@ -166,7 +166,19 @@ class Newsletters_List_REST {
 			$args['post_status'] = $widened;
 		}
 
-		$callback = static function ( $where ) use ( &$callback, $wants_sent, $wants_draft, $wants_scheduled, $wants_trash ) {
+		// Per-request token scopes the closure to this specific WP_Query.
+		// Without it, `posts_where` fires for every nested WP_Query in the
+		// same request (term queries, internal REST sub-requests, etc.)
+		// and the closure would both corrupt those unrelated queries and
+		// `remove_filter` itself before the intended WP_Query reached
+		// `posts_where`.
+		$token                            = uniqid( 'newspack_nl_bucket_', true );
+		$args['_newspack_nl_bucket_token'] = $token;
+
+		$callback = static function ( $where, $wp_query ) use ( &$callback, $token, $wants_sent, $wants_draft, $wants_scheduled, $wants_trash ) {
+			if ( ! is_object( $wp_query ) || $wp_query->get( '_newspack_nl_bucket_token' ) !== $token ) {
+				return $where;
+			}
 			global $wpdb;
 			$clauses      = [];
 			$prepare_args = [];
@@ -196,7 +208,7 @@ class Newsletters_List_REST {
 			remove_filter( 'posts_where', $callback, 10 );
 			return $where;
 		};
-		add_filter( 'posts_where', $callback, 10, 1 );
+		add_filter( 'posts_where', $callback, 10, 2 );
 
 		return $args;
 	}

--- a/includes/admin/class-newsletters-list-rest.php
+++ b/includes/admin/class-newsletters-list-rest.php
@@ -166,13 +166,10 @@ class Newsletters_List_REST {
 			$args['post_status'] = $widened;
 		}
 
-		// Per-request token scopes the closure to this specific WP_Query.
-		// Without it, `posts_where` fires for every nested WP_Query in the
-		// same request (term queries, internal REST sub-requests, etc.)
-		// and the closure would both corrupt those unrelated queries and
-		// `remove_filter` itself before the intended WP_Query reached
-		// `posts_where`.
-		$token                            = uniqid( 'newspack_nl_bucket_', true );
+		// Token-scope the closure: `posts_where` fires for every WP_Query in the request, so
+		// without this gate a nested query corrupts the WHERE and self-removes the filter
+		// before our intended query runs.
+		$token                             = uniqid( 'newspack_nl_bucket_', true );
 		$args['_newspack_nl_bucket_token'] = $token;
 
 		$callback = static function ( $where, $wp_query ) use ( &$callback, $token, $wants_sent, $wants_draft, $wants_scheduled, $wants_trash ) {

--- a/includes/admin/class-settings-rest.php
+++ b/includes/admin/class-settings-rest.php
@@ -116,9 +116,8 @@ class Settings_REST {
 
 		$provider_payload = $request->get_param( 'provider' );
 		if ( is_array( $provider_payload ) && array_key_exists( 'slug', $provider_payload ) ) {
-			$slug          = is_string( $provider_payload['slug'] ) ? $provider_payload['slug'] : '';
-			$previous_slug = Newspack_Newsletters::service_provider();
-			$valid_slugs   = Newspack_Newsletters::get_supported_providers();
+			$slug        = is_string( $provider_payload['slug'] ) ? $provider_payload['slug'] : '';
+			$valid_slugs = Newspack_Newsletters::get_supported_providers();
 			if ( '' === $slug ) {
 				$errors->add(
 					'newspack_newsletters_no_service_provider',
@@ -131,56 +130,40 @@ class Settings_REST {
 					__( 'Unknown service provider.', 'newspack-newsletters' ),
 					[ 'status' => 400 ]
 				);
-			} else {
+			} elseif ( 'manual' === $slug ) {
 				Newspack_Newsletters::set_service_provider( $slug );
-				if ( 'manual' !== $slug ) {
+			} else {
+				// Resolve the provider without committing the option — only flip on credentials success
+				// so a rejection can't leave the site pointing at an unconfigured provider.
+				$provider = Newspack_Newsletters::get_service_provider_instance( $slug );
+				if ( ! $provider || ! method_exists( $provider, 'set_api_credentials' ) ) {
+					$errors->add(
+						'newspack_newsletters_provider_unavailable',
+						__( 'The selected service provider is not available on this site.', 'newspack-newsletters' ),
+						[ 'status' => 400 ]
+					);
+				} else {
 					$credentials = isset( $provider_payload['credentials'] ) && is_array( $provider_payload['credentials'] )
 						? $provider_payload['credentials']
 						: [];
-					$provider    = Newspack_Newsletters::get_service_provider();
-					if ( ! $provider || ! method_exists( $provider, 'set_api_credentials' ) ) {
-						// Provider was registered via filter but the class
-						// failed to load — refuse to persist a credentials
-						// switch we can't actually apply.
+					// Validate the merged result, not the raw payload — a no-op save (no fields touched)
+					// is legal on an already-configured provider.
+					$merged = self::merge_credentials( $slug, $credentials, $provider );
+					if ( empty( $merged ) ) {
 						$errors->add(
-							'newspack_newsletters_provider_unavailable',
-							__( 'The selected service provider is not available on this site.', 'newspack-newsletters' ),
+							'newspack_newsletters_invalid_keys',
+							__( 'Please input credentials.', 'newspack-newsletters' ),
 							[ 'status' => 400 ]
 						);
 					} else {
-						$merged = self::merge_credentials( $slug, $credentials, $provider );
-						// Validate the merged result, not the raw payload —
-						// an already-configured provider can save with an
-						// empty edit (no fields touched), and the merge
-						// fills in the stored values so the no-op save
-						// still succeeds.
-						if ( empty( $merged ) ) {
-							$errors->add(
-								'newspack_newsletters_invalid_keys',
-								__( 'Please input credentials.', 'newspack-newsletters' ),
-								[ 'status' => 400 ]
-							);
-						} else {
-							$result = $provider->set_api_credentials( $merged );
-							if ( is_wp_error( $result ) ) {
-								foreach ( $result->errors as $code => $messages ) {
-									$errors->add( $code, implode( ' ', $messages ), [ 'status' => 400 ] );
-								}
+						$result = $provider->set_api_credentials( $merged );
+						if ( is_wp_error( $result ) ) {
+							foreach ( $result->errors as $code => $messages ) {
+								$errors->add( $code, implode( ' ', $messages ), [ 'status' => 400 ] );
 							}
+						} else {
+							Newspack_Newsletters::set_service_provider( $slug );
 						}
-					}
-				}
-				// Restore the previous provider if anything in the provider
-				// switch failed, so a rejected request doesn't leave the
-				// site pointing at an unconfigured provider. The
-				// `$previous_slug === false` branch covers a fresh site
-				// that had no provider configured before this request.
-				if ( $errors->has_errors() && $previous_slug !== $slug ) {
-					if ( $previous_slug ) {
-						Newspack_Newsletters::set_service_provider( $previous_slug );
-					} else {
-						delete_option( 'newspack_newsletters_service_provider' );
-						Newspack_Newsletters::memoize_service_provider();
 					}
 				}
 			}

--- a/includes/admin/pages/class-layouts-list-page.php
+++ b/includes/admin/pages/class-layouts-list-page.php
@@ -52,13 +52,12 @@ class Layouts_List_Page extends Admin_Page {
 
 	/**
 	 * Classic CPT list screen the React page shadows. Catches the back
-	 * button in the layout editor. Returns `null` when the Layouts
-	 * class is missing so a load-order regression degrades to "no
-	 * redirect" rather than fatalling every wp-admin request.
+	 * button in the layout editor.
 	 *
 	 * @return string|null
 	 */
 	public function get_legacy_screen_id() {
+		// Guard against a load-order regression fatalling every wp-admin request.
 		if ( ! class_exists( '\Newspack_Newsletters_Layouts' ) ) {
 			return null;
 		}

--- a/includes/admin/pages/class-layouts-list-page.php
+++ b/includes/admin/pages/class-layouts-list-page.php
@@ -52,11 +52,16 @@ class Layouts_List_Page extends Admin_Page {
 
 	/**
 	 * Classic CPT list screen the React page shadows. Catches the back
-	 * button in the layout editor.
+	 * button in the layout editor. Returns `null` when the Layouts
+	 * class is missing so a load-order regression degrades to "no
+	 * redirect" rather than fatalling every wp-admin request.
 	 *
-	 * @return string
+	 * @return string|null
 	 */
 	public function get_legacy_screen_id() {
+		if ( ! class_exists( '\Newspack_Newsletters_Layouts' ) ) {
+			return null;
+		}
 		return 'edit-' . \Newspack_Newsletters_Layouts::NEWSPACK_NEWSLETTERS_LAYOUT_CPT;
 	}
 

--- a/tests/test-newsletters-list-rest.php
+++ b/tests/test-newsletters-list-rest.php
@@ -472,6 +472,12 @@ class Newsletters_List_REST_Test extends WP_UnitTestCase {
 			$drain = new WP_Query();
 			$drain->set( '_newspack_nl_bucket_token', $args['_newspack_nl_bucket_token'] );
 			apply_filters( 'posts_where', '', $drain );
+
+			$this->assertSame(
+				$before,
+				$this->count_posts_where_callbacks(),
+				'Token-matching drain should self-remove the closure for params: ' . wp_json_encode( $params )
+			);
 		}
 	}
 

--- a/tests/test-newsletters-list-rest.php
+++ b/tests/test-newsletters-list-rest.php
@@ -456,7 +456,7 @@ class Newsletters_List_REST_Test extends WP_UnitTestCase {
 		foreach ( $cases as $params ) {
 			$before = $this->count_posts_where_callbacks();
 
-			Newsletters_List_REST::align_status_filter_with_scheduled_meta(
+			$args = Newsletters_List_REST::align_status_filter_with_scheduled_meta(
 				[],
 				$this->rest_request( $params )
 			);
@@ -467,10 +467,11 @@ class Newsletters_List_REST_Test extends WP_UnitTestCase {
 				'A posts_where callback should be installed for params: ' . wp_json_encode( $params )
 			);
 
-			// Drain so the next iteration starts from the same baseline.
-			// The closure now token-gates against the WP_Query arg, so
-			// firing `apply_filters` without a matching query is a no-op.
-			remove_all_filters( 'posts_where' );
+			// Drain only the closure we just installed by firing posts_where with a
+			// WP_Query carrying the matching token — preserves any unrelated callbacks.
+			$drain = new WP_Query();
+			$drain->set( '_newspack_nl_bucket_token', $args['_newspack_nl_bucket_token'] );
+			apply_filters( 'posts_where', '', $drain );
 		}
 	}
 

--- a/tests/test-newsletters-list-rest.php
+++ b/tests/test-newsletters-list-rest.php
@@ -467,8 +467,10 @@ class Newsletters_List_REST_Test extends WP_UnitTestCase {
 				'A posts_where callback should be installed for params: ' . wp_json_encode( $params )
 			);
 
-			// Drain the one-shot so it doesn't leak into the next iteration.
-			apply_filters( 'posts_where', '' );
+			// Drain so the next iteration starts from the same baseline.
+			// The closure now token-gates against the WP_Query arg, so
+			// firing `apply_filters` without a matching query is a no-op.
+			remove_all_filters( 'posts_where' );
 		}
 	}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Targets `epic/admin-ux-modernisation` so it can land alongside #2143 and roll into #2141 cleanly. Addresses the three HIGH-severity findings from the milestone code review.

#### 1. Guard layouts class reference against load-order regression
`includes/admin/pages/class-layouts-list-page.php`

`Layouts_List_Page::get_legacy_screen_id()` is invoked on every `current_screen` admin request via `Admin_Shell::maybe_redirect_legacy_list`. The bare `\Newspack_Newsletters_Layouts::NEWSPACK_NEWSLETTERS_LAYOUT_CPT` reference fatals every wp-admin page if that class ever fails to load (partial uninstall, autoload regression). Add a `class_exists` guard that returns `null` (a documented "no legacy redirect" contract) so the failure mode degrades gracefully.

#### 2. Token-scope the `posts_where` bucket closures
`includes/admin/class-newsletters-list-rest.php`, `includes/admin/class-ads-list-rest.php`

Both REST handlers installed self-removing closures on the global `posts_where` filter. WordPress fires that filter for **every** WP_Query in the request — so a nested query (term lookups, internal REST sub-requests, do_action hooks during args assembly) received our newsletter/ad-specific WHERE-clause SQL appended to its query AND triggered the `remove_filter` cleanup, leaving the intended WP_Query unfiltered.

Fix: stash a per-request token in `$args` (passed through as a query var), bump the closure to a 2-arg signature, and no-op unless `$wp_query->get( token_key ) === token`. The closure now only fires against its owning WP_Query.

Test drain: the test that asserts a callback gets installed per call now drains by firing `posts_where` with a stub `WP_Query` carrying the matching token (only the closure we installed self-removes; any unrelated callbacks survive). A follow-up assertion confirms the callback count returns to baseline after the drain.

#### 3. Make Settings provider switch transactional
`includes/admin/class-settings-rest.php`

`update_settings` previously called `Newspack_Newsletters::set_service_provider()` (option write) **before** validating credentials, then tried to restore on failure. The restore branch fell through to `delete_option` + `memoize_service_provider`, which re-runs the legacy `newspack_mailchimp_api_key` auto-detect — so a rejected credentials switch could silently re-select mailchimp.

Resolve the provider via `get_service_provider_instance( $slug )` (no option write), validate credentials against it, and only commit the slug on success. Removes the restore branch entirely.

No context change.

### How to test the changes in this Pull Request:

1. Pull this branch, run `n ci-build`, and load the Newsletters admin.
2. **Layouts guard**: open any wp-admin page (smoke check — the guard only matters when the Layouts class is missing, which can't be triggered without unloading it).
3. **`posts_where` race**: open the Newsletters list, filter by Sent / Draft / Scheduled / Trash, confirm rows match the chip. Same for the Ads list. Confirm no leaked WHERE on adjacent admin queries (categories list, etc.).
4. **Settings transactional**:
   - From `manual` provider, switch to Mailchimp with **invalid** credentials. Confirm the response is a 400 AND the active-provider option stays at `manual`.
   - Switch to Mailchimp with **valid** credentials. Confirm the option flips and credentials persist.
   - From a configured Mailchimp setup, save the Settings page without touching credentials. Confirm the no-op save succeeds (the merge-from-stored-values path still works).
5. PHP tests: `n test-php` (370 tests, all green).
6. JS tests: `n test-js` (195 tests, all green).

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?