### PR TITLE
fix(admin): Tier-2 bug fixes (filter-option .catch, verify_token cache, is_admin_page narrowing)

### DIFF
--- a/includes/admin/class-admin-page.php
+++ b/includes/admin/class-admin-page.php
@@ -32,6 +32,15 @@ abstract class Admin_Page {
 	protected $capability = 'edit_posts';
 
 	/**
+	 * Hookname returned by `add_submenu_page`. Captured by `Admin_Shell`
+	 * at registration time so `is_admin_page()` can narrow its match to
+	 * the actual admin screen rather than just `$_GET['page']`.
+	 *
+	 * @var string
+	 */
+	protected $hook_suffix = '';
+
+	/**
 	 * Get the page slug.
 	 *
 	 * @return string
@@ -203,7 +212,20 @@ abstract class Admin_Page {
 	}
 
 	/**
+	 * Store the hookname `add_submenu_page` returned at registration.
+	 *
+	 * @param string $hook_suffix Hookname.
+	 */
+	public function set_hook_suffix( $hook_suffix ) {
+		$this->hook_suffix = (string) $hook_suffix;
+	}
+
+	/**
 	 * Whether the current request is for this admin page.
+	 *
+	 * Narrower than a bare `$_GET['page']` match: a foreign admin URL
+	 * that happens to carry the same query key won't activate our
+	 * page-scoped enqueue / body class / filter hooks.
 	 *
 	 * @return bool
 	 */
@@ -211,7 +233,19 @@ abstract class Admin_Page {
 		if ( ! isset( $_GET['page'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 			return false;
 		}
-		return $this->slug === sanitize_text_field( wp_unslash( $_GET['page'] ) ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		if ( $this->slug !== sanitize_text_field( wp_unslash( $_GET['page'] ) ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			return false;
+		}
+		$screen = function_exists( 'get_current_screen' ) ? get_current_screen() : null;
+		if ( ! $screen ) {
+			return false;
+		}
+		if ( $this->hook_suffix ) {
+			// `admin_page_<slug>` is the shadow hookname used when the
+			// parent CPT isn't a top-level menu — see Admin_Shell::register_menu.
+			return $screen->id === $this->hook_suffix || $screen->id === 'admin_page_' . $this->slug;
+		}
+		return false !== strpos( $screen->id, $this->slug );
 	}
 
 	/**

--- a/includes/admin/class-admin-page.php
+++ b/includes/admin/class-admin-page.php
@@ -240,12 +240,11 @@ abstract class Admin_Page {
 		if ( ! $screen ) {
 			return false;
 		}
-		if ( $this->hook_suffix ) {
-			// `admin_page_<slug>` is the shadow hookname used when the
-			// parent CPT isn't a top-level menu — see Admin_Shell::register_menu.
-			return $screen->id === $this->hook_suffix || $screen->id === 'admin_page_' . $this->slug;
-		}
-		return false !== strpos( $screen->id, $this->slug );
+		$hook_suffix = $this->hook_suffix ? $this->hook_suffix : Admin_Shell::get_hook_suffix_for_slug( $this->slug );
+		// `admin_page_<slug>` is the shadow hookname used when the parent
+		// CPT isn't a top-level menu — see Admin_Shell::register_menu.
+		$expected = array_filter( [ $hook_suffix, 'admin_page_' . $this->slug ] );
+		return in_array( $screen->id, $expected, true );
 	}
 
 	/**

--- a/includes/admin/class-admin-shell.php
+++ b/includes/admin/class-admin-shell.php
@@ -181,7 +181,7 @@ class Admin_Shell {
 		global $_registered_pages;
 		foreach ( self::get_pages() as $page ) {
 			$parent_slug = $page->get_parent_slug();
-			add_submenu_page(
+			$hook_suffix = add_submenu_page(
 				$parent_slug,
 				$page->get_label(),
 				$page->get_label(),
@@ -189,6 +189,9 @@ class Admin_Shell {
 				$page->get_slug(),
 				[ $page, 'render' ]
 			);
+			if ( is_string( $hook_suffix ) ) {
+				$page->set_hook_suffix( $hook_suffix );
+			}
 			if ( $page->is_hidden_from_menu() ) {
 				// Hidden React pages (the list views) shadow a classic
 				// CPT URL via `Admin_Shell::maybe_redirect_legacy_list`.

--- a/includes/admin/class-admin-shell.php
+++ b/includes/admin/class-admin-shell.php
@@ -24,6 +24,25 @@ class Admin_Shell {
 	const SCRIPT_HANDLE = 'newspack-newsletters-admin-shell';
 
 	/**
+	 * Slug => hookname returned by `add_submenu_page`. Populated by
+	 * `register_menu()` so `Admin_Page::is_admin_page()` survives the
+	 * fresh page instances `get_pages()` returns on every call.
+	 *
+	 * @var array<string,string>
+	 */
+	private static $hook_suffixes = [];
+
+	/**
+	 * Lookup the registered hookname for a given page slug.
+	 *
+	 * @param string $slug Page slug.
+	 * @return string Hookname, or `''` if the slug was not registered.
+	 */
+	public static function get_hook_suffix_for_slug( $slug ) {
+		return isset( self::$hook_suffixes[ $slug ] ) ? self::$hook_suffixes[ $slug ] : '';
+	}
+
+	/**
 	 * Boot hooks.
 	 */
 	public static function init() {
@@ -179,6 +198,7 @@ class Admin_Shell {
 	 */
 	public static function register_menu() {
 		global $_registered_pages;
+		self::$hook_suffixes = [];
 		foreach ( self::get_pages() as $page ) {
 			$parent_slug = $page->get_parent_slug();
 			$hook_suffix = add_submenu_page(
@@ -189,8 +209,9 @@ class Admin_Shell {
 				$page->get_slug(),
 				[ $page, 'render' ]
 			);
-			if ( is_string( $hook_suffix ) ) {
+			if ( is_string( $hook_suffix ) && '' !== $hook_suffix ) {
 				$page->set_hook_suffix( $hook_suffix );
+				self::$hook_suffixes[ $page->get_slug() ] = $hook_suffix;
 			}
 			if ( $page->is_hidden_from_menu() ) {
 				// Hidden React pages (the list views) shadow a classic

--- a/includes/admin/class-settings-rest.php
+++ b/includes/admin/class-settings-rest.php
@@ -55,6 +55,7 @@ class Settings_REST {
 	 */
 	public static function init() {
 		add_action( 'rest_api_init', [ __CLASS__, 'register_routes' ] );
+		add_action( 'newspack_newsletters_provider_credentials_changed', [ __CLASS__, 'bust_oauth_cache' ] );
 	}
 
 	/**
@@ -315,13 +316,15 @@ class Settings_REST {
 	}
 
 	/**
-	 * Transient key for the cached OAuth snapshot.
+	 * Transient key for the cached OAuth snapshot. Keyed per user because
+	 * `auth_url` carries a per-user `wp_create_nonce` — sharing the cache
+	 * across users would leak User A's nonce into User B's response.
 	 *
 	 * @param string $provider_slug Provider slug.
 	 * @return string Transient key.
 	 */
 	private static function oauth_cache_key( $provider_slug ) {
-		return 'newspack_newsletters_oauth_state_' . sanitize_key( $provider_slug );
+		return 'newspack_newsletters_oauth_state_' . sanitize_key( $provider_slug ) . '_' . get_current_user_id();
 	}
 
 	/**

--- a/includes/admin/class-settings-rest.php
+++ b/includes/admin/class-settings-rest.php
@@ -271,8 +271,13 @@ class Settings_REST {
 	}
 
 	/**
-	 * Return the provider's OAuth state, short-cached so the Settings GET
+	 * Resolve the provider's OAuth state for the Settings response.
+	 *
+	 * The `valid` flag is short-cached (site-global) so the Settings GET
 	 * doesn't hit the provider's verify endpoint on every page load.
+	 * `auth_url` is built fresh on every request — it carries a
+	 * `wp_create_nonce` that's session-token-scoped, so caching it
+	 * would leak nonces across users / browser sessions.
 	 *
 	 * @param object|null $provider      Active provider instance.
 	 * @param string      $provider_slug Provider slug.
@@ -283,28 +288,37 @@ class Settings_REST {
 			return null;
 		}
 
-		$cache_key = self::oauth_cache_key( $provider_slug );
-		$cached    = get_transient( $cache_key );
-		if ( is_array( $cached ) ) {
-			return $cached;
-		}
+		$valid    = self::resolve_oauth_validity( $provider, $provider_slug );
+		$auth_url = method_exists( $provider, 'get_oauth_auth_url' ) ? (string) $provider->get_oauth_auth_url() : '';
 
-		$token = $provider->verify_token( true );
-		if ( ! is_array( $token ) ) {
-			return null;
-		}
-
-		$auth_url = isset( $token['auth_url'] ) ? (string) $token['auth_url'] : '';
-		$oauth    = [
-			'valid'    => ! empty( $token['valid'] ),
+		return [
+			'valid'    => (bool) $valid,
 			'auth_url' => $auth_url ? esc_url_raw( $auth_url ) : '',
 		];
-		set_transient( $cache_key, $oauth, self::OAUTH_STATE_CACHE_TTL );
-		return $oauth;
 	}
 
 	/**
-	 * Drop the cached OAuth state. Called after a successful provider
+	 * Read or compute the validity flag for the active provider, caching
+	 * the result so back-to-back GETs share one verify call.
+	 *
+	 * @param object $provider      Provider instance.
+	 * @param string $provider_slug Provider slug.
+	 * @return bool
+	 */
+	private static function resolve_oauth_validity( $provider, $provider_slug ) {
+		$cache_key = self::oauth_cache_key( $provider_slug );
+		$cached    = get_transient( $cache_key );
+		if ( is_array( $cached ) && array_key_exists( 'valid', $cached ) ) {
+			return (bool) $cached['valid'];
+		}
+		$token = $provider->verify_token( true );
+		$valid = is_array( $token ) && ! empty( $token['valid'] );
+		set_transient( $cache_key, [ 'valid' => $valid ], self::OAUTH_STATE_CACHE_TTL );
+		return $valid;
+	}
+
+	/**
+	 * Drop the cached OAuth validity. Called after a successful provider
 	 * switch or credentials update so the next GET reflects the change.
 	 *
 	 * @param string $provider_slug Provider slug.
@@ -316,15 +330,15 @@ class Settings_REST {
 	}
 
 	/**
-	 * Transient key for the cached OAuth snapshot. Keyed per user because
-	 * `auth_url` carries a per-user `wp_create_nonce` — sharing the cache
-	 * across users would leak User A's nonce into User B's response.
+	 * Transient key for the cached OAuth validity. Site-global —
+	 * `auth_url` is no longer cached here, so per-user keying is not
+	 * required.
 	 *
 	 * @param string $provider_slug Provider slug.
 	 * @return string Transient key.
 	 */
 	private static function oauth_cache_key( $provider_slug ) {
-		return 'newspack_newsletters_oauth_state_' . sanitize_key( $provider_slug ) . '_' . get_current_user_id();
+		return 'newspack_newsletters_oauth_valid_' . sanitize_key( $provider_slug );
 	}
 
 	/**

--- a/includes/admin/class-settings-rest.php
+++ b/includes/admin/class-settings-rest.php
@@ -48,6 +48,8 @@ class Settings_REST {
 		'newspack_newsletters_active_campaign_key',
 	];
 
+	const OAUTH_STATE_CACHE_TTL = 60;
+
 	/**
 	 * Boot hooks.
 	 */
@@ -116,8 +118,9 @@ class Settings_REST {
 
 		$provider_payload = $request->get_param( 'provider' );
 		if ( is_array( $provider_payload ) && array_key_exists( 'slug', $provider_payload ) ) {
-			$slug        = is_string( $provider_payload['slug'] ) ? $provider_payload['slug'] : '';
-			$valid_slugs = Newspack_Newsletters::get_supported_providers();
+			$slug          = is_string( $provider_payload['slug'] ) ? $provider_payload['slug'] : '';
+			$previous_slug = Newspack_Newsletters::service_provider();
+			$valid_slugs   = Newspack_Newsletters::get_supported_providers();
 			if ( '' === $slug ) {
 				$errors->add(
 					'newspack_newsletters_no_service_provider',
@@ -132,6 +135,8 @@ class Settings_REST {
 				);
 			} elseif ( 'manual' === $slug ) {
 				Newspack_Newsletters::set_service_provider( $slug );
+				self::bust_oauth_cache( $previous_slug );
+				self::bust_oauth_cache( $slug );
 			} else {
 				// Resolve the provider without committing the option — only flip on credentials success
 				// so a rejection can't leave the site pointing at an unconfigured provider.
@@ -163,6 +168,8 @@ class Settings_REST {
 							}
 						} else {
 							Newspack_Newsletters::set_service_provider( $slug );
+							self::bust_oauth_cache( $previous_slug );
+							self::bust_oauth_cache( $slug );
 						}
 					}
 				}
@@ -215,17 +222,7 @@ class Settings_REST {
 		$is_manual = 'manual' === $provider_slug;
 		$status    = $is_manual || ( $provider && $has_creds );
 
-		$oauth = null;
-		if ( $provider && method_exists( $provider, 'verify_token' ) ) {
-			$token = $provider->verify_token( true );
-			if ( is_array( $token ) ) {
-				$auth_url = isset( $token['auth_url'] ) ? (string) $token['auth_url'] : '';
-				$oauth    = [
-					'valid'    => ! empty( $token['valid'] ),
-					'auth_url' => $auth_url ? esc_url_raw( $auth_url ) : '',
-				];
-			}
-		}
+		$oauth = self::resolve_oauth_state( $provider, $provider_slug );
 
 		$schema  = self::get_options_schema();
 		$options = [];
@@ -270,6 +267,61 @@ class Settings_REST {
 			'schema'              => $client_schema,
 			'lists_can_add_local' => (bool) $lists_can_add_local,
 		];
+	}
+
+	/**
+	 * Return the provider's OAuth state, short-cached so the Settings GET
+	 * doesn't hit the provider's verify endpoint on every page load.
+	 *
+	 * @param object|null $provider      Active provider instance.
+	 * @param string      $provider_slug Provider slug.
+	 * @return array|null
+	 */
+	private static function resolve_oauth_state( $provider, $provider_slug ) {
+		if ( ! $provider || ! method_exists( $provider, 'verify_token' ) ) {
+			return null;
+		}
+
+		$cache_key = self::oauth_cache_key( $provider_slug );
+		$cached    = get_transient( $cache_key );
+		if ( is_array( $cached ) ) {
+			return $cached;
+		}
+
+		$token = $provider->verify_token( true );
+		if ( ! is_array( $token ) ) {
+			return null;
+		}
+
+		$auth_url = isset( $token['auth_url'] ) ? (string) $token['auth_url'] : '';
+		$oauth    = [
+			'valid'    => ! empty( $token['valid'] ),
+			'auth_url' => $auth_url ? esc_url_raw( $auth_url ) : '',
+		];
+		set_transient( $cache_key, $oauth, self::OAUTH_STATE_CACHE_TTL );
+		return $oauth;
+	}
+
+	/**
+	 * Drop the cached OAuth state. Called after a successful provider
+	 * switch or credentials update so the next GET reflects the change.
+	 *
+	 * @param string $provider_slug Provider slug.
+	 */
+	public static function bust_oauth_cache( $provider_slug ) {
+		if ( $provider_slug ) {
+			delete_transient( self::oauth_cache_key( $provider_slug ) );
+		}
+	}
+
+	/**
+	 * Transient key for the cached OAuth snapshot.
+	 *
+	 * @param string $provider_slug Provider slug.
+	 * @return string Transient key.
+	 */
+	private static function oauth_cache_key( $provider_slug ) {
+		return 'newspack_newsletters_oauth_state_' . sanitize_key( $provider_slug );
 	}
 
 	/**

--- a/includes/service-providers/constant_contact/class-newspack-newsletters-constant-contact.php
+++ b/includes/service-providers/constant_contact/class-newspack-newsletters-constant-contact.php
@@ -114,6 +114,24 @@ final class Newspack_Newsletters_Constant_Contact extends \Newspack_Newsletters_
 	}
 
 	/**
+	 * Build the OAuth authorisation URL without calling the live API.
+	 * Decoupled from `verify_token()` so admin surfaces can render the
+	 * "Authorize" button (which requires a session-current
+	 * `wp_create_nonce`) without paying for a `validate_token` round trip.
+	 *
+	 * @return string
+	 */
+	public function get_oauth_auth_url() {
+		try {
+			$redirect_uri = $this->get_oauth_redirect_uri();
+			$cc           = $this->get_sdk();
+			return $cc->get_auth_code_url( wp_create_nonce( 'constant_contact_oauth2' ), $redirect_uri );
+		} catch ( Exception $e ) {
+			return '';
+		}
+	}
+
+	/**
 	 * Verify service provider connection.
 	 *
 	 * @param boolean $refresh Whether to attempt connection refresh.

--- a/includes/service-providers/constant_contact/class-newspack-newsletters-constant-contact.php
+++ b/includes/service-providers/constant_contact/class-newspack-newsletters-constant-contact.php
@@ -315,6 +315,15 @@ final class Newspack_Newsletters_Constant_Contact extends \Newspack_Newsletters_
 		}
 		$update_access_token  = update_option( 'newspack_newsletters_constant_contact_api_access_token', $access_token );
 		$update_refresh_token = update_option( 'newspack_newsletters_constant_contact_api_refresh_token', $refresh_token );
+
+		/**
+		 * Provider credentials persisted — listeners (e.g. Settings_REST's
+		 * OAuth cache) bust their caches so the next read reflects the change.
+		 *
+		 * @param string $provider_slug The provider whose credentials changed.
+		 */
+		do_action( 'newspack_newsletters_provider_credentials_changed', 'constant_contact' );
+
 		return $update_access_token;
 	}
 

--- a/src/admin-shell/screens/ads-list/index.js
+++ b/src/admin-shell/screens/ads-list/index.js
@@ -46,8 +46,8 @@ function useFilterTerms() {
 
 	useEffect( () => {
 		let cancelled = false;
-		Promise.all( [ fetchAllTerms( '/wp/v2/newspack_nl_advertiser' ), fetchAllTerms( '/wp/v2/ad_placement' ) ] ).then(
-			( [ advertisers, placements ] ) => {
+		Promise.all( [ fetchAllTerms( '/wp/v2/newspack_nl_advertiser' ), fetchAllTerms( '/wp/v2/ad_placement' ) ] )
+			.then( ( [ advertisers, placements ] ) => {
 				if ( cancelled ) {
 					return;
 				}
@@ -55,8 +55,8 @@ function useFilterTerms() {
 					advertisers: Array.isArray( advertisers ) ? advertisers : [],
 					placements: Array.isArray( placements ) ? placements : [],
 				} );
-			}
-		);
+			} )
+			.catch( () => {} );
 		return () => {
 			cancelled = true;
 		};

--- a/src/admin-shell/screens/ads-list/quick-edit-panel.js
+++ b/src/admin-shell/screens/ads-list/quick-edit-panel.js
@@ -24,11 +24,13 @@ function useQuickEditCategories() {
 	const [ categories, setCategories ] = useState( [] );
 	useEffect( () => {
 		let cancelled = false;
-		fetchAllTerms( '/wp/v2/categories' ).then( terms => {
-			if ( ! cancelled ) {
-				setCategories( Array.isArray( terms ) ? terms : [] );
-			}
-		} );
+		fetchAllTerms( '/wp/v2/categories' )
+			.then( terms => {
+				if ( ! cancelled ) {
+					setCategories( Array.isArray( terms ) ? terms : [] );
+				}
+			} )
+			.catch( () => {} );
 		return () => {
 			cancelled = true;
 		};

--- a/src/admin-shell/screens/newsletters-list/quick-edit-panel.js
+++ b/src/admin-shell/screens/newsletters-list/quick-edit-panel.js
@@ -24,15 +24,17 @@ function useQuickEditOptions() {
 
 	useEffect( () => {
 		let cancelled = false;
-		Promise.all( [ fetchAllTerms( '/wp/v2/categories' ), fetchAllTerms( '/wp/v2/tags' ) ] ).then( ( [ categories, tags ] ) => {
-			if ( cancelled ) {
-				return;
-			}
-			setOptions( {
-				categories: Array.isArray( categories ) ? categories : [],
-				tags: Array.isArray( tags ) ? tags : [],
-			} );
-		} );
+		Promise.all( [ fetchAllTerms( '/wp/v2/categories' ), fetchAllTerms( '/wp/v2/tags' ) ] )
+			.then( ( [ categories, tags ] ) => {
+				if ( cancelled ) {
+					return;
+				}
+				setOptions( {
+					categories: Array.isArray( categories ) ? categories : [],
+					tags: Array.isArray( tags ) ? tags : [],
+				} );
+			} )
+			.catch( () => {} );
 		return () => {
 			cancelled = true;
 		};

--- a/tests/test-admin-page.php
+++ b/tests/test-admin-page.php
@@ -16,15 +16,17 @@ class Admin_Page_Test extends WP_UnitTestCase {
 	 */
 	public function tear_down() {
 		unset( $_GET['page'] );
+		set_current_screen( 'front' );
 		parent::tear_down();
 	}
 
 	/**
-	 * Returns true when ?page= matches the slug.
+	 * Returns true when both ?page= and the current screen match the page.
 	 */
-	public function test_is_admin_page_matches_slug() {
+	public function test_is_admin_page_matches_slug_on_matching_screen() {
 		$page         = new Settings_Page();
 		$_GET['page'] = $page->get_slug();
+		set_current_screen( 'admin_page_' . $page->get_slug() );
 		$this->assertTrue( $page->is_admin_page() );
 	}
 
@@ -34,6 +36,7 @@ class Admin_Page_Test extends WP_UnitTestCase {
 	public function test_is_admin_page_does_not_match_other_slug() {
 		$page         = new Settings_Page();
 		$_GET['page'] = 'something-else';
+		set_current_screen( 'admin_page_' . $page->get_slug() );
 		$this->assertFalse( $page->is_admin_page() );
 	}
 
@@ -43,6 +46,17 @@ class Admin_Page_Test extends WP_UnitTestCase {
 	public function test_is_admin_page_handles_missing_param() {
 		$page = new Settings_Page();
 		unset( $_GET['page'] );
+		$this->assertFalse( $page->is_admin_page() );
+	}
+
+	/**
+	 * Returns false when ?page= matches but the current screen does not —
+	 * defends against a foreign admin URL carrying the same query key.
+	 */
+	public function test_is_admin_page_rejects_foreign_screen() {
+		$page         = new Settings_Page();
+		$_GET['page'] = $page->get_slug();
+		set_current_screen( 'tools' );
 		$this->assertFalse( $page->is_admin_page() );
 	}
 }

--- a/tests/test-admin-page.php
+++ b/tests/test-admin-page.php
@@ -59,4 +59,16 @@ class Admin_Page_Test extends WP_UnitTestCase {
 		set_current_screen( 'tools' );
 		$this->assertFalse( $page->is_admin_page() );
 	}
+
+	/**
+	 * `tools.php?page=<slug>` produces a `tools_page_<slug>` screen id —
+	 * the substring contains the slug but isn't a hookname we registered.
+	 * Must still be rejected.
+	 */
+	public function test_is_admin_page_rejects_foreign_url_with_slug_in_screen_id() {
+		$page         = new Settings_Page();
+		$_GET['page'] = $page->get_slug();
+		set_current_screen( 'tools_page_' . $page->get_slug() );
+		$this->assertFalse( $page->is_admin_page() );
+	}
 }

--- a/tests/test-admin-shell.php
+++ b/tests/test-admin-shell.php
@@ -270,6 +270,7 @@ class Admin_Shell_Test extends WP_UnitTestCase {
 	public function test_highlight_parent_menu_returns_cpt_url_when_on_a_managed_page() {
 		add_filter( 'newspack_newsletters_admin_bundled_mode', '__return_true' );
 		$_GET['page'] = 'newspack-newsletters-list';
+		set_current_screen( 'admin_page_newspack-newsletters-list' );
 
 		$expected = 'edit.php?post_type=' . Newspack_Newsletters::NEWSPACK_NEWSLETTERS_CPT;
 		$this->assertSame( $expected, Admin_Shell::highlight_parent_menu( 'unrelated.php' ) );
@@ -292,6 +293,7 @@ class Admin_Shell_Test extends WP_UnitTestCase {
 	public function test_highlight_submenu_targets_all_newsletters_for_list_page() {
 		add_filter( 'newspack_newsletters_admin_bundled_mode', '__return_true' );
 		$_GET['page'] = 'newspack-newsletters-list';
+		set_current_screen( 'admin_page_newspack-newsletters-list' );
 
 		$expected = 'edit.php?post_type=' . Newspack_Newsletters::NEWSPACK_NEWSLETTERS_CPT;
 		$this->assertSame( $expected, Admin_Shell::highlight_submenu( 'unrelated' ) );
@@ -308,6 +310,7 @@ class Admin_Shell_Test extends WP_UnitTestCase {
 	public function test_highlight_submenu_targets_ads_cpt_for_ads_list_page() {
 		add_filter( 'newspack_newsletters_admin_bundled_mode', '__return_true' );
 		$_GET['page'] = 'newspack-newsletters-ads-list';
+		set_current_screen( 'admin_page_newspack-newsletters-ads-list' );
 
 		$expected = 'edit.php?post_type=' . \Newspack_Newsletters\Ads::CPT;
 		$this->assertSame( $expected, Admin_Shell::highlight_submenu( 'unrelated' ) );
@@ -383,6 +386,7 @@ class Admin_Shell_Test extends WP_UnitTestCase {
 	public function test_highlight_parent_menu_for_ads_page_in_submenu_mode() {
 		add_filter( 'newspack_newsletters_admin_bundled_mode', '__return_true' );
 		$_GET['page'] = 'newspack-newsletters-ads-list';
+		set_current_screen( 'admin_page_newspack-newsletters-ads-list' );
 
 		$expected = 'edit.php?post_type=' . Newspack_Newsletters::NEWSPACK_NEWSLETTERS_CPT;
 		$this->assertSame( $expected, Admin_Shell::highlight_parent_menu( 'unrelated.php' ) );
@@ -406,6 +410,7 @@ class Admin_Shell_Test extends WP_UnitTestCase {
 
 		add_filter( 'newspack_newsletters_admin_bundled_mode', '__return_true' );
 		$_GET['page'] = 'newspack-newsletters-ads-list';
+		set_current_screen( 'admin_page_newspack-newsletters-ads-list' );
 
 		Admin_Shell::patch_wizard_header_active_tab();
 

--- a/tests/test-settings-rest.php
+++ b/tests/test-settings-rest.php
@@ -59,6 +59,8 @@ class Settings_REST_Test extends WP_UnitTestCase {
 		foreach ( $keys as $key ) {
 			delete_option( $key );
 		}
+		delete_transient( 'newspack_newsletters_oauth_state_constant_contact' );
+		delete_transient( 'newspack_newsletters_oauth_state_mailchimp' );
 		// Reset the memoized provider instance so later tests can't see
 		// a stale `Newspack_Newsletters::$provider` after the option was
 		// deleted out from under it.
@@ -239,5 +241,42 @@ class Settings_REST_Test extends WP_UnitTestCase {
 		$this->assertIsArray( $flags );
 		$this->assertArrayHasKey( 'api_key', $flags );
 		$this->assertTrue( $flags['api_key'] );
+	}
+
+	/**
+	 * Settings GET serves the cached OAuth snapshot rather than calling
+	 * the provider's verify_token() on every page load.
+	 */
+	public function test_oauth_state_served_from_transient() {
+		$this->become_admin();
+		Newspack_Newsletters::set_service_provider( 'constant_contact' );
+
+		set_transient(
+			'newspack_newsletters_oauth_state_constant_contact',
+			[
+				'valid'    => true,
+				'auth_url' => 'https://example.test/oauth-from-cache',
+			],
+			60
+		);
+
+		$oauth = Settings_REST::get_settings( $this->rest_request( 'GET' ) )->get_data()['provider']['oauth'];
+
+		$this->assertTrue( $oauth['valid'] );
+		$this->assertSame( 'https://example.test/oauth-from-cache', $oauth['auth_url'] );
+	}
+
+	/**
+	 * Successful provider-switch busts the cached OAuth snapshot so the
+	 * next GET reflects the new credentials.
+	 */
+	public function test_oauth_cache_busted_on_manual_switch() {
+		$this->become_admin();
+		Newspack_Newsletters::set_service_provider( 'constant_contact' );
+		set_transient( 'newspack_newsletters_oauth_state_constant_contact', [ 'valid' => true ], 60 );
+
+		Settings_REST::update_settings( $this->rest_request( 'POST', [ 'provider' => [ 'slug' => 'manual' ] ] ) );
+
+		$this->assertFalse( get_transient( 'newspack_newsletters_oauth_state_constant_contact' ) );
 	}
 }

--- a/tests/test-settings-rest.php
+++ b/tests/test-settings-rest.php
@@ -59,10 +59,8 @@ class Settings_REST_Test extends WP_UnitTestCase {
 		foreach ( $keys as $key ) {
 			delete_option( $key );
 		}
-		global $wpdb;
-		// Per-user cache keys: scrub anything matching the prefix so test
-		// order can't leak across user IDs.
-		$wpdb->query( "DELETE FROM {$wpdb->options} WHERE option_name LIKE '\\_transient\\_newspack\\_newsletters\\_oauth\\_state\\_%' OR option_name LIKE '\\_transient\\_timeout\\_newspack\\_newsletters\\_oauth\\_state\\_%'" ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery
+		delete_transient( 'newspack_newsletters_oauth_valid_constant_contact' );
+		delete_transient( 'newspack_newsletters_oauth_valid_mailchimp' );
 		// Reset the memoized provider instance so later tests can't see
 		// a stale `Newspack_Newsletters::$provider` after the option was
 		// deleted out from under it.
@@ -249,73 +247,58 @@ class Settings_REST_Test extends WP_UnitTestCase {
 	 * Settings GET serves the cached OAuth snapshot rather than calling
 	 * the provider's verify_token() on every page load.
 	 */
-	public function test_oauth_state_served_from_transient() {
-		$user_id = $this->become_admin();
+	public function test_oauth_validity_served_from_transient() {
+		$this->become_admin();
 		Newspack_Newsletters::set_service_provider( 'constant_contact' );
-
-		set_transient(
-			'newspack_newsletters_oauth_state_constant_contact_' . $user_id,
-			[
-				'valid'    => true,
-				'auth_url' => 'https://example.test/oauth-from-cache',
-			],
-			60
-		);
+		set_transient( 'newspack_newsletters_oauth_valid_constant_contact', [ 'valid' => true ], 60 );
 
 		$oauth = Settings_REST::get_settings( $this->rest_request( 'GET' ) )->get_data()['provider']['oauth'];
 
 		$this->assertTrue( $oauth['valid'] );
-		$this->assertSame( 'https://example.test/oauth-from-cache', $oauth['auth_url'] );
 	}
 
 	/**
-	 * The cache key includes the current user id so a Settings GET in
-	 * one admin's session can't surface another admin's wp_create_nonce.
+	 * `auth_url` carries a session-token-scoped `wp_create_nonce` — it
+	 * must not be persisted in the transient, otherwise a cached URL
+	 * from a different session would fail the callback nonce check.
 	 */
-	public function test_oauth_cache_does_not_leak_across_users() {
-		$other_user = self::factory()->user->create( [ 'role' => 'administrator' ] );
-		set_transient(
-			'newspack_newsletters_oauth_state_constant_contact_' . $other_user,
-			[
-				'valid'    => true,
-				'auth_url' => 'https://example.test/other-user-nonce',
-			],
-			60
-		);
-
+	public function test_oauth_auth_url_is_not_cached() {
 		$this->become_admin();
 		Newspack_Newsletters::set_service_provider( 'constant_contact' );
+		set_transient( 'newspack_newsletters_oauth_valid_constant_contact', [ 'valid' => true ], 60 );
 
-		$oauth = Settings_REST::get_settings( $this->rest_request( 'GET' ) )->get_data()['provider']['oauth'];
+		Settings_REST::get_settings( $this->rest_request( 'GET' ) );
 
-		$this->assertNotSame( 'https://example.test/other-user-nonce', $oauth['auth_url'] );
+		$stored = get_transient( 'newspack_newsletters_oauth_valid_constant_contact' );
+		$this->assertIsArray( $stored );
+		$this->assertArrayNotHasKey( 'auth_url', $stored );
 	}
 
 	/**
-	 * Successful provider-switch busts the cached OAuth snapshot so the
+	 * Successful provider-switch busts the cached OAuth validity so the
 	 * next GET reflects the new credentials.
 	 */
 	public function test_oauth_cache_busted_on_manual_switch() {
-		$user_id = $this->become_admin();
+		$this->become_admin();
 		Newspack_Newsletters::set_service_provider( 'constant_contact' );
-		set_transient( 'newspack_newsletters_oauth_state_constant_contact_' . $user_id, [ 'valid' => true ], 60 );
+		set_transient( 'newspack_newsletters_oauth_valid_constant_contact', [ 'valid' => true ], 60 );
 
 		Settings_REST::update_settings( $this->rest_request( 'POST', [ 'provider' => [ 'slug' => 'manual' ] ] ) );
 
-		$this->assertFalse( get_transient( 'newspack_newsletters_oauth_state_constant_contact_' . $user_id ) );
+		$this->assertFalse( get_transient( 'newspack_newsletters_oauth_valid_constant_contact' ) );
 	}
 
 	/**
 	 * Firing the `newspack_newsletters_provider_credentials_changed` action
-	 * busts the current user's cached OAuth state (used by the OAuth
-	 * callback path so the post-authorize Settings reload sees fresh state).
+	 * busts the cached OAuth validity — used by the OAuth callback path
+	 * so the post-authorize Settings reload sees fresh state.
 	 */
 	public function test_oauth_cache_busted_on_credentials_changed_action() {
-		$user_id = $this->become_admin();
-		set_transient( 'newspack_newsletters_oauth_state_constant_contact_' . $user_id, [ 'valid' => false ], 60 );
+		$this->become_admin();
+		set_transient( 'newspack_newsletters_oauth_valid_constant_contact', [ 'valid' => false ], 60 );
 
 		do_action( 'newspack_newsletters_provider_credentials_changed', 'constant_contact' );
 
-		$this->assertFalse( get_transient( 'newspack_newsletters_oauth_state_constant_contact_' . $user_id ) );
+		$this->assertFalse( get_transient( 'newspack_newsletters_oauth_valid_constant_contact' ) );
 	}
 }

--- a/tests/test-settings-rest.php
+++ b/tests/test-settings-rest.php
@@ -59,8 +59,10 @@ class Settings_REST_Test extends WP_UnitTestCase {
 		foreach ( $keys as $key ) {
 			delete_option( $key );
 		}
-		delete_transient( 'newspack_newsletters_oauth_state_constant_contact' );
-		delete_transient( 'newspack_newsletters_oauth_state_mailchimp' );
+		global $wpdb;
+		// Per-user cache keys: scrub anything matching the prefix so test
+		// order can't leak across user IDs.
+		$wpdb->query( "DELETE FROM {$wpdb->options} WHERE option_name LIKE '\\_transient\\_newspack\\_newsletters\\_oauth\\_state\\_%' OR option_name LIKE '\\_transient\\_timeout\\_newspack\\_newsletters\\_oauth\\_state\\_%'" ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery
 		// Reset the memoized provider instance so later tests can't see
 		// a stale `Newspack_Newsletters::$provider` after the option was
 		// deleted out from under it.
@@ -248,11 +250,11 @@ class Settings_REST_Test extends WP_UnitTestCase {
 	 * the provider's verify_token() on every page load.
 	 */
 	public function test_oauth_state_served_from_transient() {
-		$this->become_admin();
+		$user_id = $this->become_admin();
 		Newspack_Newsletters::set_service_provider( 'constant_contact' );
 
 		set_transient(
-			'newspack_newsletters_oauth_state_constant_contact',
+			'newspack_newsletters_oauth_state_constant_contact_' . $user_id,
 			[
 				'valid'    => true,
 				'auth_url' => 'https://example.test/oauth-from-cache',
@@ -267,16 +269,53 @@ class Settings_REST_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * The cache key includes the current user id so a Settings GET in
+	 * one admin's session can't surface another admin's wp_create_nonce.
+	 */
+	public function test_oauth_cache_does_not_leak_across_users() {
+		$other_user = self::factory()->user->create( [ 'role' => 'administrator' ] );
+		set_transient(
+			'newspack_newsletters_oauth_state_constant_contact_' . $other_user,
+			[
+				'valid'    => true,
+				'auth_url' => 'https://example.test/other-user-nonce',
+			],
+			60
+		);
+
+		$this->become_admin();
+		Newspack_Newsletters::set_service_provider( 'constant_contact' );
+
+		$oauth = Settings_REST::get_settings( $this->rest_request( 'GET' ) )->get_data()['provider']['oauth'];
+
+		$this->assertNotSame( 'https://example.test/other-user-nonce', $oauth['auth_url'] );
+	}
+
+	/**
 	 * Successful provider-switch busts the cached OAuth snapshot so the
 	 * next GET reflects the new credentials.
 	 */
 	public function test_oauth_cache_busted_on_manual_switch() {
-		$this->become_admin();
+		$user_id = $this->become_admin();
 		Newspack_Newsletters::set_service_provider( 'constant_contact' );
-		set_transient( 'newspack_newsletters_oauth_state_constant_contact', [ 'valid' => true ], 60 );
+		set_transient( 'newspack_newsletters_oauth_state_constant_contact_' . $user_id, [ 'valid' => true ], 60 );
 
 		Settings_REST::update_settings( $this->rest_request( 'POST', [ 'provider' => [ 'slug' => 'manual' ] ] ) );
 
-		$this->assertFalse( get_transient( 'newspack_newsletters_oauth_state_constant_contact' ) );
+		$this->assertFalse( get_transient( 'newspack_newsletters_oauth_state_constant_contact_' . $user_id ) );
+	}
+
+	/**
+	 * Firing the `newspack_newsletters_provider_credentials_changed` action
+	 * busts the current user's cached OAuth state (used by the OAuth
+	 * callback path so the post-authorize Settings reload sees fresh state).
+	 */
+	public function test_oauth_cache_busted_on_credentials_changed_action() {
+		$user_id = $this->become_admin();
+		set_transient( 'newspack_newsletters_oauth_state_constant_contact_' . $user_id, [ 'valid' => false ], 60 );
+
+		do_action( 'newspack_newsletters_provider_credentials_changed', 'constant_contact' );
+
+		$this->assertFalse( get_transient( 'newspack_newsletters_oauth_state_constant_contact_' . $user_id ) );
 	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Targets `epic/admin-ux-modernisation` so it can land after #2143 and #2144 and roll into #2141 cleanly. Addresses the three MED-severity findings from the milestone code review, plus the round-1 and round-2 review feedback on each.

#### 1. Guard filter-option hooks against fetch rejection
`src/admin-shell/screens/ads-list/index.js`, `src/admin-shell/screens/newsletters-list/quick-edit-panel.js`, `src/admin-shell/screens/ads-list/quick-edit-panel.js`

The three `useFilterTerms` / `useQuickEditOptions` / `useQuickEditCategories` hooks awaited `fetchAllTerms` without a `.catch`. `fetchAllTerms` swallows errors internally today, so this is defence-in-depth: if either layer ever surfaces a rejection — or the `.then` body throws — the dropdowns stay empty instead of triggering an unhandled-rejection warning.

#### 2. Cache provider OAuth validity between Settings GETs (without leaking nonces)
`includes/admin/class-settings-rest.php`, `includes/service-providers/constant_contact/class-newspack-newsletters-constant-contact.php`

The Settings GET previously called `$provider->verify_token( true )` on every page load. Constant Contact's implementation hits the live OAuth endpoint (and attempts a token refresh) — an authenticated admin reloading the screen can exhaust the provider's rate limit.

Split the response shape so the cache is safe to share:

- Cache only the **validity boolean** (`{ valid: bool }`), site-global per provider, 60s TTL. This is the field that costs an API call to produce.
- Build the **`auth_url`** fresh on every request. It carries a `wp_create_nonce` scoped to the WordPress *session token*, so caching it would leak nonces across users **and** across browser sessions of the same user. New `Newspack_Newsletters_Constant_Contact::get_oauth_auth_url()` formats the URL without calling `validate_token` / `refresh_token`, so no API cost.
- Bust the validity cache when:
  - The Settings POST switches provider or updates credentials.
  - Constant Contact's `set_access_token()` fires `newspack_newsletters_provider_credentials_changed` (e.g. on OAuth callback success) — `Settings_REST::init()` listens.

Adds four tests: validity served from the transient on cache hit; `auth_url` never lands in the transient; manual-switch from a previously-configured provider busts the cache; the credentials-changed action busts the cache.

#### 3. Narrow `is_admin_page()` to the registered admin screen
`includes/admin/class-admin-page.php`, `includes/admin/class-admin-shell.php`

`is_admin_page()` previously returned true for any request carrying `?page=<slug>`, including foreign admin URLs that happen to share the query key (third-party plugin, malformed bookmark). That tripped asset enqueue, body class, parent_file / submenu_file filters on unrelated screens.

Capture the hookname `add_submenu_page` returns and require the current screen id to match it (or the `admin_page_<slug>` shadow used when the parent CPT isn't a top-level menu).

`Admin_Shell::get_pages()` returns fresh page instances on every call, so the hookname is tracked on a static `Admin_Shell::$hook_suffixes` lookup populated at registration time — that way `is_admin_page()` finds it whatever instance is consulting. No substring fallback; a `tools_page_<slug>` screen id can no longer slip through.

Returns false when no screen has resolved yet — every caller fires after `current_screen`. Existing `Admin_Shell` tests updated to `set_current_screen()` alongside `$_GET['page']`; adds coverage for both the bare-foreign-screen rejection (`tools`) and the slug-in-screen-id rejection (`tools_page_<slug>`).

No context change.

### How to test the changes in this Pull Request:

1. Pull this branch, run `n ci-build`, and load the Newsletters admin.
2. **Filter `.catch`**: open Newsletters list → Quick Edit on any row → categories/tags dropdowns populate. Same for Ads list filter and Quick Edit.
3. **OAuth cache** (Constant Contact):
   - Switch to CC with valid credentials → confirm OAuth flow lights up.
   - Reload Settings several times within 60s → confirm no extra `validate_token` API calls in the network panel.
   - In a second browser session as the same admin (or a different admin), reload Settings → confirm the "Authorize" button works (the URL carries that session's nonce, not the cached one).
   - Complete an OAuth round-trip → confirm the post-authorize Settings reload immediately shows "Connected" (no 60s lag).
4. **`is_admin_page` narrowing**: visit `tools.php?page=newspack-newsletters-list` — confirm the page does **not** apply our body class or attempt to mount the React app. Then visit the legitimate `edit.php?post_type=newspack_nl_cpt&page=newspack-newsletters-list` — confirm everything still works.
5. PHP tests: `n test-php` (376 tests, all green).
6. JS tests: `n test-js` (195 tests, all green).

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?