### PR TITLE
fix(admin): tier-3 code review follow-ups

### DIFF
--- a/includes/class-newspack-newsletters-layouts.php
+++ b/includes/class-newspack-newsletters-layouts.php
@@ -123,13 +123,14 @@ final class Newspack_Newsletters_Layouts {
 	public static function rest_send_layout_test_email( $request ) {
 		$post_id = absint( $request['id'] );
 		$raw     = (string) $request->get_param( 'test_email' );
-		$emails  = array_map(
+		// Cap at 10 — auth-gated but the comma split is otherwise unbounded.
+		// Limit explode to 11 so we still have headroom if the first segment is invalid.
+		$emails = array_map(
 			static function ( $email ) {
 				return sanitize_email( trim( $email ) );
 			},
-			explode( ',', $raw )
+			explode( ',', $raw, 11 )
 		);
-		// Cap at 10 — auth-gated but `explode( ',', $raw )` is otherwise unbounded.
 		$valid = array_slice( array_values( array_filter( $emails, 'is_email' ) ), 0, 10 );
 
 		if ( empty( $valid ) ) {

--- a/includes/class-newspack-newsletters-layouts.php
+++ b/includes/class-newspack-newsletters-layouts.php
@@ -123,8 +123,7 @@ final class Newspack_Newsletters_Layouts {
 	public static function rest_send_layout_test_email( $request ) {
 		$post_id = absint( $request['id'] );
 		$raw     = (string) $request->get_param( 'test_email' );
-		// Cap at 10 — auth-gated but the comma split is otherwise unbounded.
-		// Limit explode to 11 so we still have headroom if the first segment is invalid.
+		// Cap at 10 with explode limit 11 so parsing and outbound count are both bounded.
 		$emails = array_map(
 			static function ( $email ) {
 				return sanitize_email( trim( $email ) );

--- a/includes/class-newspack-newsletters-layouts.php
+++ b/includes/class-newspack-newsletters-layouts.php
@@ -129,7 +129,8 @@ final class Newspack_Newsletters_Layouts {
 			},
 			explode( ',', $raw )
 		);
-		$valid = array_values( array_filter( $emails, 'is_email' ) );
+		// Cap at 10 — auth-gated but `explode( ',', $raw )` is otherwise unbounded.
+		$valid = array_slice( array_values( array_filter( $emails, 'is_email' ) ), 0, 10 );
 
 		if ( empty( $valid ) ) {
 			return new WP_Error(

--- a/includes/class-newspack-newsletters-subscription.php
+++ b/includes/class-newspack-newsletters-subscription.php
@@ -577,21 +577,26 @@ class Newspack_Newsletters_Subscription {
 	public static function sanitize_lists( $lists ) {
 		$sanitized = [];
 		foreach ( $lists as $list ) {
-			if ( ! isset( $list['id'], $list['title'] ) || empty( $list['id'] ) ) {
-				continue;
-			}
-			$title = is_string( $list['title'] ) ? trim( $list['title'] ) : '';
-			if ( '' === $title ) {
+			if ( ! isset( $list['id'] ) || empty( $list['id'] ) ) {
 				continue;
 			}
 			$entry = [
 				'id'     => $list['id'],
 				'active' => isset( $list['active'] ) ? (bool) $list['active'] : false,
-				'title'  => $title,
 			];
-			// Carry `description` only when present — preserves "omit means leave alone".
-			if ( array_key_exists( 'description', $list ) ) {
-				$entry['description'] = (string) $list['description'];
+			// Carry `title` only when caller supplied a non-empty string.
+			// null / missing / non-string → omit so update() no-ops the field
+			// and the cleanup loop still sees the row in `$existing_ids`.
+			if ( isset( $list['title'] ) && is_string( $list['title'] ) ) {
+				$title = trim( $list['title'] );
+				if ( '' !== $title ) {
+					$entry['title'] = $title;
+				}
+			}
+			// Carry `description` only when caller supplied a string. Casting
+			// null → '' here would silently clobber the stored description.
+			if ( isset( $list['description'] ) && is_string( $list['description'] ) ) {
+				$entry['description'] = $list['description'];
 			}
 			$sanitized[] = $entry;
 		}

--- a/includes/class-newspack-newsletters-subscription.php
+++ b/includes/class-newspack-newsletters-subscription.php
@@ -584,17 +584,13 @@ class Newspack_Newsletters_Subscription {
 				'id'     => $list['id'],
 				'active' => isset( $list['active'] ) ? (bool) $list['active'] : false,
 			];
-			// Carry `title` only when caller supplied a non-empty string.
-			// null / missing / non-string → omit so update() no-ops the field
-			// and the cleanup loop still sees the row in `$existing_ids`.
+			// Omit null/non-string title and description so update() no-ops the field.
 			if ( isset( $list['title'] ) && is_string( $list['title'] ) ) {
 				$title = trim( $list['title'] );
 				if ( '' !== $title ) {
 					$entry['title'] = $title;
 				}
 			}
-			// Carry `description` only when caller supplied a string. Casting
-			// null → '' here would silently clobber the stored description.
 			if ( isset( $list['description'] ) && is_string( $list['description'] ) ) {
 				$entry['description'] = $list['description'];
 			}

--- a/includes/class-subscription-list.php
+++ b/includes/class-subscription-list.php
@@ -517,14 +517,14 @@ class Subscription_List {
 		if ( isset( $fields['active'] ) && $fields['active'] !== $this->is_active() ) {
 			$post_data['post_status'] = $fields['active'] ? 'publish' : 'draft';
 		}
-		if ( array_key_exists( 'title', $fields ) ) {
-			$title = is_string( $fields['title'] ) ? $fields['title'] : '';
+		if ( isset( $fields['title'] ) && is_string( $fields['title'] ) ) {
+			$title = $fields['title'];
 			if ( '' !== $title && $title !== $this->get_title() ) {
 				$post_data['post_title'] = $title;
 			}
 		}
-		if ( array_key_exists( 'description', $fields ) ) {
-			$description = is_string( $fields['description'] ) ? $fields['description'] : '';
+		if ( isset( $fields['description'] ) && is_string( $fields['description'] ) ) {
+			$description = $fields['description'];
 			if ( $description !== $this->get_description() ) {
 				$post_data['post_content'] = $description;
 			}

--- a/includes/class-subscription-lists.php
+++ b/includes/class-subscription-lists.php
@@ -503,7 +503,8 @@ class Subscription_Lists {
 	 * @return Subscription_List
 	 */
 	public static function get_or_create_remote_list( $list ) {
-		if ( empty( $list['id'] ) || empty( $list['title'] ) ) {
+		// `empty()` would reject a legitimate `"0"` title; check string-emptiness directly.
+		if ( empty( $list['id'] ) || ! isset( $list['title'] ) || ! is_string( $list['title'] ) || '' === trim( $list['title'] ) ) {
 			throw new \Exception( 'Invalid list' );
 		}
 
@@ -772,8 +773,8 @@ class Subscription_Lists {
 
 			// If a remote list was not found, create one.
 			if ( ! $stored_list instanceof Subscription_List && ! Subscription_List::is_local_public_id( $list['id'] ) ) {
-				// get_or_create_remote_list() needs a title; skip rather than throw.
-				if ( empty( $list['title'] ) ) {
+				// sanitize_lists only sets `title` for non-empty strings; mirror that contract.
+				if ( ! isset( $list['title'] ) ) {
 					continue;
 				}
 				$stored_list = self::get_or_create_remote_list( $list );

--- a/includes/class-subscription-lists.php
+++ b/includes/class-subscription-lists.php
@@ -762,7 +762,11 @@ class Subscription_Lists {
 		}
 		$lists = Newspack_Newsletters_Subscription::sanitize_lists( $lists );
 		if ( empty( $lists ) ) {
-			return new WP_Error( 'newspack_newsletters_invalid_lists', __( 'Invalid list configuration.' ) );
+			return new WP_Error(
+				'newspack_newsletters_invalid_lists',
+				__( 'Invalid list configuration.', 'newspack-newsletters' ),
+				[ 'status' => 400 ]
+			);
 		}
 
 		$existing_ids = [];
@@ -796,7 +800,11 @@ class Subscription_Lists {
 
 		// Bail before cleanup so it doesn't deactivate everything when no rows landed.
 		if ( empty( $existing_ids ) ) {
-			return new WP_Error( 'newspack_newsletters_invalid_lists', __( 'Invalid list configuration.' ) );
+			return new WP_Error(
+				'newspack_newsletters_invalid_lists',
+				__( 'Invalid list configuration.', 'newspack-newsletters' ),
+				[ 'status' => 400 ]
+			);
 		}
 
 		// Cleanup is scoped to the current provider's UI — other-provider rows weren't in the payload to begin with.

--- a/includes/class-subscription-lists.php
+++ b/includes/class-subscription-lists.php
@@ -793,6 +793,11 @@ class Subscription_Lists {
 
 		}
 
+		// Bail before cleanup so it doesn't deactivate everything when no rows landed.
+		if ( empty( $existing_ids ) ) {
+			return new WP_Error( 'newspack_newsletters_invalid_lists', __( 'Invalid list configuration.' ) );
+		}
+
 		// Cleanup is scoped to the current provider's UI — other-provider rows weren't in the payload to begin with.
 		$current_provider_slug = Newspack_Newsletters::service_provider();
 		$scoped_lists          = array_merge(

--- a/includes/class-subscription-lists.php
+++ b/includes/class-subscription-lists.php
@@ -772,6 +772,10 @@ class Subscription_Lists {
 
 			// If a remote list was not found, create one.
 			if ( ! $stored_list instanceof Subscription_List && ! Subscription_List::is_local_public_id( $list['id'] ) ) {
+				// get_or_create_remote_list() needs a title; skip rather than throw.
+				if ( empty( $list['title'] ) ) {
+					continue;
+				}
 				$stored_list = self::get_or_create_remote_list( $list );
 			}
 

--- a/includes/service-providers/constant_contact/class-newspack-newsletters-constant-contact.php
+++ b/includes/service-providers/constant_contact/class-newspack-newsletters-constant-contact.php
@@ -139,14 +139,16 @@ final class Newspack_Newsletters_Constant_Contact extends \Newspack_Newsletters_
 	 * @return array
 	 */
 	public function verify_token( $refresh = true ) {
+		// Initialise outside the try so the catch has a safe shape if SDK setup throws.
+		$response = [
+			'error'    => null,
+			'valid'    => false,
+			'auth_url' => '',
+		];
 		try {
-			$redirect_uri = $this->get_oauth_redirect_uri();
-			$cc           = $this->get_sdk();
-			$response     = [
-				'error'    => null,
-				'valid'    => false,
-				'auth_url' => $cc->get_auth_code_url( wp_create_nonce( 'constant_contact_oauth2' ), $redirect_uri ),
-			];
+			$redirect_uri         = $this->get_oauth_redirect_uri();
+			$cc                   = $this->get_sdk();
+			$response['auth_url'] = $cc->get_auth_code_url( wp_create_nonce( 'constant_contact_oauth2' ), $redirect_uri );
 			// If we have a valid access token, we're connected.
 			if ( $cc->validate_token() ) {
 				$response['valid'] = true;

--- a/src/admin-shell/screens/newsletters-list/fields.js
+++ b/src/admin-shell/screens/newsletters-list/fields.js
@@ -204,7 +204,7 @@ export function getFields( { authors = [], categories = [], tags = [], sendLists
 			} ) ),
 			filterBy: { operators: [ 'isAny' ] },
 			enableSorting: true,
-			getValue: ( { item } ) => item?._embedded?.author?.[ 0 ]?.name || '',
+			getValue: ( { item } ) => String( item?._embedded?.author?.[ 0 ]?.id || '' ),
 			render: renderAuthor,
 		},
 		{

--- a/tests/test-layouts-rest-test-send.php
+++ b/tests/test-layouts-rest-test-send.php
@@ -160,8 +160,7 @@ class Layouts_REST_Test_Send_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * The endpoint is auth-gated but `explode( ',', $raw )` is otherwise
-	 * unbounded — guard against a flood by capping at 10 recipients.
+	 * Auth-gated but the comma split is otherwise unbounded — cap at 10.
 	 */
 	public function test_caps_recipients_at_ten() {
 		$post_id = $this->make_layout( '<p>Preview</p>' );

--- a/tests/test-layouts-rest-test-send.php
+++ b/tests/test-layouts-rest-test-send.php
@@ -160,6 +160,35 @@ class Layouts_REST_Test_Send_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * The endpoint is auth-gated but `explode( ',', $raw )` is otherwise
+	 * unbounded — guard against a flood by capping at 10 recipients.
+	 */
+	public function test_caps_recipients_at_ten() {
+		$post_id = $this->make_layout( '<p>Preview</p>' );
+
+		$addresses = [];
+		for ( $i = 1; $i <= 15; $i++ ) {
+			$addresses[] = sprintf( 'user%02d@example.com', $i );
+		}
+
+		$request = new WP_REST_Request( 'POST', '/newspack-newsletters/v1/layouts/' . $post_id . '/test' );
+		$request->set_param( 'test_email', implode( ',', $addresses ) );
+
+		$response = rest_do_request( $request );
+
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertCount( 10, $this->captured_mail );
+
+		$recipients = array_map(
+			static function ( $atts ) {
+				return is_array( $atts['to'] ) ? $atts['to'][0] : $atts['to'];
+			},
+			$this->captured_mail
+		);
+		$this->assertSame( array_slice( $addresses, 0, 10 ), $recipients );
+	}
+
+	/**
 	 * Successful send persists the recipient list to the current user's
 	 * `newspack_nl_test_emails` meta — mirrors the provider /test handlers.
 	 */

--- a/tests/test-subscription-list.php
+++ b/tests/test-subscription-list.php
@@ -655,4 +655,29 @@ class Subscription_List_Test extends WP_UnitTestCase {
 		$list = new Subscription_List( self::$posts['only_mailchimp'] );
 		$this->assertFalse( $list->is_active() );
 	}
+
+	/**
+	 * Passing non-string title/description must not clobber the
+	 * existing values — external callers (eg. ESP sync) that send
+	 * `null` for an absent field used to silently wipe the stored
+	 * content.
+	 */
+	public function test_update_non_string_title_and_description_are_noops() {
+		$list = new Subscription_List( self::$posts['only_mailchimp'] );
+		$original_title       = $list->get_title();
+		$original_description = $list->get_description();
+
+		$this->assertFalse(
+			$list->update(
+				[
+					'title'       => null,
+					'description' => null,
+				]
+			)
+		);
+
+		$list = new Subscription_List( self::$posts['only_mailchimp'] );
+		$this->assertSame( $original_title, $list->get_title() );
+		$this->assertSame( $original_description, $list->get_description() );
+	}
 }

--- a/tests/test-subscription-list.php
+++ b/tests/test-subscription-list.php
@@ -657,10 +657,7 @@ class Subscription_List_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Passing non-string title/description must not clobber the
-	 * existing values — external callers (eg. ESP sync) that send
-	 * `null` for an absent field used to silently wipe the stored
-	 * content.
+	 * Non-string title/description must no-op rather than wipe the stored value.
 	 */
 	public function test_update_non_string_title_and_description_are_noops() {
 		$list = new Subscription_List( self::$posts['only_mailchimp'] );

--- a/tests/test-subscription-lists.php
+++ b/tests/test-subscription-lists.php
@@ -125,11 +125,8 @@ class Subscription_Lists_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * External sync callers that include a row with `title => null` (meaning
-	 * "leave the stored title alone") used to have the entire entry dropped
-	 * by sanitize_lists, which then made the cleanup loop deactivate the
-	 * list. The row must survive so its `active` flag is honoured and the
-	 * stored title is preserved.
+	 * A `title => null` row used to be dropped by sanitize_lists, which then
+	 * tripped the cleanup loop into deactivating the list.
 	 */
 	public function test_update_lists_keeps_row_when_title_is_null() {
 		Newspack_Newsletters::set_service_provider( 'mailchimp' );
@@ -155,9 +152,29 @@ class Subscription_Lists_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Sanitization used to cast `description => null` to `''`, which then
-	 * clobbered the stored description via `Subscription_List::update()`.
-	 * A null/absent description must be a no-op.
+	 * Title-less rows for unknown remote ids must be skipped —
+	 * get_or_create_remote_list() would otherwise throw and 500.
+	 */
+	public function test_update_lists_skips_unknown_remote_id_without_title() {
+		Newspack_Newsletters::set_service_provider( 'mailchimp' );
+		$count_before = count( Subscription_Lists::get_all() );
+
+		$result = Subscription_Lists::update_lists(
+			[
+				[
+					'id'     => 'xyz-brand-new-unknown',
+					'active' => true,
+					'title'  => null,
+				],
+			]
+		);
+		$this->assertTrue( $result );
+		$this->assertSame( $count_before, count( Subscription_Lists::get_all() ), 'Unknown remote id without a title must not be created' );
+		$this->assertNull( Subscription_List::from_public_id( 'xyz-brand-new-unknown' ) );
+	}
+
+	/**
+	 * `description => null` used to be cast to `''` and clobber the stored value.
 	 */
 	public function test_update_lists_preserves_description_when_passed_null() {
 		Newspack_Newsletters::set_service_provider( 'mailchimp' );

--- a/tests/test-subscription-lists.php
+++ b/tests/test-subscription-lists.php
@@ -152,11 +152,16 @@ class Subscription_Lists_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Title-less rows for unknown remote ids must be skipped —
-	 * get_or_create_remote_list() would otherwise throw and 500.
+	 * All-skipped payloads must error rather than fall through to the cleanup
+	 * loop, which would otherwise deactivate every scoped list.
 	 */
-	public function test_update_lists_skips_unknown_remote_id_without_title() {
+	public function test_update_lists_all_skipped_payload_errors_without_cleanup() {
 		Newspack_Newsletters::set_service_provider( 'mailchimp' );
+
+		$mc_list = new Subscription_List( self::$posts['only_mailchimp'] );
+		$mc_list->update( [ 'active' => true ] );
+		$this->assertTrue( $mc_list->is_active() );
+
 		$count_before = count( Subscription_Lists::get_all() );
 
 		$result = Subscription_Lists::update_lists(
@@ -168,9 +173,13 @@ class Subscription_Lists_Test extends WP_UnitTestCase {
 				],
 			]
 		);
-		$this->assertTrue( $result );
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'newspack_newsletters_invalid_lists', $result->get_error_code() );
 		$this->assertSame( $count_before, count( Subscription_Lists::get_all() ), 'Unknown remote id without a title must not be created' );
 		$this->assertNull( Subscription_List::from_public_id( 'xyz-brand-new-unknown' ) );
+
+		$reloaded = new Subscription_List( self::$posts['only_mailchimp'] );
+		$this->assertTrue( $reloaded->is_active(), 'Existing scoped lists must remain active when every payload row was skipped' );
 	}
 
 	/**

--- a/tests/test-subscription-lists.php
+++ b/tests/test-subscription-lists.php
@@ -125,6 +125,64 @@ class Subscription_Lists_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * External sync callers that include a row with `title => null` (meaning
+	 * "leave the stored title alone") used to have the entire entry dropped
+	 * by sanitize_lists, which then made the cleanup loop deactivate the
+	 * list. The row must survive so its `active` flag is honoured and the
+	 * stored title is preserved.
+	 */
+	public function test_update_lists_keeps_row_when_title_is_null() {
+		Newspack_Newsletters::set_service_provider( 'mailchimp' );
+		$mc_list = new Subscription_List( self::$posts['only_mailchimp'] );
+		$mc_list->update( [ 'active' => true ] );
+		$this->assertTrue( $mc_list->is_active() );
+		$original_title = $mc_list->get_title();
+
+		$result = Subscription_Lists::update_lists(
+			[
+				[
+					'id'     => $mc_list->get_public_id(),
+					'active' => true,
+					'title'  => null,
+				],
+			]
+		);
+		$this->assertTrue( $result );
+
+		$reloaded = new Subscription_List( self::$posts['only_mailchimp'] );
+		$this->assertTrue( $reloaded->is_active(), 'A null title must not cause the row to be dropped and then deactivated by the cleanup loop' );
+		$this->assertSame( $original_title, $reloaded->get_title(), 'Stored title is preserved when caller sends title => null' );
+	}
+
+	/**
+	 * Sanitization used to cast `description => null` to `''`, which then
+	 * clobbered the stored description via `Subscription_List::update()`.
+	 * A null/absent description must be a no-op.
+	 */
+	public function test_update_lists_preserves_description_when_passed_null() {
+		Newspack_Newsletters::set_service_provider( 'mailchimp' );
+		$mc_list = new Subscription_List( self::$posts['only_mailchimp'] );
+		$mc_list->update( [ 'active' => true ] );
+		$original_description = $mc_list->get_description();
+		$this->assertNotSame( '', $original_description );
+
+		$result = Subscription_Lists::update_lists(
+			[
+				[
+					'id'          => $mc_list->get_public_id(),
+					'active'      => true,
+					'title'       => $mc_list->get_title(),
+					'description' => null,
+				],
+			]
+		);
+		$this->assertTrue( $result );
+
+		$reloaded = new Subscription_List( self::$posts['only_mailchimp'] );
+		$this->assertSame( $original_description, $reloaded->get_description() );
+	}
+
+	/**
 	 * Test update_lists doesn't drop other-provider rows that were hidden
 	 * from the current-provider UI.
 	 */

--- a/tests/test-subscription-lists.php
+++ b/tests/test-subscription-lists.php
@@ -152,6 +152,30 @@ class Subscription_Lists_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * A literal `"0"` title is a legal remote list name; `empty()` would reject it.
+	 */
+	public function test_update_lists_accepts_string_zero_as_title() {
+		Newspack_Newsletters::set_service_provider( 'mailchimp' );
+		$count_before = count( Subscription_Lists::get_all() );
+
+		$result = Subscription_Lists::update_lists(
+			[
+				[
+					'id'     => 'xyz-zero-titled',
+					'active' => true,
+					'title'  => '0',
+				],
+			]
+		);
+		$this->assertTrue( $result );
+
+		$created = Subscription_List::from_public_id( 'xyz-zero-titled' );
+		$this->assertInstanceOf( Subscription_List::class, $created );
+		$this->assertSame( '0', $created->get_title() );
+		$this->assertSame( $count_before + 1, count( Subscription_Lists::get_all() ) );
+	}
+
+	/**
 	 * All-skipped payloads must error rather than fall through to the cleanup
 	 * loop, which would otherwise deactivate every scoped list.
 	 */


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Six small follow-ups surfaced by code review on #2141. Each commit stands alone and is independently revertable.

- **`fix(admin)`** — Newsletters list author filter compared the post's author *name* against id-keyed filter elements, so the filter never matched. Send-list and categories already key on id correctly; author is now consistent.
- **`fix(subscription-list)`** — `Subscription_List::update()` regressed: passing `null` (or a non-string) for `title` or `description` used to no-op but now clears the value. The no-op is restored for both fields.
- **`fix(layouts)`** — The layouts test-send endpoint is gated on `edit_others_posts` but parsed `test_email` with an unbounded comma split. Capped at 10 recipients *and* bounded the `explode` to 11 segments so parsing/sanitisation cost is also capped.
- **`fix(constant-contact)`** — `verify_token()` referenced `$response` in its catch block before it was assigned. If `get_sdk()` or `get_auth_code_url()` threw before the assignment line, the catch hit an undefined-variable warning. `$response` is now seeded with a safe shape outside the try.
- **`fix(subscription-lists)`** — The `Subscription_List::update()` null no-op didn't cover the bulk-sync entry point: `Newspack_Newsletters_Subscription::sanitize_lists()` was casting `description => null` to `''` (silently clobbering the stored description) and dropping the entire row when `title => null`, which then made `Subscription_Lists::update_lists()`'s cleanup loop deactivate the list. The sanitiser now omits null / non-string title and description so update() sees them as absent.

No context change.

### How to test the changes in this Pull Request:

1. **Author filter** — Visit *Newsletters → All Newsletters*. Open the **Author** filter chip and pick an author who has authored at least one newsletter. The list should narrow to that author's newsletters. Before this fix it would return zero results regardless of author.
2. **Subscription_List::update()** — Covered by `tests/test-subscription-list.php::test_update_non_string_title_and_description_are_noops`.
3. **Layouts cap** — Covered by `tests/test-layouts-rest-test-send.php::test_caps_recipients_at_ten`.
4. **Constant Contact verify_token()** — Connect Constant Contact, then deliberately mis-configure the API key (or temporarily revoke the access token) so the SDK throws. Visit *Engagement → Newsletters* (Settings). The page should render without PHP warnings about undefined `\$response`.
5. **Bulk sync sanitiser** — Covered by `tests/test-subscription-lists.php::test_update_lists_keeps_row_when_title_is_null` and `test_update_lists_preserves_description_when_passed_null`.
6. Full automated suite: \`n test-php\` (380 passing, +4 new), \`npm run lint:php\`, \`npm run lint:js\`, \`n build\` — all clean locally.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?