### PR TITLE
fix(admin-shell): four React bugs flagged in code review

### DIFF
--- a/src/admin-shell/components/quick-edit-panel/index.js
+++ b/src/admin-shell/components/quick-edit-panel/index.js
@@ -30,22 +30,11 @@ export default function QuickEditPanel( {
 	className,
 	children,
 } ) {
-	// Route X / Cancel through Modal's exit cycle by dispatching a
-	// synthetic Escape on the overlay. Modal's `handleEscapeKeyDown`
-	// runs `closeModal()` first, which adds `.is-animating-out` and
-	// waits for the slide-out animation before invoking `onRequestClose`.
-	// Calling `onClose` directly would unmount before the animation
-	// has a chance to play.
 	const requestClose = useCallback( () => {
 		if ( isBusy ) {
 			return;
 		}
-		const overlay = document.querySelector( '.newspack-newsletters-quick-edit-modal__overlay' );
-		if ( overlay ) {
-			overlay.dispatchEvent( new KeyboardEvent( 'keydown', { key: 'Escape', code: 'Escape', bubbles: true } ) );
-		} else {
-			onClose();
-		}
+		onClose();
 	}, [ isBusy, onClose ] );
 
 	const handleSubmit = event => {

--- a/src/admin-shell/header-actions-context.js
+++ b/src/admin-shell/header-actions-context.js
@@ -20,12 +20,12 @@
 
 import { createContext, useCallback, useContext, useEffect, useId, useMemo, useState } from '@wordpress/element';
 
-const HeaderActionsContext = createContext( null );
+// Split contexts so registrations don't re-render readers and vice versa:
+// `useHeaderActions` callers (screens) consume the stable API; `<PageHeader>` consumes the value.
+const HeaderActionsAPIContext = createContext( null );
+const HeaderActionsValueContext = createContext( [] );
 
 export function HeaderActionsProvider( { children } ) {
-	// `ownerOrder` keeps insertion order so we can resolve "the most
-	// recent registration" without scanning timestamps. `actionsByOwner`
-	// holds each registration's array.
 	const [ registry, setRegistry ] = useState( () => ( {
 		ownerOrder: [],
 		actionsByOwner: {},
@@ -59,6 +59,8 @@ export function HeaderActionsProvider( { children } ) {
 		[]
 	);
 
+	const api = useMemo( () => ( { upsert, remove } ), [ upsert, remove ] );
+
 	const visibleActions = useMemo( () => {
 		const { ownerOrder, actionsByOwner } = registry;
 		if ( ownerOrder.length === 0 ) {
@@ -67,9 +69,11 @@ export function HeaderActionsProvider( { children } ) {
 		return actionsByOwner[ ownerOrder[ ownerOrder.length - 1 ] ] || [];
 	}, [ registry ] );
 
-	const value = useMemo( () => ( { actions: visibleActions, upsert, remove } ), [ visibleActions, upsert, remove ] );
-
-	return <HeaderActionsContext.Provider value={ value }>{ children }</HeaderActionsContext.Provider>;
+	return (
+		<HeaderActionsAPIContext.Provider value={ api }>
+			<HeaderActionsValueContext.Provider value={ visibleActions }>{ children }</HeaderActionsValueContext.Provider>
+		</HeaderActionsAPIContext.Provider>
+	);
 }
 
 /**
@@ -77,8 +81,7 @@ export function HeaderActionsProvider( { children } ) {
  * `<PageHeader />` component to render the action row.
  */
 export function useHeaderActionsValue() {
-	const ctx = useContext( HeaderActionsContext );
-	return ctx ? ctx.actions : [];
+	return useContext( HeaderActionsValueContext );
 }
 
 /**
@@ -100,14 +103,14 @@ export function useHeaderActionsValue() {
  * @param {Array} actions Memoised array of action descriptors.
  */
 export function useHeaderActions( actions ) {
-	const ctx = useContext( HeaderActionsContext );
+	const api = useContext( HeaderActionsAPIContext );
 	const ownerId = useId();
 
 	useEffect( () => {
-		if ( ! ctx ) {
+		if ( ! api ) {
 			return undefined;
 		}
-		ctx.upsert( ownerId, Array.isArray( actions ) ? actions : [] );
-		return () => ctx.remove( ownerId );
-	}, [ ctx, ownerId, actions ] );
+		api.upsert( ownerId, Array.isArray( actions ) ? actions : [] );
+		return () => api.remove( ownerId );
+	}, [ api, ownerId, actions ] );
 }

--- a/src/admin-shell/page-header.js
+++ b/src/admin-shell/page-header.js
@@ -38,8 +38,14 @@ function useNewspackHeader() {
 			return undefined;
 		}
 
+		// Re-query synchronously — MutationObserver only fires on future mutations.
+		const synchronous = wrapper.querySelector( '.newspack-wizard__header' );
+		if ( synchronous ) {
+			setTarget( synchronous );
+			return undefined;
+		}
+
 		// Newspack admin-header's React app rewrites this subtree on mount.
-		// Watch for the slot to appear and capture it once.
 		const observer = new MutationObserver( () => {
 			const found = wrapper.querySelector( '.newspack-wizard__header' );
 			if ( found ) {

--- a/src/admin-shell/screens/settings/index.js
+++ b/src/admin-shell/screens/settings/index.js
@@ -4,7 +4,7 @@ import {
 	__experimentalHStack as HStack, // eslint-disable-line @wordpress/no-unsafe-wp-apis
 	__experimentalVStack as VStack, // eslint-disable-line @wordpress/no-unsafe-wp-apis
 } from '@wordpress/components';
-import { useCallback, useEffect, useState } from '@wordpress/element';
+import { useCallback, useEffect, useMemo, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 
 import { notifyError, notifySuccess } from '../../notices';
@@ -27,21 +27,12 @@ export default function SettingsScreen() {
 	const [ pendingOptions, setPendingOptions ] = useState( {} );
 	const [ isSaving, setIsSaving ] = useState( false );
 
-	// Resync pending state whenever fresh provider data lands (post-save
-	// reload, OAuth authorise, manual refresh). Depending on the whole
-	// `data.provider` object — not just `savedSlug` — so that saving new
-	// credentials for the *same* provider also clears the plaintext from
-	// the input and flips Save back to a clean state.
 	useEffect( () => {
 		setPendingSlug( savedSlug );
-		setPendingCredentials( {} );
-	}, [ data?.provider, savedSlug ] );
-
-	useEffect( () => {
-		setPendingOptions( {} );
-	}, [ data?.options ] );
+	}, [ savedSlug ] );
 
 	const handleAuthorized = useCallback( () => {
+		setPendingCredentials( {} );
 		reloadSettings();
 		reloadLists();
 	}, [ reloadSettings, reloadLists ] );
@@ -59,46 +50,87 @@ export default function SettingsScreen() {
 		setPendingCredentials( {} );
 	}, [] );
 
+	const newsletterOptionsSchema = useMemo( () => ( data?.schema || [] ).filter( field => field.key !== LETTERHEAD_KEY ), [ data?.schema ] );
+	const letterheadSchema = useMemo( () => ( data?.schema || [] ).filter( field => field.key === LETTERHEAD_KEY ), [ data?.schema ] );
+	const newsletterOptionKeys = useMemo( () => newsletterOptionsSchema.map( f => f.key ), [ newsletterOptionsSchema ] );
+	const letterheadOptionKeys = useMemo( () => letterheadSchema.map( f => f.key ), [ letterheadSchema ] );
+
 	const slugDirty = pendingSlug !== savedSlug;
 	const credentialsDirty = Object.keys( pendingCredentials ).length > 0;
-	const optionsDirty = Object.keys( pendingOptions ).length > 0;
-	const isDirty = slugDirty || credentialsDirty || optionsDirty;
+	const providerDirty = slugDirty || credentialsDirty;
+	const pendingOptionKeys = Object.keys( pendingOptions );
+	const newsletterOptionsDirty = pendingOptionKeys.some( k => newsletterOptionKeys.includes( k ) );
+	const letterheadOptionsDirty = pendingOptionKeys.some( k => letterheadOptionKeys.includes( k ) );
 
-	const handleSave = useCallback( async () => {
-		const payload = {};
-		if ( slugDirty || credentialsDirty ) {
-			payload.provider = { slug: pendingSlug };
-			if ( pendingSlug !== 'manual' && credentialsDirty ) {
-				const submitted = {};
-				Object.keys( pendingCredentials ).forEach( key => {
-					const value = pendingCredentials[ key ];
-					if ( typeof value === 'string' && value.length > 0 ) {
-						submitted[ key ] = value;
-					}
-				} );
-				payload.provider.credentials = submitted;
-			}
-		}
-		if ( optionsDirty ) {
-			payload.options = { ...pendingOptions };
-		}
-		if ( Object.keys( payload ).length === 0 ) {
+	const clearOptionKeys = useCallback( keys => {
+		setPendingOptions( prev => {
+			const next = { ...prev };
+			keys.forEach( k => delete next[ k ] );
+			return next;
+		} );
+	}, [] );
+
+	const handleSaveProvider = useCallback( async () => {
+		if ( ! providerDirty ) {
 			return;
+		}
+		const payload = { provider: { slug: pendingSlug } };
+		if ( pendingSlug !== 'manual' && credentialsDirty ) {
+			const submitted = {};
+			Object.keys( pendingCredentials ).forEach( key => {
+				const value = pendingCredentials[ key ];
+				if ( typeof value === 'string' && value.length > 0 ) {
+					submitted[ key ] = value;
+				}
+			} );
+			payload.provider.credentials = submitted;
 		}
 		setIsSaving( true );
 		try {
 			await saveSettings( payload );
-			notifySuccess( __( 'Settings saved.', 'newspack-newsletters' ) );
-			if ( payload.provider ) {
-				reloadLists();
-			}
+			notifySuccess( __( 'Provider settings saved.', 'newspack-newsletters' ) );
+			setPendingCredentials( {} );
+			reloadLists();
 		} catch ( err ) {
-			const message = err?.message || __( 'Could not save settings. Check the credentials and try again.', 'newspack-newsletters' );
-			notifyError( message );
+			notifyError( err?.message || __( 'Could not save settings. Check the credentials and try again.', 'newspack-newsletters' ) );
 		} finally {
 			setIsSaving( false );
 		}
-	}, [ slugDirty, credentialsDirty, optionsDirty, pendingSlug, pendingCredentials, pendingOptions, saveSettings, reloadLists ] );
+	}, [ providerDirty, credentialsDirty, pendingSlug, pendingCredentials, saveSettings, reloadLists ] );
+
+	const saveOptionsSubset = useCallback(
+		async ( keys, successMessage ) => {
+			const subset = {};
+			keys.forEach( key => {
+				if ( Object.prototype.hasOwnProperty.call( pendingOptions, key ) ) {
+					subset[ key ] = pendingOptions[ key ];
+				}
+			} );
+			if ( Object.keys( subset ).length === 0 ) {
+				return;
+			}
+			setIsSaving( true );
+			try {
+				await saveSettings( { options: subset } );
+				notifySuccess( successMessage );
+				clearOptionKeys( keys );
+			} catch ( err ) {
+				notifyError( err?.message || __( 'Could not save settings.', 'newspack-newsletters' ) );
+			} finally {
+				setIsSaving( false );
+			}
+		},
+		[ pendingOptions, saveSettings, clearOptionKeys ]
+	);
+
+	const handleSaveNewsletterOptions = useCallback(
+		() => saveOptionsSubset( newsletterOptionKeys, __( 'Newsletter options saved.', 'newspack-newsletters' ) ),
+		[ saveOptionsSubset, newsletterOptionKeys ]
+	);
+	const handleSaveLetterhead = useCallback(
+		() => saveOptionsSubset( letterheadOptionKeys, __( 'Letterhead saved.', 'newspack-newsletters' ) ),
+		[ saveOptionsSubset, letterheadOptionKeys ]
+	);
 
 	if ( isLoading && ! data ) {
 		return (
@@ -118,9 +150,6 @@ export default function SettingsScreen() {
 		);
 	}
 
-	const newsletterOptionsSchema = ( data?.schema || [] ).filter( field => field.key !== LETTERHEAD_KEY );
-	const letterheadSchema = ( data?.schema || [] ).filter( field => field.key === LETTERHEAD_KEY );
-
 	return (
 		<VStack spacing={ 12 } className="newspack-newsletters-settings">
 			<ProviderSection
@@ -131,8 +160,8 @@ export default function SettingsScreen() {
 				onSlugChange={ onSlugChange }
 				onCredentialChange={ updateCredential }
 				onAuthorized={ handleAuthorized }
-				onSave={ handleSave }
-				isDirty={ isDirty }
+				onSave={ handleSaveProvider }
+				isDirty={ providerDirty }
 				isSaving={ isSaving }
 				disabled={ isSaving }
 			/>
@@ -143,8 +172,8 @@ export default function SettingsScreen() {
 				activeProvider={ savedSlug }
 				pendingValues={ pendingOptions }
 				onChange={ updateOption }
-				onSave={ handleSave }
-				isDirty={ isDirty }
+				onSave={ handleSaveNewsletterOptions }
+				isDirty={ newsletterOptionsDirty }
 				isSaving={ isSaving }
 				disabled={ isSaving }
 			/>
@@ -155,8 +184,8 @@ export default function SettingsScreen() {
 				activeProvider={ savedSlug }
 				pendingValues={ pendingOptions }
 				onChange={ updateOption }
-				onSave={ handleSave }
-				isDirty={ isDirty }
+				onSave={ handleSaveLetterhead }
+				isDirty={ letterheadOptionsDirty }
 				isSaving={ isSaving }
 				disabled={ isSaving }
 			/>

--- a/src/admin-shell/screens/settings/index.js
+++ b/src/admin-shell/screens/settings/index.js
@@ -52,8 +52,15 @@ export default function SettingsScreen() {
 
 	const newsletterOptionsSchema = useMemo( () => ( data?.schema || [] ).filter( field => field.key !== LETTERHEAD_KEY ), [ data?.schema ] );
 	const letterheadSchema = useMemo( () => ( data?.schema || [] ).filter( field => field.key === LETTERHEAD_KEY ), [ data?.schema ] );
-	const newsletterOptionKeys = useMemo( () => newsletterOptionsSchema.map( f => f.key ), [ newsletterOptionsSchema ] );
-	const letterheadOptionKeys = useMemo( () => letterheadSchema.map( f => f.key ), [ letterheadSchema ] );
+	// Restrict to fields visible under the saved provider so stale other-provider keys don't get POSTed.
+	const newsletterOptionKeys = useMemo(
+		() => newsletterOptionsSchema.filter( f => ! f.provider || f.provider === savedSlug ).map( f => f.key ),
+		[ newsletterOptionsSchema, savedSlug ]
+	);
+	const letterheadOptionKeys = useMemo(
+		() => letterheadSchema.filter( f => ! f.provider || f.provider === savedSlug ).map( f => f.key ),
+		[ letterheadSchema, savedSlug ]
+	);
 
 	const slugDirty = pendingSlug !== savedSlug;
 	const credentialsDirty = Object.keys( pendingCredentials ).length > 0;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Four React bugs surfaced by the admin UX milestone code review. All scoped to `src/admin-shell/`; each commit stands alone and is independently revertable.

- **`page-header.js`** — `useNewspackHeader` race: the portal-slot `useState` query ran during initial render, but the `MutationObserver` was only attached in the subsequent effect. A slot that appeared between those two ticks would never be picked up. The effect now re-queries synchronously before falling back to the observer.
- **`quick-edit-panel/index.js`** — replaced the synthetic `Escape` keydown dispatch with a direct call to the user-provided `onClose`. The old code coupled to `@wp/components` Modal's private `handleEscapeKeyDown` and bypassed the documented focus-return contract. Trade-off: the X / Cancel buttons no longer animate the slide-out (real Escape and overlay-click still do, via Modal's own `onRequestClose`).
- **`screens/settings/index.js`** — Settings cards now compute and consume per-card dirty flags (`providerDirty`, `newsletterOptionsDirty`, `letterheadOptionsDirty`) and dispatch to dedicated save handlers. Saving Letterhead no longer lights up Provider / Newsletter Options' Save buttons, and a save no longer wipes pending state on unrelated cards. The data-driven useEffect that cleared `pendingCredentials` / `pendingOptions` on every reload was removed; clearing now happens explicitly in each save handler's success path (and in `handleAuthorized` for the OAuth flow).
- **`header-actions-context.js`** — split the context into `HeaderActionsAPIContext` (stable `{ upsert, remove }`) and `HeaderActionsValueContext` (the actions array). Screens that consume the API via `useHeaderActions` no longer re-render every time another screen registers / unregisters actions. Public surface (`HeaderActionsProvider`, `useHeaderActions`, `useHeaderActionsValue`) is unchanged.

No context change.

### How to test the changes in this Pull Request:

1. **Page-header slot race** — Hard to provoke reliably; the bug was a real-world race between `newspack-plugin`'s admin-header React mount and the chassis page-header's `useState` snapshot. Sanity check: load the Newsletters list and confirm the page-header buttons portal into the dark Newspack strip alongside the breadcrumb. Existing `page-header.test.js` covers the happy paths (10 tests passing).
2. **QuickEditPanel close** — Open a newsletter or ad row's Quick Edit panel. Confirm:
   - Real `Escape` still closes with the Modal slide-out animation.
   - Clicking outside (when not dirty) closes with the animation.
   - X button and Cancel button close instantly (no animation), focus returns to the row's action button.
3. **Settings per-card dirty** — In Settings:
   - Edit Letterhead → only Letterhead's Save lights up; Provider / Newsletter Options' Save stays disabled.
   - Edit Newsletter Options → only that card's Save lights up.
   - Type plaintext credentials → only Provider's Save lights up.
   - With credentials typed, save Letterhead → credentials remain typed (previously wiped).
   - With Newsletter Options dirty, save Letterhead → Newsletter Options edits remain (previously wiped).
4. **HeaderActions re-render storm** — Profile-only. Register two screens via `useHeaderActions` and verify the un-registering one doesn't trigger a re-render of the still-mounted one's `useEffect`. Existing tests at `page-header.test.js` still pass (covers all the registration semantics).
5. Full check: `n test-js` (195 passing), `npm run lint:js` (clean), `n build` (clean).

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?