### PR TITLE
perf(newsletters-list): cap distinct-options REST queries at 500

### DIFF
--- a/includes/admin/class-newsletters-list-rest.php
+++ b/includes/admin/class-newsletters-list-rest.php
@@ -25,6 +25,12 @@ class Newsletters_List_REST {
 	const SEND_LIST_QUERY_PARAM = 'newspack_newsletters_send_list_id';
 
 	/**
+	 * Defensive cap on each filter-options query so a site with tens of
+	 * thousands of newsletters can't blow up the payload (or the SQL).
+	 */
+	const FILTER_OPTIONS_LIMIT = 500;
+
+	/**
 	 * Boot hooks.
 	 */
 	public static function init() {
@@ -331,8 +337,10 @@ class Newsletters_List_REST {
 				 FROM {$wpdb->posts} p
 				 WHERE p.post_type = %s
 				   AND p.post_status NOT IN ( 'auto-draft' )
-				   AND p.post_author <> 0" . $user_scope_sql,
-				$cpt
+				   AND p.post_author <> 0" . $user_scope_sql . '
+				 LIMIT %d',
+				$cpt,
+				self::FILTER_OPTIONS_LIMIT
 			)
 		);
 		// phpcs:enable WordPress.DB.DirectDatabaseQuery, WordPress.DB.PreparedSQL.NotPrepared
@@ -376,9 +384,11 @@ class Newsletters_List_REST {
 				 WHERE p.post_type = %s
 				   AND p.post_status NOT IN ( 'auto-draft' )
 				   AND tt.taxonomy = %s" . $user_scope_sql . '
-				 ORDER BY t.name ASC',
+				 ORDER BY t.name ASC
+				 LIMIT %d',
 				$cpt,
-				$taxonomy
+				$taxonomy,
+				self::FILTER_OPTIONS_LIMIT
 			),
 			ARRAY_A
 		);
@@ -414,8 +424,10 @@ class Newsletters_List_REST {
 				   AND pm.meta_value <> ''
 				   AND p.post_type = %s
 				   AND p.post_status NOT IN ( 'auto-draft' )" . $user_scope_sql . '
-				 ORDER BY pm.meta_value ASC',
-				$cpt
+				 ORDER BY pm.meta_value ASC
+				 LIMIT %d',
+				$cpt,
+				self::FILTER_OPTIONS_LIMIT
 			)
 		);
 		// phpcs:enable WordPress.DB.DirectDatabaseQuery, WordPress.DB.PreparedSQL.NotPrepared

--- a/includes/admin/class-newsletters-list-rest.php
+++ b/includes/admin/class-newsletters-list-rest.php
@@ -338,6 +338,7 @@ class Newsletters_List_REST {
 				 WHERE p.post_type = %s
 				   AND p.post_status NOT IN ( 'auto-draft' )
 				   AND p.post_author <> 0" . $user_scope_sql . '
+				 ORDER BY p.post_author ASC
 				 LIMIT %d',
 				$cpt,
 				self::FILTER_OPTIONS_LIMIT

--- a/tests/test-newsletters-list-rest.php
+++ b/tests/test-newsletters-list-rest.php
@@ -1251,6 +1251,33 @@ class Newsletters_List_REST_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Filter-options queries are capped at `FILTER_OPTIONS_LIMIT` rows
+	 * so a site with tens of thousands of newsletters can't blow up the
+	 * payload (or the SQL). Exercised via `send_list_id`, but the same
+	 * literal `LIMIT` clause guards the authors and terms queries too.
+	 */
+	public function test_filter_options_caps_results_at_filter_options_limit() {
+		wp_set_current_user( self::factory()->user->create( [ 'role' => 'editor' ] ) );
+		$cpt   = Newspack_Newsletters::NEWSPACK_NEWSLETTERS_CPT;
+		$cap   = Newsletters_List_REST::FILTER_OPTIONS_LIMIT;
+		$total = $cap + 5;
+
+		for ( $i = 0; $i < $total; $i++ ) {
+			self::factory()->post->create(
+				[
+					'post_type'   => $cpt,
+					'post_status' => 'publish',
+					'meta_input'  => [ 'send_list_id' => sprintf( 'list-%04d', $i ) ],
+				]
+			);
+		}
+
+		$send_lists = Newsletters_List_REST::rest_get_filter_options()->get_data()['send_lists'];
+
+		$this->assertCount( $cap, $send_lists, 'Send-list options should be capped at FILTER_OPTIONS_LIMIT.' );
+	}
+
+	/**
 	 * A user without `edit_others_posts` only sees options derived from
 	 * their own newsletters — never leaks authors / terms / send-list
 	 * IDs from other publishers' drafts or private rows.


### PR DESCRIPTION
## Summary

The `/filter-options` endpoint that populates the Newsletters list filter dropdowns runs three `$wpdb->get_results()` / `get_col()` queries (distinct authors, distinct categories/tags, distinct `send_list_id` meta) with no `LIMIT`. On a site with 100k+ newsletters the payload — and the SQL itself — is unbounded.

This PR adds a defensive cap of 500 rows on each query via a single `FILTER_OPTIONS_LIMIT` class constant, applied through the existing `prepare()` calls as `LIMIT %d`. Each query has a deterministic `ORDER BY` before the cap so the 500 rows returned are stable across calls (authors by `post_author ASC`; terms by `t.name ASC`; send-list IDs by `pm.meta_value ASC`).

## Acceptance

- [x] Each `$wpdb->get_results()` / `get_col()` in `Newsletters_List_REST::get_authors_used()`, `get_terms_used()`, and `get_send_list_ids_used()` carries an `ORDER BY` followed by a `LIMIT` clause (via `prepare()`).
- [x] PHPUnit test (`test_filter_options_caps_results_at_filter_options_limit`) injects `FILTER_OPTIONS_LIMIT + 5` distinct `send_list_id` values and asserts the response is exactly `FILTER_OPTIONS_LIMIT` rows. Same literal `LIMIT` clause guards the authors and terms queries — covered by inspection rather than three slow fixture loops.
- [x] Full `Newsletters_List_REST_Test` class passes (42 tests, 166 assertions).
- [x] `n npm run lint:php` clean.

No UX change. The cap is purely defensive — sites with fewer than 500 distinct authors / terms / send-list IDs see no difference, which is every realistic site today.

## Milestone

Post-merge follow-up landing on `epic/admin-ux-modernisation` — the milestone roll-up is tracked in **#2141**, alongside the other follow-ups (#2143–#2147).

## Linear

NEWS-2295 — https://linear.app/a8c/issue/NEWS-2295/cap-distinct-options-rest-queries-with-limit

## Context

No context change.