### PR TITLE
refactor(admin-pages): hoist React_List_Page + Hidden_React_List_Page bases

### DIFF
--- a/includes/admin/pages/class-ads-list-page.php
+++ b/includes/admin/pages/class-ads-list-page.php
@@ -7,7 +7,7 @@
  * returned by `get_parent_slug()` — either the ads CPT entry as a
  * top-level menu or the Newsletters CPT entry when the ads screen is
  * grouped underneath it. The React page is kept out of the visible menu
- * via `is_hidden_from_menu()` / submenu removal; the visible click target
+ * via the inherited `is_hidden_from_menu()`; the visible click target
  * remains the auto-generated `edit.php?post_type=newspack_nl_ads_cpt`
  * entry that `Ads::add_ads_page` creates. `Admin_Shell::maybe_redirect_legacy_list`
  * 302s the legacy URL to the React page.
@@ -17,7 +17,6 @@
 
 namespace Newspack\Newsletters\Admin\Pages;
 
-use Newspack\Newsletters\Admin\Admin_Page;
 use Newspack_Newsletters;
 use Newspack_Newsletters\Ads;
 
@@ -26,7 +25,7 @@ defined( 'ABSPATH' ) || exit;
 /**
  * "Newsletter Ads" list page — registered in both modes.
  */
-class Ads_List_Page extends Admin_Page {
+class Ads_List_Page extends Hidden_React_List_Page {
 	/**
 	 * Page slug.
 	 *
@@ -75,34 +74,6 @@ class Ads_List_Page extends Admin_Page {
 	}
 
 	/**
-	 * The visible click target is `Ads::add_ads_page`'s entry — our
-	 * React page lives behind a redirect, not a separate sidebar entry.
-	 *
-	 * @return bool
-	 */
-	public function is_hidden_from_menu() {
-		return true;
-	}
-
-	/**
-	 * Active top-level menu while the ads list page is rendered.
-	 *
-	 * `Ads::add_ads_page` registers the visible ads entry as either a
-	 * top-level menu (when the user can edit ads but not newsletters)
-	 * or as a submenu under the Newsletters CPT (the common case).
-	 * Highlight matches: in top-level mode the parent IS the ads CPT
-	 * URL itself; in submenu mode the parent is the Newsletters CPT.
-	 *
-	 * @return string
-	 */
-	public function get_parent_file() {
-		if ( Ads::display_ads_menu_item_separately() ) {
-			return 'edit.php?post_type=' . Ads::CPT;
-		}
-		return 'edit.php?post_type=' . Newspack_Newsletters::NEWSPACK_NEWSLETTERS_CPT;
-	}
-
-	/**
 	 * Submenu entry to highlight while the ads list page is rendered.
 	 *
 	 * Always points at the ads CPT URL — that's the visible click
@@ -126,17 +97,12 @@ class Ads_List_Page extends Admin_Page {
 	}
 
 	/**
-	 * Build the redirect URL for the legacy ads CPT list.
+	 * Post type the React page lives under in the admin URL.
 	 *
-	 * @param array $forwarded Forwarded query args.
 	 * @return string
 	 */
-	public function get_legacy_redirect_target( $forwarded = [] ) {
-		return \Newspack\Newsletters\Admin\Admin_Shell::build_legacy_redirect_target(
-			Ads::CPT,
-			$this->slug,
-			$forwarded
-		);
+	public function get_redirect_post_type() {
+		return Ads::CPT;
 	}
 
 	/**

--- a/includes/admin/pages/class-advertisers-list-page.php
+++ b/includes/admin/pages/class-advertisers-list-page.php
@@ -14,7 +14,6 @@
 
 namespace Newspack\Newsletters\Admin\Pages;
 
-use Newspack\Newsletters\Admin\Admin_Page;
 use Newspack_Newsletters;
 use Newspack_Newsletters\Ads;
 
@@ -23,7 +22,7 @@ defined( 'ABSPATH' ) || exit;
 /**
  * "Advertisers" list page — registered in both modes.
  */
-class Advertisers_List_Page extends Admin_Page {
+class Advertisers_List_Page extends Hidden_React_List_Page {
 	/**
 	 * Page slug.
 	 *
@@ -48,34 +47,6 @@ class Advertisers_List_Page extends Admin_Page {
 	 * @return string
 	 */
 	public function get_parent_slug() {
-		if ( Ads::display_ads_menu_item_separately() ) {
-			return 'edit.php?post_type=' . Ads::CPT;
-		}
-		return 'edit.php?post_type=' . Newspack_Newsletters::NEWSPACK_NEWSLETTERS_CPT;
-	}
-
-	/**
-	 * The visible click target is the auto-generated taxonomy submenu
-	 * `edit-tags.php?taxonomy=newspack_nl_advertiser` (in standalone) or
-	 * the wizard's "Advertisers" tab (in bundled, where
-	 * `Newsletters_Wizard::registered_taxonomy_advertiser` flips
-	 * `show_in_menu` off). Either way our React page lives behind a
-	 * redirect, not a separate sidebar entry.
-	 *
-	 * @return bool
-	 */
-	public function is_hidden_from_menu() {
-		return true;
-	}
-
-	/**
-	 * Active top-level menu while the advertisers list is rendered.
-	 * Same dynamic placement as the ads list — top-level ads CPT or the
-	 * newsletters CPT depending on `display_ads_menu_item_separately()`.
-	 *
-	 * @return string
-	 */
-	public function get_parent_file() {
 		if ( Ads::display_ads_menu_item_separately() ) {
 			return 'edit.php?post_type=' . Ads::CPT;
 		}
@@ -108,20 +79,13 @@ class Advertisers_List_Page extends Admin_Page {
 	}
 
 	/**
-	 * Build the redirect URL for the legacy advertisers term-management
-	 * screen. Same shape as the ads list redirect — the React page lives
-	 * at `edit.php?post_type=newspack_nl_ads_cpt&page=<slug>` regardless
-	 * of which taxonomy URL the user came from.
+	 * Post type the React page lives under in the admin URL — the ads
+	 * CPT, regardless of which taxonomy URL the user came from.
 	 *
-	 * @param array $forwarded Forwarded query args.
 	 * @return string
 	 */
-	public function get_legacy_redirect_target( $forwarded = [] ) {
-		return \Newspack\Newsletters\Admin\Admin_Shell::build_legacy_redirect_target(
-			Ads::CPT,
-			$this->slug,
-			$forwarded
-		);
+	public function get_redirect_post_type() {
+		return Ads::CPT;
 	}
 
 	/**

--- a/includes/admin/pages/class-hidden-react-list-page.php
+++ b/includes/admin/pages/class-hidden-react-list-page.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * Abstract hidden React list-page base.
+ *
+ * Adds the "registered but invisible" submenu plumbing on top of
+ * `React_List_Page`: the page is routable via its slug but stripped
+ * from the sidebar by `Admin_Shell::register_menu`. Subclasses keep
+ * `get_parent_slug()` (mode-aware) and `get_submenu_file()` (target
+ * of the highlight); this base defaults `get_parent_file()` to the
+ * same URL as `get_parent_slug()`, which is the right answer for
+ * every hidden React page in the milestone.
+ *
+ * @package Newspack_Newsletters
+ */
+
+namespace Newspack\Newsletters\Admin\Pages;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Base for hidden-submenu React list pages.
+ */
+abstract class Hidden_React_List_Page extends React_List_Page {
+	/**
+	 * Hidden from the sidebar — accessed by 302ing the legacy URL.
+	 *
+	 * @return bool
+	 */
+	public function is_hidden_from_menu() {
+		return true;
+	}
+
+	/**
+	 * Highlight the same top-level entry the page is registered under.
+	 * Mirroring `get_parent_slug()` is the right default for every
+	 * hidden React page in the milestone; subclasses can override for
+	 * a different highlight target.
+	 *
+	 * @return string
+	 */
+	public function get_parent_file() {
+		return $this->get_parent_slug();
+	}
+}

--- a/includes/admin/pages/class-layouts-list-page.php
+++ b/includes/admin/pages/class-layouts-list-page.php
@@ -7,7 +7,6 @@
 
 namespace Newspack\Newsletters\Admin\Pages;
 
-use Newspack\Newsletters\Admin\Admin_Page;
 use Newspack_Newsletters;
 
 defined( 'ABSPATH' ) || exit;
@@ -15,7 +14,7 @@ defined( 'ABSPATH' ) || exit;
 /**
  * "Layouts" list page — always registered (prebuilts ship with the plugin).
  */
-class Layouts_List_Page extends Admin_Page {
+class Layouts_List_Page extends React_List_Page {
 	/**
 	 * Page slug.
 	 *
@@ -68,15 +67,10 @@ class Layouts_List_Page extends Admin_Page {
 	 * The React page lives under the newsletters CPT menu, not the layouts
 	 * CPT — that's the `post_type` arg used here.
 	 *
-	 * @param array $forwarded Forwarded query args.
 	 * @return string
 	 */
-	public function get_legacy_redirect_target( $forwarded = [] ) {
-		return \Newspack\Newsletters\Admin\Admin_Shell::build_legacy_redirect_target(
-			Newspack_Newsletters::NEWSPACK_NEWSLETTERS_CPT,
-			$this->slug,
-			$forwarded
-		);
+	public function get_redirect_post_type() {
+		return Newspack_Newsletters::NEWSPACK_NEWSLETTERS_CPT;
 	}
 
 	/**

--- a/includes/admin/pages/class-newsletters-list-page.php
+++ b/includes/admin/pages/class-newsletters-list-page.php
@@ -11,7 +11,6 @@
 
 namespace Newspack\Newsletters\Admin\Pages;
 
-use Newspack\Newsletters\Admin\Admin_Page;
 use Newspack_Newsletters;
 
 defined( 'ABSPATH' ) || exit;
@@ -19,7 +18,7 @@ defined( 'ABSPATH' ) || exit;
 /**
  * "All Newsletters" page — registered in both modes.
  */
-class Newsletters_List_Page extends Admin_Page {
+class Newsletters_List_Page extends Hidden_React_List_Page {
 	/**
 	 * Page slug.
 	 *
@@ -42,36 +41,12 @@ class Newsletters_List_Page extends Admin_Page {
 	/**
 	 * Register under the newsletters CPT parent. `Admin_Shell::register_menu`
 	 * removes the visible submenu after registration because
-	 * `is_hidden_from_menu()` returns true here.
+	 * `is_hidden_from_menu()` returns true (inherited from
+	 * `Hidden_React_List_Page`).
 	 *
 	 * @return string
 	 */
 	public function get_parent_slug() {
-		return 'edit.php?post_type=' . Newspack_Newsletters::NEWSPACK_NEWSLETTERS_CPT;
-	}
-
-	/**
-	 * The visible click target is the auto-generated "All Newsletters"
-	 * submenu — our React page lives behind a redirect, not a separate
-	 * sidebar entry.
-	 *
-	 * @return bool
-	 */
-	public function is_hidden_from_menu() {
-		return true;
-	}
-
-	/**
-	 * Force the Newsletters CPT to be the active top-level menu while
-	 * the React list page is rendered. The page registers under the
-	 * CPT parent and is then hidden via `is_hidden_from_menu()` /
-	 * `remove_submenu_page`, so we still need to keep the parent menu
-	 * highlighted explicitly — otherwise the sidebar would collapse
-	 * to an inactive state once the matching submenu entry is gone.
-	 *
-	 * @return string
-	 */
-	public function get_parent_file() {
 		return 'edit.php?post_type=' . Newspack_Newsletters::NEWSPACK_NEWSLETTERS_CPT;
 	}
 
@@ -96,16 +71,11 @@ class Newsletters_List_Page extends Admin_Page {
 	}
 
 	/**
-	 * Build the redirect URL for the legacy newsletters CPT list.
+	 * Post type the React page lives under in the admin URL.
 	 *
-	 * @param array $forwarded Forwarded query args.
 	 * @return string
 	 */
-	public function get_legacy_redirect_target( $forwarded = [] ) {
-		return \Newspack\Newsletters\Admin\Admin_Shell::build_legacy_redirect_target(
-			Newspack_Newsletters::NEWSPACK_NEWSLETTERS_CPT,
-			$this->slug,
-			$forwarded
-		);
+	public function get_redirect_post_type() {
+		return Newspack_Newsletters::NEWSPACK_NEWSLETTERS_CPT;
 	}
 }

--- a/includes/admin/pages/class-react-list-page.php
+++ b/includes/admin/pages/class-react-list-page.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * Abstract React list-page base.
+ *
+ * Shared scaffold for the React DataView pages that shadow a classic
+ * `edit.php?post_type=…` or `edit-tags.php?taxonomy=…` screen. The
+ * subclass provides the post_type used in the React page URL via
+ * `get_redirect_post_type()`; this base wires the corresponding
+ * legacy-list redirect through `Admin_Shell::build_legacy_redirect_target`.
+ *
+ * @package Newspack_Newsletters
+ */
+
+namespace Newspack\Newsletters\Admin\Pages;
+
+use Newspack\Newsletters\Admin\Admin_Page;
+use Newspack\Newsletters\Admin\Admin_Shell;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Base for admin list pages backed by a React shell.
+ */
+abstract class React_List_Page extends Admin_Page {
+	/**
+	 * `post_type` slug the React page lives under in the admin URL:
+	 * `edit.php?post_type=<this>&page=<slug>`. Used by the legacy-list
+	 * redirect to build the canonical React URL.
+	 *
+	 * @return string
+	 */
+	abstract public function get_redirect_post_type();
+
+	/**
+	 * Default redirect: hand the page's CPT slug + own slug to the
+	 * shared `Admin_Shell` helper. Subclasses can still override for
+	 * non-standard targets.
+	 *
+	 * @param array $forwarded Forwarded query args.
+	 * @return string
+	 */
+	public function get_legacy_redirect_target( $forwarded = [] ) {
+		return Admin_Shell::build_legacy_redirect_target(
+			$this->get_redirect_post_type(),
+			$this->slug,
+			$forwarded
+		);
+	}
+}

--- a/newspack-newsletters.php
+++ b/newspack-newsletters.php
@@ -77,6 +77,8 @@ require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/tracking/class-admin.
 require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/class-newspack-newsletters.php';
 require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/plugins/woocommerce-memberships/class-woocommerce-memberships.php';
 require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/admin/class-admin-page.php';
+require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/admin/pages/class-react-list-page.php';
+require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/admin/pages/class-hidden-react-list-page.php';
 require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/admin/pages/class-newsletters-list-page.php';
 require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/admin/pages/class-ads-list-page.php';
 require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/admin/pages/class-advertisers-list-page.php';


### PR DESCRIPTION
## Summary

Four list-page classes (`Newsletters_List_Page`, `Ads_List_Page`, `Advertisers_List_Page`, `Layouts_List_Page`) re-implemented the same legacy-URL → React-page redirect, and three of them re-implemented the hidden-submenu plumbing on top. This PR hoists the common shape into two abstract bases under `includes/admin/pages/`:

- **`React_List_Page`** (extends `Admin_Page`) — provides `get_legacy_redirect_target()` via a single `get_redirect_post_type()` template method, so subclasses just declare which CPT slug their React page lives under.
- **`Hidden_React_List_Page`** (extends `React_List_Page`) — adds `is_hidden_from_menu() = true` and a `get_parent_file()` default that mirrors `get_parent_slug()` (the right answer for every hidden React page in the milestone).

### What each concrete class drops

| Class | `is_hidden_from_menu` | `get_parent_file` | `get_legacy_redirect_target` |
|---|---|---|---|
| `Newsletters_List_Page` | ✓ inherited | ✓ inherited | ✓ inherited |
| `Ads_List_Page` | ✓ inherited | ✓ inherited | ✓ inherited |
| `Advertisers_List_Page` | ✓ inherited | ✓ inherited | ✓ inherited |
| `Layouts_List_Page` | n/a (visible) | n/a | ✓ inherited |

Each subclass adds a small `get_redirect_post_type()` returning the existing CPT slug and keeps page-specific overrides (`get_submenu_file`, `get_legacy_screen_id`, `get_wizard_tab_url`, etc.).

### Deviation from the ticket spec

NEWS-2291 lists Layouts among the "hidden submenu" pages, but `Layouts_List_Page` doesn't override `is_hidden_from_menu()` — it's a *visible* submenu under Newsletters (positioned at index 2). Only Newsletters / Ads / Advertisers share the hidden-submenu plumbing. The two-tier base (`React_List_Page` outer, `Hidden_React_List_Page` inner) lets Layouts ride the outer base for the legacy-redirect win without inheriting hidden-submenu behaviour it doesn't want.

## Diff stats

```
includes/admin/pages/class-ads-list-page.php            44 +++------------------
includes/admin/pages/class-advertisers-list-page.php    46 +++-------------------
includes/admin/pages/class-hidden-react-list-page.php   45 ++++++++++++++++++++++ (new)
includes/admin/pages/class-layouts-list-page.php        12 ++----
includes/admin/pages/class-newsletters-list-page.php    42 +++-----------------
includes/admin/pages/class-react-list-page.php          50 +++++++++++++++++++++++ (new)
newspack-newsletters.php                                 2 +
7 files changed, 116 insertions(+), 125 deletions(-)
```

Net concrete-class reduction: **−104 LOC** across the four subclasses. New base files add **95 LOC** (mostly phpdoc). The qualitative win is bigger than the line count suggests — adding a new React list page is now four small methods instead of seven.

## Acceptance

- [x] Two new abstract bases live alongside the concrete pages under `includes/admin/pages/`.
- [x] All four concrete classes extend the appropriate base and drop the duplicated methods.
- [x] `newspack-newsletters.php` requires the two new base classes before the four concrete ones (matters because the classmap is plus manual ordering — see AGENTS.md).
- [x] `composer dump-autoload` regenerated.
- [x] Full PHPUnit suite passes (383 tests, 2123 assertions) including `Newsletters_List_Page_Test`, `Ads_List_Page_Test`, `Advertisers_List_Page_Test`, `Admin_Page_Test`, `Admin_Shell_Test`.
- [x] `n npm run lint:php` clean.

## Milestone

Post-merge follow-up landing on `epic/admin-ux-modernisation` — milestone roll-up tracked in **#2141**.

## Linear

NEWS-2291 — https://linear.app/a8c/issue/NEWS-2291/hoist-hidden-react-list-page-base-class-for-the-four-react-list

## Context

No context change.