### PR TITLE
refactor(ads): extract Ads::get_top_level_url() helper

### DIFF
--- a/includes/admin/pages/class-ads-list-page.php
+++ b/includes/admin/pages/class-ads-list-page.php
@@ -17,7 +17,6 @@
 
 namespace Newspack\Newsletters\Admin\Pages;
 
-use Newspack_Newsletters;
 use Newspack_Newsletters\Ads;
 
 defined( 'ABSPATH' ) || exit;
@@ -67,10 +66,7 @@ class Ads_List_Page extends Hidden_React_List_Page {
 	 * @return string
 	 */
 	public function get_parent_slug() {
-		if ( Ads::display_ads_menu_item_separately() ) {
-			return 'edit.php?post_type=' . Ads::CPT;
-		}
-		return 'edit.php?post_type=' . Newspack_Newsletters::NEWSPACK_NEWSLETTERS_CPT;
+		return Ads::get_top_level_url();
 	}
 
 	/**

--- a/includes/admin/pages/class-advertisers-list-page.php
+++ b/includes/admin/pages/class-advertisers-list-page.php
@@ -47,10 +47,7 @@ class Advertisers_List_Page extends Hidden_React_List_Page {
 	 * @return string
 	 */
 	public function get_parent_slug() {
-		if ( Ads::display_ads_menu_item_separately() ) {
-			return 'edit.php?post_type=' . Ads::CPT;
-		}
-		return 'edit.php?post_type=' . Newspack_Newsletters::NEWSPACK_NEWSLETTERS_CPT;
+		return Ads::get_top_level_url();
 	}
 
 	/**

--- a/includes/ads/class-ads.php
+++ b/includes/ads/class-ads.php
@@ -178,6 +178,21 @@ final class Ads {
 	}
 
 	/**
+	 * Top-level admin URL the Newsletter Ads family of pages lives under.
+	 * Resolves the bundled-vs-standalone branch on `display_ads_menu_item_separately()`
+	 * in one place — pages composing menu URLs should call this rather
+	 * than re-implementing the if/else.
+	 *
+	 * @return string
+	 */
+	public static function get_top_level_url() {
+		if ( self::display_ads_menu_item_separately() ) {
+			return 'edit.php?post_type=' . self::CPT;
+		}
+		return 'edit.php?post_type=' . Newspack_Newsletters::NEWSPACK_NEWSLETTERS_CPT;
+	}
+
+	/**
 	 * Display Newsletter Ads as a separate menu item, if the user can't edit Newsletters but can edit Newsletter Ads.
 	 * Otherwise, the Newsletter Ads will be a submenu item under Newsletters.
 	 */


### PR DESCRIPTION
## Summary

Two list-page classes (`Ads_List_Page` and `Advertisers_List_Page`) each re-implemented the same `if ( Ads::display_ads_menu_item_separately() )` branch in their `get_parent_slug()` method, returning either `edit.php?post_type=<ads_cpt>` (standalone) or `edit.php?post_type=<newsletters_cpt>` (bundled). This PR collapses the branch into a single helper on the existing `Ads` class.

```php
public static function get_top_level_url() {
    if ( self::display_ads_menu_item_separately() ) {
        return 'edit.php?post_type=' . self::CPT;
    }
    return 'edit.php?post_type=' . Newspack_Newsletters::NEWSPACK_NEWSLETTERS_CPT;
}
```

Each call site collapses from a five-line if/else to `return Ads::get_top_level_url();`.

### Deviation from the ticket spec

NEWS-2292 proposes a `Ads_Menu_Placement::get_top_level_url()` class, but no `Ads_Menu_Placement` exists today — `Ads::display_ads_menu_item_separately()` (the predicate the new helper wraps) already lives on the `Ads` class. Adding a sibling static there keeps the rule co-located with its source-of-truth predicate; spinning up a new class for one method would be overkill.

The ticket also lists `class-layouts-list-page.php` among the call sites — but post-#2149 Layouts doesn't branch on `display_ads_menu_item_separately()` at all (its `get_parent_slug` returns the newsletters CPT URL unconditionally). So this PR touches two call sites, not three.

### What this PR doesn't change

`Advertisers_List_Page::get_submenu_file()` also branches on the same predicate but composes a different URL (`edit-tags.php?taxonomy=<advertiser_tax>&post_type=<…>`). It could be refactored to use a smaller `get_top_level_post_type()` helper, but that's a separate concern — left out to keep the diff to what the ticket actually asked for. Filing a sibling ticket if it's worth doing.

## Acceptance

- [x] `Ads::get_top_level_url()` added as a sibling of `display_ads_menu_item_separately()`.
- [x] `Ads_List_Page::get_parent_slug()` and `Advertisers_List_Page::get_parent_slug()` collapsed to one-liners.
- [x] Stale `use Newspack_Newsletters;` import removed from `Ads_List_Page` (Advertisers still uses it on the submenu_file branch — kept).
- [x] Existing `Ads_List_Page_Test` (7) and `Advertisers_List_Page_Test` (8) pass — the public `get_parent_slug()` return values are unchanged.
- [x] `n npm run lint:php` clean.

Net: +17 / −9 LOC, with the rule centralised.

## Milestone

Post-merge follow-up landing on `epic/admin-ux-modernisation` — milestone roll-up tracked in **#2141**.

## Linear

NEWS-2292 — https://linear.app/a8c/issue/NEWS-2292/extract-ads-menu-placementget-top-level-url-helper

## Context

No context change.