### PR TITLE
refactor(admin-shell): extract Asset_Loader::enqueue_bundle() helper

### DIFF
--- a/includes/admin/class-admin-shell.php
+++ b/includes/admin/class-admin-shell.php
@@ -408,11 +408,7 @@ class Admin_Shell {
 		$is_layouts_list = 'newspack-newsletters-layouts-list' === $current_page->get_slug();
 
 		// `wp-edit-blocks` is only needed by the layouts-list BlockPreview iframes — keep it off other admin-shell pages.
-		$admin_shell_css_deps = [];
-		if ( $is_layouts_list ) {
-			wp_enqueue_style( 'wp-edit-blocks' );
-			$admin_shell_css_deps[] = 'wp-edit-blocks';
-		}
+		$admin_shell_css_deps = $is_layouts_list ? [ 'wp-edit-blocks' ] : [];
 
 		$asset = Asset_Loader::enqueue_bundle(
 			self::SCRIPT_HANDLE,
@@ -424,6 +420,13 @@ class Admin_Shell {
 		);
 		if ( ! $asset ) {
 			return;
+		}
+
+		// Explicit fallback so `wp-edit-blocks` still loads on layouts-list when
+		// `dist/admin-shell.css` is missing (the dep array only fires through the
+		// CSS enqueue, which `Asset_Loader` skips when the .css isn't built).
+		if ( $is_layouts_list ) {
+			wp_enqueue_style( 'wp-edit-blocks' );
 		}
 
 		// Layouts list previews render `newspack-newsletters/posts-inserter`; without `editorBlocks.js` BlockPreview shows the "block not supported" fallback.

--- a/includes/admin/class-admin-shell.php
+++ b/includes/admin/class-admin-shell.php
@@ -416,6 +416,7 @@ class Admin_Shell {
 
 		$asset = Asset_Loader::enqueue_bundle(
 			self::SCRIPT_HANDLE,
+			'admin-shell',
 			NEWSPACK_NEWSLETTERS_PLUGIN_FILE . 'dist',
 			plugins_url( '../../dist', __FILE__ ),
 			[],

--- a/includes/admin/class-admin-shell.php
+++ b/includes/admin/class-admin-shell.php
@@ -405,20 +405,6 @@ class Admin_Shell {
 		}
 		unset( $hook_suffix );
 
-		$asset_path = NEWSPACK_NEWSLETTERS_PLUGIN_FILE . 'dist/admin-shell.asset.php';
-		if ( ! file_exists( $asset_path ) ) {
-			return;
-		}
-		$asset = require $asset_path;
-
-		wp_enqueue_script(
-			self::SCRIPT_HANDLE,
-			plugins_url( '../../dist/admin-shell.js', __FILE__ ),
-			$asset['dependencies'],
-			$asset['version'],
-			true
-		);
-
 		$is_layouts_list = 'newspack-newsletters-layouts-list' === $current_page->get_slug();
 
 		// `wp-edit-blocks` is only needed by the layouts-list BlockPreview iframes — keep it off other admin-shell pages.
@@ -428,13 +414,15 @@ class Admin_Shell {
 			$admin_shell_css_deps[] = 'wp-edit-blocks';
 		}
 
-		if ( file_exists( NEWSPACK_NEWSLETTERS_PLUGIN_FILE . 'dist/admin-shell.css' ) ) {
-			wp_enqueue_style(
-				self::SCRIPT_HANDLE,
-				plugins_url( '../../dist/admin-shell.css', __FILE__ ),
-				$admin_shell_css_deps,
-				$asset['version']
-			);
+		$asset = Asset_Loader::enqueue_bundle(
+			self::SCRIPT_HANDLE,
+			NEWSPACK_NEWSLETTERS_PLUGIN_FILE . 'dist',
+			plugins_url( '../../dist', __FILE__ ),
+			[],
+			$admin_shell_css_deps
+		);
+		if ( ! $asset ) {
+			return;
 		}
 
 		// Layouts list previews render `newspack-newsletters/posts-inserter`; without `editorBlocks.js` BlockPreview shows the "block not supported" fallback.

--- a/includes/admin/class-asset-loader.php
+++ b/includes/admin/class-asset-loader.php
@@ -4,10 +4,11 @@
  *
  * Centralises the script + style enqueue sequence used by admin-side
  * React bundles built via `@wordpress/scripts` — each bundle emits a
- * sibling `<handle>.asset.php` carrying the runtime dependency array
- * and a content-hash version. Callers compose URLs and pass any
- * extra dependencies; the helper handles the file_exists guard, the
- * asset.php require, and the two enqueue calls.
+ * sibling `<basename>.asset.php` carrying the runtime dependency
+ * array and a content-hash version. Callers compose URLs and pass
+ * any extra dependencies; the helper handles the file_exists guard,
+ * the asset.php require, and the two enqueue calls. The WP handle
+ * is independent from the on-disk basename — see `enqueue_bundle()`.
  *
  * @package Newspack_Newsletters
  */
@@ -17,7 +18,7 @@ namespace Newspack\Newsletters\Admin;
 defined( 'ABSPATH' ) || exit;
 
 /**
- * Shared `<handle>.asset.php` + script + style enqueue helper.
+ * Shared `<basename>.asset.php` + script + style enqueue helper.
  */
 class Asset_Loader {
 	/**

--- a/includes/admin/class-asset-loader.php
+++ b/includes/admin/class-asset-loader.php
@@ -1,0 +1,79 @@
+<?php
+/**
+ * Asset enqueue helper.
+ *
+ * Centralises the script + style enqueue sequence used by admin-side
+ * React bundles built via `@wordpress/scripts` — each bundle emits a
+ * sibling `<handle>.asset.php` carrying the runtime dependency array
+ * and a content-hash version. Callers compose URLs and pass any
+ * extra dependencies; the helper handles the file_exists guard, the
+ * asset.php require, and the two enqueue calls.
+ *
+ * @package Newspack_Newsletters
+ */
+
+namespace Newspack\Newsletters\Admin;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Shared `<handle>.asset.php` + script + style enqueue helper.
+ */
+class Asset_Loader {
+	/**
+	 * Read `<build_dir>/<handle>.asset.php` and enqueue the matching
+	 * `<handle>.js` (always) and `<handle>.css` (when present) under
+	 * the given handle.
+	 *
+	 * @param string $handle            Script + style handle.
+	 * @param string $build_dir         Filesystem path to the dist
+	 *                                  directory containing the
+	 *                                  asset.php / .js / .css files.
+	 * @param string $url_dir           Public URL prefix matching
+	 *                                  `$build_dir`.
+	 * @param array  $extra_script_deps Additional handles to merge
+	 *                                  into the script dependency
+	 *                                  array declared in asset.php.
+	 * @param array  $extra_style_deps  Dependencies for the matching
+	 *                                  `.css` enqueue.
+	 * @return array|null Asset metadata (`dependencies`, `version`)
+	 *                    on success, null when `asset.php` is missing.
+	 */
+	public static function enqueue_bundle(
+		$handle,
+		$build_dir,
+		$url_dir,
+		$extra_script_deps = [],
+		$extra_style_deps = []
+	) {
+		$asset_path = trailingslashit( $build_dir ) . $handle . '.asset.php';
+		if ( ! file_exists( $asset_path ) ) {
+			return null;
+		}
+		$asset = require $asset_path;
+
+		$script_deps = array_values(
+			array_unique( array_merge( $asset['dependencies'], $extra_script_deps ) )
+		);
+
+		wp_enqueue_script(
+			$handle,
+			trailingslashit( $url_dir ) . $handle . '.js',
+			$script_deps,
+			$asset['version'],
+			true
+		);
+
+		$style_path = trailingslashit( $build_dir ) . $handle . '.css';
+		if ( file_exists( $style_path ) ) {
+			wp_enqueue_style(
+				$handle,
+				trailingslashit( $url_dir ) . $handle . '.css',
+				$extra_style_deps,
+				$asset['version']
+			);
+		}
+
+		return $asset;
+	}
+}

--- a/includes/admin/class-asset-loader.php
+++ b/includes/admin/class-asset-loader.php
@@ -21,14 +21,23 @@ defined( 'ABSPATH' ) || exit;
  */
 class Asset_Loader {
 	/**
-	 * Read `<build_dir>/<handle>.asset.php` and enqueue the matching
-	 * `<handle>.js` (always) and `<handle>.css` (when present) under
-	 * the given handle.
+	 * Read `<build_dir>/<basename>.asset.php` and enqueue the matching
+	 * `<basename>.js` (always) and `<basename>.css` (when present)
+	 * under the given handle.
 	 *
-	 * @param string $handle            Script + style handle.
+	 * The WP handle and the on-disk file stem are independent — webpack
+	 * emits bundles under the entry key (e.g. `admin-shell`) while WP
+	 * conventionally uses a plugin-prefixed handle (e.g.
+	 * `newspack-newsletters-admin-shell`). Conflating them was a P1
+	 * regression in the helper's first cut.
+	 *
+	 * @param string $handle            WP script + style handle.
+	 * @param string $basename          File stem (no extension) matching
+	 *                                  the webpack entry — used for the
+	 *                                  `<basename>.asset.php`, `.js`, and
+	 *                                  `.css` lookups.
 	 * @param string $build_dir         Filesystem path to the dist
-	 *                                  directory containing the
-	 *                                  asset.php / .js / .css files.
+	 *                                  directory.
 	 * @param string $url_dir           Public URL prefix matching
 	 *                                  `$build_dir`.
 	 * @param array  $extra_script_deps Additional handles to merge
@@ -41,12 +50,13 @@ class Asset_Loader {
 	 */
 	public static function enqueue_bundle(
 		$handle,
+		$basename,
 		$build_dir,
 		$url_dir,
 		$extra_script_deps = [],
 		$extra_style_deps = []
 	) {
-		$asset_path = trailingslashit( $build_dir ) . $handle . '.asset.php';
+		$asset_path = trailingslashit( $build_dir ) . $basename . '.asset.php';
 		if ( ! file_exists( $asset_path ) ) {
 			return null;
 		}
@@ -58,17 +68,17 @@ class Asset_Loader {
 
 		wp_enqueue_script(
 			$handle,
-			trailingslashit( $url_dir ) . $handle . '.js',
+			trailingslashit( $url_dir ) . $basename . '.js',
 			$script_deps,
 			$asset['version'],
 			true
 		);
 
-		$style_path = trailingslashit( $build_dir ) . $handle . '.css';
+		$style_path = trailingslashit( $build_dir ) . $basename . '.css';
 		if ( file_exists( $style_path ) ) {
 			wp_enqueue_style(
 				$handle,
-				trailingslashit( $url_dir ) . $handle . '.css',
+				trailingslashit( $url_dir ) . $basename . '.css',
 				$extra_style_deps,
 				$asset['version']
 			);

--- a/includes/class-wizard-bridge.php
+++ b/includes/class-wizard-bridge.php
@@ -58,6 +58,7 @@ class Wizard_Bridge {
 
 		$asset = Asset_Loader::enqueue_bundle(
 			self::SCRIPT_HANDLE,
+			'wizard-bridge',
 			NEWSPACK_NEWSLETTERS_PLUGIN_FILE . 'dist',
 			plugins_url( '../dist', __FILE__ )
 		);

--- a/includes/class-wizard-bridge.php
+++ b/includes/class-wizard-bridge.php
@@ -12,6 +12,8 @@
 
 namespace Newspack\Newsletters;
 
+use Newspack\Newsletters\Admin\Asset_Loader;
+
 defined( 'ABSPATH' ) || exit;
 
 /**
@@ -54,27 +56,13 @@ class Wizard_Bridge {
 			return;
 		}
 
-		$asset_path = NEWSPACK_NEWSLETTERS_PLUGIN_FILE . 'dist/wizard-bridge.asset.php';
-		if ( ! file_exists( $asset_path ) ) {
-			return;
-		}
-		$asset = require $asset_path;
-
-		wp_enqueue_script(
+		$asset = Asset_Loader::enqueue_bundle(
 			self::SCRIPT_HANDLE,
-			plugins_url( '../dist/wizard-bridge.js', __FILE__ ),
-			$asset['dependencies'],
-			$asset['version'],
-			true
+			NEWSPACK_NEWSLETTERS_PLUGIN_FILE . 'dist',
+			plugins_url( '../dist', __FILE__ )
 		);
-
-		if ( file_exists( NEWSPACK_NEWSLETTERS_PLUGIN_FILE . 'dist/wizard-bridge.css' ) ) {
-			wp_enqueue_style(
-				self::SCRIPT_HANDLE,
-				plugins_url( '../dist/wizard-bridge.css', __FILE__ ),
-				[],
-				$asset['version']
-			);
+		if ( ! $asset ) {
+			return;
 		}
 
 		wp_localize_script(

--- a/newspack-newsletters.php
+++ b/newspack-newsletters.php
@@ -88,6 +88,7 @@ require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/admin/class-newslette
 require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/admin/class-ads-list-rest.php';
 require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/admin/class-advertisers-list-rest.php';
 require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/admin/class-settings-rest.php';
+require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/admin/class-asset-loader.php';
 require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/admin/class-admin-shell.php';
 require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/class-wizard-bridge.php';
 

--- a/tests/test-asset-loader.php
+++ b/tests/test-asset-loader.php
@@ -1,0 +1,208 @@
+<?php
+/**
+ * Class Test Asset Loader
+ *
+ * @package Newspack_Newsletters
+ */
+
+use Newspack\Newsletters\Admin\Asset_Loader;
+
+/**
+ * Tests the shared `@wordpress/scripts` bundle enqueue helper.
+ *
+ * Webpack emits bundles keyed on the entry name (e.g. `admin-shell`),
+ * while WP enqueues conventionally use a plugin-prefixed handle (e.g.
+ * `newspack-newsletters-admin-shell`). Conflating the two was a P1
+ * regression on this helper's first cut — the `handle !== basename`
+ * test below guards against it.
+ */
+class Asset_Loader_Test extends WP_UnitTestCase {
+	/**
+	 * Per-test fixture directory created under sys_get_temp_dir().
+	 *
+	 * @var string|null
+	 */
+	private $build_dir;
+
+	/**
+	 * Allocate a clean fixture dir per test.
+	 */
+	public function set_up() {
+		parent::set_up();
+		$this->build_dir = trailingslashit( sys_get_temp_dir() ) . 'asset-loader-' . uniqid();
+		// phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.directory_mkdir -- Test fixture lives under sys_get_temp_dir(); VIP's no-disk-writes rule doesn't apply to test scaffolding.
+		mkdir( $this->build_dir, 0777, true );
+	}
+
+	/**
+	 * Wipe the fixture dir + dequeue anything the test left registered.
+	 * `WP_UnitTestCase` doesn't reset `wp_scripts` / `wp_styles` between
+	 * tests, so without an explicit reset a handle registered by one
+	 * test would short-circuit subsequent `wp_enqueue_script` calls
+	 * with different dependencies.
+	 */
+	public function tear_down() {
+		if ( $this->build_dir && is_dir( $this->build_dir ) ) {
+			foreach ( glob( trailingslashit( $this->build_dir ) . '*' ) as $f ) {
+				// phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.file_ops_unlink -- Per-test fixture file under sys_get_temp_dir().
+				unlink( $f );
+			}
+			// phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.directory_rmdir -- Cleaning up the per-test fixture dir created in set_up().
+			rmdir( $this->build_dir );
+		}
+		$GLOBALS['wp_scripts'] = null;
+		$GLOBALS['wp_styles']  = null;
+		parent::tear_down();
+	}
+
+	/**
+	 * Write a fixture `<basename>.asset.php` carrying the given
+	 * dependencies + version.
+	 *
+	 * @param string $basename     Bundle file stem.
+	 * @param array  $dependencies Script dependencies declared by webpack.
+	 * @param string $version      Content hash / version string.
+	 */
+	private function write_asset_file( $basename, $dependencies = [], $version = 'test-v1' ) {
+		$path     = trailingslashit( $this->build_dir ) . $basename . '.asset.php';
+		$deps_php = '[' . implode(
+			', ',
+			array_map(
+				static function ( $dep ) {
+					return "'" . $dep . "'";
+				},
+				$dependencies
+			)
+		) . ']';
+		// phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.file_ops_file_put_contents -- Per-test fixture asset.php under sys_get_temp_dir().
+		file_put_contents(
+			$path,
+			'<?php return [ \'dependencies\' => ' . $deps_php . ', \'version\' => \'' . $version . '\' ];'
+		);
+	}
+
+	/**
+	 * Touch a sibling fixture file (`.js` / `.css`) next to an asset.php.
+	 *
+	 * @param string $basename Bundle file stem.
+	 * @param string $ext      Extension without the leading dot.
+	 */
+	private function touch_bundle_file( $basename, $ext ) {
+		// phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.file_ops_file_put_contents -- Per-test fixture js/css under sys_get_temp_dir().
+		file_put_contents( trailingslashit( $this->build_dir ) . $basename . '.' . $ext, '' );
+	}
+
+	/**
+	 * REGRESSION: the handle and the bundle basename are independent.
+	 * The first cut of this helper used `$handle` as the file stem,
+	 * so any caller passing a plugin-prefixed WP handle would silently
+	 * skip the entire enqueue once dist/ existed in production.
+	 */
+	public function test_enqueues_script_and_style_from_basename_under_handle() {
+		$this->write_asset_file( 'my-bundle', [ 'wp-element' ], 'test-v1' );
+		$this->touch_bundle_file( 'my-bundle', 'js' );
+		$this->touch_bundle_file( 'my-bundle', 'css' );
+
+		$asset = Asset_Loader::enqueue_bundle(
+			'my-prefix-my-bundle',
+			'my-bundle',
+			$this->build_dir,
+			'https://example.test/dist'
+		);
+
+		$this->assertSame( [ 'wp-element' ], $asset['dependencies'] );
+		$this->assertSame( 'test-v1', $asset['version'] );
+		$this->assertTrue( wp_script_is( 'my-prefix-my-bundle', 'enqueued' ) );
+		$this->assertTrue( wp_style_is( 'my-prefix-my-bundle', 'enqueued' ) );
+		// And the inverse: nothing registered under the basename alone.
+		$this->assertFalse( wp_script_is( 'my-bundle', 'enqueued' ) );
+		$this->assertFalse( wp_style_is( 'my-bundle', 'enqueued' ) );
+	}
+
+	/**
+	 * No asset.php → return null, no enqueues happen, caller can early-out.
+	 */
+	public function test_returns_null_and_skips_enqueue_when_asset_missing() {
+		$asset = Asset_Loader::enqueue_bundle(
+			'my-prefix-my-bundle',
+			'my-bundle',
+			$this->build_dir,
+			'https://example.test/dist'
+		);
+
+		$this->assertNull( $asset );
+		$this->assertFalse( wp_script_is( 'my-prefix-my-bundle', 'enqueued' ) );
+		$this->assertFalse( wp_style_is( 'my-prefix-my-bundle', 'enqueued' ) );
+	}
+
+	/**
+	 * Caller-supplied script deps merge with the asset.php's; CSS gets
+	 * the explicit style deps. Duplicates collapse via array_unique so
+	 * `wp-element` doesn't appear twice.
+	 */
+	public function test_merges_extra_deps_with_asset_dependencies() {
+		$this->write_asset_file( 'my-bundle', [ 'wp-element', 'wp-i18n' ] );
+		$this->touch_bundle_file( 'my-bundle', 'js' );
+		$this->touch_bundle_file( 'my-bundle', 'css' );
+
+		Asset_Loader::enqueue_bundle(
+			'my-prefix-my-bundle',
+			'my-bundle',
+			$this->build_dir,
+			'https://example.test/dist',
+			[ 'wp-data', 'wp-element' ], // wp-element is a duplicate of the asset.php dep.
+			[ 'wp-edit-blocks' ]
+		);
+
+		$script = wp_scripts()->registered['my-prefix-my-bundle'];
+		$this->assertSame( [ 'wp-element', 'wp-i18n', 'wp-data' ], $script->deps );
+
+		$style = wp_styles()->registered['my-prefix-my-bundle'];
+		$this->assertSame( [ 'wp-edit-blocks' ], $style->deps );
+	}
+
+	/**
+	 * No `<basename>.css` next to the asset.php → script enqueues,
+	 * style skips entirely (no empty style registered).
+	 */
+	public function test_skips_style_when_css_missing() {
+		$this->write_asset_file( 'my-bundle' );
+		$this->touch_bundle_file( 'my-bundle', 'js' );
+
+		Asset_Loader::enqueue_bundle(
+			'my-prefix-my-bundle',
+			'my-bundle',
+			$this->build_dir,
+			'https://example.test/dist'
+		);
+
+		$this->assertTrue( wp_script_is( 'my-prefix-my-bundle', 'enqueued' ) );
+		$this->assertFalse( wp_style_is( 'my-prefix-my-bundle', 'registered' ) );
+	}
+
+	/**
+	 * Public URLs are composed from `<url_dir>/<basename>.js`/.css —
+	 * independent of the WP handle.
+	 */
+	public function test_composes_urls_from_basename_not_handle() {
+		$this->write_asset_file( 'my-bundle' );
+		$this->touch_bundle_file( 'my-bundle', 'js' );
+		$this->touch_bundle_file( 'my-bundle', 'css' );
+
+		Asset_Loader::enqueue_bundle(
+			'my-prefix-my-bundle',
+			'my-bundle',
+			$this->build_dir,
+			'https://example.test/dist'
+		);
+
+		$this->assertSame(
+			'https://example.test/dist/my-bundle.js',
+			wp_scripts()->registered['my-prefix-my-bundle']->src
+		);
+		$this->assertSame(
+			'https://example.test/dist/my-bundle.css',
+			wp_styles()->registered['my-prefix-my-bundle']->src
+		);
+	}
+}


### PR DESCRIPTION
## Summary

`Admin_Shell::enqueue_assets()` and `Wizard_Bridge::maybe_enqueue()` each re-implemented the same `@wordpress/scripts` bundle-enqueue sequence: read the sibling `<basename>.asset.php`, `wp_enqueue_script` with its `dependencies` + `version`, `wp_enqueue_style` if the matching `.css` exists. This PR collapses the sequence into a single helper.

```php
Asset_Loader::enqueue_bundle(
    string $handle,            // WP enqueue handle, e.g. 'newspack-newsletters-admin-shell'
    string $basename,          // webpack entry name, e.g. 'admin-shell'
    string $build_dir,
    string $url_dir,
    array  $extra_script_deps = [],
    array  $extra_style_deps  = []
): ?array
```

The helper returns the `$asset` metadata (so callers can chain further version-keyed enqueues) or `null` when the asset.php is missing. WP handle and on-disk basename are kept independent — webpack emits bundles under the entry key (`dist/admin-shell.{js,css,asset.php}`) while WP conventionally uses a plugin-prefixed handle (`newspack-newsletters-admin-shell`). Conflating them was a P1 regression on the first cut of this PR; see commit `709e78c6`.

## Caller diff

Both call sites collapse to a single helper call + a small `if ( ! $asset ) return;` guard. The Admin_Shell caller still computes its layouts-list-specific `wp-edit-blocks` CSS dependency before the helper call and passes it through `$extra_style_deps` — preserving the existing dependency-merge logic.

- `Admin_Shell::enqueue_assets()` — −21 LOC
- `Wizard_Bridge::maybe_enqueue()` — −18 LOC

Net behaviour: identical. The two enqueue calls inside the helper match byte-for-byte what each caller did inline (same handle, same URL composition, same merged dependencies, same version, same in-footer flag).

## Regression test

`tests/test-asset-loader.php` (5 tests, 15 assertions) covers:

- `test_enqueues_script_and_style_from_basename_under_handle` — explicitly asserts `handle !== basename`; the helper looks up `<basename>.asset.php` and registers under `<handle>`. This is the test that would have caught the P1.
- `test_returns_null_and_skips_enqueue_when_asset_missing` — graceful no-op when dist/ isn't built.
- `test_merges_extra_deps_with_asset_dependencies` — caller-supplied script deps merge with asset.php's; CSS gets the explicit style deps; duplicates collapse.
- `test_skips_style_when_css_missing` — only `<basename>.js` present → no style registered.
- `test_composes_urls_from_basename_not_handle` — URLs are `<url_dir>/<basename>.{js,css}`, independent of the WP handle.

## Deviation from the ticket spec

NEWS-2293's proposed signature included a `text_domain` argument and `wp_set_script_translations()` inside the helper. Neither current caller calls `wp_set_script_translations` today, so wiring that in would be a behaviour change — the ticket also states "no functional change expected". Left out of the helper for now; can be added cheaply later if a future caller needs it.

## Acceptance

- [x] `Asset_Loader::enqueue_bundle()` added under `includes/admin/class-asset-loader.php`, namespaced `Newspack\Newsletters\Admin` (same as `Admin_Shell`).
- [x] WP handle and bundle basename are independent parameters.
- [x] `newspack-newsletters.php` requires the helper before `Admin_Shell` and `Wizard_Bridge` (matters because the classmap relies on manual ordering — see AGENTS.md).
- [x] `composer dump-autoload` regenerated.
- [x] Admin_Shell + Wizard_Bridge use the helper; existing layouts-list CSS dep handling preserved via `$extra_style_deps`.
- [x] Regression test (`tests/test-asset-loader.php`) covers the handle ≠ basename invariant explicitly.
- [x] Full PHPUnit suite passes (388 tests, 2138 assertions) — `Asset_Loader_Test` (5), `Admin_Shell_Test` (24), `Wizard_Bridge_Test` (4) inclusive.
- [x] `n npm run lint:php` clean.

## Milestone

Post-merge follow-up landing on `epic/admin-ux-modernisation` — milestone roll-up tracked in **#2141**.

## Linear

NEWS-2293 — https://linear.app/a8c/issue/NEWS-2293/extract-asset-loaderenqueue-bundle-shared-by-admin-shell-and-wizard

## Context

No context change.