### PR TITLE
refactor(service-provider): hoist is_layout_post() into base class

### DIFF
--- a/includes/service-providers/active_campaign/class-newspack-newsletters-active-campaign.php
+++ b/includes/service-providers/active_campaign/class-newspack-newsletters-active-campaign.php
@@ -1576,7 +1576,7 @@ final class Newspack_Newsletters_Active_Campaign extends \Newspack_Newsletters_S
 		// Layouts share the email editor (so the bundle, MJML refresh, and
 		// editor chrome all load) but must never create or update an ESP
 		// campaign — the post type is the boundary.
-		if ( Newspack_Newsletters_Layouts::NEWSPACK_NEWSLETTERS_LAYOUT_CPT === get_post_type( $post_id ) ) {
+		if ( $this->is_layout_post( $post_id ) ) {
 			return;
 		}
 		$post = get_post( $post_id );

--- a/includes/service-providers/class-newspack-newsletters-service-provider.php
+++ b/includes/service-providers/class-newspack-newsletters-service-provider.php
@@ -416,6 +416,19 @@ abstract class Newspack_Newsletters_Service_Provider implements Newspack_Newslet
 	}
 
 	/**
+	 * Whether the given post is a layout-CPT post. Layouts share the
+	 * email editor surface with newsletters but must never trigger ESP
+	 * campaign sync / dispatch — every lifecycle hook in this class
+	 * (and its subclasses) gates on this.
+	 *
+	 * @param int|\WP_Post $post_or_id Post ID or post object.
+	 * @return bool
+	 */
+	protected function is_layout_post( $post_or_id ) {
+		return Newspack_Newsletters_Layouts::NEWSPACK_NEWSLETTERS_LAYOUT_CPT === get_post_type( $post_or_id );
+	}
+
+	/**
 	 * Send a newsletter.
 	 *
 	 * @param WP_Post $post The post object — typically a newsletter, but
@@ -430,7 +443,7 @@ abstract class Newspack_Newsletters_Service_Provider implements Newspack_Newslet
 		$post_id = $post->ID;
 
 		// Defence in depth: layouts must never dispatch a campaign, regardless of upstream guards.
-		if ( Newspack_Newsletters_Layouts::NEWSPACK_NEWSLETTERS_LAYOUT_CPT === get_post_type( $post ) ) {
+		if ( $this->is_layout_post( $post ) ) {
 			return null;
 		}
 

--- a/includes/service-providers/constant_contact/class-newspack-newsletters-constant-contact.php
+++ b/includes/service-providers/constant_contact/class-newspack-newsletters-constant-contact.php
@@ -935,7 +935,7 @@ final class Newspack_Newsletters_Constant_Contact extends \Newspack_Newsletters_
 		// Layouts share the email editor (so the bundle, MJML refresh, and
 		// editor chrome all load) but must never create or update an ESP
 		// campaign — the post type is the boundary.
-		if ( Newspack_Newsletters_Layouts::NEWSPACK_NEWSLETTERS_LAYOUT_CPT === get_post_type( $post_id ) ) {
+		if ( $this->is_layout_post( $post_id ) ) {
 			return;
 		}
 		if ( ! Newspack_Newsletters_Editor::is_editing_email( $post_id ) ) {

--- a/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp.php
+++ b/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp.php
@@ -1225,7 +1225,7 @@ final class Newspack_Newsletters_Mailchimp extends \Newspack_Newsletters_Service
 		// Layouts share the email editor (so the bundle, MJML refresh, and
 		// editor chrome all load) but must never create or update an ESP
 		// campaign — the post type is the boundary.
-		if ( Newspack_Newsletters_Layouts::NEWSPACK_NEWSLETTERS_LAYOUT_CPT === get_post_type( $post_id ) ) {
+		if ( $this->is_layout_post( $post_id ) ) {
 			return;
 		}
 		$post = get_post( $post_id );


### PR DESCRIPTION
## Summary

Four call sites in the service-provider hierarchy each re-implemented the same inline guard against the layout CPT (layouts share the email-editor UI surface but must never trigger ESP campaign sync or dispatch):

```php
if ( Newspack_Newsletters_Layouts::NEWSPACK_NEWSLETTERS_LAYOUT_CPT === get_post_type( $post_id ) ) {
    return;
}
```

This PR hoists the predicate into a single protected helper on the base class.

```php
protected function is_layout_post( $post_or_id ) {
    return Newspack_Newsletters_Layouts::NEWSPACK_NEWSLETTERS_LAYOUT_CPT === get_post_type( $post_or_id );
}
```

The helper accepts either an int post ID or a `WP_Post` object — `get_post_type()` handles both, which matters because `send_newsletter()` receives the post object while the meta-update hooks receive a post ID.

## Call sites updated

| Class | Method | Argument |
|---|---|---|
| `Newspack_Newsletters_Service_Provider` (base) | `send_newsletter()` | `WP_Post` |
| `Newspack_Newsletters_Mailchimp` | `updated_post_meta()` | post ID |
| `Newspack_Newsletters_Active_Campaign` | `updated_post_meta()` | post ID |
| `Newspack_Newsletters_Constant_Contact` | `updated_post_meta()` | post ID |

Each subclass replaces the verbatim guard with `if ( $this->is_layout_post( $post_id ) ) return;`. The base class's `send_newsletter()` does the same.

### Deviation from the ticket spec

NEWS-2294's example referred to the constant as `Newspack_Newsletters_Layouts::CPT`; the actual constant is `Newspack_Newsletters_Layouts::NEWSPACK_NEWSLETTERS_LAYOUT_CPT`. The helper uses the real constant. No effect on the proposed shape.

## Acceptance

- [x] `is_layout_post()` added to the base class as a `protected` method.
- [x] All four call sites use the helper (1 base + 3 subclasses).
- [x] `tests/test-layouts-send-suppression.php` (3 tests) stays green — the layout-CPT bypass still fires.
- [x] Full PHPUnit suite passes (388 tests, 2138 assertions).
- [x] `n npm run lint:php` clean.

## Milestone

Post-merge follow-up landing on `epic/admin-ux-modernisation` — milestone roll-up tracked in **#2141**.

## Linear

NEWS-2294 — https://linear.app/a8c/issue/NEWS-2294/hoist-is-layout-post-guard-into-service-provider-base-class

## Context

No context change.