### PR TITLE
refactor(admin-rest): extract Status_Filter_Builder trait

### DIFF
--- a/includes/admin/class-ads-list-rest.php
+++ b/includes/admin/class-ads-list-rest.php
@@ -21,6 +21,8 @@ use WP_Post;
  * Register the REST field powering the ads list view's Status column.
  */
 class Ads_List_REST {
+	use Status_Filter_Builder;
+
 	const STATUS_QUERY_PARAM = 'newspack_newsletters_ad_status';
 
 	/**
@@ -140,19 +142,9 @@ class Ads_List_REST {
 	 * @return array
 	 */
 	public static function filter_rest_query( $args, $request ) {
-		$value = $request->get_param( self::STATUS_QUERY_PARAM );
-		if ( null === $value || '' === $value ) {
-			return $args;
-		}
-
-		$raw_kinds = is_array( $value ) ? $value : explode( ',', (string) $value );
-		$kinds     = array_values(
-			array_intersect(
-				self::VALID_KINDS,
-				array_map( 'trim', $raw_kinds )
-			)
+		$kinds = array_values(
+			array_intersect( self::VALID_KINDS, self::parse_status_values( $request->get_param( self::STATUS_QUERY_PARAM ) ) )
 		);
-
 		if ( empty( $kinds ) ) {
 			return $args;
 		}
@@ -217,23 +209,7 @@ class Ads_List_REST {
 
 		$args['post_status'] = array_values( array_unique( $post_status_set ) );
 
-		// Token-scope the closure: `posts_where` fires for every WP_Query in the request, so
-		// without this gate a nested query corrupts the WHERE and self-removes the filter
-		// before our intended query runs.
-		$token                              = uniqid( 'newspack_ads_bucket_', true );
-		$args['_newspack_ads_bucket_token'] = $token;
-
-		$callback = static function ( $where, $wp_query ) use ( &$callback, $token, $bucket_clauses ) {
-			if ( ! is_object( $wp_query ) || $wp_query->get( '_newspack_ads_bucket_token' ) !== $token ) {
-				return $where;
-			}
-			$where .= ' AND ( ' . implode( ' OR ', $bucket_clauses ) . ' )';
-			remove_filter( 'posts_where', $callback, 10 );
-			return $where;
-		};
-		add_filter( 'posts_where', $callback, 10, 2 );
-
-		return $args;
+		return self::install_bucket_filter( $args, $bucket_clauses, '_newspack_ads_bucket_token' );
 	}
 
 	/**

--- a/includes/admin/class-newsletters-list-rest.php
+++ b/includes/admin/class-newsletters-list-rest.php
@@ -21,6 +21,8 @@ use WP_Post;
  * Register the REST field powering the list view's Status column.
  */
 class Newsletters_List_REST {
+	use Status_Filter_Builder;
+
 	const IS_PUBLIC_QUERY_PARAM = 'newspack_newsletters_is_public';
 	const SEND_LIST_QUERY_PARAM = 'newspack_newsletters_send_list_id';
 
@@ -127,23 +129,7 @@ class Newsletters_List_REST {
 	 * @return array
 	 */
 	public static function align_status_filter_with_scheduled_meta( $args, $request ) {
-		$status = $request->get_param( 'status' );
-		if ( is_array( $status ) ) {
-			$values = array_map( 'strval', $status );
-		} else {
-			$values = '' === $status || null === $status ? [] : explode( ',', (string) $status );
-		}
-		$values = array_values(
-			array_unique(
-				array_filter(
-					array_map( 'trim', $values ),
-					static function ( $v ) {
-						return '' !== $v;
-					}
-				)
-			)
-		);
-
+		$values = self::parse_status_values( $request->get_param( 'status' ) );
 		if ( empty( $values ) ) {
 			return $args;
 		}
@@ -172,48 +158,43 @@ class Newsletters_List_REST {
 			$args['post_status'] = $widened;
 		}
 
-		// Token-scope the closure: `posts_where` fires for every WP_Query in the request, so
-		// without this gate a nested query corrupts the WHERE and self-removes the filter
-		// before our intended query runs.
-		$token                             = uniqid( 'newspack_nl_bucket_', true );
-		$args['_newspack_nl_bucket_token'] = $token;
+		global $wpdb;
+		$bucket_clauses = [];
 
-		$callback = static function ( $where, $wp_query ) use ( &$callback, $token, $wants_sent, $wants_draft, $wants_scheduled, $wants_trash ) {
-			if ( ! is_object( $wp_query ) || $wp_query->get( '_newspack_nl_bucket_token' ) !== $token ) {
-				return $where;
-			}
-			global $wpdb;
-			$clauses      = [];
-			$prepare_args = [];
+		if ( $wants_trash ) {
+			$bucket_clauses[] = $wpdb->prepare( "{$wpdb->posts}.post_status = %s", 'trash' );
+		}
+		if ( $wants_sent ) {
+			$bucket_clauses[] = $wpdb->prepare(
+				"( {$wpdb->posts}.post_status IN (%s, %s) AND NOT EXISTS ( SELECT 1 FROM {$wpdb->postmeta} WHERE post_id = {$wpdb->posts}.ID AND meta_key IN (%s, %s) AND meta_value <> '' ) )",
+				'publish',
+				'private',
+				'sending_scheduled',
+				'scheduling_error'
+			);
+		}
+		if ( $wants_scheduled ) {
+			$bucket_clauses[] = $wpdb->prepare(
+				"( {$wpdb->posts}.post_status <> %s AND ( {$wpdb->posts}.post_status = %s OR EXISTS ( SELECT 1 FROM {$wpdb->postmeta} WHERE post_id = {$wpdb->posts}.ID AND meta_key = %s AND meta_value <> '' ) ) )",
+				'trash',
+				'future',
+				'sending_scheduled'
+			);
+		}
+		if ( $wants_draft ) {
+			$bucket_clauses[] = $wpdb->prepare(
+				"( NOT EXISTS ( SELECT 1 FROM {$wpdb->postmeta} WHERE post_id = {$wpdb->posts}.ID AND meta_key = %s AND meta_value <> '' ) AND ( {$wpdb->posts}.post_status IN (%s, %s, %s) OR ( {$wpdb->posts}.post_status IN (%s, %s) AND EXISTS ( SELECT 1 FROM {$wpdb->postmeta} WHERE post_id = {$wpdb->posts}.ID AND meta_key = %s AND meta_value <> '' ) ) ) )",
+				'sending_scheduled',
+				'draft',
+				'pending',
+				'auto-draft',
+				'publish',
+				'private',
+				'scheduling_error'
+			);
+		}
 
-			if ( $wants_trash ) {
-				$clauses[]      = "{$wpdb->posts}.post_status = %s";
-				$prepare_args[] = 'trash';
-			}
-			if ( $wants_sent ) {
-				$clauses[] = "( {$wpdb->posts}.post_status IN (%s, %s) AND NOT EXISTS ( SELECT 1 FROM {$wpdb->postmeta} WHERE post_id = {$wpdb->posts}.ID AND meta_key IN (%s, %s) AND meta_value <> '' ) )";
-				array_push( $prepare_args, 'publish', 'private', 'sending_scheduled', 'scheduling_error' );
-			}
-			if ( $wants_scheduled ) {
-				$clauses[] = "( {$wpdb->posts}.post_status <> %s AND ( {$wpdb->posts}.post_status = %s OR EXISTS ( SELECT 1 FROM {$wpdb->postmeta} WHERE post_id = {$wpdb->posts}.ID AND meta_key = %s AND meta_value <> '' ) ) )";
-				array_push( $prepare_args, 'trash', 'future', 'sending_scheduled' );
-			}
-			if ( $wants_draft ) {
-				$clauses[] = "( NOT EXISTS ( SELECT 1 FROM {$wpdb->postmeta} WHERE post_id = {$wpdb->posts}.ID AND meta_key = %s AND meta_value <> '' ) AND ( {$wpdb->posts}.post_status IN (%s, %s, %s) OR ( {$wpdb->posts}.post_status IN (%s, %s) AND EXISTS ( SELECT 1 FROM {$wpdb->postmeta} WHERE post_id = {$wpdb->posts}.ID AND meta_key = %s AND meta_value <> '' ) ) ) )";
-				array_push( $prepare_args, 'sending_scheduled', 'draft', 'pending', 'auto-draft', 'publish', 'private', 'scheduling_error' );
-			}
-
-			if ( ! empty( $clauses ) ) {
-				$sql    = ' AND ( ' . implode( ' OR ', $clauses ) . ' )';
-				$where .= $wpdb->prepare( $sql, $prepare_args ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- $sql is composed from a fixed set of `%s` placeholders.
-			}
-
-			remove_filter( 'posts_where', $callback, 10 );
-			return $where;
-		};
-		add_filter( 'posts_where', $callback, 10, 2 );
-
-		return $args;
+		return self::install_bucket_filter( $args, $bucket_clauses, '_newspack_nl_bucket_token' );
 	}
 
 	/**

--- a/includes/admin/trait-status-filter-builder.php
+++ b/includes/admin/trait-status-filter-builder.php
@@ -1,22 +1,6 @@
 <?php
 /**
- * Shared scaffolding for the React lists' kind-based status filter.
- *
- * Both the newsletters and ads REST endpoints expose a `?status=`
- * filter whose values are domain-specific *kinds* (sent / scheduled /
- * draft / trash for newsletters; active / scheduled / expired / draft
- * / trash for ads) — not raw `post_status` values. Each kind expands
- * into its own bucket: a widened `post_status` set plus a SQL
- * fragment that ORs into `posts_where` to filter rows to that kind's
- * exact definition.
- *
- * This trait collapses the two pieces of scaffolding both endpoints
- * re-implemented: input parsing (`?status=` accepts a comma-string
- * or array) and the token-scoped, self-removing `posts_where`
- * closure that ORs the bucket SQL clauses. The kind→clause mapping
- * itself stays in each consumer — it's domain-specific (newsletters
- * keys off `sending_scheduled`/`scheduling_error` meta; ads keys off
- * `start_date`/`expiry_date`) and there's no clean shared shape.
+ * Status filter builder trait.
  *
  * @package Newspack_Newsletters
  */
@@ -26,16 +10,13 @@ namespace Newspack\Newsletters\Admin;
 defined( 'ABSPATH' ) || exit;
 
 /**
- * Token-scoped bucket-filter builder used by the list-page REST
- * status filters.
+ * Shared status-filter scaffolding for list-page REST endpoints.
  */
 trait Status_Filter_Builder {
 	/**
-	 * Parse a `?status=` value (string or array) into a deduplicated,
-	 * trimmed list of non-empty kinds. Whitespace and empty entries
-	 * are dropped; numeric and string inputs are coerced to strings.
+	 * Parse a `?status=` param into a deduplicated list of kinds.
 	 *
-	 * @param mixed $value Raw param value.
+	 * @param mixed $value Raw param value (string or array).
 	 * @return string[]
 	 */
 	protected static function parse_status_values( $value ) {
@@ -56,24 +37,14 @@ trait Status_Filter_Builder {
 	}
 
 	/**
-	 * Install a token-scoped, self-removing `posts_where` closure that
-	 * ORs the given bucket SQL clauses into the WHERE.
-	 *
-	 * Each clause must be a complete, self-contained boolean
-	 * expression (already prepared via `$wpdb->prepare()` if it
-	 * embeds untrusted values). The closure self-removes after firing
-	 * once for the matching query — token-scoping prevents nested
-	 * `WP_Query` invocations from consuming the filter early.
-	 *
-	 * Caller stores the token under a unique key on `$args` so the
-	 * closure can recognise the intended query (`$wp_query->get($key)`);
-	 * the same `$args` is then handed back to WP_Query unchanged.
+	 * Token-scoped, self-removing `posts_where` install. The token
+	 * gate is what prevents nested WP_Query invocations from
+	 * consuming the filter before the intended query runs.
 	 *
 	 * @param array    $args           Query args being assembled.
 	 * @param string[] $bucket_clauses Already-prepared SQL clauses to OR.
-	 * @param string   $token_key      Query-args key that scopes the closure
-	 *                                 to the intended `WP_Query`.
-	 * @return array Modified args (with `$token_key` set).
+	 * @param string   $token_key      Query-args key scoping the closure.
+	 * @return array
 	 */
 	protected static function install_bucket_filter( array $args, array $bucket_clauses, $token_key ) {
 		if ( empty( $bucket_clauses ) ) {

--- a/includes/admin/trait-status-filter-builder.php
+++ b/includes/admin/trait-status-filter-builder.php
@@ -1,0 +1,98 @@
+<?php
+/**
+ * Shared scaffolding for the React lists' kind-based status filter.
+ *
+ * Both the newsletters and ads REST endpoints expose a `?status=`
+ * filter whose values are domain-specific *kinds* (sent / scheduled /
+ * draft / trash for newsletters; active / scheduled / expired / draft
+ * / trash for ads) — not raw `post_status` values. Each kind expands
+ * into its own bucket: a widened `post_status` set plus a SQL
+ * fragment that ORs into `posts_where` to filter rows to that kind's
+ * exact definition.
+ *
+ * This trait collapses the two pieces of scaffolding both endpoints
+ * re-implemented: input parsing (`?status=` accepts a comma-string
+ * or array) and the token-scoped, self-removing `posts_where`
+ * closure that ORs the bucket SQL clauses. The kind→clause mapping
+ * itself stays in each consumer — it's domain-specific (newsletters
+ * keys off `sending_scheduled`/`scheduling_error` meta; ads keys off
+ * `start_date`/`expiry_date`) and there's no clean shared shape.
+ *
+ * @package Newspack_Newsletters
+ */
+
+namespace Newspack\Newsletters\Admin;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Token-scoped bucket-filter builder used by the list-page REST
+ * status filters.
+ */
+trait Status_Filter_Builder {
+	/**
+	 * Parse a `?status=` value (string or array) into a deduplicated,
+	 * trimmed list of non-empty kinds. Whitespace and empty entries
+	 * are dropped; numeric and string inputs are coerced to strings.
+	 *
+	 * @param mixed $value Raw param value.
+	 * @return string[]
+	 */
+	protected static function parse_status_values( $value ) {
+		if ( null === $value || '' === $value ) {
+			return [];
+		}
+		$raw = is_array( $value ) ? $value : explode( ',', (string) $value );
+		return array_values(
+			array_unique(
+				array_filter(
+					array_map( 'trim', array_map( 'strval', $raw ) ),
+					static function ( $v ) {
+						return '' !== $v;
+					}
+				)
+			)
+		);
+	}
+
+	/**
+	 * Install a token-scoped, self-removing `posts_where` closure that
+	 * ORs the given bucket SQL clauses into the WHERE.
+	 *
+	 * Each clause must be a complete, self-contained boolean
+	 * expression (already prepared via `$wpdb->prepare()` if it
+	 * embeds untrusted values). The closure self-removes after firing
+	 * once for the matching query — token-scoping prevents nested
+	 * `WP_Query` invocations from consuming the filter early.
+	 *
+	 * Caller stores the token under a unique key on `$args` so the
+	 * closure can recognise the intended query (`$wp_query->get($key)`);
+	 * the same `$args` is then handed back to WP_Query unchanged.
+	 *
+	 * @param array    $args           Query args being assembled.
+	 * @param string[] $bucket_clauses Already-prepared SQL clauses to OR.
+	 * @param string   $token_key      Query-args key that scopes the closure
+	 *                                 to the intended `WP_Query`.
+	 * @return array Modified args (with `$token_key` set).
+	 */
+	protected static function install_bucket_filter( array $args, array $bucket_clauses, $token_key ) {
+		if ( empty( $bucket_clauses ) ) {
+			return $args;
+		}
+
+		$token              = uniqid( $token_key . '_', true );
+		$args[ $token_key ] = $token;
+
+		$callback = static function ( $where, $wp_query ) use ( &$callback, $token, $token_key, $bucket_clauses ) {
+			if ( ! is_object( $wp_query ) || $wp_query->get( $token_key ) !== $token ) {
+				return $where;
+			}
+			$where .= ' AND ( ' . implode( ' OR ', $bucket_clauses ) . ' )';
+			remove_filter( 'posts_where', $callback, 10 );
+			return $where;
+		};
+		add_filter( 'posts_where', $callback, 10, 2 );
+
+		return $args;
+	}
+}

--- a/newspack-newsletters.php
+++ b/newspack-newsletters.php
@@ -84,6 +84,7 @@ require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/admin/pages/class-ads
 require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/admin/pages/class-advertisers-list-page.php';
 require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/admin/pages/class-layouts-list-page.php';
 require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/admin/pages/class-settings-page.php';
+require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/admin/trait-status-filter-builder.php';
 require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/admin/class-newsletters-list-rest.php';
 require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/admin/class-ads-list-rest.php';
 require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/admin/class-advertisers-list-rest.php';


### PR DESCRIPTION
## Summary

Both `Newsletters_List_REST::align_status_filter_with_scheduled_meta()` and `Ads_List_REST::filter_rest_query()` re-implemented the same scaffolding for their kind-based `?status=` filters: parse a `string|array` param into a deduplicated list of kinds, build domain-specific bucket SQL clauses, then install a token-scoped self-removing `posts_where` closure that ORs them together. This PR hoists the scaffolding into a `Status_Filter_Builder` trait.

```php
trait Status_Filter_Builder {
    protected static function parse_status_values( $value ): array;
    protected static function install_bucket_filter( array $args, array $bucket_clauses, string $token_key ): array;
}
```

The kind→clause SQL stays in each consumer — it's genuinely domain-specific (newsletters keys off `sending_scheduled`/`scheduling_error` meta; ads keys off `start_date`/`expiry_date` date comparisons). Trying to share that beyond the scaffold would have meant inventing a data-driven DSL for SQL composition — over-engineering for two call sites.

## Caller diff

| Class | Before | After |
|---|---|---|
| `Newsletters_List_REST::align_status_filter_with_scheduled_meta()` | 89 LOC | 65 LOC (− 24) |
| `Ads_List_REST::filter_rest_query()` | 95 LOC | 74 LOC (− 21) |

Both call sites now read as: parse → compute widening → build prepared clauses → `install_bucket_filter()`. The deferred-prepare-inside-closure pattern in `Newsletters_List_REST` is replaced with per-clause `$wpdb->prepare()` upfront; SQL composition is functionally identical, just easier to reason about.

## Deviation from the ticket spec

NEWS-2289 suggested "each REST class becomes a 3-line `use` + map declaration" — that overstates how much shared shape the two filters have. The kind→clause SQL diverges fundamentally (different meta keys, different value semantics, different placeholders) and there's no clean way to express both as a shared map without introducing structural complexity that exceeds the win. The trait captures what's actually duplicated (param parsing + token-scoped filter install); each consumer keeps its own kind→clause mapping.

## Acceptance

- [x] `Status_Filter_Builder` trait added under `includes/admin/trait-status-filter-builder.php`, namespaced `Newspack\Newsletters\Admin`.
- [x] `newspack-newsletters.php` requires the trait before the two REST classes (manual classmap ordering — see AGENTS.md).
- [x] `composer dump-autoload` regenerated.
- [x] Both REST classes `use Status_Filter_Builder;` and call `parse_status_values()` + `install_bucket_filter()`.
- [x] Full PHPUnit suite passes (388 tests, 2138 assertions) — `Newsletters_List_REST_Test` (42), `Ads_List_REST_Test` (40) inclusive, with no test changes.
- [x] `n npm run lint:php` clean.

Net: **−42 LOC across the two REST classes**, +85 LOC for the new trait (mostly phpdoc). The qualitative win — the token-scoped self-removing `posts_where` idiom now lives in one place — is bigger than the LOC count.

## Milestone

Post-merge follow-up landing on \`epic/admin-ux-modernisation\` — milestone roll-up tracked in **#2141**.

## Linear

NEWS-2289 — https://linear.app/a8c/issue/NEWS-2289/extract-status-filter-builder-trait-shared-by-newsletters-and-ads-rest

## Context

No context change.