### PR TITLE
refactor(admin-rest): extract Rest_Status_Field trait

### DIFF
--- a/includes/admin/class-ads-list-rest.php
+++ b/includes/admin/class-ads-list-rest.php
@@ -21,6 +21,7 @@ use WP_Post;
  * Register the REST field powering the ads list view's Status column.
  */
 class Ads_List_REST {
+	use Rest_Status_Field;
 	use Status_Filter_Builder;
 
 	const STATUS_QUERY_PARAM = 'newspack_newsletters_ad_status';
@@ -296,46 +297,24 @@ class Ads_List_REST {
 	 * Register REST fields on the ads CPT.
 	 */
 	public static function register_rest_fields() {
-		register_rest_field(
+		self::register_status_field(
 			Ads::CPT,
 			'newspack_newsletters_ad_status',
 			[
-				'get_callback' => [ __CLASS__, 'rest_get_status' ],
-				'schema'       => [
-					'context'    => [ 'view', 'edit' ],
-					'type'       => 'object',
-					'readonly'   => true,
-					'properties' => [
-						'kind'       => [
-							'type' => 'string',
-							'enum' => [ 'active', 'scheduled', 'expired', 'draft', 'trash' ],
-						],
-						'starts_at'  => [
-							'type' => [ 'integer', 'null' ],
-						],
-						'expires_at' => [
-							'type' => [ 'integer', 'null' ],
-						],
-					],
+				'kind'       => [
+					'type' => 'string',
+					'enum' => [ 'active', 'scheduled', 'expired', 'draft', 'trash' ],
+				],
+				'starts_at'  => [
+					'type' => [ 'integer', 'null' ],
+				],
+				'expires_at' => [
+					'type' => [ 'integer', 'null' ],
 				],
 			]
 		);
 	}
 
-	/**
-	 * REST `get_callback` adapter — receives the prepared post array.
-	 *
-	 * @param array            $post_array  Prepared post response.
-	 * @param string           $field_name  Field name (unused).
-	 * @param \WP_REST_Request $request     Request object (unused).
-	 * @param string           $object_type Object type (unused).
-	 * @return array Status payload.
-	 */
-	public static function rest_get_status( $post_array, $field_name = '', $request = null, $object_type = '' ) {
-		unset( $field_name, $request, $object_type );
-		$post = isset( $post_array['id'] ) ? get_post( $post_array['id'] ) : null;
-		return self::get_status_for_post( $post );
-	}
 	/**
 	 * Compute the consolidated status payload for an ad post.
 	 *

--- a/includes/admin/class-newsletters-list-rest.php
+++ b/includes/admin/class-newsletters-list-rest.php
@@ -21,6 +21,7 @@ use WP_Post;
  * Register the REST field powering the list view's Status column.
  */
 class Newsletters_List_REST {
+	use Rest_Status_Field;
 	use Status_Filter_Builder;
 
 	const IS_PUBLIC_QUERY_PARAM = 'newspack_newsletters_is_public';
@@ -428,50 +429,22 @@ class Newsletters_List_REST {
 	 * Register REST fields on the newsletters CPT.
 	 */
 	public static function register_rest_fields() {
-		register_rest_field(
+		self::register_status_field(
 			Newspack_Newsletters::NEWSPACK_NEWSLETTERS_CPT,
 			'newspack_newsletters_status',
 			[
-				'get_callback' => [ __CLASS__, 'rest_get_status' ],
-				'schema'       => [
-					'context'    => [ 'view', 'edit' ],
-					'type'       => 'object',
-					'readonly'   => true,
-					'properties' => [
-						'kind'         => [
-							'type' => 'string',
-							'enum' => [ 'draft', 'sent', 'scheduled', 'trash' ],
-						],
-						'sent_at'      => [
-							'type' => [ 'integer', 'null' ],
-						],
-						'scheduled_at' => [
-							'type' => [ 'integer', 'null' ],
-						],
-					],
+				'kind'         => [
+					'type' => 'string',
+					'enum' => [ 'draft', 'sent', 'scheduled', 'trash' ],
+				],
+				'sent_at'      => [
+					'type' => [ 'integer', 'null' ],
+				],
+				'scheduled_at' => [
+					'type' => [ 'integer', 'null' ],
 				],
 			]
 		);
-	}
-
-	/**
-	 * REST `get_callback` adapter — receives the prepared post array.
-	 *
-	 * Matches WP's documented field-callback signature so future strict-mode
-	 * runtimes and IDE tooling don't flag a mismatch:
-	 * `( $object, $field_name, $request, $object_type )`. Only `$object` is
-	 * used; the rest are accepted defensively.
-	 *
-	 * @param array            $post_array  Prepared post response.
-	 * @param string           $field_name  Field name (unused).
-	 * @param \WP_REST_Request $request     Request object (unused).
-	 * @param string           $object_type Object type (unused).
-	 * @return array Status payload.
-	 */
-	public static function rest_get_status( $post_array, $field_name = '', $request = null, $object_type = '' ) {
-		unset( $field_name, $request, $object_type );
-		$post = isset( $post_array['id'] ) ? get_post( $post_array['id'] ) : null;
-		return self::get_status_for_post( $post );
 	}
 
 	/**

--- a/includes/admin/trait-rest-status-field.php
+++ b/includes/admin/trait-rest-status-field.php
@@ -1,0 +1,58 @@
+<?php
+/**
+ * REST status field trait.
+ *
+ * @package Newspack_Newsletters
+ */
+
+namespace Newspack\Newsletters\Admin;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Shared `register_rest_field` scaffolding for list-page status fields.
+ *
+ * Using classes must implement a `get_status_for_post( WP_Post|null $post ): array` method.
+ */
+trait Rest_Status_Field {
+	/**
+	 * Adapter matching WP's documented field-callback signature
+	 * (`( $object, $field_name, $request, $object_type )`) — only
+	 * `$object` is used; the rest are accepted defensively for
+	 * future strict-mode runtimes and IDE tooling.
+	 *
+	 * @param array  $post_array  Prepared post response.
+	 * @param string $field_name  Unused.
+	 * @param mixed  $request     Unused.
+	 * @param string $object_type Unused.
+	 * @return array
+	 */
+	public static function rest_get_status( $post_array, $field_name = '', $request = null, $object_type = '' ) {
+		unset( $field_name, $request, $object_type );
+		$post = isset( $post_array['id'] ) ? get_post( $post_array['id'] ) : null;
+		return static::get_status_for_post( $post );
+	}
+
+	/**
+	 * Register a status field on the given CPT.
+	 *
+	 * @param string $cpt        CPT slug.
+	 * @param string $field_name REST field name.
+	 * @param array  $properties Schema `properties` map.
+	 */
+	protected static function register_status_field( $cpt, $field_name, array $properties ) {
+		register_rest_field(
+			$cpt,
+			$field_name,
+			[
+				'get_callback' => [ static::class, 'rest_get_status' ],
+				'schema'       => [
+					'context'    => [ 'view', 'edit' ],
+					'type'       => 'object',
+					'readonly'   => true,
+					'properties' => $properties,
+				],
+			]
+		);
+	}
+}

--- a/includes/admin/trait-rest-status-field.php
+++ b/includes/admin/trait-rest-status-field.php
@@ -12,7 +12,7 @@ defined( 'ABSPATH' ) || exit;
 /**
  * Shared `register_rest_field` scaffolding for list-page status fields.
  *
- * Using classes must implement a `get_status_for_post( WP_Post|null $post ): array` method.
+ * Using classes must implement a static `get_status_for_post( \WP_Post|null $post ): array` method.
  */
 trait Rest_Status_Field {
 	/**

--- a/newspack-newsletters.php
+++ b/newspack-newsletters.php
@@ -84,6 +84,7 @@ require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/admin/pages/class-ads
 require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/admin/pages/class-advertisers-list-page.php';
 require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/admin/pages/class-layouts-list-page.php';
 require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/admin/pages/class-settings-page.php';
+require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/admin/trait-rest-status-field.php';
 require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/admin/trait-status-filter-builder.php';
 require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/admin/class-newsletters-list-rest.php';
 require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/admin/class-ads-list-rest.php';


### PR DESCRIPTION
## Summary

Both list-page REST classes registered their custom `status` field with byte-identical scaffolding — same `register_rest_field()` shape (context `[ view, edit ]`, type `object`, readonly `true`), same `rest_get_status` adapter (just unpacks the post array and delegates to `get_status_for_post`). Only the CPT, the field name, and the `properties` map differ.

This PR hoists the shared shape into a `Rest_Status_Field` trait sitting alongside `Status_Filter_Builder`:

```php
trait Rest_Status_Field {
    public static function rest_get_status( $post_array, $field_name = '', $request = null, $object_type = '' );
    protected static function register_status_field( $cpt, $field_name, array $properties );
}
```

Using classes implement `get_status_for_post( WP_Post|null $post ): array` — the trait calls it via `static::` so each REST class's domain-specific status resolution stays in place.

## Caller diff

| Class | Before (LOC) | After (LOC) | Δ |
|---|---:|---:|---:|
| `Newsletters_List_REST::register_rest_fields` + `rest_get_status` | ~45 | ~19 | −26 |
| `Ads_List_REST::register_rest_fields` + `rest_get_status` | ~37 | ~18 | −19 |

Each caller now reads as a single `register_status_field()` call with just the per-CPT properties map.

## Acceptance

- [x] `Rest_Status_Field` trait at `includes/admin/trait-rest-status-field.php`, namespaced `Newspack\Newsletters\Admin`.
- [x] `newspack-newsletters.php` requires the trait before the two REST classes.
- [x] `composer dump-autoload` regenerated.
- [x] Both REST classes `use Rest_Status_Field;` and drop the inline `register_rest_field` block + `rest_get_status` method.
- [x] REST contract is byte-identical: `Newsletters_List_REST_Test` (42) and `Ads_List_REST_Test` (40) pass unchanged.
- [x] Full PHPUnit suite passes (388 tests, 2138 assertions).
- [x] `n npm run lint:php` clean.

Net: **−47 LOC** across the two REST classes; new trait ~50 LOC (mostly required phpdoc for VIP coding standards).

## Milestone

Post-merge follow-up landing on `epic/admin-ux-modernisation` — milestone roll-up tracked in **#2141**.

## Linear

NEWS-2290 — https://linear.app/a8c/issue/NEWS-2290/extract-register-status-field-helper-for-newsletters-and-ads-rest

## Context

No context change.