### PR TITLE
refactor(admin-shell): tidy _embed param and notice helper usage

### DIFF
--- a/src/admin-shell/screens/layouts-list/use-layouts-data.js
+++ b/src/admin-shell/screens/layouts-list/use-layouts-data.js
@@ -17,8 +17,7 @@ function buildPath( view ) {
 		defaultStatuses: DEFAULT_STATUSES,
 		// `offset` overrides `page` so page 1 can reserve slots for prebuilts.
 		supportsOffset: true,
-		// Legacy `_embed=1` returns author + taxonomy in one go for grid tooltips.
-		extraParams: { _embed: '1' },
+		extraParams: { _embed: 'author,wp:term' },
 		arrayParams: [ { viewKey: 'author', param: 'author' } ],
 	} );
 	return `${ COLLECTION_PATH }${ toQueryString( params ) }`;

--- a/src/wizard-bridge/local-list-modal-host.js
+++ b/src/wizard-bridge/local-list-modal-host.js
@@ -1,9 +1,8 @@
 import apiFetch from '@wordpress/api-fetch';
-import { dispatch } from '@wordpress/data';
 import { useCallback, useEffect, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import { store as noticesStore } from '@wordpress/notices';
 
+import { notifyError } from '../admin-shell/notices';
 import LocalListModal from '../admin-shell/screens/settings/local-list-modal';
 import LocalListDeleteModal from '../admin-shell/screens/settings/local-list-delete-modal';
 import { EVENTS } from './events';
@@ -74,8 +73,7 @@ export default function LocalListModalHost() {
 			document.dispatchEvent( new CustomEvent( EVENTS.LOCAL_LIST_DELETED, { detail: { listId: list.db_id } } ) );
 			setDeletePending( null );
 		} catch ( err ) {
-			dispatch( noticesStore ).createErrorNotice( err?.message || __( 'Could not delete the local list.', 'newspack-newsletters' ), {
-				type: 'snackbar',
+			notifyError( err?.message || __( 'Could not delete the local list.', 'newspack-newsletters' ), {
 				explicitDismiss: true,
 			} );
 		} finally {


### PR DESCRIPTION
Two micro-fixes from the admin UX code-review follow-up backlog (no Linear tickets — too small to warrant their own).

## Changes

- **Layouts list `_embed` made explicit.** `src/admin-shell/screens/layouts-list/use-layouts-data.js` now requests `_embed=author,wp:term` instead of the legacy `_embed=1`. On this CPT those are the only embeddable groups, so the response is byte-for-byte identical — the change is purely about explicit intent and consistency with `newsletters-list`/`ads-list`.

- **Wizard-bridge notice routed via the helper.** `src/wizard-bridge/local-list-modal-host.js` now calls `notifyError( msg, { explicitDismiss: true } )` instead of dispatching to `noticesStore` directly. Functionally identical: `notifyError` is a thin wrapper around the same `@wordpress/notices` store and already defaults `type: 'snackbar'`. Drops two now-unused imports.

## Why not separate PRs / Linear tickets

The original admin-UX code-review backlog flagged four "polish" items. On inspection two of them weren't real (status-filter REST contract was scoped correctly; Delete/Delete-permanently is an intentional two-step UX pattern). The remaining two are too small to warrant their own ticket but worth folding in opportunistically — hence one combined PR.

## Test plan

- [ ] `n test-js` — JS test suite passes
- [ ] `n npm run lint:js` — JS lint passes
- [ ] `n build` — assets rebuild
- [ ] Smoke layouts list: rows render with author + advertiser/category terms as before
- [ ] Smoke local-list delete error path: confirm the error snackbar still appears and is dismissible

## Context

No context change.