### PR TITLE
refactor(admin-shell): split into focused classes + page-owned assets

### DIFF
--- a/includes/admin/class-admin-page.php
+++ b/includes/admin/class-admin-page.php
@@ -212,6 +212,26 @@ abstract class Admin_Page {
 	}
 
 	/**
+	 * Extra CSS deps for the admin-shell bundle — the only way to force
+	 * load order relative to `admin-shell.css`.
+	 *
+	 * @return string[]
+	 */
+	public function get_admin_shell_style_deps() {
+		return [];
+	}
+
+	/**
+	 * Page-specific extras attached after the admin-shell bundle is
+	 * registered under `$handle`.
+	 *
+	 * @param string $handle Admin-shell script handle.
+	 */
+	public function enqueue_extras( $handle ) {
+		unset( $handle );
+	}
+
+	/**
 	 * Store the hookname `add_submenu_page` returned at registration.
 	 *
 	 * @param string $hook_suffix Hookname.

--- a/includes/admin/class-admin-page.php
+++ b/includes/admin/class-admin-page.php
@@ -134,8 +134,8 @@ abstract class Admin_Page {
 	 * `WP_Screen::id` of the classic CPT list this page shadows, or
 	 * `null` when the page doesn't replace a legacy URL. Hidden React
 	 * pages typically declare an id like `'edit-newspack_nl_cpt'` so
-	 * `Admin_Shell::maybe_redirect_legacy_list` can 302 the legacy
-	 * URL across to the React surface.
+	 * `Admin_Shell_Legacy_Redirect::maybe_redirect_legacy_list` can
+	 * 302 the legacy URL across to the React surface.
 	 *
 	 * @return string|null
 	 */

--- a/includes/admin/class-admin-page.php
+++ b/includes/admin/class-admin-page.php
@@ -32,9 +32,10 @@ abstract class Admin_Page {
 	protected $capability = 'edit_posts';
 
 	/**
-	 * Hookname returned by `add_submenu_page`. Captured by `Admin_Shell`
-	 * at registration time so `is_admin_page()` can narrow its match to
-	 * the actual admin screen rather than just `$_GET['page']`.
+	 * Hookname returned by `add_submenu_page`. Captured by
+	 * `Admin_Shell_Menu` at registration time so `is_admin_page()` can
+	 * narrow its match to the actual admin screen rather than just
+	 * `$_GET['page']`.
 	 *
 	 * @var string
 	 */
@@ -260,9 +261,9 @@ abstract class Admin_Page {
 		if ( ! $screen ) {
 			return false;
 		}
-		$hook_suffix = $this->hook_suffix ? $this->hook_suffix : Admin_Shell::get_hook_suffix_for_slug( $this->slug );
+		$hook_suffix = $this->hook_suffix ? $this->hook_suffix : Admin_Shell_Menu::get_hook_suffix_for_slug( $this->slug );
 		// `admin_page_<slug>` is the shadow hookname used when the parent
-		// CPT isn't a top-level menu — see Admin_Shell::register_menu.
+		// CPT isn't a top-level menu — see Admin_Shell_Menu::register_menu.
 		$expected = array_filter( [ $hook_suffix, 'admin_page_' . $this->slug ] );
 		return in_array( $screen->id, $expected, true );
 	}

--- a/includes/admin/class-admin-shell-assets.php
+++ b/includes/admin/class-admin-shell-assets.php
@@ -1,0 +1,172 @@
+<?php
+/**
+ * Admin shell — asset enqueue.
+ *
+ * Owns the admin-shell bundle enqueue and the inline-script patch that
+ * fixes the newspack-plugin wizard header's tab-selection state on
+ * hidden React subpages.
+ *
+ * @package Newspack_Newsletters
+ */
+
+namespace Newspack\Newsletters\Admin;
+
+use Newspack_Newsletters;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Asset enqueue.
+ */
+class Admin_Shell_Assets {
+	const SCRIPT_HANDLE = 'newspack-newsletters-admin-shell';
+
+	/**
+	 * Boot hooks.
+	 */
+	public static function init() {
+		add_action( 'admin_enqueue_scripts', [ __CLASS__, 'enqueue' ] );
+		// Priority 99 so we run after newspack-plugin's wizard header
+		// has registered its script — `wp_add_inline_script` needs the
+		// handle in place to attach.
+		add_action( 'admin_enqueue_scripts', [ __CLASS__, 'patch_wizard_header_active_tab' ], 99 );
+	}
+
+	/**
+	 * Enqueue the shared admin-shell bundle on registered admin pages.
+	 * Pages contribute style deps via `get_admin_shell_style_deps()` and
+	 * sibling enqueues via `enqueue_extras()` so this method stays
+	 * branch-free.
+	 */
+	public static function enqueue() {
+		$current_page = Admin_Shell::get_current_page();
+		if ( ! $current_page ) {
+			return;
+		}
+
+		$asset = Asset_Loader::enqueue_bundle(
+			self::SCRIPT_HANDLE,
+			'admin-shell',
+			NEWSPACK_NEWSLETTERS_PLUGIN_FILE . 'dist',
+			plugins_url( '../../dist', __FILE__ ),
+			[],
+			$current_page->get_admin_shell_style_deps()
+		);
+		if ( ! $asset ) {
+			return;
+		}
+
+		$current_page->enqueue_extras( self::SCRIPT_HANDLE );
+
+		wp_localize_script(
+			self::SCRIPT_HANDLE,
+			'newspackNewslettersAdmin',
+			[
+				'currentPage'     => $current_page->get_slug(),
+				'mountId'         => $current_page->get_mount_id(),
+				'label'           => $current_page->get_label(),
+				'bundledMode'     => Admin_Shell::is_bundled_mode(),
+				'classicSettings' => \Newspack_Newsletters_Settings::get_settings_url(),
+				'restNonce'       => wp_create_nonce( 'wp_rest' ),
+				'restUrl'         => esc_url_raw( rest_url() ),
+				// `admin_url()` rather than assuming `/wp-admin/` lives at the document origin — subdirectory and multisite installs put it under a path.
+				'adminUrl'        => esc_url_raw( admin_url() ),
+				'cptSlug'         => Newspack_Newsletters::NEWSPACK_NEWSLETTERS_CPT,
+			]
+		);
+	}
+
+	/**
+	 * Patch the newspack-plugin wizard header's "selected" tab state
+	 * for hidden React subpages. The wizard's `WizardsAdminHeader`
+	 * (`src/wizards/admin-header/index.tsx`) decides the active tab
+	 * via strict `window.location.href === tab.href` equality, which
+	 * breaks for our hidden React subpages — the live URL has an
+	 * extra `&page=…` query the tab href doesn't carry. Each page
+	 * declares the canonical tab URL via `get_wizard_tab_url()`; we
+	 * inject a tiny inline script after the wizard header script to
+	 * flip the matching `<a>` to `.selected` once the React component
+	 * has mounted. Runs only when the wizard header script is
+	 * registered (i.e. bundled mode + the wizard recognises the
+	 * screen — for ads, that's via `Newsletters_Wizard::get_tabs()`).
+	 *
+	 * Upstream fix tracked separately; the wizard's URL-equality
+	 * check should accept subpages so this workaround can be removed.
+	 */
+	public static function patch_wizard_header_active_tab() {
+		$current_page = Admin_Shell::get_current_page();
+		if ( ! $current_page ) {
+			return;
+		}
+		if ( ! wp_script_is( 'newspack-wizards-admin-header', 'registered' ) ) {
+			return;
+		}
+
+		$tab_url           = $current_page->get_wizard_tab_url();
+		$breadcrumb_label  = $current_page->get_wizard_header_label();
+
+		if ( null === $tab_url && null === $breadcrumb_label ) {
+			return;
+		}
+
+		// Single inline-script payload covers both patches. Each runs
+		// independently — the wizard renders its DOM after this script is
+		// parsed, so we observe document.body and re-apply on every
+		// mutation until the targets exist (and once after, to defend
+		// against React rerenders that swap the nodes).
+		$tab_url_json    = null === $tab_url ? 'null' : wp_json_encode( $tab_url );
+		$breadcrumb_json = null === $breadcrumb_label ? 'null' : wp_json_encode( $breadcrumb_label );
+
+		// The wizard renders its DOM after this script is parsed and may
+		// re-render its header on route changes, so the observer waits
+		// for the targets, patches once both are present, and then
+		// disconnects. A deferred follow-up apply() run catches an
+		// immediate post-mount rerender without leaving the observer
+		// attached for the lifetime of the page.
+		wp_add_inline_script(
+			'newspack-wizards-admin-header',
+			sprintf(
+				'( function () {
+					var tabUrl = %1$s;
+					var breadcrumb = %2$s;
+					var observer = null;
+					function apply() {
+						var tabDone = ! tabUrl;
+						var breadcrumbDone = ! breadcrumb;
+						if ( tabUrl ) {
+							var links = document.querySelectorAll( ".newspack-tabbed-navigation a" );
+							links.forEach( function ( link ) {
+								if ( link.href === tabUrl ) {
+									link.classList.add( "selected" );
+								}
+							} );
+							tabDone = links.length > 0;
+						}
+						if ( breadcrumb ) {
+							var heading = document.querySelector( ".newspack-wizard__title h2" );
+							if ( heading ) {
+								if ( heading.textContent !== breadcrumb ) {
+									heading.textContent = breadcrumb;
+								}
+								breadcrumbDone = true;
+							}
+						}
+						if ( tabDone && breadcrumbDone && observer ) {
+							observer.disconnect();
+							observer = null;
+							setTimeout( function () {
+								apply();
+							}, 0 );
+						}
+					}
+					apply();
+					var root = document.querySelector( ".newspack-wizard" ) || document.body;
+					observer = new MutationObserver( apply );
+					observer.observe( root, { childList: true, subtree: true } );
+				} )();',
+				$tab_url_json,
+				$breadcrumb_json
+			)
+		);
+	}
+}

--- a/includes/admin/class-admin-shell-legacy-redirect.php
+++ b/includes/admin/class-admin-shell-legacy-redirect.php
@@ -1,0 +1,161 @@
+<?php
+/**
+ * Admin shell — legacy CPT list redirect.
+ *
+ * Owns the `current_screen` hook that 302s the classic
+ * `edit.php?post_type=…` URLs through to their React replacements,
+ * and the helper that builds the redirect target.
+ *
+ * @package Newspack_Newsletters
+ */
+
+namespace Newspack\Newsletters\Admin;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Classic CPT list → React page redirect plumbing.
+ */
+class Admin_Shell_Legacy_Redirect {
+	/**
+	 * Query args we forward from the legacy URL onto the React page so the
+	 * JS side can seed initial view state. `paged` is deliberately
+	 * omitted — the legacy WP list table uses 20 items per page while the
+	 * DataView defaults to 25, so a `paged=N` carry-over would point at
+	 * the wrong slice anyway. Stick to filter / search / sort args that
+	 * map cleanly onto DataViews state.
+	 */
+	const FORWARDED_LEGACY_ARGS = [
+		'post_status',
+		's',
+		'orderby',
+		'order',
+		'author',
+		'categories',
+		'tags',
+		'newspack_newsletters_send_list_id',
+	];
+
+	/**
+	 * Boot hooks.
+	 */
+	public static function init() {
+		add_action( 'current_screen', [ __CLASS__, 'maybe_redirect_legacy_list' ] );
+	}
+
+	/**
+	 * Are any of the bulk-action selectors set to a real value (i.e. not
+	 * the `-1` "no action selected" sentinel WP submits when the user
+	 * leaves the dropdown alone)? Both `action` (top-of-table dropdown)
+	 * and `action2` (bottom-of-table dropdown) are checked.
+	 *
+	 * @return bool
+	 */
+	private static function has_real_get_action() {
+		foreach ( [ 'action', 'action2' ] as $key ) {
+			// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Read-only nav check.
+			if ( ! isset( $_GET[ $key ] ) ) {
+				continue;
+			}
+			// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Read-only nav check.
+			$value = sanitize_text_field( wp_unslash( $_GET[ $key ] ) );
+			if ( '' !== $value && '-1' !== $value ) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	/**
+	 * Redirect legacy CPT list GET requests (deep links, browser
+	 * history, third-party menu links) to the matching React page.
+	 * Each chassis page declares its legacy screen id and redirect
+	 * target — this handler iterates pages and lets the matching one
+	 * supply the destination. Form-submission GETs that carry
+	 * `?action=` are left alone so classic admin flows continue to
+	 * work. Filter / search / sort args are forwarded so the React
+	 * page can pre-fill view state — see `getInitialView` on the JS
+	 * side.
+	 *
+	 * @param \WP_Screen $screen Current screen.
+	 */
+	public static function maybe_redirect_legacy_list( $screen ) {
+		if ( ! is_admin() || ! $screen instanceof \WP_Screen ) {
+			return;
+		}
+		if ( ! isset( $_SERVER['REQUEST_METHOD'] ) || 'GET' !== $_SERVER['REQUEST_METHOD'] ) {
+			return;
+		}
+
+		$matching_page = null;
+		foreach ( Admin_Shell::get_pages() as $page ) {
+			if ( $screen->id === $page->get_legacy_screen_id() ) {
+				$matching_page = $page;
+				break;
+			}
+		}
+		if ( ! $matching_page ) {
+			return;
+		}
+
+		// `action=-1` (and the bottom dropdown's `action2=-1`) is WP's
+		// "no bulk action selected" sentinel — typically left in the URL
+		// after the user submits the bulk-actions form without picking
+		// one. Treat it as a no-op so those stale URLs still redirect to
+		// the React page; only bypass for real action values.
+		if ( self::has_real_get_action() ) {
+			return;
+		}
+
+		$forwarded = [];
+		foreach ( self::FORWARDED_LEGACY_ARGS as $key ) {
+			// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Read-only nav check.
+			if ( ! isset( $_GET[ $key ] ) ) {
+				continue;
+			}
+			// phpcs:ignore WordPress.Security.NonceVerification.Recommended,WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Sanitised below.
+			$value = wp_unslash( $_GET[ $key ] );
+			if ( '' === $value ) {
+				continue;
+			}
+			$forwarded[ $key ] = is_array( $value ) ? array_map( 'sanitize_text_field', $value ) : sanitize_text_field( $value );
+		}
+
+		$target = $matching_page->get_legacy_redirect_target( $forwarded );
+		if ( ! $target ) {
+			return;
+		}
+
+		wp_safe_redirect( $target );
+		exit;
+	}
+
+	/**
+	 * Build a redirect target URL for a chassis-managed page.
+	 * Centralises the `?post_type=…&page=…&<forwarded>` shape so each
+	 * page only has to hand over its CPT slug + page slug.
+	 *
+	 * @param string       $post_type CPT slug the page shadows.
+	 * @param string       $page_slug The React page's `?page=` slug.
+	 * @param array|string $forwarded Forwarded query args, or a `post_status` string.
+	 * @return string
+	 */
+	public static function build_legacy_redirect_target( $post_type, $page_slug, $forwarded = [] ) {
+		$args = [
+			'post_type' => $post_type,
+			'page'      => $page_slug,
+		];
+
+		if ( is_string( $forwarded ) ) {
+			$forwarded = '' === $forwarded ? [] : [ 'post_status' => $forwarded ];
+		}
+
+		foreach ( self::FORWARDED_LEGACY_ARGS as $key ) {
+			if ( ! empty( $forwarded[ $key ] ) ) {
+				$args[ $key ] = $forwarded[ $key ];
+			}
+		}
+
+		return add_query_arg( $args, admin_url( 'edit.php' ) );
+	}
+}

--- a/includes/admin/class-admin-shell-menu.php
+++ b/includes/admin/class-admin-shell-menu.php
@@ -1,0 +1,170 @@
+<?php
+/**
+ * Admin shell — menu registration.
+ *
+ * Owns the chassis-managed submenu entries and the
+ * register-time hookname registry `Admin_Page::is_admin_page()`
+ * consults at request time.
+ *
+ * @package Newspack_Newsletters
+ */
+
+namespace Newspack\Newsletters\Admin;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Admin menu + submenu registration.
+ */
+class Admin_Shell_Menu {
+	/**
+	 * Slug => hookname returned by `add_submenu_page`. Populated by
+	 * `register_menu()` so `Admin_Page::is_admin_page()` survives the
+	 * fresh page instances `Admin_Shell::get_pages()` returns on every
+	 * call.
+	 *
+	 * @var array<string,string>
+	 */
+	private static $hook_suffixes = [];
+
+	/**
+	 * Lookup the registered hookname for a given page slug.
+	 *
+	 * @param string $slug Page slug.
+	 * @return string Hookname, or `''` if the slug was not registered.
+	 */
+	public static function get_hook_suffix_for_slug( $slug ) {
+		return isset( self::$hook_suffixes[ $slug ] ) ? self::$hook_suffixes[ $slug ] : '';
+	}
+
+	/**
+	 * Boot hooks.
+	 */
+	public static function init() {
+		add_action( 'admin_menu', [ __CLASS__, 'register_menu' ] );
+		// Priority 999 so we run after every contributor has registered
+		// (auto-generated CPT submenus, ads, third-party plugins).
+		// Reordering earlier wouldn't be stable — a later registration
+		// would just append past us.
+		add_action( 'admin_menu', [ __CLASS__, 'reorder_submenus' ], 999 );
+	}
+
+	/**
+	 * Reposition chassis submenu entries that declare a fixed index.
+	 *
+	 * Fires on `admin_menu` at priority 999 — after every other
+	 * `add_submenu_page` call, including auto-generated CPT submenus
+	 * (`_add_post_type_submenus`) and third-party additions. For each
+	 * page that returns a non-null `get_submenu_index()`, the entry is
+	 * unset from its current numeric key in `$submenu[ $parent_slug ]`
+	 * and re-inserted at the desired array index. Re-keying with
+	 * `array_values()` guarantees a clean 0-based sequence so WP's
+	 * downstream sorting doesn't reshuffle us back.
+	 */
+	public static function reorder_submenus() {
+		global $submenu;
+		foreach ( Admin_Shell::get_pages() as $page ) {
+			$desired_index = $page->get_submenu_index();
+			if ( null === $desired_index ) {
+				continue;
+			}
+			$parent_slug = $page->get_parent_slug();
+			if ( empty( $submenu[ $parent_slug ] ) ) {
+				continue;
+			}
+
+			// Snapshot to a 0-based list so index arithmetic is
+			// predictable. WP keeps numeric keys (5, 10, …) on auto
+			// submenus; the slug index lookup below is key-agnostic.
+			$entries = array_values( $submenu[ $parent_slug ] );
+
+			$found_at = null;
+			foreach ( $entries as $idx => $entry ) {
+				if ( ( $entry[2] ?? '' ) === $page->get_slug() ) {
+					$found_at = $idx;
+					break;
+				}
+			}
+			if ( null === $found_at ) {
+				continue;
+			}
+
+			$entry = $entries[ $found_at ];
+			array_splice( $entries, $found_at, 1 );
+			$insert = max( 0, min( $desired_index, count( $entries ) ) );
+			array_splice( $entries, $insert, 0, [ $entry ] );
+
+			// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- Reordering an admin-menu structure that WP itself populates this global with.
+			$submenu[ $parent_slug ] = $entries;
+		}
+	}
+
+	/**
+	 * Register React-shell pages.
+	 *
+	 * Every page registers under a concrete parent slug returned by
+	 * `get_parent_slug()` — passing `null` is unsafe because WP's
+	 * `get_plugin_page_hookname` mixes the parent into the registered
+	 * hookname, and `add_submenu_page`'s registration- and `admin.php`'s
+	 * URL-derived lookup-time resolution can drift when the parent
+	 * isn't itself a top-level menu. Pages that should be invisible
+	 * still register, then opt in to `is_hidden_from_menu()` so
+	 * `remove_submenu_page` strips the menu entry after registration —
+	 * keeping the URL routable while leaving no sidebar entry. The
+	 * list views use this to shadow the auto-generated `edit.php?
+	 * post_type=…` submenus, which `maybe_redirect_legacy_list` then
+	 * 302s to the React page; because the redirect preserves the
+	 * `post_type` query, `newspack-plugin`'s `Newsletters_Wizard`
+	 * (when present) recognises the screen and renders the dark
+	 * Newspack admin-header chrome on top.
+	 *
+	 * Pages that should remain visible (e.g. Settings in standalone
+	 * mode) leave `is_hidden_from_menu()` at its default and surface
+	 * as normal submenus under their declared parent.
+	 */
+	public static function register_menu() {
+		global $_registered_pages;
+		self::$hook_suffixes = [];
+		foreach ( Admin_Shell::get_pages() as $page ) {
+			$parent_slug = $page->get_parent_slug();
+			$hook_suffix = add_submenu_page(
+				$parent_slug,
+				$page->get_label(),
+				$page->get_label(),
+				$page->get_capability(),
+				$page->get_slug(),
+				[ $page, 'render' ]
+			);
+			if ( is_string( $hook_suffix ) && '' !== $hook_suffix ) {
+				$page->set_hook_suffix( $hook_suffix );
+				self::$hook_suffixes[ $page->get_slug() ] = $hook_suffix;
+			}
+			if ( $page->is_hidden_from_menu() ) {
+				// Hidden React pages (the list views) shadow a classic
+				// CPT URL via `Admin_Shell_Legacy_Redirect::maybe_redirect_legacy_list`.
+				// `add_submenu_page` registers the callback under the
+				// hookname WP computes from the page's parent — that
+				// matches `user_can_access_admin_page`'s access check
+				// (which resolves the parent the same way), but
+				// **doesn't** match `admin.php`'s page-render lookup
+				// at line ~182, which uses the URL-derived parent
+				// (`edit.php?post_type=$typenow`). When the typenow
+				// CPT isn't itself a top-level menu (true for the ads
+				// CPT in submenu mode), `$admin_page_hooks` doesn't
+				// carry it and the URL-derived hookname falls back to
+				// the `admin_page_*` prefix. Mirror the action under
+				// that prefix so `admin.php` finds and dispatches it.
+				$shadow_hookname = 'admin_page_' . $page->get_slug();
+				if ( ! has_action( $shadow_hookname ) ) {
+					add_action( $shadow_hookname, [ $page, 'render' ] );
+					// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- Mirroring an admin-page registration that WP itself populates this global with on `add_submenu_page`. The standard WordPress.WP.GlobalVariablesOverride rule guards against accidental clobbers; we add (not replace) one entry whose hookname is unique to this plugin.
+					$_registered_pages[ $shadow_hookname ] = true;
+				}
+				// Strip the visible submenu the registration produced —
+				// the user-facing entry is the auto-generated CPT
+				// submenu we redirect from, not a separate React link.
+				remove_submenu_page( $parent_slug, $page->get_slug() );
+			}
+		}
+	}
+}

--- a/includes/admin/class-admin-shell.php
+++ b/includes/admin/class-admin-shell.php
@@ -15,25 +15,17 @@ namespace Newspack\Newsletters\Admin;
 
 defined( 'ABSPATH' ) || exit;
 
-use Newspack_Newsletters;
-
 /**
  * Registers the React-based Newsletters admin shell.
  */
 class Admin_Shell {
-	const SCRIPT_HANDLE = 'newspack-newsletters-admin-shell';
-
 	/**
 	 * Boot hooks.
 	 */
 	public static function init() {
 		Admin_Shell_Menu::init();
 		Admin_Shell_Legacy_Redirect::init();
-		add_action( 'admin_enqueue_scripts', [ __CLASS__, 'enqueue_assets' ] );
-		// Priority 99 so we run after newspack-plugin's wizard header
-		// has registered its script — `wp_add_inline_script` needs the
-		// handle in place to attach.
-		add_action( 'admin_enqueue_scripts', [ __CLASS__, 'patch_wizard_header_active_tab' ], 99 );
+		Admin_Shell_Assets::init();
 		add_filter( 'admin_body_class', [ __CLASS__, 'add_body_class' ] );
 		add_filter( 'parent_file', [ __CLASS__, 'highlight_parent_menu' ] );
 		add_filter( 'submenu_file', [ __CLASS__, 'highlight_submenu' ] );
@@ -97,147 +89,6 @@ class Admin_Shell {
 			$classes .= ' newspack-newsletters-admin-screen--bundled';
 		}
 		return $classes;
-	}
-
-	/**
-	 * Enqueue the shared admin-shell bundle on registered admin pages.
-	 * Pages contribute style deps via `get_admin_shell_style_deps()` and
-	 * sibling enqueues via `enqueue_extras()` so this method stays
-	 * branch-free.
-	 *
-	 * @param string $hook_suffix Current admin page hook suffix.
-	 */
-	public static function enqueue_assets( $hook_suffix ) {
-		$current_page = self::get_current_page();
-		if ( ! $current_page ) {
-			return;
-		}
-		unset( $hook_suffix );
-
-		$asset = Asset_Loader::enqueue_bundle(
-			self::SCRIPT_HANDLE,
-			'admin-shell',
-			NEWSPACK_NEWSLETTERS_PLUGIN_FILE . 'dist',
-			plugins_url( '../../dist', __FILE__ ),
-			[],
-			$current_page->get_admin_shell_style_deps()
-		);
-		if ( ! $asset ) {
-			return;
-		}
-
-		$current_page->enqueue_extras( self::SCRIPT_HANDLE );
-
-		wp_localize_script(
-			self::SCRIPT_HANDLE,
-			'newspackNewslettersAdmin',
-			[
-				'currentPage'     => $current_page->get_slug(),
-				'mountId'         => $current_page->get_mount_id(),
-				'label'           => $current_page->get_label(),
-				'bundledMode'     => self::is_bundled_mode(),
-				'classicSettings' => \Newspack_Newsletters_Settings::get_settings_url(),
-				'restNonce'       => wp_create_nonce( 'wp_rest' ),
-				'restUrl'         => esc_url_raw( rest_url() ),
-				// `admin_url()` rather than assuming `/wp-admin/` lives at the document origin — subdirectory and multisite installs put it under a path.
-				'adminUrl'        => esc_url_raw( admin_url() ),
-				'cptSlug'         => Newspack_Newsletters::NEWSPACK_NEWSLETTERS_CPT,
-			]
-		);
-	}
-
-	/**
-	 * Patch the newspack-plugin wizard header's "selected" tab state
-	 * for hidden React subpages. The wizard's `WizardsAdminHeader`
-	 * (`src/wizards/admin-header/index.tsx`) decides the active tab
-	 * via strict `window.location.href === tab.href` equality, which
-	 * breaks for our hidden React subpages — the live URL has an
-	 * extra `&page=…` query the tab href doesn't carry. Each page
-	 * declares the canonical tab URL via `get_wizard_tab_url()`; we
-	 * inject a tiny inline script after the wizard header script to
-	 * flip the matching `<a>` to `.selected` once the React component
-	 * has mounted. Runs only when the wizard header script is
-	 * registered (i.e. bundled mode + the wizard recognises the
-	 * screen — for ads, that's via `Newsletters_Wizard::get_tabs()`).
-	 *
-	 * Upstream fix tracked separately; the wizard's URL-equality
-	 * check should accept subpages so this workaround can be removed.
-	 */
-	public static function patch_wizard_header_active_tab() {
-		$current_page = self::get_current_page();
-		if ( ! $current_page ) {
-			return;
-		}
-		if ( ! wp_script_is( 'newspack-wizards-admin-header', 'registered' ) ) {
-			return;
-		}
-
-		$tab_url           = $current_page->get_wizard_tab_url();
-		$breadcrumb_label  = $current_page->get_wizard_header_label();
-
-		if ( null === $tab_url && null === $breadcrumb_label ) {
-			return;
-		}
-
-		// Single inline-script payload covers both patches. Each runs
-		// independently — the wizard renders its DOM after this script is
-		// parsed, so we observe document.body and re-apply on every
-		// mutation until the targets exist (and once after, to defend
-		// against React rerenders that swap the nodes).
-		$tab_url_json    = null === $tab_url ? 'null' : wp_json_encode( $tab_url );
-		$breadcrumb_json = null === $breadcrumb_label ? 'null' : wp_json_encode( $breadcrumb_label );
-
-		// The wizard renders its DOM after this script is parsed and may
-		// re-render its header on route changes, so the observer waits
-		// for the targets, patches once both are present, and then
-		// disconnects. A deferred follow-up apply() run catches an
-		// immediate post-mount rerender without leaving the observer
-		// attached for the lifetime of the page.
-		wp_add_inline_script(
-			'newspack-wizards-admin-header',
-			sprintf(
-				'( function () {
-					var tabUrl = %1$s;
-					var breadcrumb = %2$s;
-					var observer = null;
-					function apply() {
-						var tabDone = ! tabUrl;
-						var breadcrumbDone = ! breadcrumb;
-						if ( tabUrl ) {
-							var links = document.querySelectorAll( ".newspack-tabbed-navigation a" );
-							links.forEach( function ( link ) {
-								if ( link.href === tabUrl ) {
-									link.classList.add( "selected" );
-								}
-							} );
-							tabDone = links.length > 0;
-						}
-						if ( breadcrumb ) {
-							var heading = document.querySelector( ".newspack-wizard__title h2" );
-							if ( heading ) {
-								if ( heading.textContent !== breadcrumb ) {
-									heading.textContent = breadcrumb;
-								}
-								breadcrumbDone = true;
-							}
-						}
-						if ( tabDone && breadcrumbDone && observer ) {
-							observer.disconnect();
-							observer = null;
-							setTimeout( function () {
-								apply();
-							}, 0 );
-						}
-					}
-					apply();
-					var root = document.querySelector( ".newspack-wizard" ) || document.body;
-					observer = new MutationObserver( apply );
-					observer.observe( root, { childList: true, subtree: true } );
-				} )();',
-				$tab_url_json,
-				$breadcrumb_json
-			)
-		);
 	}
 
 	/**

--- a/includes/admin/class-admin-shell.php
+++ b/includes/admin/class-admin-shell.php
@@ -395,6 +395,9 @@ class Admin_Shell {
 
 	/**
 	 * Enqueue the shared admin-shell bundle on registered admin pages.
+	 * Pages contribute style deps via `get_admin_shell_style_deps()` and
+	 * sibling enqueues via `enqueue_extras()` so this method stays
+	 * branch-free.
 	 *
 	 * @param string $hook_suffix Current admin page hook suffix.
 	 */
@@ -405,66 +408,19 @@ class Admin_Shell {
 		}
 		unset( $hook_suffix );
 
-		$is_layouts_list = 'newspack-newsletters-layouts-list' === $current_page->get_slug();
-
-		// `wp-edit-blocks` is only needed by the layouts-list BlockPreview iframes — keep it off other admin-shell pages.
-		$admin_shell_css_deps = $is_layouts_list ? [ 'wp-edit-blocks' ] : [];
-
 		$asset = Asset_Loader::enqueue_bundle(
 			self::SCRIPT_HANDLE,
 			'admin-shell',
 			NEWSPACK_NEWSLETTERS_PLUGIN_FILE . 'dist',
 			plugins_url( '../../dist', __FILE__ ),
 			[],
-			$admin_shell_css_deps
+			$current_page->get_admin_shell_style_deps()
 		);
 		if ( ! $asset ) {
 			return;
 		}
 
-		// Explicit fallback so `wp-edit-blocks` still loads on layouts-list when
-		// `dist/admin-shell.css` is missing (the dep array only fires through the
-		// CSS enqueue, which `Asset_Loader` skips when the .css isn't built).
-		if ( $is_layouts_list ) {
-			wp_enqueue_style( 'wp-edit-blocks' );
-		}
-
-		// Layouts list previews render `newspack-newsletters/posts-inserter`; without `editorBlocks.js` BlockPreview shows the "block not supported" fallback.
-		if ( $is_layouts_list ) {
-			// Localise on the admin-shell handle so the global is set before `admin-shell.js` runs — NewsletterPreview reads `sample_assets_url` at mount.
-			wp_localize_script(
-				self::SCRIPT_HANDLE,
-				'newspack_email_editor_data',
-				\Newspack_Newsletters_Editor::get_email_editor_data()
-			);
-
-			$blocks_js = NEWSPACK_NEWSLETTERS_PLUGIN_FILE . 'dist/editorBlocks.js';
-			if ( file_exists( $blocks_js ) ) {
-				wp_enqueue_script(
-					'newspack-newsletters-editor-blocks',
-					plugins_url( '../../dist/editorBlocks.js', __FILE__ ),
-					[],
-					filemtime( $blocks_js ),
-					true
-				);
-			}
-			$blocks_css = NEWSPACK_NEWSLETTERS_PLUGIN_FILE . 'dist/editorBlocks.css';
-			if ( file_exists( $blocks_css ) ) {
-				wp_enqueue_style(
-					'newspack-newsletters-editor-blocks',
-					plugins_url( '../../dist/editorBlocks.css', __FILE__ ),
-					[],
-					filemtime( $blocks_css )
-				);
-			}
-
-			// theme.json compilation, passed to NewsletterPreview for in-iframe injection so the parent admin chrome isn't affected by its generic selectors.
-			wp_add_inline_script(
-				self::SCRIPT_HANDLE,
-				'window.newspackNewslettersGlobalStyles = ' . wp_json_encode( wp_get_global_stylesheet() ) . ';',
-				'before'
-			);
-		}
+		$current_page->enqueue_extras( self::SCRIPT_HANDLE );
 
 		wp_localize_script(
 			self::SCRIPT_HANDLE,
@@ -477,9 +433,7 @@ class Admin_Shell {
 				'classicSettings' => \Newspack_Newsletters_Settings::get_settings_url(),
 				'restNonce'       => wp_create_nonce( 'wp_rest' ),
 				'restUrl'         => esc_url_raw( rest_url() ),
-				// Pass `admin_url()` so JS doesn't have to assume `/wp-admin/`
-				// lives at the document origin — subdirectory installs and
-				// some multisite setups put it under a path.
+				// `admin_url()` rather than assuming `/wp-admin/` lives at the document origin — subdirectory and multisite installs put it under a path.
 				'adminUrl'        => esc_url_raw( admin_url() ),
 				'cptSlug'         => Newspack_Newsletters::NEWSPACK_NEWSLETTERS_CPT,
 			]

--- a/includes/admin/class-admin-shell.php
+++ b/includes/admin/class-admin-shell.php
@@ -24,34 +24,10 @@ class Admin_Shell {
 	const SCRIPT_HANDLE = 'newspack-newsletters-admin-shell';
 
 	/**
-	 * Slug => hookname returned by `add_submenu_page`. Populated by
-	 * `register_menu()` so `Admin_Page::is_admin_page()` survives the
-	 * fresh page instances `get_pages()` returns on every call.
-	 *
-	 * @var array<string,string>
-	 */
-	private static $hook_suffixes = [];
-
-	/**
-	 * Lookup the registered hookname for a given page slug.
-	 *
-	 * @param string $slug Page slug.
-	 * @return string Hookname, or `''` if the slug was not registered.
-	 */
-	public static function get_hook_suffix_for_slug( $slug ) {
-		return isset( self::$hook_suffixes[ $slug ] ) ? self::$hook_suffixes[ $slug ] : '';
-	}
-
-	/**
 	 * Boot hooks.
 	 */
 	public static function init() {
-		add_action( 'admin_menu', [ __CLASS__, 'register_menu' ] );
-		// Priority 999 so we run after every contributor has registered
-		// (auto-generated CPT submenus, ads, third-party plugins).
-		// Reordering earlier wouldn't be stable — a later registration
-		// would just append past us.
-		add_action( 'admin_menu', [ __CLASS__, 'reorder_submenus' ], 999 );
+		Admin_Shell_Menu::init();
 		add_action( 'admin_enqueue_scripts', [ __CLASS__, 'enqueue_assets' ] );
 		// Priority 99 so we run after newspack-plugin's wizard header
 		// has registered its script — `wp_add_inline_script` needs the
@@ -61,56 +37,6 @@ class Admin_Shell {
 		add_filter( 'admin_body_class', [ __CLASS__, 'add_body_class' ] );
 		add_filter( 'parent_file', [ __CLASS__, 'highlight_parent_menu' ] );
 		add_filter( 'submenu_file', [ __CLASS__, 'highlight_submenu' ] );
-	}
-
-	/**
-	 * Reposition chassis submenu entries that declare a fixed index.
-	 *
-	 * Fires on `admin_menu` at priority 999 — after every other
-	 * `add_submenu_page` call, including auto-generated CPT submenus
-	 * (`_add_post_type_submenus`) and third-party additions. For each
-	 * page that returns a non-null `get_submenu_index()`, the entry is
-	 * unset from its current numeric key in `$submenu[ $parent_slug ]`
-	 * and re-inserted at the desired array index. Re-keying with
-	 * `array_values()` guarantees a clean 0-based sequence so WP's
-	 * downstream sorting doesn't reshuffle us back.
-	 */
-	public static function reorder_submenus() {
-		global $submenu;
-		foreach ( self::get_pages() as $page ) {
-			$desired_index = $page->get_submenu_index();
-			if ( null === $desired_index ) {
-				continue;
-			}
-			$parent_slug = $page->get_parent_slug();
-			if ( empty( $submenu[ $parent_slug ] ) ) {
-				continue;
-			}
-
-			// Snapshot to a 0-based list so index arithmetic is
-			// predictable. WP keeps numeric keys (5, 10, …) on auto
-			// submenus; the slug index lookup below is key-agnostic.
-			$entries = array_values( $submenu[ $parent_slug ] );
-
-			$found_at = null;
-			foreach ( $entries as $idx => $entry ) {
-				if ( ( $entry[2] ?? '' ) === $page->get_slug() ) {
-					$found_at = $idx;
-					break;
-				}
-			}
-			if ( null === $found_at ) {
-				continue;
-			}
-
-			$entry = $entries[ $found_at ];
-			array_splice( $entries, $found_at, 1 );
-			$insert = max( 0, min( $desired_index, count( $entries ) ) );
-			array_splice( $entries, $insert, 0, [ $entry ] );
-
-			// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- Reordering an admin-menu structure that WP itself populates this global with.
-			$submenu[ $parent_slug ] = $entries;
-		}
 	}
 
 	/**
@@ -171,75 +97,6 @@ class Admin_Shell {
 			$classes .= ' newspack-newsletters-admin-screen--bundled';
 		}
 		return $classes;
-	}
-
-	/**
-	 * Register React-shell pages.
-	 *
-	 * Every page registers under a concrete parent slug returned by
-	 * `get_parent_slug()` — passing `null` is unsafe because WP's
-	 * `get_plugin_page_hookname` mixes the parent into the registered
-	 * hookname, and `add_submenu_page`'s registration- and `admin.php`'s
-	 * URL-derived lookup-time resolution can drift when the parent
-	 * isn't itself a top-level menu. Pages that should be invisible
-	 * still register, then opt in to `is_hidden_from_menu()` so
-	 * `remove_submenu_page` strips the menu entry after registration —
-	 * keeping the URL routable while leaving no sidebar entry. The
-	 * list views use this to shadow the auto-generated `edit.php?
-	 * post_type=…` submenus, which `maybe_redirect_legacy_list` then
-	 * 302s to the React page; because the redirect preserves the
-	 * `post_type` query, `newspack-plugin`'s `Newsletters_Wizard`
-	 * (when present) recognises the screen and renders the dark
-	 * Newspack admin-header chrome on top.
-	 *
-	 * Pages that should remain visible (e.g. Settings in standalone
-	 * mode) leave `is_hidden_from_menu()` at its default and surface
-	 * as normal submenus under their declared parent.
-	 */
-	public static function register_menu() {
-		global $_registered_pages;
-		self::$hook_suffixes = [];
-		foreach ( self::get_pages() as $page ) {
-			$parent_slug = $page->get_parent_slug();
-			$hook_suffix = add_submenu_page(
-				$parent_slug,
-				$page->get_label(),
-				$page->get_label(),
-				$page->get_capability(),
-				$page->get_slug(),
-				[ $page, 'render' ]
-			);
-			if ( is_string( $hook_suffix ) && '' !== $hook_suffix ) {
-				$page->set_hook_suffix( $hook_suffix );
-				self::$hook_suffixes[ $page->get_slug() ] = $hook_suffix;
-			}
-			if ( $page->is_hidden_from_menu() ) {
-				// Hidden React pages (the list views) shadow a classic
-				// CPT URL via `Admin_Shell::maybe_redirect_legacy_list`.
-				// `add_submenu_page` registers the callback under the
-				// hookname WP computes from the page's parent — that
-				// matches `user_can_access_admin_page`'s access check
-				// (which resolves the parent the same way), but
-				// **doesn't** match `admin.php`'s page-render lookup
-				// at line ~182, which uses the URL-derived parent
-				// (`edit.php?post_type=$typenow`). When the typenow
-				// CPT isn't itself a top-level menu (true for the ads
-				// CPT in submenu mode), `$admin_page_hooks` doesn't
-				// carry it and the URL-derived hookname falls back to
-				// the `admin_page_*` prefix. Mirror the action under
-				// that prefix so `admin.php` finds and dispatches it.
-				$shadow_hookname = 'admin_page_' . $page->get_slug();
-				if ( ! has_action( $shadow_hookname ) ) {
-					add_action( $shadow_hookname, [ $page, 'render' ] );
-					// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- Mirroring an admin-page registration that WP itself populates this global with on `add_submenu_page`. The standard WordPress.WP.GlobalVariablesOverride rule guards against accidental clobbers; we add (not replace) one entry whose hookname is unique to this plugin.
-					$_registered_pages[ $shadow_hookname ] = true;
-				}
-				// Strip the visible submenu the registration produced —
-				// the user-facing entry is the auto-generated CPT
-				// submenu we redirect from, not a separate React link.
-				remove_submenu_page( $parent_slug, $page->get_slug() );
-			}
-		}
 	}
 
 	/**

--- a/includes/admin/class-admin-shell.php
+++ b/includes/admin/class-admin-shell.php
@@ -28,12 +28,12 @@ class Admin_Shell {
 	 */
 	public static function init() {
 		Admin_Shell_Menu::init();
+		Admin_Shell_Legacy_Redirect::init();
 		add_action( 'admin_enqueue_scripts', [ __CLASS__, 'enqueue_assets' ] );
 		// Priority 99 so we run after newspack-plugin's wizard header
 		// has registered its script — `wp_add_inline_script` needs the
 		// handle in place to attach.
 		add_action( 'admin_enqueue_scripts', [ __CLASS__, 'patch_wizard_header_active_tab' ], 99 );
-		add_action( 'current_screen', [ __CLASS__, 'maybe_redirect_legacy_list' ] );
 		add_filter( 'admin_body_class', [ __CLASS__, 'add_body_class' ] );
 		add_filter( 'parent_file', [ __CLASS__, 'highlight_parent_menu' ] );
 		add_filter( 'submenu_file', [ __CLASS__, 'highlight_submenu' ] );
@@ -97,157 +97,6 @@ class Admin_Shell {
 			$classes .= ' newspack-newsletters-admin-screen--bundled';
 		}
 		return $classes;
-	}
-
-	/**
-	 * Query args we forward from the legacy URL onto the React page so the
-	 * JS side can seed initial view state. `paged` is deliberately
-	 * omitted — the legacy WP list table uses 20 items per page while the
-	 * DataView defaults to 25, so a `paged=N` carry-over would point at
-	 * the wrong slice anyway. Stick to filter / search / sort args that
-	 * map cleanly onto DataViews state.
-	 */
-	const FORWARDED_LEGACY_ARGS = [
-		'post_status',
-		's',
-		'orderby',
-		'order',
-		'author',
-		'categories',
-		'tags',
-		'newspack_newsletters_send_list_id',
-	];
-
-	/**
-	 * Are any of the bulk-action selectors set to a real value (i.e. not
-	 * the `-1` "no action selected" sentinel WP submits when the user
-	 * leaves the dropdown alone)? Both `action` (top-of-table dropdown)
-	 * and `action2` (bottom-of-table dropdown) are checked.
-	 *
-	 * @return bool
-	 */
-	private static function has_real_get_action() {
-		foreach ( [ 'action', 'action2' ] as $key ) {
-			// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Read-only nav check.
-			if ( ! isset( $_GET[ $key ] ) ) {
-				continue;
-			}
-			// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Read-only nav check.
-			$value = sanitize_text_field( wp_unslash( $_GET[ $key ] ) );
-			if ( '' !== $value && '-1' !== $value ) {
-				return true;
-			}
-		}
-		return false;
-	}
-
-	/**
-	 * Redirect legacy CPT list GET requests (deep links, browser
-	 * history, third-party menu links) to the matching React page.
-	 * Each chassis page declares its legacy screen id and redirect
-	 * target — this handler iterates pages and lets the matching one
-	 * supply the destination. Form-submission GETs that carry
-	 * `?action=` are left alone so classic admin flows continue to
-	 * work. Filter / search / sort args are forwarded so the React
-	 * page can pre-fill view state — see `getInitialView` on the JS
-	 * side.
-	 *
-	 * @param \WP_Screen $screen Current screen.
-	 */
-	public static function maybe_redirect_legacy_list( $screen ) {
-		if ( ! is_admin() || ! $screen instanceof \WP_Screen ) {
-			return;
-		}
-		if ( ! isset( $_SERVER['REQUEST_METHOD'] ) || 'GET' !== $_SERVER['REQUEST_METHOD'] ) {
-			return;
-		}
-
-		$matching_page = null;
-		foreach ( self::get_pages() as $page ) {
-			if ( $screen->id === $page->get_legacy_screen_id() ) {
-				$matching_page = $page;
-				break;
-			}
-		}
-		if ( ! $matching_page ) {
-			return;
-		}
-
-		// `action=-1` (and the bottom dropdown's `action2=-1`) is WP's
-		// "no bulk action selected" sentinel — typically left in the URL
-		// after the user submits the bulk-actions form without picking
-		// one. Treat it as a no-op so those stale URLs still redirect to
-		// the React page; only bypass for real action values.
-		if ( self::has_real_get_action() ) {
-			return;
-		}
-
-		$forwarded = [];
-		foreach ( self::FORWARDED_LEGACY_ARGS as $key ) {
-			// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Read-only nav check.
-			if ( ! isset( $_GET[ $key ] ) ) {
-				continue;
-			}
-			// phpcs:ignore WordPress.Security.NonceVerification.Recommended,WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Sanitised below.
-			$value = wp_unslash( $_GET[ $key ] );
-			if ( '' === $value ) {
-				continue;
-			}
-			$forwarded[ $key ] = is_array( $value ) ? array_map( 'sanitize_text_field', $value ) : sanitize_text_field( $value );
-		}
-
-		$target = $matching_page->get_legacy_redirect_target( $forwarded );
-		if ( ! $target ) {
-			return;
-		}
-
-		wp_safe_redirect( $target );
-		exit;
-	}
-
-	/**
-	 * Build a redirect target URL for a chassis-managed page.
-	 * Centralises the `?post_type=…&page=…&<forwarded>` shape so each
-	 * page only has to hand over its CPT slug + page slug.
-	 *
-	 * @param string       $post_type CPT slug the page shadows.
-	 * @param string       $page_slug The React page's `?page=` slug.
-	 * @param array|string $forwarded Forwarded query args, or a `post_status` string.
-	 * @return string
-	 */
-	public static function build_legacy_redirect_target( $post_type, $page_slug, $forwarded = [] ) {
-		$args = [
-			'post_type' => $post_type,
-			'page'      => $page_slug,
-		];
-
-		if ( is_string( $forwarded ) ) {
-			$forwarded = '' === $forwarded ? [] : [ 'post_status' => $forwarded ];
-		}
-
-		foreach ( self::FORWARDED_LEGACY_ARGS as $key ) {
-			if ( ! empty( $forwarded[ $key ] ) ) {
-				$args[ $key ] = $forwarded[ $key ];
-			}
-		}
-
-		return add_query_arg( $args, admin_url( 'edit.php' ) );
-	}
-
-	/**
-	 * Newsletters-list redirect target — kept for back-compat with
-	 * existing tests. Equivalent to calling
-	 * `Newsletters_List_Page::get_legacy_redirect_target()`.
-	 *
-	 * @param array|string $forwarded Forwarded query args, or a `post_status` string.
-	 * @return string
-	 */
-	public static function get_legacy_redirect_target( $forwarded = [] ) {
-		return self::build_legacy_redirect_target(
-			Newspack_Newsletters::NEWSPACK_NEWSLETTERS_CPT,
-			'newspack-newsletters-list',
-			$forwarded
-		);
 	}
 
 	/**

--- a/includes/admin/pages/class-ads-list-page.php
+++ b/includes/admin/pages/class-ads-list-page.php
@@ -9,7 +9,7 @@
  * grouped underneath it. The React page is kept out of the visible menu
  * via the inherited `is_hidden_from_menu()`; the visible click target
  * remains the auto-generated `edit.php?post_type=newspack_nl_ads_cpt`
- * entry that `Ads::add_ads_page` creates. `Admin_Shell::maybe_redirect_legacy_list`
+ * entry that `Ads::add_ads_page` creates. `Admin_Shell_Legacy_Redirect::maybe_redirect_legacy_list`
  * 302s the legacy URL to the React page.
  *
  * @package Newspack_Newsletters

--- a/includes/admin/pages/class-hidden-react-list-page.php
+++ b/includes/admin/pages/class-hidden-react-list-page.php
@@ -4,7 +4,7 @@
  *
  * Adds the "registered but invisible" submenu plumbing on top of
  * `React_List_Page`: the page is routable via its slug but stripped
- * from the sidebar by `Admin_Shell::register_menu`. Subclasses keep
+ * from the sidebar by `Admin_Shell_Menu::register_menu`. Subclasses keep
  * `get_parent_slug()` (mode-aware) and `get_submenu_file()` (target
  * of the highlight); this base defaults `get_parent_file()` to the
  * same URL as `get_parent_slug()`, which is the right answer for

--- a/includes/admin/pages/class-layouts-list-page.php
+++ b/includes/admin/pages/class-layouts-list-page.php
@@ -91,4 +91,58 @@ class Layouts_List_Page extends React_List_Page {
 	public function get_wizard_header_label() {
 		return __( 'Newsletters / Layouts', 'newspack-newsletters' );
 	}
+
+	/**
+	 * BlockPreview iframes need `wp-edit-blocks` loaded before
+	 * `admin-shell.css`.
+	 *
+	 * @return string[]
+	 */
+	public function get_admin_shell_style_deps() {
+		return [ 'wp-edit-blocks' ];
+	}
+
+	/**
+	 * Layouts-specific bundle: `editorBlocks` assets for BlockPreview,
+	 * the email-editor data `NewsletterPreview` reads at mount, and the
+	 * compiled global stylesheet injected into the preview iframe.
+	 *
+	 * @param string $handle Admin-shell script handle.
+	 */
+	public function enqueue_extras( $handle ) {
+		// Fallback for dev mode: `Asset_Loader` skips the CSS enqueue (and its dep chain) when `dist/admin-shell.css` is missing.
+		wp_enqueue_style( 'wp-edit-blocks' );
+
+		wp_localize_script(
+			$handle,
+			'newspack_email_editor_data',
+			\Newspack_Newsletters_Editor::get_email_editor_data()
+		);
+
+		$blocks_js = NEWSPACK_NEWSLETTERS_PLUGIN_FILE . 'dist/editorBlocks.js';
+		if ( file_exists( $blocks_js ) ) {
+			wp_enqueue_script(
+				'newspack-newsletters-editor-blocks',
+				plugins_url( '../../../dist/editorBlocks.js', __FILE__ ),
+				[],
+				filemtime( $blocks_js ),
+				true
+			);
+		}
+		$blocks_css = NEWSPACK_NEWSLETTERS_PLUGIN_FILE . 'dist/editorBlocks.css';
+		if ( file_exists( $blocks_css ) ) {
+			wp_enqueue_style(
+				'newspack-newsletters-editor-blocks',
+				plugins_url( '../../../dist/editorBlocks.css', __FILE__ ),
+				[],
+				filemtime( $blocks_css )
+			);
+		}
+
+		wp_add_inline_script(
+			$handle,
+			'window.newspackNewslettersGlobalStyles = ' . wp_json_encode( wp_get_global_stylesheet() ) . ';',
+			'before'
+		);
+	}
 }

--- a/includes/admin/pages/class-newsletters-list-page.php
+++ b/includes/admin/pages/class-newsletters-list-page.php
@@ -39,7 +39,7 @@ class Newsletters_List_Page extends Hidden_React_List_Page {
 	}
 
 	/**
-	 * Register under the newsletters CPT parent. `Admin_Shell::register_menu`
+	 * Register under the newsletters CPT parent. `Admin_Shell_Menu::register_menu`
 	 * removes the visible submenu after registration because
 	 * `is_hidden_from_menu()` returns true (inherited from
 	 * `Hidden_React_List_Page`).

--- a/includes/admin/pages/class-react-list-page.php
+++ b/includes/admin/pages/class-react-list-page.php
@@ -6,7 +6,8 @@
  * `edit.php?post_type=…` or `edit-tags.php?taxonomy=…` screen. The
  * subclass provides the post_type used in the React page URL via
  * `get_redirect_post_type()`; this base wires the corresponding
- * legacy-list redirect through `Admin_Shell::build_legacy_redirect_target`.
+ * legacy-list redirect through
+ * `Admin_Shell_Legacy_Redirect::build_legacy_redirect_target`.
  *
  * @package Newspack_Newsletters
  */
@@ -14,7 +15,7 @@
 namespace Newspack\Newsletters\Admin\Pages;
 
 use Newspack\Newsletters\Admin\Admin_Page;
-use Newspack\Newsletters\Admin\Admin_Shell;
+use Newspack\Newsletters\Admin\Admin_Shell_Legacy_Redirect;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -33,14 +34,14 @@ abstract class React_List_Page extends Admin_Page {
 
 	/**
 	 * Default redirect: hand the page's CPT slug + own slug to the
-	 * shared `Admin_Shell` helper. Subclasses can still override for
-	 * non-standard targets.
+	 * shared helper. Subclasses can still override for non-standard
+	 * targets.
 	 *
 	 * @param array $forwarded Forwarded query args.
 	 * @return string
 	 */
 	public function get_legacy_redirect_target( $forwarded = [] ) {
-		return Admin_Shell::build_legacy_redirect_target(
+		return Admin_Shell_Legacy_Redirect::build_legacy_redirect_target(
 			$this->get_redirect_post_type(),
 			$this->slug,
 			$forwarded

--- a/newspack-newsletters.php
+++ b/newspack-newsletters.php
@@ -93,6 +93,7 @@ require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/admin/class-settings-
 require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/admin/class-asset-loader.php';
 require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/admin/class-admin-shell-menu.php';
 require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/admin/class-admin-shell-legacy-redirect.php';
+require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/admin/class-admin-shell-assets.php';
 require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/admin/class-admin-shell.php';
 require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/class-wizard-bridge.php';
 

--- a/newspack-newsletters.php
+++ b/newspack-newsletters.php
@@ -92,6 +92,7 @@ require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/admin/class-advertise
 require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/admin/class-settings-rest.php';
 require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/admin/class-asset-loader.php';
 require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/admin/class-admin-shell-menu.php';
+require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/admin/class-admin-shell-legacy-redirect.php';
 require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/admin/class-admin-shell.php';
 require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/class-wizard-bridge.php';
 

--- a/newspack-newsletters.php
+++ b/newspack-newsletters.php
@@ -91,6 +91,7 @@ require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/admin/class-ads-list-
 require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/admin/class-advertisers-list-rest.php';
 require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/admin/class-settings-rest.php';
 require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/admin/class-asset-loader.php';
+require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/admin/class-admin-shell-menu.php';
 require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/admin/class-admin-shell.php';
 require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/class-wizard-bridge.php';
 

--- a/src/admin-shell/admin-globals.js
+++ b/src/admin-shell/admin-globals.js
@@ -8,7 +8,7 @@
  *
  * The values are PHP-side mirrors; if they ever drift from the real
  * registration, the fallbacks here are a safety net rather than a
- * source of truth — see `Admin_Shell::enqueue_assets`.
+ * source of truth — see `Admin_Shell_Assets::enqueue`.
  */
 
 const DEFAULT_ADMIN_URL = '/wp-admin/';

--- a/src/admin-shell/index.js
+++ b/src/admin-shell/index.js
@@ -33,6 +33,6 @@ domReady( () => {
 
 	// Prefer the PHP-localised label so the rendered heading/title stays
 	// aligned with the admin menu label registered in PHP (see
-	// `Admin_Shell::enqueue_assets`). Registry label is the fallback.
+	// `Admin_Shell_Assets::enqueue`). Registry label is the fallback.
 	createRoot( target ).render( <App label={ resolveLabel( currentPage ) } Screen={ entry.component } /> );
 } );

--- a/tests/test-admin-shell.php
+++ b/tests/test-admin-shell.php
@@ -6,6 +6,7 @@
  */
 
 use Newspack\Newsletters\Admin\Admin_Shell;
+use Newspack\Newsletters\Admin\Admin_Shell_Assets;
 use Newspack\Newsletters\Admin\Admin_Shell_Legacy_Redirect;
 use Newspack\Newsletters\Admin\Admin_Shell_Menu;
 use Newspack\Newsletters\Admin\Pages\Newsletters_List_Page;
@@ -415,7 +416,7 @@ class Admin_Shell_Test extends WP_UnitTestCase {
 		$_GET['page'] = 'newspack-newsletters-ads-list';
 		set_current_screen( 'admin_page_newspack-newsletters-ads-list' );
 
-		Admin_Shell::patch_wizard_header_active_tab();
+		Admin_Shell_Assets::patch_wizard_header_active_tab();
 
 		$inline = wp_scripts()->get_data( 'newspack-wizards-admin-header', 'after' );
 		$this->assertIsArray( $inline );
@@ -444,7 +445,7 @@ class Admin_Shell_Test extends WP_UnitTestCase {
 		add_filter( 'newspack_newsletters_admin_bundled_mode', '__return_true' );
 		$_GET['page'] = 'newspack-newsletters-list';
 
-		Admin_Shell::patch_wizard_header_active_tab();
+		Admin_Shell_Assets::patch_wizard_header_active_tab();
 
 		$inline = wp_scripts()->get_data( 'newspack-wizards-admin-header', 'after' );
 		$this->assertEmpty( $inline, 'No inline script should be attached when the current page has no wizard-tab override.' );

--- a/tests/test-admin-shell.php
+++ b/tests/test-admin-shell.php
@@ -6,6 +6,7 @@
  */
 
 use Newspack\Newsletters\Admin\Admin_Shell;
+use Newspack\Newsletters\Admin\Admin_Shell_Menu;
 
 /**
  * Admin Shell Test.
@@ -344,7 +345,7 @@ class Admin_Shell_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * `Admin_Shell::register_menu` registers each hidden page's
+	 * `Admin_Shell_Menu::register_menu` registers each hidden page's
 	 * callback under both the parent-derived hookname (what
 	 * `add_submenu_page` returns) and the URL-derived `admin_page_*`
 	 * hookname `admin.php` line ~182 looks up at request time. Without
@@ -356,7 +357,7 @@ class Admin_Shell_Test extends WP_UnitTestCase {
 		add_filter( 'newspack_newsletters_admin_bundled_mode', '__return_true' );
 
 		// Run the same hook the admin chrome would fire.
-		Admin_Shell::register_menu();
+		Admin_Shell_Menu::register_menu();
 
 		global $_registered_pages;
 

--- a/tests/test-admin-shell.php
+++ b/tests/test-admin-shell.php
@@ -6,7 +6,9 @@
  */
 
 use Newspack\Newsletters\Admin\Admin_Shell;
+use Newspack\Newsletters\Admin\Admin_Shell_Legacy_Redirect;
 use Newspack\Newsletters\Admin\Admin_Shell_Menu;
+use Newspack\Newsletters\Admin\Pages\Newsletters_List_Page;
 
 /**
  * Admin Shell Test.
@@ -114,7 +116,7 @@ class Admin_Shell_Test extends WP_UnitTestCase {
 	 * isolated from `wp_safe_redirect`'s exit behaviour.
 	 */
 	public function test_legacy_list_url_redirects_to_react_page() {
-		$target = Admin_Shell::get_legacy_redirect_target();
+		$target = ( new Newsletters_List_Page() )->get_legacy_redirect_target();
 		$this->assertStringContainsString( 'edit.php?', $target );
 		$this->assertStringContainsString( 'post_type=' . Newspack_Newsletters::NEWSPACK_NEWSLETTERS_CPT, $target );
 		$this->assertStringContainsString( 'page=newspack-newsletters-list', $target );
@@ -128,7 +130,7 @@ class Admin_Shell_Test extends WP_UnitTestCase {
 	 * back-compat with the original signature.
 	 */
 	public function test_legacy_redirect_forwards_post_status() {
-		$target = Admin_Shell::get_legacy_redirect_target( 'trash' );
+		$target = ( new Newsletters_List_Page() )->get_legacy_redirect_target( 'trash' );
 		$this->assertStringContainsString( 'post_status=trash', $target );
 		$this->assertStringContainsString( 'page=newspack-newsletters-list', $target );
 	}
@@ -139,7 +141,7 @@ class Admin_Shell_Test extends WP_UnitTestCase {
 	 * with equivalent view state — Copilot review #2095.
 	 */
 	public function test_legacy_redirect_forwards_search_and_sort() {
-		$target = Admin_Shell::get_legacy_redirect_target(
+		$target = ( new Newsletters_List_Page() )->get_legacy_redirect_target(
 			[
 				's'       => 'weeklydigest',
 				'orderby' => 'title',
@@ -157,7 +159,7 @@ class Admin_Shell_Test extends WP_UnitTestCase {
 	 * doesn't translate cleanly. The redirect drops it on the floor.
 	 */
 	public function test_legacy_redirect_drops_paged() {
-		$target = Admin_Shell::get_legacy_redirect_target( [ 'paged' => '3' ] );
+		$target = ( new Newsletters_List_Page() )->get_legacy_redirect_target( [ 'paged' => '3' ] );
 		$this->assertStringNotContainsString( 'paged=3', $target );
 	}
 
@@ -166,7 +168,7 @@ class Admin_Shell_Test extends WP_UnitTestCase {
 	 * legacy → React redirect so bookmarked filtered URLs round-trip.
 	 */
 	public function test_legacy_redirect_forwards_new_filter_params() {
-		$target  = Admin_Shell::get_legacy_redirect_target(
+		$target  = ( new Newsletters_List_Page() )->get_legacy_redirect_target(
 			[
 				'author'                            => '42,7',
 				'categories'                        => '12',
@@ -195,7 +197,7 @@ class Admin_Shell_Test extends WP_UnitTestCase {
 
 		$screen = WP_Screen::get( 'edit-' . Newspack_Newsletters::NEWSPACK_NEWSLETTERS_CPT );
 
-		$reflection = new ReflectionMethod( Admin_Shell::class, 'has_real_get_action' );
+		$reflection = new ReflectionMethod( Admin_Shell_Legacy_Redirect::class, 'has_real_get_action' );
 		$reflection->setAccessible( true );
 
 		// `has_real_get_action` is the gate the live redirect uses; if it

--- a/tests/test-ads-list-page.php
+++ b/tests/test-ads-list-page.php
@@ -80,7 +80,7 @@ class Ads_List_Page_Test extends WP_UnitTestCase {
 
 	/**
 	 * Legacy screen id matches the classic ads CPT list so
-	 * `Admin_Shell::maybe_redirect_legacy_list` can route the GET
+	 * `Admin_Shell_Legacy_Redirect::maybe_redirect_legacy_list` can route the GET
 	 * request to the React page.
 	 */
 	public function test_legacy_screen_id_matches_ads_cpt() {

--- a/tests/test-ads-list-page.php
+++ b/tests/test-ads-list-page.php
@@ -95,7 +95,7 @@ class Ads_List_Page_Test extends WP_UnitTestCase {
 	 * hidden React subpage (live URL has an extra `&page=…` query)
 	 * and the tab renders without `.selected`. The default base
 	 * implementation returns `null`; the override here is what makes
-	 * `Admin_Shell::patch_wizard_header_active_tab` flip the tab.
+	 * `Admin_Shell_Assets::patch_wizard_header_active_tab` flip the tab.
 	 */
 	public function test_wizard_tab_url_targets_ads_cpt() {
 		$page = new Ads_List_Page();

--- a/tests/test-advertisers-list-page.php
+++ b/tests/test-advertisers-list-page.php
@@ -84,7 +84,7 @@ class Advertisers_List_Page_Test extends WP_UnitTestCase {
 
 	/**
 	 * Legacy screen id matches the classic taxonomy term-management
-	 * screen so `Admin_Shell::maybe_redirect_legacy_list` can route the
+	 * screen so `Admin_Shell_Legacy_Redirect::maybe_redirect_legacy_list` can route the
 	 * GET request to the React page. `WP_Screen::id` for
 	 * `edit-tags.php?taxonomy=X` is `edit-X`.
 	 */

--- a/tests/test-newsletters-list-page.php
+++ b/tests/test-newsletters-list-page.php
@@ -52,7 +52,7 @@ class Newsletters_List_Page_Test extends WP_UnitTestCase {
 	 * hookname matches what `admin.php` computes at request time, then
 	 * is marked hidden so the visible submenu entry is stripped — its
 	 * actual click target is the auto-generated CPT submenu, redirected
-	 * by `Admin_Shell::maybe_redirect_legacy_list`.
+	 * by `Admin_Shell_Legacy_Redirect::maybe_redirect_legacy_list`.
 	 */
 	public function test_registers_hidden_under_the_newsletters_cpt() {
 		$page = new Newsletters_List_Page();


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Closes NEWS-2296.

Pure refactor of the `~621 LOC` `Admin_Shell` class into three focused collaborators, leaving residual `Admin_Shell` as orchestration-only:

- `Admin_Shell_Menu` — admin menu + submenu registration, the `$hook_suffixes` registry, and the `reorder_submenus` late-priority pass.
- `Admin_Shell_Legacy_Redirect` — the `current_screen` redirect that 302s classic `edit.php?post_type=…` URLs to their React replacements, plus the `build_legacy_redirect_target` helper.
- `Admin_Shell_Assets` — the admin-shell bundle enqueue + the wizard-header tab-selection inline-script patch.
- `Admin_Shell` (residual) — `init` (delegates to the three above), `get_pages`, `is_bundled_mode`, `get_current_page`, `add_body_class`, `highlight_parent_menu`, `highlight_submenu`.

The most concrete win — removing the layouts-list-specific branch from the shared enqueue — comes via a template method on `Admin_Page`:

- `get_admin_shell_style_deps()` — page-declared CSS deps merged into the admin-shell bundle.
- `enqueue_extras( $handle )` — page-specific sibling enqueues / `wp_localize_script` payloads.

`Layouts_List_Page` overrides both so `wp-edit-blocks`, the `editorBlocks` assets, the email-editor data, and the compiled global stylesheet are all owned by the page instead of leaking into the shell. Adding a new list page with extra assets no longer touches `Admin_Shell_Assets`.

No behaviour change intended — tests retargeted at new class homes only.

No context change.

### How to test the changes in this Pull Request:

Automated:

1. `n test-php` — 388/388 should pass.
2. `n test-js` — 195/195 should pass.
3. `n npm run lint:php` and `n npm run lint:js` — both clean.
4. `n build` — succeeds.

Manual (each surface should look and behave identically to `epic/admin-ux-modernisation` head):

1. In **standalone mode** (deactivate newspack-plugin), visit each admin page — Newsletters list, Newsletter Ads list, Advertisers list, Layouts list, Settings. Confirm each loads, sidebar highlight is correct, DataView filter / search / sort work, and the Layouts page's BlockPreview iframes render the `posts-inserter` block (this exercises the page-owned `enqueue_extras` path).
2. In **bundled mode** (activate newspack-plugin), repeat (1) excluding Settings (which now lives under Engagement > Newsletters in newspack-plugin). Confirm the wizard-header tab patching keeps the Ads tab `.selected` on the Ads list page.
3. **Legacy redirects.** Visit `edit.php?post_type=newspack_nl_cpt`, `edit.php?post_type=newspack_nl_ads_cpt`, and the advertisers term-management screen — each should 302 to its React replacement. Add `?post_status=trash`, `?s=foo&orderby=title`, `?author=…` — the forwarded args should arrive on the React URL.
4. **Bulk-action sentinel.** `edit.php?post_type=newspack_nl_cpt&action=-1` should still redirect (sentinel is treated as no-op); `…&action=trash` should *not* redirect (real action bypasses).

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable? — No new tests (pure refactor); existing tests retargeted at new class homes.
* [x] Have you successfully ran tests with your changes locally?