### PR TITLE
refactor: trim verbose code comments across milestone files

### DIFF
--- a/includes/admin/class-admin-page.php
+++ b/includes/admin/class-admin-page.php
@@ -23,19 +23,12 @@ abstract class Admin_Page {
 	/**
 	 * Capability required to view the page.
 	 *
-	 * Defaults to `edit_posts` so users who could previously edit newsletters via
-	 * the (now hidden) CPT menu retain access. Pages requiring elevated access —
-	 * Settings being the canonical example — override this.
-	 *
 	 * @var string
 	 */
 	protected $capability = 'edit_posts';
 
 	/**
-	 * Hookname returned by `add_submenu_page`. Captured by
-	 * `Admin_Shell_Menu` at registration time so `is_admin_page()` can
-	 * narrow its match to the actual admin screen rather than just
-	 * `$_GET['page']`.
+	 * Hookname returned by `add_submenu_page`, captured at registration.
 	 *
 	 * @var string
 	 */
@@ -69,25 +62,16 @@ abstract class Admin_Page {
 	/**
 	 * Parent menu slug for `add_submenu_page`.
 	 *
-	 * Override in subclasses to return the URL of the parent menu the
-	 * page is registered under. WP's `get_plugin_page_hookname` mixes
-	 * `$admin_page_hooks[ $parent_slug ]` into the hookname, so the
-	 * value here has to match what the lookup at request time sees —
-	 * passing `null` is unsafe because registration- and lookup-time
-	 * resolution can drift. Hidden pages (`is_hidden_from_menu()`)
-	 * register under the same parent then get unhooked from the
-	 * sidebar after registration via `remove_submenu_page`, keeping
-	 * the URL routable while staying invisible.
+	 * Subclasses return a concrete value — passing `null` is unsafe
+	 * because WP's hookname computation mixes the parent in and
+	 * registration- and lookup-time resolution can drift.
 	 *
 	 * @return string|null
 	 */
 	abstract public function get_parent_slug();
 
 	/**
-	 * Whether the page should be removed from the visible submenu list
-	 * after registration. Default: visible. Hidden pages still register
-	 * (URL routable) but `remove_submenu_page` strips the menu entry
-	 * so it doesn't appear in the sidebar.
+	 * Whether the page should be unhooked from the visible submenu list.
 	 *
 	 * @return bool
 	 */
@@ -96,16 +80,7 @@ abstract class Admin_Page {
 	}
 
 	/**
-	 * `parent_file` override for menu-highlighting.
-	 *
-	 * `Admin_Shell::highlight_parent_menu` filters the global
-	 * `parent_file` and delegates to this method when the current
-	 * request resolves to this page. Return the URL of the top-level
-	 * menu that should appear active (e.g.
-	 * `'edit.php?post_type=newspack_nl_cpt'`), or `null` to let WP's
-	 * native resolution stand. Pages hidden from the menu via
-	 * `is_hidden_from_menu()` will typically need a non-null override
-	 * so the sidebar doesn't collapse to an inactive state.
+	 * `parent_file` override for menu-highlighting; `null` defers to WP.
 	 *
 	 * @return string|null
 	 */
@@ -114,15 +89,7 @@ abstract class Admin_Page {
 	}
 
 	/**
-	 * `submenu_file` override for menu-highlighting.
-	 *
-	 * Companion to `get_parent_file()`. Returns the URL of the
-	 * specific submenu entry that should appear active when this page
-	 * is rendered, or `null` to defer to WP's default resolution.
-	 * Visible submenus (where `get_parent_slug()` returns a real
-	 * value) usually return `null` because WP's auto-detection is
-	 * correct; hidden React pages return the URL of the click-target
-	 * submenu they shadow.
+	 * `submenu_file` override for menu-highlighting; `null` defers to WP.
 	 *
 	 * @return string|null
 	 */
@@ -131,11 +98,7 @@ abstract class Admin_Page {
 	}
 
 	/**
-	 * `WP_Screen::id` of the classic CPT list this page shadows, or
-	 * `null` when the page doesn't replace a legacy URL. Hidden React
-	 * pages typically declare an id like `'edit-newspack_nl_cpt'` so
-	 * `Admin_Shell_Legacy_Redirect::maybe_redirect_legacy_list` can
-	 * 302 the legacy URL across to the React surface.
+	 * `WP_Screen::id` of the classic CPT list this page shadows.
 	 *
 	 * @return string|null
 	 */
@@ -144,10 +107,7 @@ abstract class Admin_Page {
 	}
 
 	/**
-	 * Build the URL the legacy CPT list redirects to for this page.
-	 * Returns `null` when the page doesn't shadow a legacy URL — the
-	 * redirect handler skips it. Forwarded args (filter / search /
-	 * sort) are appended so the React side can seed its initial view.
+	 * Build the URL the legacy CPT list redirects to.
 	 *
 	 * @param array $forwarded Forwarded query args.
 	 * @return string|null
@@ -158,17 +118,11 @@ abstract class Admin_Page {
 
 	/**
 	 * URL of the newspack-plugin admin-header tab whose `selected`
-	 * state should reflect this page, or `null` when no patching is
-	 * required. The wizard header (`WizardsAdminHeader`) decides which
-	 * tab is active via strict `window.location.href === tab.href`
-	 * equality, which breaks for hidden React subpages — the live URL
-	 * has an extra `&page=…` query the tab href doesn't carry. Pages
-	 * that are conceptually a subpage of an existing wizard tab
-	 * override this; the chassis flips the matching `<a>` to selected
-	 * via inline script after the React header mounts. Returning
-	 * `null` is the right default — most pages either have no wizard
-	 * tabs (the wizard's `get_tabs()` only renders them on the ads /
-	 * advertisers screens) or are themselves the canonical tab URL.
+	 * state should reflect this page.
+	 *
+	 * Override on hidden subpages whose live URL carries an extra
+	 * `&page=…` the tab href doesn't — the wizard header's strict
+	 * URL equality check would otherwise miss them.
 	 *
 	 * @return string|null
 	 */
@@ -177,16 +131,11 @@ abstract class Admin_Page {
 	}
 
 	/**
-	 * Desired 0-based array index within the parent submenu list.
+	 * Desired 0-based index within the parent submenu list.
 	 *
-	 * Returning a non-null value triggers a late-priority pass over
-	 * the global `$submenu` that physically reorders this page's
-	 * entry. We can't lean on `add_submenu_page`'s `$position`
-	 * argument because it keys on numeric positions that collide
-	 * unpredictably with auto-registered CPT entries (`edit.php`
-	 * adds "All Newsletters" and "Add New …" at runtime-derived
-	 * keys, so passing position 3 doesn't reliably slot between
-	 * them).
+	 * `add_submenu_page`'s `$position` is unreliable here — numeric
+	 * positions collide with auto-registered CPT entries — so a
+	 * late-priority pass over `$submenu` does the reordering.
 	 *
 	 * @return int|null
 	 */
@@ -197,14 +146,10 @@ abstract class Admin_Page {
 	/**
 	 * Override the wizard header breadcrumb text for this page.
 	 *
-	 * Newspack-plugin's `Newsletters_Wizard` resolves the breadcrumb
-	 * from its `admin_screens` map keyed on CPT / page / taxonomy
-	 * slugs. For `edit.php?post_type=…&page=…` URLs the resolution
-	 * prefers the post_type, so a hidden React subpage (or a visible
-	 * submenu the wizard doesn't recognise) ends up showing the
-	 * parent CPT's label. Pages can override here to inject the
-	 * correct text via inline script after the wizard header mounts.
-	 * Returning `null` defers to the wizard's own resolution.
+	 * Newspack-plugin's wizard prefers `post_type` over `page` slug
+	 * when resolving the breadcrumb, so a hidden React subpage ends
+	 * up showing the parent CPT's label. Override to inject the
+	 * correct text via inline script after the header mounts.
 	 *
 	 * @return string|null
 	 */
@@ -244,10 +189,6 @@ abstract class Admin_Page {
 	/**
 	 * Whether the current request is for this admin page.
 	 *
-	 * Narrower than a bare `$_GET['page']` match: a foreign admin URL
-	 * that happens to carry the same query key won't activate our
-	 * page-scoped enqueue / body class / filter hooks.
-	 *
 	 * @return bool
 	 */
 	public function is_admin_page() {
@@ -262,8 +203,7 @@ abstract class Admin_Page {
 			return false;
 		}
 		$hook_suffix = $this->hook_suffix ? $this->hook_suffix : Admin_Shell_Menu::get_hook_suffix_for_slug( $this->slug );
-		// `admin_page_<slug>` is the shadow hookname used when the parent
-		// CPT isn't a top-level menu — see Admin_Shell_Menu::register_menu.
+		// `admin_page_<slug>` is the shadow hookname used when the parent CPT isn't a top-level menu — see Admin_Shell_Menu::register_menu.
 		$expected = array_filter( [ $hook_suffix, 'admin_page_' . $this->slug ] );
 		return in_array( $screen->id, $expected, true );
 	}

--- a/includes/admin/class-admin-shell-assets.php
+++ b/includes/admin/class-admin-shell-assets.php
@@ -2,10 +2,6 @@
 /**
  * Admin shell — asset enqueue.
  *
- * Owns the admin-shell bundle enqueue and the inline-script patch that
- * fixes the newspack-plugin wizard header's tab-selection state on
- * hidden React subpages.
- *
  * @package Newspack_Newsletters
  */
 
@@ -16,7 +12,7 @@ use Newspack_Newsletters;
 defined( 'ABSPATH' ) || exit;
 
 /**
- * Asset enqueue.
+ * Asset enqueue + wizard-header inline-script patch.
  */
 class Admin_Shell_Assets {
 	const SCRIPT_HANDLE = 'newspack-newsletters-admin-shell';
@@ -26,17 +22,15 @@ class Admin_Shell_Assets {
 	 */
 	public static function init() {
 		add_action( 'admin_enqueue_scripts', [ __CLASS__, 'enqueue' ] );
-		// Priority 99 so we run after newspack-plugin's wizard header
-		// has registered its script — `wp_add_inline_script` needs the
-		// handle in place to attach.
+		// Priority 99 so we run after newspack-plugin's wizard header has registered its script — `wp_add_inline_script` needs the handle in place.
 		add_action( 'admin_enqueue_scripts', [ __CLASS__, 'patch_wizard_header_active_tab' ], 99 );
 	}
 
 	/**
 	 * Enqueue the shared admin-shell bundle on registered admin pages.
-	 * Pages contribute style deps via `get_admin_shell_style_deps()` and
-	 * sibling enqueues via `enqueue_extras()` so this method stays
-	 * branch-free.
+	 *
+	 * Pages contribute style deps via `get_admin_shell_style_deps()`
+	 * and sibling enqueues via `enqueue_extras()`.
 	 */
 	public static function enqueue() {
 		$current_page = Admin_Shell::get_current_page();
@@ -69,7 +63,6 @@ class Admin_Shell_Assets {
 				'classicSettings' => \Newspack_Newsletters_Settings::get_settings_url(),
 				'restNonce'       => wp_create_nonce( 'wp_rest' ),
 				'restUrl'         => esc_url_raw( rest_url() ),
-				// `admin_url()` rather than assuming `/wp-admin/` lives at the document origin — subdirectory and multisite installs put it under a path.
 				'adminUrl'        => esc_url_raw( admin_url() ),
 				'cptSlug'         => Newspack_Newsletters::NEWSPACK_NEWSLETTERS_CPT,
 			]
@@ -77,21 +70,13 @@ class Admin_Shell_Assets {
 	}
 
 	/**
-	 * Patch the newspack-plugin wizard header's "selected" tab state
-	 * for hidden React subpages. The wizard's `WizardsAdminHeader`
-	 * (`src/wizards/admin-header/index.tsx`) decides the active tab
-	 * via strict `window.location.href === tab.href` equality, which
-	 * breaks for our hidden React subpages — the live URL has an
-	 * extra `&page=…` query the tab href doesn't carry. Each page
-	 * declares the canonical tab URL via `get_wizard_tab_url()`; we
-	 * inject a tiny inline script after the wizard header script to
-	 * flip the matching `<a>` to `.selected` once the React component
-	 * has mounted. Runs only when the wizard header script is
-	 * registered (i.e. bundled mode + the wizard recognises the
-	 * screen — for ads, that's via `Newsletters_Wizard::get_tabs()`).
+	 * Patch the wizard header's "selected" tab state for hidden React subpages.
 	 *
-	 * Upstream fix tracked separately; the wizard's URL-equality
-	 * check should accept subpages so this workaround can be removed.
+	 * The wizard's strict `window.location.href === tab.href` check
+	 * breaks for subpages (live URL carries an extra `&page=…`). Each
+	 * page declares its canonical tab URL + breadcrumb label; this
+	 * injects an observer that flips the matching `<a>` to `.selected`
+	 * and rewrites the heading once the wizard mounts.
 	 */
 	public static function patch_wizard_header_active_tab() {
 		$current_page = Admin_Shell::get_current_page();
@@ -102,27 +87,16 @@ class Admin_Shell_Assets {
 			return;
 		}
 
-		$tab_url           = $current_page->get_wizard_tab_url();
-		$breadcrumb_label  = $current_page->get_wizard_header_label();
+		$tab_url          = $current_page->get_wizard_tab_url();
+		$breadcrumb_label = $current_page->get_wizard_header_label();
 
 		if ( null === $tab_url && null === $breadcrumb_label ) {
 			return;
 		}
 
-		// Single inline-script payload covers both patches. Each runs
-		// independently — the wizard renders its DOM after this script is
-		// parsed, so we observe document.body and re-apply on every
-		// mutation until the targets exist (and once after, to defend
-		// against React rerenders that swap the nodes).
 		$tab_url_json    = null === $tab_url ? 'null' : wp_json_encode( $tab_url );
 		$breadcrumb_json = null === $breadcrumb_label ? 'null' : wp_json_encode( $breadcrumb_label );
 
-		// The wizard renders its DOM after this script is parsed and may
-		// re-render its header on route changes, so the observer waits
-		// for the targets, patches once both are present, and then
-		// disconnects. A deferred follow-up apply() run catches an
-		// immediate post-mount rerender without leaving the observer
-		// attached for the lifetime of the page.
 		wp_add_inline_script(
 			'newspack-wizards-admin-header',
 			sprintf(

--- a/includes/admin/class-admin-shell-legacy-redirect.php
+++ b/includes/admin/class-admin-shell-legacy-redirect.php
@@ -2,10 +2,6 @@
 /**
  * Admin shell — legacy CPT list redirect.
  *
- * Owns the `current_screen` hook that 302s the classic
- * `edit.php?post_type=…` URLs through to their React replacements,
- * and the helper that builds the redirect target.
- *
  * @package Newspack_Newsletters
  */
 
@@ -18,12 +14,10 @@ defined( 'ABSPATH' ) || exit;
  */
 class Admin_Shell_Legacy_Redirect {
 	/**
-	 * Query args we forward from the legacy URL onto the React page so the
-	 * JS side can seed initial view state. `paged` is deliberately
-	 * omitted — the legacy WP list table uses 20 items per page while the
-	 * DataView defaults to 25, so a `paged=N` carry-over would point at
-	 * the wrong slice anyway. Stick to filter / search / sort args that
-	 * map cleanly onto DataViews state.
+	 * Query args forwarded from the legacy URL onto the React page.
+	 *
+	 * `paged` is deliberately omitted — legacy WP_List_Table uses 20
+	 * per page vs DataView's 25, so the slice wouldn't translate.
 	 */
 	const FORWARDED_LEGACY_ARGS = [
 		'post_status',
@@ -44,10 +38,8 @@ class Admin_Shell_Legacy_Redirect {
 	}
 
 	/**
-	 * Are any of the bulk-action selectors set to a real value (i.e. not
-	 * the `-1` "no action selected" sentinel WP submits when the user
-	 * leaves the dropdown alone)? Both `action` (top-of-table dropdown)
-	 * and `action2` (bottom-of-table dropdown) are checked.
+	 * Whether `action` / `action2` carry a real value (i.e. not WP's
+	 * `-1` "no action selected" sentinel).
 	 *
 	 * @return bool
 	 */
@@ -67,15 +59,11 @@ class Admin_Shell_Legacy_Redirect {
 	}
 
 	/**
-	 * Redirect legacy CPT list GET requests (deep links, browser
-	 * history, third-party menu links) to the matching React page.
-	 * Each chassis page declares its legacy screen id and redirect
-	 * target — this handler iterates pages and lets the matching one
-	 * supply the destination. Form-submission GETs that carry
-	 * `?action=` are left alone so classic admin flows continue to
-	 * work. Filter / search / sort args are forwarded so the React
-	 * page can pre-fill view state — see `getInitialView` on the JS
-	 * side.
+	 * Redirect legacy CPT list GETs to the matching React page.
+	 *
+	 * Form-submission GETs carrying `?action=…` are left alone so
+	 * classic admin flows continue to work; the `-1` sentinel from
+	 * a stale bulk-action submit is treated as a no-op.
 	 *
 	 * @param \WP_Screen $screen Current screen.
 	 */
@@ -98,11 +86,6 @@ class Admin_Shell_Legacy_Redirect {
 			return;
 		}
 
-		// `action=-1` (and the bottom dropdown's `action2=-1`) is WP's
-		// "no bulk action selected" sentinel — typically left in the URL
-		// after the user submits the bulk-actions form without picking
-		// one. Treat it as a no-op so those stale URLs still redirect to
-		// the React page; only bypass for real action values.
 		if ( self::has_real_get_action() ) {
 			return;
 		}
@@ -132,8 +115,6 @@ class Admin_Shell_Legacy_Redirect {
 
 	/**
 	 * Build a redirect target URL for a chassis-managed page.
-	 * Centralises the `?post_type=…&page=…&<forwarded>` shape so each
-	 * page only has to hand over its CPT slug + page slug.
 	 *
 	 * @param string       $post_type CPT slug the page shadows.
 	 * @param string       $page_slug The React page's `?page=` slug.

--- a/includes/admin/class-admin-shell-menu.php
+++ b/includes/admin/class-admin-shell-menu.php
@@ -2,10 +2,6 @@
 /**
  * Admin shell — menu registration.
  *
- * Owns the chassis-managed submenu entries and the
- * register-time hookname registry `Admin_Page::is_admin_page()`
- * consults at request time.
- *
  * @package Newspack_Newsletters
  */
 
@@ -18,10 +14,9 @@ defined( 'ABSPATH' ) || exit;
  */
 class Admin_Shell_Menu {
 	/**
-	 * Slug => hookname returned by `add_submenu_page`. Populated by
-	 * `register_menu()` so `Admin_Page::is_admin_page()` survives the
-	 * fresh page instances `Admin_Shell::get_pages()` returns on every
-	 * call.
+	 * Slug => hookname returned by `add_submenu_page`. Captured at
+	 * registration so `Admin_Page::is_admin_page()` can narrow its
+	 * match to the actual screen.
 	 *
 	 * @var array<string,string>
 	 */
@@ -42,24 +37,15 @@ class Admin_Shell_Menu {
 	 */
 	public static function init() {
 		add_action( 'admin_menu', [ __CLASS__, 'register_menu' ] );
-		// Priority 999 so we run after every contributor has registered
-		// (auto-generated CPT submenus, ads, third-party plugins).
-		// Reordering earlier wouldn't be stable — a later registration
-		// would just append past us.
+		// Priority 999 so we run after every other contributor — auto-generated CPT submenus, ads, third-party plugins.
 		add_action( 'admin_menu', [ __CLASS__, 'reorder_submenus' ], 999 );
 	}
 
 	/**
 	 * Reposition chassis submenu entries that declare a fixed index.
 	 *
-	 * Fires on `admin_menu` at priority 999 — after every other
-	 * `add_submenu_page` call, including auto-generated CPT submenus
-	 * (`_add_post_type_submenus`) and third-party additions. For each
-	 * page that returns a non-null `get_submenu_index()`, the entry is
-	 * unset from its current numeric key in `$submenu[ $parent_slug ]`
-	 * and re-inserted at the desired array index. Re-keying with
-	 * `array_values()` guarantees a clean 0-based sequence so WP's
-	 * downstream sorting doesn't reshuffle us back.
+	 * Runs late so it sees the final submenu array; re-keys with
+	 * `array_values()` so WP's downstream sort doesn't reshuffle us.
 	 */
 	public static function reorder_submenus() {
 		global $submenu;
@@ -73,9 +59,6 @@ class Admin_Shell_Menu {
 				continue;
 			}
 
-			// Snapshot to a 0-based list so index arithmetic is
-			// predictable. WP keeps numeric keys (5, 10, …) on auto
-			// submenus; the slug index lookup below is key-agnostic.
 			$entries = array_values( $submenu[ $parent_slug ] );
 
 			$found_at = null;
@@ -100,27 +83,10 @@ class Admin_Shell_Menu {
 	}
 
 	/**
-	 * Register React-shell pages.
+	 * Register chassis pages as submenus.
 	 *
-	 * Every page registers under a concrete parent slug returned by
-	 * `get_parent_slug()` — passing `null` is unsafe because WP's
-	 * `get_plugin_page_hookname` mixes the parent into the registered
-	 * hookname, and `add_submenu_page`'s registration- and `admin.php`'s
-	 * URL-derived lookup-time resolution can drift when the parent
-	 * isn't itself a top-level menu. Pages that should be invisible
-	 * still register, then opt in to `is_hidden_from_menu()` so
-	 * `remove_submenu_page` strips the menu entry after registration —
-	 * keeping the URL routable while leaving no sidebar entry. The
-	 * list views use this to shadow the auto-generated `edit.php?
-	 * post_type=…` submenus, which `maybe_redirect_legacy_list` then
-	 * 302s to the React page; because the redirect preserves the
-	 * `post_type` query, `newspack-plugin`'s `Newsletters_Wizard`
-	 * (when present) recognises the screen and renders the dark
-	 * Newspack admin-header chrome on top.
-	 *
-	 * Pages that should remain visible (e.g. Settings in standalone
-	 * mode) leave `is_hidden_from_menu()` at its default and surface
-	 * as normal submenus under their declared parent.
+	 * Hidden pages stay URL-routable but the visible submenu entry is
+	 * stripped after registration.
 	 */
 	public static function register_menu() {
 		global $_registered_pages;
@@ -140,29 +106,13 @@ class Admin_Shell_Menu {
 				self::$hook_suffixes[ $page->get_slug() ] = $hook_suffix;
 			}
 			if ( $page->is_hidden_from_menu() ) {
-				// Hidden React pages (the list views) shadow a classic
-				// CPT URL via `Admin_Shell_Legacy_Redirect::maybe_redirect_legacy_list`.
-				// `add_submenu_page` registers the callback under the
-				// hookname WP computes from the page's parent — that
-				// matches `user_can_access_admin_page`'s access check
-				// (which resolves the parent the same way), but
-				// **doesn't** match `admin.php`'s page-render lookup
-				// at line ~182, which uses the URL-derived parent
-				// (`edit.php?post_type=$typenow`). When the typenow
-				// CPT isn't itself a top-level menu (true for the ads
-				// CPT in submenu mode), `$admin_page_hooks` doesn't
-				// carry it and the URL-derived hookname falls back to
-				// the `admin_page_*` prefix. Mirror the action under
-				// that prefix so `admin.php` finds and dispatches it.
+				// WP's admin.php uses a URL-derived hookname for the page render lookup; when the parent CPT isn't a top-level menu it falls back to `admin_page_*`. Mirror the action there so the page still dispatches.
 				$shadow_hookname = 'admin_page_' . $page->get_slug();
 				if ( ! has_action( $shadow_hookname ) ) {
 					add_action( $shadow_hookname, [ $page, 'render' ] );
-					// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- Mirroring an admin-page registration that WP itself populates this global with on `add_submenu_page`. The standard WordPress.WP.GlobalVariablesOverride rule guards against accidental clobbers; we add (not replace) one entry whose hookname is unique to this plugin.
+					// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- Adding a single plugin-unique entry, not clobbering.
 					$_registered_pages[ $shadow_hookname ] = true;
 				}
-				// Strip the visible submenu the registration produced —
-				// the user-facing entry is the auto-generated CPT
-				// submenu we redirect from, not a separate React link.
 				remove_submenu_page( $parent_slug, $page->get_slug() );
 			}
 		}

--- a/includes/admin/class-admin-shell.php
+++ b/includes/admin/class-admin-shell.php
@@ -2,12 +2,6 @@
 /**
  * Admin shell bootstrap.
  *
- * Provides the React mount infrastructure (asset enqueue, page
- * registry, mode detection) the list-screen pages plug into. The
- * chassis itself does not introduce its own top-level menu — pages
- * register as submenus under the Newsletters CPT menu so the
- * existing menu structure is preserved.
- *
  * @package Newspack_Newsletters
  */
 
@@ -16,7 +10,7 @@ namespace Newspack\Newsletters\Admin;
 defined( 'ABSPATH' ) || exit;
 
 /**
- * Registers the React-based Newsletters admin shell.
+ * Newsletters admin shell — orchestration.
  */
 class Admin_Shell {
 	/**
@@ -32,11 +26,7 @@ class Admin_Shell {
 	}
 
 	/**
-	 * Filter the global `parent_file` so the sidebar's top-level menu
-	 * highlights correctly while a chassis-managed page is rendered.
-	 * Each page declares its own override via `Admin_Page::get_parent_file()`
-	 * — that's where the dynamic logic lives (e.g. ads switching
-	 * between top-level and submenu mode based on user caps).
+	 * `parent_file` filter — delegates to the current page.
 	 *
 	 * @param string $parent_file The current parent file value.
 	 * @return string
@@ -53,11 +43,7 @@ class Admin_Shell {
 	}
 
 	/**
-	 * Filter the global `submenu_file` so the active submenu entry
-	 * matches the page on screen. Each page declares its own override
-	 * via `Admin_Page::get_submenu_file()`; visible submenus typically
-	 * return `null` (WP's auto-detection is correct), while hidden
-	 * React pages name the auto-generated CPT submenu they shadow.
+	 * `submenu_file` filter — delegates to the current page.
 	 *
 	 * @param string $submenu_file The current submenu file value.
 	 * @return string
@@ -74,8 +60,7 @@ class Admin_Shell {
 	}
 
 	/**
-	 * Add a body class on chassis-managed admin pages so our SCSS can scope
-	 * the white-canvas styling without bleeding into other admin screens.
+	 * Add a body class on chassis-managed admin pages so SCSS can scope styling.
 	 *
 	 * @param string $classes Existing body classes (space-separated).
 	 * @return string
@@ -115,8 +100,8 @@ class Admin_Shell {
 		 * Filters whether the admin shell should run in bundled mode.
 		 *
 		 * Bundled mode means newspack-plugin is the canonical surface for
-		 * shared settings (Engagement > Newsletters); standalone mode means
-		 * this plugin owns its own settings page.
+		 * shared settings (Engagement > Newsletters); standalone mode
+		 * means this plugin owns its own settings page.
 		 *
 		 * @param bool $is_bundled Default detection: whether the Newspack core class is loaded.
 		 */
@@ -124,10 +109,10 @@ class Admin_Shell {
 	}
 
 	/**
-	 * Get the registered admin pages, filtered by mode.
+	 * Registered admin pages, filtered by mode.
 	 *
-	 * In bundled mode the Settings page is omitted because the canonical
-	 * settings surface is newspack-plugin's Engagement > Newsletters page.
+	 * Settings is omitted in bundled mode — newspack-plugin's Engagement >
+	 * Newsletters is the canonical settings surface.
 	 *
 	 * @return Admin_Page[]
 	 */

--- a/includes/admin/class-ads-list-rest.php
+++ b/includes/admin/class-ads-list-rest.php
@@ -133,7 +133,7 @@ class Ads_List_REST {
 		$post_status_set = [];
 		$bucket_clauses  = [];
 
-		// `private` is publish-equivalent for lifecycle kinds (a private ad with valid dates is just a publish ad with restricted visibility); `future` folds into `scheduled` only.
+		// `private` is publish-equivalent for lifecycle kinds (a private ad with valid dates is just a published ad with restricted visibility); `future` folds into `scheduled` only.
 		foreach ( $kinds as $kind ) {
 			switch ( $kind ) {
 				case 'trash':

--- a/includes/admin/class-ads-list-rest.php
+++ b/includes/admin/class-ads-list-rest.php
@@ -2,11 +2,6 @@
 /**
  * REST surface for the Newsletter Ads list DataView.
  *
- * Adds a read-only `newspack_newsletters_ad_status` field on the ads CPT
- * that consolidates `post_status` and the date-driven lifecycle
- * (`start_date` / `expiry_date` meta) into a single payload, so the
- * React side never has to re-derive state from raw meta.
- *
  * @package Newspack_Newsletters
  */
 
@@ -18,7 +13,10 @@ use Newspack_Newsletters\Ads;
 use WP_Post;
 
 /**
- * Register the REST field powering the ads list view's Status column.
+ * Adds a read-only `newspack_newsletters_ad_status` REST field on the
+ * ads CPT consolidating `post_status` + date-driven lifecycle into a
+ * single payload, plus the status-filter and meta-sort rails the
+ * React DataView needs.
  */
 class Ads_List_REST {
 	use Rest_Status_Field;
@@ -52,8 +50,8 @@ class Ads_List_REST {
 	}
 
 	/**
-	 * Virtual REST orderby tokens. Applied via posts_clauses LEFT JOIN
-	 * in `apply_meta_sort_clauses`, not WP_Query meta args.
+	 * Virtual REST orderby tokens. Applied via `posts_clauses` LEFT
+	 * JOIN in `apply_meta_sort_clauses`, not WP_Query meta args.
 	 */
 	const VIRTUAL_ORDERBY_TOKENS = [
 		'start_date'  => [
@@ -79,22 +77,11 @@ class Ads_List_REST {
 	];
 
 	/**
-	 * Register tracking impression / click meta on the ads CPT subtype
-	 * so the React columns can read them via the REST `meta` block and
-	 * sort via `orderby=meta_value_num`. The meta is written by the
-	 * tracking layer (`Newspack_Newsletters\Tracking\Click` and
-	 * `Ads::track_ad_impression`) but was never previously registered,
-	 * so it didn't surface in REST.
+	 * Register tracking impression / click meta as REST-readable.
 	 *
-	 * `auth_callback` returns `false` so the meta is read-only via
-	 * REST — these are server-managed telemetry counters and the
-	 * posts endpoint must not accept client writes (stats tampering
-	 * vector). Direct `update_post_meta()` calls from the tracking
-	 * layer aren't gated by `auth_callback` and continue to work; the
-	 * gate only fires on the REST update path's `current_user_can(
-	 * 'edit_post_meta', … )` check. The schema also declares
-	 * `readonly: true` so REST clients see the field as documentation-
-	 * level read-only.
+	 * `auth_callback => __return_false` makes the meta read-only via
+	 * REST — these are server-managed counters; direct `update_post_meta`
+	 * from the tracking layer isn't gated by `auth_callback`.
 	 */
 	public static function register_meta() {
 		$readonly_counter_args = [
@@ -115,28 +102,18 @@ class Ads_List_REST {
 
 	/**
 	 * Valid kind values accepted on the `STATUS_QUERY_PARAM`. Anything
-	 * outside this list is ignored so unexpected input can't widen the
-	 * result set.
+	 * outside this list is ignored.
 	 */
 	const VALID_KINDS = [ 'active', 'scheduled', 'expired', 'draft', 'trash' ];
 
 	/**
-	 * Translate the React list's kind-based status filter
-	 * (`active|scheduled|expired|draft|trash`) into native query args
-	 * plus a one-shot `posts_where` callback that ORs each selected
-	 * kind into its own complete bucket (`post_status` + the
-	 * date-driven meta condition where applicable). The Status column
-	 * renders the derived kind, and the filter targets the same kinds
-	 * — so the displayed and filtered sets always match.
+	 * Translate the kind-based status filter into native query args
+	 * plus a `posts_where` callback that ORs each kind into its own
+	 * bucket (`post_status` + date-driven meta condition).
 	 *
-	 * The bucketed `posts_where` approach is what lets us mix
-	 * non-publish kinds (`draft`/`trash`) with publish-driven kinds
-	 * (`active`/`scheduled`/`expired`) in the same selection: a plain
-	 * draft row passes the `draft` bucket without having to satisfy
-	 * any meta condition, while an expired row passes the `expired`
-	 * bucket only when its `expiry_date` meta is in the past. A flat
-	 * `meta_query` would AND the meta condition across all rows and
-	 * silently drop the drafts.
+	 * Bucketing is what lets `draft`/`trash` mix with the publish-
+	 * driven kinds in the same selection — a flat `meta_query` would
+	 * AND the meta condition across all rows and drop the drafts.
 	 *
 	 * @param array            $args    Query args being assembled.
 	 * @param \WP_REST_Request $request Incoming REST request.
@@ -156,19 +133,7 @@ class Ads_List_REST {
 		$post_status_set = [];
 		$bucket_clauses  = [];
 
-		// `private` is treated as publish-equivalent for the lifecycle
-		// kinds: a private ad with valid dates is functionally a published
-		// ad with restricted visibility, so it should surface in the same
-		// active/scheduled/expired buckets as a public publish row. The
-		// React list also requests `private` by default (see
-		// `DEFAULT_STATUSES` in build-query.js), so excluding it here
-		// would make private rows disappear the moment any kind filter
-		// is applied.
-		//
-		// `future` (WP-scheduled via the standard Publish-Schedule UI)
-		// is folded into the `scheduled` bucket only — those rows haven't
-		// published yet, so `active` and `expired` lifecycle resolution
-		// doesn't apply.
+		// `private` is publish-equivalent for lifecycle kinds (a private ad with valid dates is just a publish ad with restricted visibility); `future` folds into `scheduled` only.
 		foreach ( $kinds as $kind ) {
 			switch ( $kind ) {
 				case 'trash':
@@ -214,9 +179,9 @@ class Ads_List_REST {
 	}
 
 	/**
-	 * Widen the REST orderby enum to accept our virtual tokens.
-	 * Required because `rest_validate_request_arg` runs the enum
-	 * check before the `rest_${CPT}_query` filter can rewrite.
+	 * Widen the REST orderby enum to accept our virtual tokens —
+	 * `rest_validate_request_arg` runs the enum check before
+	 * `rest_${CPT}_query` can rewrite.
 	 *
 	 * @param array $params Collection params from the posts controller.
 	 * @return array
@@ -236,7 +201,7 @@ class Ads_List_REST {
 	}
 
 	/**
-	 * Query var carrying meta-sort intent through to apply_meta_sort_clauses.
+	 * Query var carrying meta-sort intent through to `apply_meta_sort_clauses`.
 	 */
 	const META_SORT_QUERY_VAR = 'newspack_ads_meta_sort';
 
@@ -266,8 +231,8 @@ class Ads_List_REST {
 	}
 
 	/**
-	 * LEFT JOIN postmeta and order by it so rows missing the sorted key
-	 * still appear (a plain meta_key would inner-join them out).
+	 * LEFT JOIN postmeta and order by it so rows missing the sorted
+	 * key still appear (a plain `meta_key` arg would inner-join them out).
 	 *
 	 * @param array     $clauses WP_Query SQL clauses.
 	 * @param \WP_Query $query   The WP_Query running the SQL.
@@ -337,13 +302,7 @@ class Ads_List_REST {
 			return $payload;
 		}
 
-		// WP-scheduled ads (the standard Publish-Schedule UI sets
-		// `post_status=future`) resolve to `scheduled`. The React
-		// renderer reads `starts_at` to show "Starts <date>", so we
-		// expose `post_date_gmt` as the timestamp — that's the moment
-		// WordPress will auto-publish the row. `start_date` /
-		// `expiry_date` meta are ignored on `future` rows; WP's own
-		// scheduling owns the lifecycle until the row publishes.
+		// `future` (WP's Publish-Schedule) is `scheduled`; `post_date_gmt` is the auto-publish moment, and `start_date` / `expiry_date` meta don't apply until it publishes.
 		if ( 'future' === $post->post_status ) {
 			$payload['kind']      = 'scheduled';
 			$starts_at            = strtotime( $post->post_date_gmt . ' UTC' );
@@ -351,25 +310,12 @@ class Ads_List_REST {
 			return $payload;
 		}
 
-		// `private` is treated as publish-equivalent for kind resolution:
-		// a private ad with valid dates is functionally a published ad
-		// with restricted visibility, so it should surface as
-		// active/scheduled/expired the same way. Falling through to the
-		// `draft` default would mislabel the row in the list and hide it
-		// from the lifecycle filters.
 		if ( in_array( $post->post_status, [ 'publish', 'private' ], true ) ) {
 			$today       = gmdate( 'Y-m-d' );
 			$start_date  = (string) get_post_meta( $post->ID, 'start_date', true );
 			$expiry_date = (string) get_post_meta( $post->ID, 'expiry_date', true );
 
-			// Use noon UTC so the resulting timestamp lands on the
-			// intended calendar day in any reasonable site timezone —
-			// midnight UTC would render as the previous day for users
-			// behind UTC. The underlying meta is date-only, so the
-			// time-of-day component is just a presentation safeguard.
-			// Normalise `strtotime` failures to `null` so the REST
-			// schema's `integer|null` declaration holds even if the
-			// meta is malformed.
+			// Noon UTC so the timestamp lands on the intended calendar day in any reasonable site timezone; date-only meta makes the time-of-day a presentation safeguard.
 			if ( '' !== $start_date ) {
 				$starts_at            = strtotime( $start_date . ' 12:00:00 UTC' );
 				$payload['starts_at'] = false === $starts_at ? null : $starts_at;

--- a/includes/admin/class-advertisers-list-rest.php
+++ b/includes/admin/class-advertisers-list-rest.php
@@ -2,19 +2,6 @@
 /**
  * REST surface for the Newsletter Advertisers list DataView.
  *
- * The Advertiser taxonomy is registered with `show_in_rest => true`, so
- * the standard `/wp/v2/newspack_nl_advertiser` collection endpoint
- * handles list/create/read/update/delete out of the box. This class adds
- * the validation rails the React DataView needs on top of those defaults.
- *
- * Currently:
- *
- *  - Reject `parent === self` on term updates. WP enforces parent != self
- *    for `wp_insert_term` (the new term doesn't exist yet to be self-
- *    referencing) but not for `wp_update_term`, so a PATCH that sets
- *    `parent` to the term's own id would silently persist a self-loop
- *    that breaks the React TreeSelect.
- *
  * @package Newspack_Newsletters
  */
 
@@ -28,22 +15,20 @@ use WP_REST_Request;
 
 /**
  * Validation rails for the Advertiser taxonomy REST endpoints.
+ *
+ * The taxonomy's `show_in_rest` collection handles CRUD by default;
+ * this class adds the rules the React DataView needs on top — currently
+ * blocking self-referential `parent` on term updates.
  */
 class Advertisers_List_REST {
 	/**
 	 * Boot hooks.
 	 *
-	 * The natural surface — `rest_pre_insert_<taxonomy>` — is unusable
-	 * here: `WP_REST_Terms_Controller::update_item` does not call
-	 * `is_wp_error()` on the value `prepare_item_for_database()` returns,
-	 * so a WP_Error from that filter is cast to an array and silently
-	 * discarded. `wp_update_term` itself does not fire `pre_insert_term`
-	 * (it only fires in `wp_insert_term`), and `wp_update_term_parent`
-	 * expects an integer return (no error path). The remaining clean
-	 * surface is `rest_request_before_callbacks`, which fires after
-	 * routing (so `$request['id']` is populated) and before the
-	 * controller callback runs — returning WP_Error there short-circuits
-	 * the dispatch and becomes the response.
+	 * `rest_pre_insert_<taxonomy>` is unusable here — the terms
+	 * controller's `update_item` doesn't `is_wp_error()` the prepared
+	 * value, so the WP_Error is cast to array and silently dropped.
+	 * `rest_request_before_callbacks` fires after routing and treats
+	 * a returned WP_Error as the response.
 	 */
 	public static function init() {
 		add_filter( 'rest_request_before_callbacks', [ __CLASS__, 'guard_parent_self' ], 10, 3 );
@@ -52,24 +37,15 @@ class Advertisers_List_REST {
 	/**
 	 * Block term updates whose `parent` equals the term's own id.
 	 *
-	 * Scoped to update-shaped requests against the advertiser taxonomy:
-	 * the route is `/wp/v2/<taxonomy>/<id>` and the method is one of
-	 * POST/PUT/PATCH (the WP terms controller registers all three on the
-	 * editable methods constant).
-	 *
-	 * @param mixed           $response Result of any earlier filter (passed through unless we override).
-	 * @param array           $handler  Route handler details (callback, permission_callback, methods, args, …).
+	 * @param mixed           $response Earlier filter result; passed through if non-null.
+	 * @param array           $handler  Route handler details.
 	 * @param WP_REST_Request $request  Incoming REST request.
 	 * @return mixed
 	 */
 	public static function guard_parent_self( $response, $handler, $request ) {
 		unset( $handler );
 
-		// An earlier callback on this filter may have already short-
-		// circuited the dispatch (permission check, another guard, etc.).
-		// Bail before any further work so a non-null `$response` is
-		// passed through unchanged — overwriting it with a WP_Error
-		// from this guard would mask the earlier signal.
+		// Earlier callback already short-circuited — don't mask its signal.
 		if ( null !== $response ) {
 			return $response;
 		}
@@ -78,14 +54,6 @@ class Advertisers_List_REST {
 			return $response;
 		}
 
-		// Scope to single-term update endpoints on the advertiser
-		// taxonomy: `/wp/v2/<taxonomy>/<id>`. The route path drives the
-		// gate; the `id` and `parent` values are read from the request
-		// params directly via ArrayAccess (`$request['id']` /
-		// `$request->get_param( 'parent' )`) so the guard doesn't depend
-		// on whatever `get_route()` happens to return — that's currently
-		// the URL, but using params keeps the implementation robust if
-		// WP ever swaps in the matched route pattern.
 		$route   = $request->get_route();
 		$pattern = '#^/wp/v2/' . preg_quote( Ads::ADVERTISER_TAX, '#' ) . '/\d+$#';
 		if ( ! preg_match( $pattern, $route ) ) {

--- a/includes/admin/class-asset-loader.php
+++ b/includes/admin/class-asset-loader.php
@@ -2,14 +2,6 @@
 /**
  * Asset enqueue helper.
  *
- * Centralises the script + style enqueue sequence used by admin-side
- * React bundles built via `@wordpress/scripts` — each bundle emits a
- * sibling `<basename>.asset.php` carrying the runtime dependency
- * array and a content-hash version. Callers compose URLs and pass
- * any extra dependencies; the helper handles the file_exists guard,
- * the asset.php require, and the two enqueue calls. The WP handle
- * is independent from the on-disk basename — see `enqueue_bundle()`.
- *
  * @package Newspack_Newsletters
  */
 
@@ -18,36 +10,25 @@ namespace Newspack\Newsletters\Admin;
 defined( 'ABSPATH' ) || exit;
 
 /**
- * Shared `<basename>.asset.php` + script + style enqueue helper.
+ * Shared `@wordpress/scripts` bundle enqueue helper — reads
+ * `<basename>.asset.php` for deps + version, then enqueues `.js` and
+ * (when present) `.css` under the given handle.
  */
 class Asset_Loader {
 	/**
 	 * Read `<build_dir>/<basename>.asset.php` and enqueue the matching
-	 * `<basename>.js` (always) and `<basename>.css` (when present)
-	 * under the given handle.
+	 * `<basename>.js` + `<basename>.css` under the given handle.
 	 *
-	 * The WP handle and the on-disk file stem are independent — webpack
-	 * emits bundles under the entry key (e.g. `admin-shell`) while WP
-	 * conventionally uses a plugin-prefixed handle (e.g.
-	 * `newspack-newsletters-admin-shell`). Conflating them was a P1
-	 * regression in the helper's first cut.
+	 * The WP handle and the on-disk basename are independent — webpack
+	 * keys bundles by entry name, WP wants a plugin-prefixed handle.
 	 *
 	 * @param string $handle            WP script + style handle.
-	 * @param string $basename          File stem (no extension) matching
-	 *                                  the webpack entry — used for the
-	 *                                  `<basename>.asset.php`, `.js`, and
-	 *                                  `.css` lookups.
-	 * @param string $build_dir         Filesystem path to the dist
-	 *                                  directory.
-	 * @param string $url_dir           Public URL prefix matching
-	 *                                  `$build_dir`.
-	 * @param array  $extra_script_deps Additional handles to merge
-	 *                                  into the script dependency
-	 *                                  array declared in asset.php.
-	 * @param array  $extra_style_deps  Dependencies for the matching
-	 *                                  `.css` enqueue.
-	 * @return array|null Asset metadata (`dependencies`, `version`)
-	 *                    on success, null when `asset.php` is missing.
+	 * @param string $basename          File stem matching the webpack entry.
+	 * @param string $build_dir         Filesystem path to the dist directory.
+	 * @param string $url_dir           Public URL prefix matching `$build_dir`.
+	 * @param array  $extra_script_deps Handles to merge into the script deps.
+	 * @param array  $extra_style_deps  Handles to merge into the style deps.
+	 * @return array|null Asset metadata, or null when `asset.php` is missing.
 	 */
 	public static function enqueue_bundle(
 		$handle,

--- a/includes/admin/class-newsletters-list-rest.php
+++ b/includes/admin/class-newsletters-list-rest.php
@@ -2,11 +2,6 @@
 /**
  * REST surface for the Newsletters list DataView.
  *
- * Adds a read-only `newspack_newsletters_status` field on the newsletters
- * CPT that consolidates `post_status`, `is_newsletter_sent()`, and the
- * scheduled-send signals into a single payload, so the React side never
- * has to re-derive sent/scheduled state from raw meta.
- *
  * @package Newspack_Newsletters
  */
 
@@ -18,7 +13,10 @@ use Newspack_Newsletters;
 use WP_Post;
 
 /**
- * Register the REST field powering the list view's Status column.
+ * Adds a read-only `newspack_newsletters_status` field on the newsletters
+ * CPT consolidating `post_status` + sent / scheduled signals, plus the
+ * filter-option payload and meta-aware query rewrites the React DataView
+ * needs.
  */
 class Newsletters_List_REST {
 	use Rest_Status_Field;
@@ -60,11 +58,8 @@ class Newsletters_List_REST {
 	}
 
 	/**
-	 * Translate the React list's `newspack_newsletters_is_public` query arg
-	 * into a `meta_query` clause so the Public-page filter actually narrows
-	 * the result set. Strict whitelist: accepts only `'1'` / `'0'` (or
-	 * boolean `true` / `false`) — anything else is ignored so unexpected
-	 * values can't silently flip the filter.
+	 * Translate `newspack_newsletters_is_public` into a `meta_query`
+	 * clause. Strict whitelist: only `1`/`0` (or boolean) accepted.
 	 *
 	 * @param array            $args    Query args being assembled.
 	 * @param \WP_REST_Request $request Incoming REST request.
@@ -78,7 +73,6 @@ class Newsletters_List_REST {
 		} elseif ( false === $value || '0' === $value || 0 === $value ) {
 			$is_public = false;
 		} else {
-			// Null, empty string, or anything outside the whitelist — pass through.
 			return $args;
 		}
 
@@ -110,20 +104,13 @@ class Newsletters_List_REST {
 	}
 
 	/**
-	 * Align the Status filter with the kind `get_status_for_post` would
-	 * emit. The DataView filter values are raw `post_status` strings,
-	 * but the column derives Sent/Scheduled/Draft from a mix of status
-	 * and `sending_scheduled` / `scheduling_error` meta. Without this
-	 * adapter, raw post_status filtering misclassifies rows in both
-	 * directions (e.g. an in-flight publish leaks under Sent; a
-	 * publish-with-`scheduling_error` is invisible under Draft).
+	 * Align the Status filter with the kind `get_status_for_post` emits.
 	 *
-	 * Strategy: map the selection to kinds (sent/draft/scheduled/trash),
-	 * widen `post_status` to every status the chosen kinds' SQL branches
-	 * reference (so WP_Query doesn't strip away reachable rows), and
-	 * install a `posts_where` whose OR-branches encode the renderer's
-	 * exact conditions for each chosen kind. The callback removes itself
-	 * after firing so it stays scoped to the single query.
+	 * Raw `post_status` filtering misclassifies rows in both directions
+	 * (an in-flight publish leaks under Sent; a publish-with-error is
+	 * invisible under Draft). Map selection → kinds, widen `post_status`
+	 * to every status the kinds' SQL branches reference, and install a
+	 * scoped `posts_where` whose OR-branches mirror the renderer.
 	 *
 	 * @param array            $args    Query args being assembled.
 	 * @param \WP_REST_Request $request Incoming REST request.
@@ -140,10 +127,7 @@ class Newsletters_List_REST {
 		$wants_scheduled = in_array( 'future', $values, true );
 		$wants_trash     = in_array( 'trash', $values, true );
 
-		// Widen `post_status` to every status the chosen kinds' SQL
-		// branches reference. WP_Query applies `post_status IN (...)`
-		// before our `posts_where` fires, so anything outside the
-		// widened set is unreachable.
+		// WP_Query applies `post_status IN (…)` before our `posts_where` fires; anything outside the widened set is unreachable.
 		$widened = $values;
 		if ( $wants_sent || $wants_draft || $wants_scheduled ) {
 			$widened = array_merge( $widened, [ 'publish', 'private' ] );
@@ -240,7 +224,7 @@ class Newsletters_List_REST {
 	}
 
 	/**
-	 * Register the helper route that feeds the React list filter dropdowns.
+	 * Register the helper route feeding the React list filter dropdowns.
 	 */
 	public static function register_rest_routes() {
 		register_rest_route(
@@ -269,9 +253,8 @@ class Newsletters_List_REST {
 
 	/**
 	 * One-shot payload of every option list the React filter dropdowns
-	 * consume. Scoped to newsletters the current user can edit, so a
-	 * publisher without `edit_others_posts` only sees options derived
-	 * from their own rows — mirrors what the list itself shows.
+	 * consume. Scoped to newsletters the current user can edit so the
+	 * filters match what the list itself shows.
 	 *
 	 * @return \WP_REST_Response
 	 */
@@ -289,8 +272,8 @@ class Newsletters_List_REST {
 
 	/**
 	 * SQL fragment scoping a `wp_posts p` join to rows the current user
-	 * can edit — empty string for users with `edit_others_posts` (full
-	 * visibility), `AND p.post_author = <id>` otherwise.
+	 * can edit — empty string for `edit_others_posts`, an authorship
+	 * filter otherwise.
 	 *
 	 * @return string
 	 */
@@ -306,7 +289,7 @@ class Newsletters_List_REST {
 	/**
 	 * Distinct authors of any non-auto-draft newsletter in scope.
 	 *
-	 * @param string $user_scope_sql User-scope WHERE fragment from `build_user_post_scope_sql`.
+	 * @param string $user_scope_sql User-scope WHERE fragment.
 	 * @return array<array{id: int, label: string}>
 	 */
 	private static function get_authors_used( $user_scope_sql = '' ) {
@@ -350,7 +333,7 @@ class Newsletters_List_REST {
 	 * Distinct terms applied to any in-scope newsletter, in the given taxonomy.
 	 *
 	 * @param string $taxonomy       `category` or `post_tag`.
-	 * @param string $user_scope_sql User-scope WHERE fragment from `build_user_post_scope_sql`.
+	 * @param string $user_scope_sql User-scope WHERE fragment.
 	 * @return array<array{id: int, label: string}>
 	 */
 	private static function get_terms_used( $taxonomy, $user_scope_sql = '' ) {
@@ -388,10 +371,10 @@ class Newsletters_List_REST {
 	}
 
 	/**
-	 * Distinct non-empty `send_list_id` meta values across in-scope newsletters.
-	 * Friendly-name resolution is deferred (Known gaps); raw IDs ship.
+	 * Distinct non-empty `send_list_id` meta values across in-scope
+	 * newsletters. Friendly-name resolution deferred; raw IDs ship.
 	 *
-	 * @param string $user_scope_sql User-scope WHERE fragment from `build_user_post_scope_sql`.
+	 * @param string $user_scope_sql User-scope WHERE fragment.
 	 * @return array<array{id: string, label: string}>
 	 */
 	private static function get_send_list_ids_used( $user_scope_sql = '' ) {
@@ -450,12 +433,9 @@ class Newsletters_List_REST {
 	/**
 	 * Compute the consolidated status payload for a newsletter post.
 	 *
-	 * Resolution order matters: trash takes precedence (we don't want to
-	 * mask trashed-but-previously-sent items as sent), then sent (covers
-	 * publish/private with the post's publish-date fallback), then
-	 * scheduled (`post_status=future` or the `sending_scheduled` meta
-	 * flag set during an in-flight ESP dispatch), finally draft as the
-	 * catch-all.
+	 * Resolution order: trash (so a trashed sent row doesn't mask as
+	 * sent) → sent → scheduled (`future` or `sending_scheduled` meta)
+	 * → draft as the catch-all.
 	 *
 	 * @param WP_Post|null $post Post object.
 	 * @return array { kind, sent_at, scheduled_at }
@@ -501,28 +481,11 @@ class Newsletters_List_REST {
 	}
 
 	/**
-	 * Read-only equivalent of `Newspack_Newsletters::is_newsletter_sent` —
-	 * mirrors its resolution logic exactly but never writes to `post_meta`.
+	 * Read-only equivalent of `Newspack_Newsletters::is_newsletter_sent`.
 	 *
-	 * `is_newsletter_sent` calls `set_newsletter_sent` to back-fill the
-	 * `newsletter_sent` meta whenever a published post is missing it (or
-	 * has mismatched meta), so calling it from the REST GET would issue
-	 * one write per row in the response. This list endpoint is read-only
-	 * by contract — derive the timestamp without mutating.
-	 *
-	 * Resolution order matches `is_newsletter_sent`:
-	 *
-	 * 1. `sending_scheduled` / `scheduling_error` meta suppress sent state.
-	 * 2. Compute the publish timestamp first (`0` when the post isn't
-	 *    `publish` / `private`).
-	 * 3. Accept `newsletter_sent` meta only when it is positive AND equals
-	 *    the publish timestamp. Stale meta on a draft / scheduled row
-	 *    therefore reports as "not sent", and a published row with
-	 *    mismatched meta reports the publish timestamp instead of the
-	 *    drifted meta value.
-	 * 4. Otherwise, for `publish` / `private` rows, return the publish
-	 *    timestamp.
-	 * 5. Otherwise return `null`.
+	 * `is_newsletter_sent` back-fills `newsletter_sent` meta on a stale
+	 * row, so calling it from this REST GET would issue a write per
+	 * response row. Derive the timestamp without mutating instead.
 	 *
 	 * @param WP_Post $post Post object.
 	 * @return int|null Sent timestamp, or null when not (yet) sent.
@@ -540,10 +503,7 @@ class Newsletters_List_REST {
 		$post_datetime = $is_published ? get_post_datetime( $post, 'date', 'gmt' ) : false;
 		$publish_date  = $post_datetime ? $post_datetime->getTimestamp() : 0;
 
-		// Only accept `newsletter_sent` when it actually matches the
-		// publish timestamp. Anything else is stale / mismatched meta
-		// that `is_newsletter_sent` would otherwise overwrite — we just
-		// ignore it instead.
+		// Only accept `newsletter_sent` when it matches the publish timestamp — anything else is the stale meta `is_newsletter_sent` would otherwise overwrite.
 		if ( 0 < $sent && $sent === $publish_date ) {
 			return $sent;
 		}

--- a/includes/admin/class-settings-rest.php
+++ b/includes/admin/class-settings-rest.php
@@ -22,10 +22,9 @@ class Settings_REST {
 	const ROUTE         = 'admin-shell/settings';
 
 	/**
-	 * Allowlist of credential fields exposed to the React shell, keyed by
-	 * provider slug. Constant Contact's `api_credentials()` also returns
-	 * `access_token` / `refresh_token` — long-lived OAuth secrets that
-	 * never need to leave the server.
+	 * Credential fields exposed to the React shell, keyed by provider
+	 * slug. Excludes long-lived OAuth secrets (Constant Contact's
+	 * `access_token` / `refresh_token`) — those never leave the server.
 	 */
 	const PROVIDER_CREDENTIAL_ALLOWLIST = [
 		'mailchimp'        => [ 'api_key' ],
@@ -34,11 +33,9 @@ class Settings_REST {
 	];
 
 	/**
-	 * Settings-list option keys that are managed by the provider /
-	 * credentials section, not the cross-cutting options section. These
-	 * skip the options schema so `get_settings_list()`'s provider-scoped
-	 * *non-credential* entries (e.g. `newspack_mailchimp_auto_append_footer`)
-	 * still surface as options.
+	 * Settings-list option keys managed by the credentials section.
+	 * Skipped by the options schema so provider-scoped *non-credential*
+	 * entries (e.g. `newspack_mailchimp_auto_append_footer`) still surface.
 	 */
 	const PROVIDER_CREDENTIAL_OPTION_KEYS = [
 		'newspack_mailchimp_api_key',
@@ -271,13 +268,11 @@ class Settings_REST {
 	}
 
 	/**
-	 * Resolve the provider's OAuth state for the Settings response.
+	 * Resolve the provider's OAuth state.
 	 *
-	 * The `valid` flag is short-cached (site-global) so the Settings GET
-	 * doesn't hit the provider's verify endpoint on every page load.
-	 * `auth_url` is built fresh on every request — it carries a
-	 * `wp_create_nonce` that's session-token-scoped, so caching it
-	 * would leak nonces across users / browser sessions.
+	 * `valid` is short-cached; `auth_url` is rebuilt every request
+	 * because its `wp_create_nonce` is session-token-scoped — caching
+	 * it would leak nonces across users.
 	 *
 	 * @param object|null $provider      Active provider instance.
 	 * @param string      $provider_slug Provider slug.
@@ -330,9 +325,7 @@ class Settings_REST {
 	}
 
 	/**
-	 * Transient key for the cached OAuth validity. Site-global —
-	 * `auth_url` is no longer cached here, so per-user keying is not
-	 * required.
+	 * Transient key for the cached OAuth validity (site-global).
 	 *
 	 * @param string $provider_slug Provider slug.
 	 * @return string Transient key.

--- a/includes/admin/pages/class-ads-list-page.php
+++ b/includes/admin/pages/class-ads-list-page.php
@@ -2,15 +2,12 @@
 /**
  * Newsletter Ads list admin page (React DataView).
  *
- * Replaces the classic WP_List_Table for the ads CPT in both standalone
- * and bundled modes. The page registers under the concrete parent slug
- * returned by `get_parent_slug()` — either the ads CPT entry as a
- * top-level menu or the Newsletters CPT entry when the ads screen is
- * grouped underneath it. The React page is kept out of the visible menu
- * via the inherited `is_hidden_from_menu()`; the visible click target
- * remains the auto-generated `edit.php?post_type=newspack_nl_ads_cpt`
- * entry that `Ads::add_ads_page` creates. `Admin_Shell_Legacy_Redirect::maybe_redirect_legacy_list`
- * 302s the legacy URL to the React page.
+ * Replaces the classic ads CPT WP_List_Table in both standalone and
+ * bundled modes. Registers as a hidden submenu under the parent WP
+ * resolves to at access-check time; the visible click target is the
+ * auto-generated `edit.php?post_type=newspack_nl_ads_cpt` submenu
+ * which `Admin_Shell_Legacy_Redirect::maybe_redirect_legacy_list`
+ * 302s to the React page.
  *
  * @package Newspack_Newsletters
  */
@@ -35,12 +32,8 @@ class Ads_List_Page extends Hidden_React_List_Page {
 	/**
 	 * Get the page label.
 	 *
-	 * Matches the ads CPT's `menu_name` label rather than `all_items`
-	 * — keeps the React page title short ("Newsletter Ads" instead of
-	 * "All Newsletter Ads"). Intentionally diverges from
-	 * `Newsletters_List_Page`'s `all_items` convention; the visible
-	 * click target is the auto-generated CPT submenu, so this label
-	 * only surfaces as the React page's `<h1>` and the browser tab.
+	 * Matches the CPT's `menu_name` (not `all_items`) — keeps the
+	 * React `<h1>` short.
 	 *
 	 * @return string
 	 */
@@ -49,19 +42,9 @@ class Ads_List_Page extends Hidden_React_List_Page {
 	}
 
 	/**
-	 * Register under the parent WP resolves to at access-check time
-	 * (`user_can_access_admin_page` → `get_admin_page_parent`), which
-	 * is mode-dependent:
-	 *
-	 * - Top-level mode: `Ads::add_ads_page` calls `add_menu_page` for
-	 *   the ads CPT URL, so it's a top-level menu and the resolution
-	 *   returns the ads CPT URL itself.
-	 * - Submenu mode: the ads CPT URL is a submenu of the newsletters
-	 *   CPT, so the resolution returns the newsletters CPT URL.
-	 *
-	 * `Ads::init_hooks()` runs before `Admin_Shell::init()` (see
-	 * `newspack-newsletters.php` require order), so by the time we
-	 * register here the ads menu placement has happened.
+	 * Register under the parent WP resolves to at access-check time —
+	 * mode-dependent (top-level when the ads CPT has its own menu,
+	 * under the newsletters CPT otherwise).
 	 *
 	 * @return string
 	 */
@@ -70,12 +53,8 @@ class Ads_List_Page extends Hidden_React_List_Page {
 	}
 
 	/**
-	 * Submenu entry to highlight while the ads list page is rendered.
-	 *
-	 * Always points at the ads CPT URL — that's the visible click
-	 * target whether `Ads::add_ads_page` placed it as a top-level
-	 * menu (which adds itself as the first submenu under itself) or
-	 * as a submenu under the Newsletters CPT.
+	 * Submenu entry to highlight — always the ads CPT URL, regardless
+	 * of where `Ads::add_ads_page` placed it.
 	 *
 	 * @return string
 	 */
@@ -102,13 +81,8 @@ class Ads_List_Page extends Hidden_React_List_Page {
 	}
 
 	/**
-	 * The newspack-plugin admin header (`WizardsAdminHeader`) renders
-	 * an "Ads" tab pointing at `edit.php?post_type=newspack_nl_ads_cpt`
-	 * for the wizard's ads / advertisers screens. Our React page lives
-	 * at the same URL plus `&page=newspack-newsletters-ads-list`, so
-	 * the wizard's strict URL equality match never fires here. Return
-	 * the canonical Ads tab URL so `Admin_Shell` can flip the matching
-	 * `<a>` to `.selected` after the header mounts.
+	 * Canonical Ads tab URL — the wizard header's strict URL equality
+	 * check would otherwise miss our `&page=…` subpage.
 	 *
 	 * @return string
 	 */

--- a/includes/admin/pages/class-advertisers-list-page.php
+++ b/includes/admin/pages/class-advertisers-list-page.php
@@ -2,12 +2,10 @@
 /**
  * Newsletter Advertisers list admin page (React DataView).
  *
- * Replaces the classic taxonomy term-management screen for the
- * Advertiser taxonomy (`newspack_nl_advertiser`) with a React
- * DataView, in both standalone and bundled modes. Mirrors the ads
- * list page — registers as a hidden submenu under the ads CPT
- * parent and 302s the legacy
- * `edit-tags.php?taxonomy=newspack_nl_advertiser` URL across.
+ * Replaces the classic taxonomy term-management screen for
+ * `newspack_nl_advertiser`. Mirrors the ads list page — hidden
+ * submenu under the ads CPT parent; the legacy `edit-tags.php`
+ * URL 302s to the React page.
  *
  * @package Newspack_Newsletters
  */
@@ -40,9 +38,7 @@ class Advertisers_List_Page extends Hidden_React_List_Page {
 	}
 
 	/**
-	 * Register under the parent WP resolves to at access-check time.
-	 * Mirrors `Ads_List_Page::get_parent_slug` — top-level when the
-	 * ads CPT is its own menu, under the newsletters CPT otherwise.
+	 * Mirrors `Ads_List_Page::get_parent_slug` — mode-dependent.
 	 *
 	 * @return string
 	 */
@@ -51,10 +47,10 @@ class Advertisers_List_Page extends Hidden_React_List_Page {
 	}
 
 	/**
-	 * Match the auto-generated taxonomy submenu URL so the sidebar entry
-	 * highlights. The advertiser tax is shared with the newsletters CPT
-	 * (the only one with `show_in_menu`), so submenu mode highlights
-	 * under the newsletters CPT URL.
+	 * Match the auto-generated taxonomy submenu URL so the sidebar
+	 * entry highlights. The advertiser tax is shared with the
+	 * newsletters CPT; submenu mode highlights under the newsletters
+	 * CPT URL.
 	 *
 	 * @return string
 	 */
@@ -66,8 +62,8 @@ class Advertisers_List_Page extends Hidden_React_List_Page {
 	}
 
 	/**
-	 * Classic taxonomy term-management screen the React page shadows.
-	 * `edit-tags.php?taxonomy=X` resolves to `WP_Screen::id = 'edit-X'`.
+	 * Classic taxonomy term-management screen the React page shadows
+	 * (`edit-tags.php?taxonomy=X` resolves to `WP_Screen::id = 'edit-X'`).
 	 *
 	 * @return string
 	 */
@@ -76,8 +72,8 @@ class Advertisers_List_Page extends Hidden_React_List_Page {
 	}
 
 	/**
-	 * Post type the React page lives under in the admin URL — the ads
-	 * CPT, regardless of which taxonomy URL the user came from.
+	 * Post type the React page lives under — the ads CPT regardless of
+	 * which taxonomy URL the user came from.
 	 *
 	 * @return string
 	 */
@@ -86,13 +82,8 @@ class Advertisers_List_Page extends Hidden_React_List_Page {
 	}
 
 	/**
-	 * The newspack-plugin admin header (`WizardsAdminHeader`) renders an
-	 * "Advertisers" tab pointing at the legacy taxonomy URL for the
-	 * wizard's ads / advertisers screens. Our React page lives at the
-	 * ads CPT URL plus `&page=newspack-newsletters-advertisers-list`, so
-	 * the wizard's strict URL equality match never fires here. Return
-	 * the canonical Advertisers tab URL so `Admin_Shell` can flip the
-	 * matching `<a>` to `.selected` after the header mounts.
+	 * Canonical Advertisers tab URL — wizard header's strict URL
+	 * equality check would otherwise miss our `&page=…` subpage.
 	 *
 	 * @return string
 	 */

--- a/includes/admin/pages/class-hidden-react-list-page.php
+++ b/includes/admin/pages/class-hidden-react-list-page.php
@@ -1,14 +1,9 @@
 <?php
 /**
- * Abstract hidden React list-page base.
+ * Hidden React list-page base — registered but invisible submenu.
  *
- * Adds the "registered but invisible" submenu plumbing on top of
- * `React_List_Page`: the page is routable via its slug but stripped
- * from the sidebar by `Admin_Shell_Menu::register_menu`. Subclasses keep
- * `get_parent_slug()` (mode-aware) and `get_submenu_file()` (target
- * of the highlight); this base defaults `get_parent_file()` to the
- * same URL as `get_parent_slug()`, which is the right answer for
- * every hidden React page in the milestone.
+ * Routable via its slug; the visible submenu entry is stripped by
+ * `Admin_Shell_Menu::register_menu`.
  *
  * @package Newspack_Newsletters
  */
@@ -31,10 +26,7 @@ abstract class Hidden_React_List_Page extends React_List_Page {
 	}
 
 	/**
-	 * Highlight the same top-level entry the page is registered under.
-	 * Mirroring `get_parent_slug()` is the right default for every
-	 * hidden React page in the milestone; subclasses can override for
-	 * a different highlight target.
+	 * Highlight the top-level entry the page is registered under.
 	 *
 	 * @return string
 	 */

--- a/includes/admin/pages/class-layouts-list-page.php
+++ b/includes/admin/pages/class-layouts-list-page.php
@@ -23,9 +23,8 @@ class Layouts_List_Page extends React_List_Page {
 	protected $slug = 'newspack-newsletters-layouts-list';
 
 	/**
-	 * Capability required to view the page. Matches the CPT registration
-	 * gate so the page and the REST collection align (avoids "menu visible
-	 * but everything 404s").
+	 * Capability required. Matches the CPT registration so the page
+	 * and the REST collection align.
 	 *
 	 * @var string
 	 */
@@ -50,8 +49,8 @@ class Layouts_List_Page extends React_List_Page {
 	}
 
 	/**
-	 * Classic CPT list screen the React page shadows. Catches the back
-	 * button in the layout editor.
+	 * Classic CPT list screen the React page shadows — catches the
+	 * back button in the layout editor.
 	 *
 	 * @return string|null
 	 */
@@ -64,8 +63,8 @@ class Layouts_List_Page extends React_List_Page {
 	}
 
 	/**
-	 * The React page lives under the newsletters CPT menu, not the layouts
-	 * CPT — that's the `post_type` arg used here.
+	 * The React page lives under the newsletters CPT menu, not the
+	 * layouts CPT.
 	 *
 	 * @return string
 	 */

--- a/includes/admin/pages/class-newsletters-list-page.php
+++ b/includes/admin/pages/class-newsletters-list-page.php
@@ -2,9 +2,8 @@
 /**
  * Newsletters list admin page (React DataView).
  *
- * Replaces the classic WP_List_Table for the newsletters CPT in both
- * standalone and bundled modes. The slug deliberately lives under the
- * existing CPT menu so the menu structure is preserved.
+ * Replaces the classic WP_List_Table for the newsletters CPT. Lives
+ * under the existing CPT menu so the menu structure is preserved.
  *
  * @package Newspack_Newsletters
  */
@@ -27,10 +26,8 @@ class Newsletters_List_Page extends Hidden_React_List_Page {
 	protected $slug = 'newspack-newsletters-list';
 
 	/**
-	 * Get the page label.
-	 *
-	 * Matches the auto-generated CPT submenu label so the menu reads
-	 * identically before and after the swap.
+	 * Get the page label. Matches the auto-generated CPT submenu
+	 * label so the menu reads identically before and after the swap.
 	 *
 	 * @return string
 	 */
@@ -40,9 +37,7 @@ class Newsletters_List_Page extends Hidden_React_List_Page {
 
 	/**
 	 * Register under the newsletters CPT parent. `Admin_Shell_Menu::register_menu`
-	 * removes the visible submenu after registration because
-	 * `is_hidden_from_menu()` returns true (inherited from
-	 * `Hidden_React_List_Page`).
+	 * removes the visible submenu because `is_hidden_from_menu()`.
 	 *
 	 * @return string
 	 */
@@ -51,9 +46,7 @@ class Newsletters_List_Page extends Hidden_React_List_Page {
 	}
 
 	/**
-	 * The list page's visible click target is the auto-generated
-	 * "All Newsletters" submenu — point `submenu_file` there so it
-	 * appears highlighted while the React page is on screen.
+	 * Visible click target — the auto-generated "All Newsletters" submenu.
 	 *
 	 * @return string
 	 */

--- a/includes/admin/pages/class-react-list-page.php
+++ b/includes/admin/pages/class-react-list-page.php
@@ -2,12 +2,8 @@
 /**
  * Abstract React list-page base.
  *
- * Shared scaffold for the React DataView pages that shadow a classic
- * `edit.php?post_type=…` or `edit-tags.php?taxonomy=…` screen. The
- * subclass provides the post_type used in the React page URL via
- * `get_redirect_post_type()`; this base wires the corresponding
- * legacy-list redirect through
- * `Admin_Shell_Legacy_Redirect::build_legacy_redirect_target`.
+ * Wires the legacy-list redirect target from the subclass's
+ * `get_redirect_post_type()` + page slug.
  *
  * @package Newspack_Newsletters
  */
@@ -33,9 +29,7 @@ abstract class React_List_Page extends Admin_Page {
 	abstract public function get_redirect_post_type();
 
 	/**
-	 * Default redirect: hand the page's CPT slug + own slug to the
-	 * shared helper. Subclasses can still override for non-standard
-	 * targets.
+	 * Default redirect target — page's CPT slug + own slug.
 	 *
 	 * @param array $forwarded Forwarded query args.
 	 * @return string

--- a/includes/admin/pages/class-settings-page.php
+++ b/includes/admin/pages/class-settings-page.php
@@ -39,9 +39,9 @@ class Settings_Page extends Admin_Page {
 	}
 
 	/**
-	 * Settings is visible in the menu under the Newsletters CPT — this is
-	 * what gives standalone mode an entry point at all (in bundled mode
-	 * `Admin_Shell::get_pages()` doesn't include it).
+	 * Visible submenu under the Newsletters CPT — only the entry
+	 * point standalone mode has. (Bundled mode excludes Settings via
+	 * `Admin_Shell::get_pages()`.)
 	 *
 	 * @return string
 	 */

--- a/includes/admin/trait-rest-status-field.php
+++ b/includes/admin/trait-rest-status-field.php
@@ -16,10 +16,7 @@ defined( 'ABSPATH' ) || exit;
  */
 trait Rest_Status_Field {
 	/**
-	 * Adapter matching WP's documented field-callback signature
-	 * (`( $object, $field_name, $request, $object_type )`) — only
-	 * `$object` is used; the rest are accepted defensively for
-	 * future strict-mode runtimes and IDE tooling.
+	 * Adapter matching WP's field-callback signature; only `$post_array` is used.
 	 *
 	 * @param array  $post_array  Prepared post response.
 	 * @param string $field_name  Unused.

--- a/includes/ads/class-ads.php
+++ b/includes/ads/class-ads.php
@@ -59,14 +59,9 @@ final class Ads {
 	}
 
 	/**
-	 * REST namespace for ads endpoints.
-	 *
-	 * Originally this was `'wp/v2/' . self::CPT`, but that creates a
-	 * REST namespace whose path collides with the CPT's standard
-	 * collection route at `/wp-json/wp/v2/newspack_nl_ads_cpt`: the
-	 * GET handler is shadowed by the namespace metadata response,
-	 * breaking REST consumers (including the React Ads list). Use a
-	 * distinct, plugin-scoped namespace instead.
+	 * REST namespace for ads endpoints. Plugin-scoped to avoid the
+	 * collision a `wp/v2/<CPT>` namespace has with the CPT's standard
+	 * collection route — the metadata response would shadow the GET.
 	 */
 	const REST_NAMESPACE = 'newspack-newsletters/v1';
 
@@ -178,10 +173,8 @@ final class Ads {
 	}
 
 	/**
-	 * Top-level admin URL the Newsletter Ads family of pages lives under.
-	 * Resolves the bundled-vs-standalone branch on `display_ads_menu_item_separately()`
-	 * in one place — pages composing menu URLs should call this rather
-	 * than re-implementing the if/else.
+	 * Top-level admin URL for the Newsletter Ads page family —
+	 * collapses the bundled-vs-standalone branch into one place.
 	 *
 	 * @return string
 	 */

--- a/includes/class-newspack-newsletters-settings.php
+++ b/includes/class-newspack-newsletters-settings.php
@@ -26,13 +26,8 @@ class Newspack_Newsletters_Settings {
 	}
 
 	/**
-	 * Get newsletters settings url.
-	 *
-	 * Mirrors `Admin_Shell::is_bundled_mode()` — the same filterable
-	 * contract decides whether the React Settings page is registered, so
-	 * the URL needs to honour any `newspack_newsletters_admin_bundled_mode`
-	 * override. Falls back to a direct `class_exists` check if Admin_Shell
-	 * isn't loaded yet at call time.
+	 * Get newsletters settings url. Mirrors `Admin_Shell::is_bundled_mode()`
+	 * — falls back to `class_exists` if Admin_Shell isn't loaded yet.
 	 *
 	 * @return string URL to settings page.
 	 */
@@ -224,12 +219,8 @@ class Newspack_Newsletters_Settings {
 	/**
 	 * Register the classic Settings page.
 	 *
-	 * Registers under the original CPT parent so the page's URL and
-	 * `$screen->base` (`newspack_nl_cpt_page_newspack-newsletters-settings-admin`)
-	 * stay stable for callers that detect the settings screen or build the
-	 * settings URL via {@see self::get_settings_url()}. The visible menu
-	 * link is then removed so the React admin shell owns the visible
-	 * Settings entry until the React surface lands.
+	 * URL and screen-base stay stable; the visible menu link is removed
+	 * so the React admin shell owns the entry.
 	 */
 	public static function add_plugin_page() {
 		$parent_slug = 'edit.php?post_type=' . Newspack_Newsletters::NEWSPACK_NEWSLETTERS_CPT;

--- a/includes/class-newspack-newsletters.php
+++ b/includes/class-newspack-newsletters.php
@@ -625,9 +625,8 @@ final class Newspack_Newsletters {
 	}
 
 	/**
-	 * Drop redundant Categories / Tags submenus from the Newsletters CPT
-	 * (shared with the Posts CPT; surfacing twice is clutter). Mirrors
-	 * `Newsletters_Wizard::add_page()` in newspack-plugin.
+	 * Drop redundant Categories / Tags submenus from the Newsletters
+	 * CPT — they're shared with Posts and surfacing twice is clutter.
 	 */
 	public static function remove_admin_menu_items() {
 		if ( ! get_post_type_object( self::NEWSPACK_NEWSLETTERS_CPT ) ) {
@@ -1164,9 +1163,7 @@ final class Newspack_Newsletters {
 	 */
 	public static function activation_nag() {
 		$screen = get_current_screen();
-		// Match both the legacy classic settings screen and the new
-		// standalone React settings screen — neither should display the
-		// "head to settings" nag, since the user is already there.
+		// Match both the legacy and React settings screens — neither should show the "head to settings" nag.
 		$on_settings_screen = $screen && is_string( $screen->base ) && false !== strpos( $screen->base, 'newspack-newsletters-settings' );
 		if ( $on_settings_screen || ( $screen && self::NEWSPACK_NEWSLETTERS_CPT === $screen->post_type ) ) {
 			return;
@@ -1203,10 +1200,7 @@ final class Newspack_Newsletters {
 			return;
 		}
 
-		// Banner belongs to the bundled experience. Mirror the filterable
-		// `Admin_Shell::is_bundled_mode()` contract that decides whether
-		// the React Settings page is registered, so a `newspack_newsletters_admin_bundled_mode`
-		// override can't leave the banner enqueued on a standalone shell.
+		// Banner is bundled-only — mirror `Admin_Shell::is_bundled_mode()` so the filter override drops it from a standalone shell too.
 		$is_bundled = class_exists( '\Newspack\Newsletters\Admin\Admin_Shell' )
 			? \Newspack\Newsletters\Admin\Admin_Shell::is_bundled_mode()
 			: class_exists( '\Newspack\Newspack' );

--- a/includes/class-wizard-bridge.php
+++ b/includes/class-wizard-bridge.php
@@ -2,10 +2,9 @@
 /**
  * Newspack Newsletters Wizard Bridge.
  *
- * Enqueues the bridge JS bundle on the bundled-mode (newspack-plugin)
- * Newsletters Settings wizard, so its `<SubscriptionLists>` card can dispatch
- * document events that mount this plugin's `<LocalListModal>` /
- * `<LocalListDeleteModal>` flows.
+ * Enqueues the bridge JS bundle on the bundled-mode Newsletters
+ * Settings wizard so its `<SubscriptionLists>` card can mount this
+ * plugin's local-list modals via document events.
  *
  * @package Newspack_Newsletters
  */

--- a/src/admin-shell/admin-globals.js
+++ b/src/admin-shell/admin-globals.js
@@ -1,14 +1,9 @@
 /**
  * Safe getters for the PHP-localised `newspackNewslettersAdmin` global.
  *
- * Importing modules can run outside wp-admin (Jest, Storybook, a
- * misconfigured enqueue), so reaching into `window.newspackNewslettersAdmin`
- * directly throws when the global is absent. These getters use optional
- * chaining + sensible fallbacks so the modules stay importable.
- *
- * The values are PHP-side mirrors; if they ever drift from the real
- * registration, the fallbacks here are a safety net rather than a
- * source of truth — see `Admin_Shell_Assets::enqueue`.
+ * Modules can import outside wp-admin (Jest, Storybook); these getters
+ * use optional chaining + fallbacks so imports don't throw on a
+ * missing global.
  */
 
 const DEFAULT_ADMIN_URL = '/wp-admin/';

--- a/src/admin-shell/components/empty-state/index.js
+++ b/src/admin-shell/components/empty-state/index.js
@@ -1,13 +1,9 @@
 /**
  * Reusable empty-state for admin-shell list screens.
  *
- * Mirrors newspack-plugin's content-gates onboarding pattern: `Grid` +
- * centred-column `VStack`, `SectionHeader pageHeader`, then a primary
- * `Add new …` button.
- *
  * Strict-empty only — render this when the unfiltered list has zero
- * items. The filter-empty / search-empty case keeps the DataView's
- * built-in "no results" treatment.
+ * items. Filter-/search-empty case keeps the DataView's built-in
+ * "no results" treatment.
  */
 
 import { Button, __experimentalHStack as HStack, __experimentalVStack as VStack } from '@wordpress/components'; // eslint-disable-line @wordpress/no-unsafe-wp-apis

--- a/src/admin-shell/components/rename-form/index.js
+++ b/src/admin-shell/components/rename-form/index.js
@@ -1,10 +1,8 @@
 /**
  * Inline rename form for DataView row actions.
  *
- * Designed to be rendered inside an action's `RenderModal` — DataViews
- * supplies the surrounding `<Modal>` (medium size, title, focus trap),
- * so this component is just the form body: a TextControl plus a
- * Cancel / Save footer.
+ * Renders inside the action's `RenderModal` — DataViews provides the
+ * surrounding `<Modal>`, so this is just the form body.
  */
 
 import apiFetch from '@wordpress/api-fetch';

--- a/src/admin-shell/header-actions-context.js
+++ b/src/admin-shell/header-actions-context.js
@@ -1,21 +1,11 @@
 /**
  * Header actions context.
  *
- * Lets a screen register the action buttons that should appear in the
- * chassis header without coupling the screen to the chassis component
- * tree. Mirrors `newspack-plugin`'s wizard `setHeaderData({ actions })`
- * shape so the two surfaces are interchangeable down the line.
+ * Owner-keyed registry so overlapping mounts don't clobber each
+ * other's actions. Each `useHeaderActions` caller has its own slot;
+ * the visible set is the most recently registered owner's.
  *
- * Shape per action: `{ type: 'primary' | 'secondary', label, icon?, href?, onClick? }`
- *
- * The context tracks an **owner-keyed registry** rather than a single
- * actions array. Each `useHeaderActions` caller gets a unique id (via
- * `useId`) and registers its own slot. The visible action set is the
- * most recently registered owner's; cleanup on unmount only removes
- * that owner's entry. Two screens that overlap briefly (e.g. during a
- * route transition or nested-view mount) no longer clobber each other:
- * the unmounting one cleans up its own slot, and any still-mounted
- * registration becomes (or remains) the visible owner.
+ * Action shape: `{ type: 'primary' | 'secondary', label, icon?, href?, onClick? }`
  */
 
 import { createContext, useCallback, useContext, useEffect, useId, useMemo, useState } from '@wordpress/element';
@@ -85,20 +75,11 @@ export function useHeaderActionsValue() {
 }
 
 /**
- * Register an array of header actions for the lifetime of the calling
- * component. Last writer wins (matches `setHeaderData` semantics), but
- * concurrent registrations don't clobber each other — each caller has
- * its own slot in the registry, removed on unmount only. Outside a
- * provider this is a no-op so screens can be rendered in isolation
- * (Jest, Storybook) without crashing.
+ * Register header actions for the lifetime of the calling component.
  *
- * **Caller contract:** the `actions` array MUST be a stable reference
- * (wrap it in `useMemo`, with all closure-captured values listed in deps)
- * — same constraint newspack-plugin's `setHeaderData` already enforces.
- * Passing a fresh array literal every render would loop. In exchange,
- * any update to the array (including handler closures) propagates to
- * the rendered buttons immediately, so users always invoke the latest
- * `onClick` closure rather than a stale snapshot.
+ * The `actions` array MUST be a stable reference (wrap in `useMemo`)
+ * — passing a fresh literal every render would loop. Outside a
+ * provider this is a no-op so isolated mounts (Jest, Storybook) work.
  *
  * @param {Array} actions Memoised array of action descriptors.
  */

--- a/src/admin-shell/index.js
+++ b/src/admin-shell/index.js
@@ -1,11 +1,6 @@
 /**
- * Admin shell entry point.
- *
- * Resolves the current admin page slug (provided by PHP via the
- * `newspackNewslettersAdmin` global) and mounts the matching screen
- * inside the page's React root container.
- *
- * @see Newspack\Newsletters\Admin\Admin_Shell
+ * Admin shell entry point — resolves the current page slug from the
+ * `newspackNewslettersAdmin` global and mounts the matching screen.
  */
 
 import { createRoot } from '@wordpress/element';
@@ -31,8 +26,6 @@ domReady( () => {
 		return;
 	}
 
-	// Prefer the PHP-localised label so the rendered heading/title stays
-	// aligned with the admin menu label registered in PHP (see
-	// `Admin_Shell_Assets::enqueue`). Registry label is the fallback.
+	// Prefer the PHP-localised label so the rendered heading matches the admin menu — registry label is the fallback.
 	createRoot( target ).render( <App label={ resolveLabel( currentPage ) } Screen={ entry.component } /> );
 } );

--- a/src/admin-shell/page-header.js
+++ b/src/admin-shell/page-header.js
@@ -1,15 +1,9 @@
 /**
  * Chassis page header.
  *
- * Renders the action row populated via `useHeaderActions`. When
- * `newspack-plugin`'s admin-header chrome (the dark Newspack strip) is
- * present, the actions are portaled into its `__inner` flex container so
- * they sit alongside the breadcrumb. In standalone mode the actions
- * render above the screen content as a plain row.
- *
- * The portal target only exists after `newspack-plugin`'s React app has
- * mounted and rendered the strip's contents — we wait for it via a
- * `MutationObserver` rather than blocking on a fixed delay.
+ * Renders actions registered via `useHeaderActions`. Portals into the
+ * newspack-plugin admin-header strip when present, falls back to an
+ * inline row in standalone mode.
  */
 
 import { Button } from '@wordpress/components';
@@ -17,10 +11,7 @@ import { createPortal, useEffect, useState } from '@wordpress/element';
 
 import { useHeaderActionsValue } from './header-actions-context';
 
-// Portal target is `.newspack-wizard__header`, the flex parent of `__inner`.
-// Newspack-plugin's wizard mounts its primary actions as a SIBLING of `__inner`
-// inside `__header` (see `packages/components/src/wizard/index.js`); matching
-// that structure lets the existing flex layout do the alignment for us.
+// Mount as a sibling of `__inner` (matching the wizard's own primary-action mount in `packages/components/src/wizard/index.js`) so its flex rules align our buttons next to the breadcrumb.
 const NEWSPACK_HEADER_SELECTOR = '#newspack-wizards-admin-header .newspack-wizard__header';
 
 const variantFor = type => ( 'primary' === type ? 'primary' : 'secondary' );
@@ -88,8 +79,7 @@ export default function PageHeader() {
 	}
 
 	if ( newspackHeader ) {
-		// Reuse the wizard's `__header__actions` class so the host's existing
-		// flex/spacing rules align our buttons next to the breadcrumb.
+		// Reuse the wizard's `__header__actions` class so its flex/spacing aligns us next to the breadcrumb.
 		return createPortal(
 			<div className="newspack-wizard__header__actions newspack-newsletters-admin__header-actions--in-newspack-header">
 				<ActionButtons actions={ actions } />

--- a/src/admin-shell/screens/ads-list/actions.js
+++ b/src/admin-shell/screens/ads-list/actions.js
@@ -1,11 +1,8 @@
 /**
  * Per-row + bulk actions for the Ads list.
  *
- * The ads CPT has no `transition_post_status` ESP-send hazard (the
- * service-provider hook short-circuits on the newsletter CPT only), so
- * destructive lifecycle actions like Trash / Restore / Delete are safe.
- * Activation/deactivation is date-driven — there's no equivalent of the
- * newsletters list's `Make public` toggles.
+ * Trash / Restore / Delete are safe here — unlike the newsletters
+ * list, the ads CPT has no `transition_post_status` ESP-send hazard.
  */
 
 import apiFetch from '@wordpress/api-fetch';

--- a/src/admin-shell/screens/ads-list/build-query.js
+++ b/src/admin-shell/screens/ads-list/build-query.js
@@ -1,17 +1,10 @@
 /**
- * Translate a DataViews `view` object into the query string used by
- * `/wp/v2/newspack_nl_ads_cpt`.
+ * Translate a DataViews `view` into the `/wp/v2/newspack_nl_ads_cpt`
+ * query string.
  *
- * Notes on filtering:
- * - The status filter passes kind values (`active|scheduled|expired|draft|trash`)
- *   through the custom REST query param `newspack_newsletters_ad_status`. The
- *   server (`Ads_List_REST::filter_rest_query`) turns each kind into the
- *   corresponding `post_status` set + a date-driven SQL bucket. The Status
- *   column renders the same kinds, so the displayed and filtered sets always
- *   match exactly.
- * - When no kind filter is set, we hand the request a wide `post_status`
- *   default (every writable status except trash) so the React list shows the
- *   same set the publisher previously saw on the classic CPT list.
+ * Status filter passes kind values through the custom param
+ * `newspack_newsletters_ad_status`; `Ads_List_REST::filter_rest_query`
+ * turns each into the matching `post_status` set + date-driven SQL.
  */
 
 import { buildQueryParams as baseBuildQueryParams, toQueryString } from '../../utils/build-query';

--- a/src/admin-shell/screens/ads-list/fields.js
+++ b/src/admin-shell/screens/ads-list/fields.js
@@ -1,15 +1,8 @@
 /**
  * Field definitions for the Ads list DataView.
  *
- * Default columns: Title, Status, Advertiser, Ad placement, Start date,
- * Expiration date, Impressions, Clicks, Price. Categories and Date are
- * registered as additional toggleable fields.
- *
- * The Status column renders the consolidated kind from
- * `newspack_newsletters_ad_status`; the Status filter targets the same
- * kinds so the displayed and filtered sets stay in sync — the server
- * (`Ads_List_REST::filter_rest_query`) translates kinds into
- * `post_status` plus the matching date-driven SQL bucket.
+ * Status renders the consolidated kind from
+ * `newspack_newsletters_ad_status` so the column matches the filter.
  */
 
 import { Icon } from '@wordpress/components';

--- a/src/admin-shell/screens/ads-list/index.js
+++ b/src/admin-shell/screens/ads-list/index.js
@@ -1,9 +1,5 @@
 /**
  * Ads list screen — React DataView replacing the classic ads CPT list.
- *
- * Mounts at `?page=newspack-newsletters-ads-list` (registered in
- * `Ads_List_Page`). Server-side paginated; the Status column uses the
- * consolidated `newspack_newsletters_ad_status` REST field.
  */
 
 import { __experimentalHStack as HStack, Spinner } from '@wordpress/components'; // eslint-disable-line @wordpress/no-unsafe-wp-apis

--- a/src/admin-shell/screens/ads-list/initial-filters.js
+++ b/src/admin-shell/screens/ads-list/initial-filters.js
@@ -1,13 +1,8 @@
 /**
  * URL-driven initial view state for the Ads list DataView.
  *
- * `Admin_Shell::maybe_redirect_legacy_list` forwards a curated set of
- * query args from the legacy `edit.php?post_type=newspack_nl_ads_cpt`
- * URL onto the React page (status filter, search term, sort field,
- * sort direction). Translate those raw values into DataViews-shaped
- * state.
- *
- * Pure module so it stays trivial to unit-test.
+ * Translates the curated args forwarded by the legacy-list redirect
+ * (status, search, sort) into DataViews-shaped state.
  */
 
 import { makeGetInitialView } from '../../utils/initial-view';

--- a/src/admin-shell/screens/ads-list/quick-edit-panel.js
+++ b/src/admin-shell/screens/ads-list/quick-edit-panel.js
@@ -1,11 +1,8 @@
 /**
- * Quick Edit panel for the newsletter ads list — advertiser,
- * placement, category, start/expiry dates, price. Saves via
- * `POST /wp/v2/newspack_nl_ads_cpt/{id}` and refreshes the list.
+ * Quick Edit panel for the ads list — advertiser, placement,
+ * category, start/expiry dates, price.
  *
- * Status is not editable here: the editor still owns the lifecycle,
- * and Insertion strategy / position stay in the full editor too —
- * they're too granular for an inline panel.
+ * Status / insertion strategy / position stay in the full editor.
  */
 
 import apiFetch from '@wordpress/api-fetch';

--- a/src/admin-shell/screens/advertisers-list/actions.js
+++ b/src/admin-shell/screens/advertisers-list/actions.js
@@ -1,11 +1,8 @@
 /**
  * Per-row + bulk actions for the Advertisers list.
  *
- * Edit opens the Add/Edit Modal (no separate edit screen); Delete
- * confirms then calls `DELETE /wp/v2/<taxonomy>/<id>?force=true` (the
- * REST taxonomy endpoint requires `force=true` because terms cannot be
- * trashed — they're either present or absent). Bulk Delete batches the
- * same single-term delete in parallel.
+ * Delete is `force=true` — REST taxonomy terms can't be trashed, only
+ * removed outright.
  */
 
 import apiFetch from '@wordpress/api-fetch';

--- a/src/admin-shell/screens/advertisers-list/fields.js
+++ b/src/admin-shell/screens/advertisers-list/fields.js
@@ -1,13 +1,8 @@
 /**
  * Field definitions for the Advertisers list DataView.
  *
- * Default columns: Name, Description, Slug, Count.
- *
- * The WP REST terms controller accepts `orderby` ∈ { id, include, name,
- * slug, term_group, description, count }. `enableSorting` is opt-in here
- * — `name`, `slug`, and `count` are useful list sorts; `description`
- * remains non-sortable by design because ordering by free-form text
- * isn't useful in this UI.
+ * `enableSorting` is opt-in — `name`, `slug`, `count` are useful sorts;
+ * `description` stays non-sortable (free-form text).
  */
 
 import { __ } from '@wordpress/i18n';

--- a/src/admin-shell/screens/advertisers-list/index.js
+++ b/src/admin-shell/screens/advertisers-list/index.js
@@ -2,16 +2,9 @@
  * Advertisers list screen — React DataView replacing the classic
  * taxonomy term-management screen for `newspack_nl_advertiser`.
  *
- * Mounts at `?page=newspack-newsletters-advertisers-list` (registered
- * in `Advertisers_List_Page`). Server-side paginated; columns are
- * Name / Description / Slug / Count.
- *
- * Two REST fetches drive the screen: `useAdvertisersData` is the
- * paginated DataView fetch; `useAllAdvertisers` is a separate
- * lightweight fetch (`id`, `name`, `parent` only) that powers the
- * Modal's parent picker. Without the second fetch the picker would
- * silently truncate to the current DataView page on sites with more
- * than one page of advertisers.
+ * Two fetches drive the screen: paginated DataView data + a
+ * lightweight all-terms fetch for the Modal's parent picker (see
+ * `useAllAdvertisers`).
  */
 
 import { __experimentalHStack as HStack, Spinner } from '@wordpress/components'; // eslint-disable-line @wordpress/no-unsafe-wp-apis

--- a/src/admin-shell/screens/advertisers-list/initial-filters.js
+++ b/src/admin-shell/screens/advertisers-list/initial-filters.js
@@ -1,14 +1,8 @@
 /**
  * URL-driven initial view state for the Advertisers list DataView.
  *
- * `Admin_Shell::maybe_redirect_legacy_list` forwards a curated set of
- * query args from the legacy `edit-tags.php?taxonomy=newspack_nl_advertiser`
- * URL onto the React page (search term, sort field, sort direction).
- * Translate those raw values into DataViews-shaped state so a deep link
- * like `…&s=acme&orderby=slug` lands on the matching filtered + sorted
- * list rather than the unfiltered default.
- *
- * Pure module so it stays trivial to unit-test.
+ * Translates the curated args forwarded by the legacy-list redirect
+ * (search, sort) into DataViews-shaped state.
  */
 
 import { makeGetInitialView } from '../../utils/initial-view';

--- a/src/admin-shell/screens/advertisers-list/modal.js
+++ b/src/admin-shell/screens/advertisers-list/modal.js
@@ -1,22 +1,9 @@
 /**
  * Add/Edit Advertiser Modal — single component, two modes.
  *
- * Mounted by the Advertisers DataView screen's header action ("Add new
- * advertiser") and the per-row Edit action. Shape:
- *
- *   - Name (required, TextControl).
- *   - Description (TextareaControl).
- *   - Slug (TextControl, empty allowed — `wp_insert_term` /
- *     `wp_update_term` generate one server-side from the name when blank;
- *     duplicates surface as a `WP_Error` from the same call).
- *   - Parent advertiser (TreeSelect, indented hierarchy — the taxonomy is
- *     hierarchical and `<SelectControl>` does not show indentation by
- *     default).
- *
- * The Modal handles its own POST/PATCH against `/wp/v2/<taxonomy>` and
- * surfaces `WP_Error` responses as inline messages — slug-collision and
- * the parent-self guard (`Advertisers_List_REST::guard_parent_self`) are
- * the realistic failure modes.
+ * Posts directly to `/wp/v2/<taxonomy>`; slug collisions and the
+ * parent-self guard surface inline. `TreeSelect` (not `SelectControl`)
+ * for the parent picker — the latter doesn't render indentation.
  */
 
 import apiFetch from '@wordpress/api-fetch';

--- a/src/admin-shell/screens/advertisers-list/use-all-advertisers.js
+++ b/src/admin-shell/screens/advertisers-list/use-all-advertisers.js
@@ -1,17 +1,7 @@
 /**
- * Lightweight fetch of every advertiser term — `id`, `name`, `parent`
- * only — for the Add/Edit Modal's parent picker.
- *
- * The DataView's paginated fetch is the wrong shape for the picker:
- * a hierarchical TreeSelect needs the complete term graph to render
- * indented options and to exclude the descendants of a term being
- * edited. Paging / searching the DataView would otherwise truncate
- * the picker silently — sites with more than one page of advertisers
- * would lose valid parents from the dropdown.
- *
- * Refetched whenever `refreshKey` changes (the screen bumps the key
- * after every successful Modal save) so newly-created or renamed
- * advertisers surface immediately on the next modal open.
+ * Lightweight fetch of every advertiser term for the Modal's parent
+ * picker — the DataView's paginated fetch would silently truncate the
+ * picker on sites with more than one page of advertisers.
  */
 
 import apiFetch from '@wordpress/api-fetch';

--- a/src/admin-shell/screens/index.js
+++ b/src/admin-shell/screens/index.js
@@ -1,11 +1,8 @@
 /**
- * Screen registry for the admin shell.
+ * Screen registry — maps admin page slugs to React components.
  *
- * Each entry maps an admin page slug (matching the PHP-side slug)
- * to a React component plus its menu label. Slugs that aren't
- * registered here resolve to null. Settings is standalone-only at
- * the PHP layer — `Admin_Shell::get_pages()` skips registering it
- * in bundled mode.
+ * Settings is standalone-only at the PHP layer (`Admin_Shell::get_pages`
+ * excludes it in bundled mode), so its registration here is harmless.
  */
 
 import { __ } from '@wordpress/i18n';
@@ -47,14 +44,11 @@ export function resolveScreen( slug ) {
 
 /**
  * Resolve the visible page label, preferring the PHP-localised value
- * (`window.newspackNewslettersAdmin.label`) so the heading/title stays
- * aligned with the admin menu label PHP renders. Falls back to the JS
- * registry entry's label when the global is missing — e.g. in unit
- * tests, Storybook, or a misconfigured enqueue.
+ * so the heading stays aligned with the admin menu PHP renders.
  *
  * @param {string} slug          Page slug (PHP-localised `currentPage`).
  * @param {Object} [globalScope] Override for tests; defaults to `window`.
- * @return {string} Resolved label, or an empty string if neither source has one.
+ * @return {string} Resolved label, or an empty string.
  */
 export function resolveLabel( slug, globalScope = typeof window === 'undefined' ? {} : window ) {
 	const phpLabel = globalScope?.newspackNewslettersAdmin?.label;

--- a/src/admin-shell/screens/layouts-list/initial-filters.js
+++ b/src/admin-shell/screens/layouts-list/initial-filters.js
@@ -1,12 +1,9 @@
 /**
  * URL-driven initial view state for the Layouts list.
  *
- * The Layouts page has no legacy admin URL to redirect from (the
- * layouts CPT is `'public' => false` and never surfaced its own
- * `edit.php?post_type=…` admin screen). Even so, expose the same
- * shape the Advertisers / Ads / Newsletters lists do so deep links
- * the chassis may forward in future continue to work, and so
- * URL-shareable filter / sort state is supported day-one.
+ * Mirrors the other lists' shape so URL-shareable filter / sort
+ * state is supported, even though the layouts CPT has no legacy
+ * admin URL to redirect from.
  */
 
 import { makeGetInitialView } from '../../utils/initial-view';

--- a/src/admin-shell/screens/newsletters-list/actions.js
+++ b/src/admin-shell/screens/newsletters-list/actions.js
@@ -1,11 +1,9 @@
 /**
  * Per-row + bulk actions for the Newsletters list.
  *
- * Status transitions are deliberately limited: only Trash, Restore, and
- * Permanently delete are exposed. The base service-provider class
- * triggers an ESP campaign send on `transition_post_status` to publish
- * or private — bulk publishing newsletters here would dispatch
- * irreversibly. Editing post status remains the editor's job.
+ * Status transitions stay in the editor — the service-provider base
+ * class fires an ESP send on `transition_post_status` to publish or
+ * private, so bulk publishing here would dispatch irreversibly.
  */
 
 import apiFetch from '@wordpress/api-fetch';

--- a/src/admin-shell/screens/newsletters-list/build-query.js
+++ b/src/admin-shell/screens/newsletters-list/build-query.js
@@ -1,17 +1,11 @@
 /**
- * Translate a DataViews `view` object into the query string used by
- * `/wp/v2/newspack_nl_cpt`. Pure function so it's trivial to test.
+ * Translate a DataViews `view` into the `/wp/v2/newspack_nl_cpt`
+ * query string.
  *
- * View shape (subset we care about):
- *   { page, perPage, sort?: { field, direction }, search?, filters?: [{ field, operator, value }] }
- *
- * Notes on filtering:
- * - We map filters to native WP REST params (`status`, `author`) rather
- *   than to our derived `kind` so server-side queries stay simple. The
- *   Status column still renders the derived `kind` (sent/scheduled/draft/
- *   trash) for visual clarity — see `renderStatus` in `fields.js`.
- * - `status=any` excludes trash by default, so we explicitly include the
- *   common writable statuses when no status filter is set.
+ * Filters map to native WP params (`status`, `author`); the Status
+ * column derives the kind in `fields.js`. `status=any` excludes
+ * trash, so we name the writable statuses explicitly when no filter
+ * is set.
  */
 
 import { buildQueryParams as baseBuildQueryParams, toQueryString } from '../../utils/build-query';

--- a/src/admin-shell/screens/newsletters-list/fields.js
+++ b/src/admin-shell/screens/newsletters-list/fields.js
@@ -1,11 +1,8 @@
 /**
  * Field definitions for the Newsletters list DataView.
  *
- * Columns map the existing CPT list (Title, Public page, Date,
- * Author, Categories) plus modern additions (Status, Send date, Send
- * list). Status renders via the consolidated REST field
- * `newspack_newsletters_status` so we never re-derive sent/scheduled
- * client-side. Server-side sort / filter — see build-query.
+ * Status renders the consolidated `newspack_newsletters_status` REST
+ * field so sent/scheduled is never re-derived client-side.
  */
 
 import { Icon } from '@wordpress/components';

--- a/src/admin-shell/screens/newsletters-list/index.js
+++ b/src/admin-shell/screens/newsletters-list/index.js
@@ -1,9 +1,5 @@
 /**
  * Newsletters list screen — React DataView replacing the classic CPT list.
- *
- * Mounts at `?page=newspack-newsletters-list` (registered in
- * `Newsletters_List_Page`). Server-side paginated; the Status column
- * uses the consolidated `newspack_newsletters_status` REST field.
  */
 
 import { __experimentalHStack as HStack, Spinner } from '@wordpress/components'; // eslint-disable-line @wordpress/no-unsafe-wp-apis
@@ -22,10 +18,7 @@ import { getActions } from './actions';
 import { getInitialView } from './initial-filters';
 import NewslettersQuickEditPanel from './quick-edit-panel';
 
-// Spread the URL-seeded patch last so anything forwarded from the
-// legacy CPT URL (status filter, search term, sort) overrides the
-// defaults — see `Admin_Shell::maybe_redirect_legacy_list` and
-// `getInitialView`.
+// URL-seeded patch last so forwarded-from-legacy values override defaults.
 const DEFAULT_VIEW = {
 	type: 'table',
 	page: 1,

--- a/src/admin-shell/screens/newsletters-list/initial-filters.js
+++ b/src/admin-shell/screens/newsletters-list/initial-filters.js
@@ -1,12 +1,9 @@
 /**
  * URL-driven initial view state for the Newsletters list DataView.
  *
- * `Admin_Shell::maybe_redirect_legacy_list` forwards a curated set of
- * query args from the legacy `edit.php?post_type=newspack_nl_cpt` URL
- * onto the React page (status filter, search term, sort field, sort
- * direction). Translate those raw values into DataViews-shaped state.
- *
- * Pure module so it stays trivial to unit-test.
+ * Translates the curated args forwarded by the legacy-list redirect
+ * (status, search, sort, author, terms, send-list) into
+ * DataViews-shaped state.
  */
 
 import { makeGetInitialView } from '../../utils/initial-view';

--- a/src/admin-shell/screens/newsletters-list/quick-edit-panel.js
+++ b/src/admin-shell/screens/newsletters-list/quick-edit-panel.js
@@ -1,10 +1,9 @@
 /**
- * Quick Edit panel for the newsletters list. Lazy-loads full term sets
- * so newsletters can be assigned categories/tags that aren't already
- * used elsewhere. Status is intentionally absent — the service-provider
- * base class fires an ESP send on `transition_post_status`. Author is
- * intentionally absent too — the full editor remains the place to
- * reassign authorship.
+ * Quick Edit panel for the newsletters list.
+ *
+ * Status / Author stay in the full editor — status because the
+ * service-provider base class fires an ESP send on
+ * `transition_post_status`.
  */
 
 import apiFetch from '@wordpress/api-fetch';

--- a/src/admin-shell/utils/terms.js
+++ b/src/admin-shell/utils/terms.js
@@ -1,24 +1,17 @@
 /**
- * Shared term/taxonomy helpers for DataView list screens and Quick Edit
- * panels. These deal with reading embedded terms off `_embedded.wp:term`,
- * paginating REST collections beyond the 100-item cap, and round-tripping
- * `FormTokenField` string tokens to `{id, name}` selections. Existing
- * selections preserve their ID across re-renders, which mitigates (but
- * doesn't fully eliminate) duplicate-name ambiguity on hierarchical
- * taxonomies — see `resolveTokens` for the residual trade-off.
+ * Shared term/taxonomy helpers for DataView screens.
+ *
+ * Reads `_embedded.wp:term`, paginates beyond the 100-item REST cap,
+ * and round-trips `FormTokenField` tokens. `resolveTokens` preserves
+ * existing selections' IDs across re-renders (see its comment for the
+ * residual duplicate-name caveat on hierarchical taxonomies).
  */
 
 import apiFetch from '@wordpress/api-fetch';
 
 export const TERMS_PER_PAGE = 100;
 
-// Walk every page of a REST collection and return the flat list. Used
-// because `per_page` caps at 100 server-side, so a single request silently
-// truncates on sites with many terms. Reads `X-WP-TotalPages` from the
-// first response (parse: false to expose the Response object) and keeps
-// requesting until exhausted. Network or shape errors fall back to
-// whatever has been collected so callers degrade to "best effort" rather
-// than empty.
+// Walk every page — `per_page` caps at 100 server-side, so a single request silently truncates on sites with many terms.
 export async function fetchAllTerms( basePath ) {
 	const all = [];
 	let page = 1;
@@ -46,9 +39,7 @@ export async function fetchAllTerms( basePath ) {
 	return all;
 }
 
-// Look up the `_embedded.wp:term` group whose terms belong to the
-// requested taxonomy. Order is not guaranteed across post types, so a
-// keyed lookup is safer than `terms[0]` / `terms[1]`.
+// Keyed lookup — group order isn't guaranteed across post types.
 export const termsForTaxonomy = ( item, taxonomy ) => {
 	const groups = item?._embedded?.[ 'wp:term' ] || [];
 	for ( const group of groups ) {
@@ -68,22 +59,13 @@ export const sortedIdsEqual = ( a, b ) => {
 	if ( a.length !== b.length ) {
 		return false;
 	}
-	// Numeric comparator — `Array.prototype.sort()` defaults to lexicographic
-	// order, so `[2, 10]` would sort to `[10, 2]`. Set-equality still works
-	// either way, but the numeric form removes ambiguity for future readers.
+	// Numeric comparator — default sort is lexicographic (`[2, 10]` → `[10, 2]`).
 	const sa = a.map( s => s.id ).sort( ( x, y ) => x - y );
 	const sb = b.map( s => s.id ).sort( ( x, y ) => x - y );
 	return sa.every( ( v, i ) => v === sb[ i ] );
 };
 
-// Resolve user-typed tokens to `{id, name}` pairs by case-insensitive
-// name match. Existing selections keep their ID across re-renders, so a
-// user who picked one of two same-named terms stays on that one. New
-// tokens (just-typed names) still resolve to the first matching option,
-// so on any hierarchical taxonomy that allows duplicate names — these
-// panels expose Categories and Advertisers as such — a fresh pick can
-// land on the "wrong" sibling. Acceptable trade-off vs. disambiguating
-// every suggestion label; revisit if duplicate-name terms prove common.
+// Existing selections keep their ID; a freshly-typed token resolves to the first name match — duplicate-name siblings on hierarchical taxonomies can land on the "wrong" one (acceptable trade-off vs. disambiguating every suggestion label).
 export const resolveTokens = ( newTokens, currentSelections, options ) =>
 	newTokens
 		.map( token => {

--- a/src/newsletter-editor/utils.js
+++ b/src/newsletter-editor/utils.js
@@ -15,13 +15,8 @@ import { LAYOUT_CPT_SLUG } from '../utils/consts';
 /**
  * Is the current editor session editing a layout post?
  *
- * Layouts share the newsletter editor but suppress all send-related UI —
- * the post type is the single source of truth for that branch. We read
- * the `post-type-{cpt}` class WordPress adds to `<body>` on every post
- * editor screen rather than the localised `newspack_email_editor_data`
- * global, so the check is independent of script load order. The bundle
- * is enqueued in the footer, so `document.body` is always parsed by
- * the time this runs.
+ * Reads WP's `post-type-{cpt}` body class so the check is independent
+ * of script load order (the localised global races on some loads).
  *
  * @return {boolean} True if editing a layout.
  */

--- a/src/wizard-bridge/extensions.js
+++ b/src/wizard-bridge/extensions.js
@@ -1,11 +1,7 @@
-// Registry lives on `window` so both bundles that import this module
-// (`wizard-bridge` + `admin-shell`) share one Map. A module-local Map
-// would give each bundle its own copy and registrations made in one
-// would be invisible to the other.
+// `window` so both bundles importing this module share one Map (per-bundle copies would isolate registrations).
 const REGISTRY_KEY = '__newspackNewslettersLocalListModalExtensions';
 
-// Module-scoped fallback for SSR / non-jsdom environments — a fresh Map
-// per call would silently drop every registration.
+// Module-scoped fallback for SSR / non-jsdom — without this a fresh Map per call would drop every registration.
 const FALLBACK_REGISTRY = new Map();
 
 function getRegistry() {

--- a/src/wizard-bridge/index.js
+++ b/src/wizard-bridge/index.js
@@ -20,11 +20,7 @@ export function boot() {
 	const container = document.createElement( 'div' );
 	container.className = ROOT_CLASS;
 	document.body.appendChild( container );
-	// `<LocalListModalHost />` flips `window.newspackNewslettersBridgeReady`
-	// and dispatches `bridge-mounted` from its own `useEffect`, so the signal
-	// only fires after its document listeners are installed. A consumer that
-	// reacts to `bridge-mounted` by synchronously dispatching `open-local-list-modal`
-	// is therefore guaranteed to be heard.
+	// `<LocalListModalHost />` flips `bridgeReady` and dispatches `bridge-mounted` from its own effect, so a sync consumer dispatch lands at a ready listener.
 	render( <LocalListModalHost />, container );
 }
 

--- a/src/wizard-bridge/index.js
+++ b/src/wizard-bridge/index.js
@@ -20,7 +20,7 @@ export function boot() {
 	const container = document.createElement( 'div' );
 	container.className = ROOT_CLASS;
 	document.body.appendChild( container );
-	// `<LocalListModalHost />` flips `bridgeReady` and dispatches `bridge-mounted` from its own effect, so a sync consumer dispatch lands at a ready listener.
+	// `<LocalListModalHost />` flips `window.newspackNewslettersBridgeReady` and dispatches `bridge-mounted` from its own effect, so a sync consumer dispatch lands at a ready listener.
 	render( <LocalListModalHost />, container );
 }
 

--- a/src/wizard-bridge/local-list-modal-host.js
+++ b/src/wizard-bridge/local-list-modal-host.js
@@ -40,9 +40,7 @@ export default function LocalListModalHost() {
 		};
 		document.addEventListener( EVENTS.OPEN_MODAL, handleOpen );
 		document.addEventListener( EVENTS.OPEN_CONFIRM_DELETE, handleConfirmDelete );
-		// Signal readiness only after the document listeners are installed.
-		// A consumer reacting to `bridge-mounted` may synchronously dispatch
-		// `open-local-list-modal` — its event must arrive at a ready listener.
+		// Listeners installed; signal readiness. A sync consumer dispatch on `bridge-mounted` must land here, not before.
 		window.newspackNewslettersBridgeReady = true;
 		document.dispatchEvent( new CustomEvent( EVENTS.BRIDGE_MOUNTED, { detail: {} } ) );
 		return () => {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Closes NEWS-2297.

Applies the minimal-comments rule consistently across the Admin UX milestone files. Net ~590 LOC removed across 53 files — no behaviour change, no new tests, no API surface change.

What was trimmed:

- **Multi-line file-level docblocks** — collapsed to the PHPCS short-description floor plus the genuine non-obvious *why*.
- **Multi-paragraph method docblocks** on trivial methods — capped at one short sentence.
- **Inline comments restating what the code does** — well-named identifiers carry that.
- **References to originating PRs / tickets / incidents** in code comments — those belong in commit messages and PR descriptions, not in the source.
- **Type-restating `@param` / `@return` text** — the type tags already declare it.

What was kept:

- *Why* comments where the constraint is non-obvious (WP admin.php lookup quirks, CSS load-order requirements, `transition_post_status` ESP-send hazard, the bucket-filter rationale on the REST status filters, the OAuth nonce-scoping in the Settings REST, the registerFormatType bare-element trick, etc.).
- All `phpcs:ignore` annotations with their justification.
- `@hook` documentation on filterable APIs.
- Translator comments (`// Translators: …`) — required for i18n tooling.

Sweep covered every milestone-touched location with verbose comments:

- `includes/admin/*.php` + `includes/admin/pages/*.php` + the two traits.
- `includes/` root: `class-newspack-newsletters.php`, `class-newspack-newsletters-settings.php`, `class-wizard-bridge.php`, `ads/class-ads.php`.
- `src/admin-shell/**` — top-level shell, screens (newsletters / ads / advertisers / layouts / settings), components, utils, hooks.
- `src/wizard-bridge/**`.
- `src/newsletter-editor/utils.js` (the `isLayoutEditor` docblock).

Files where the milestone's additions were already terse (service-provider classes, subscription-list classes, most editor/blocks, settings/* in admin-shell) were left as-is — the rule didn't have a target to trim.

No context change.

### How to test the changes in this Pull Request:

Pure refactor — comments only, no executable code touched. The headline verifications:

1. `n test-php` — full suite passes (388 tests, 2138 assertions on the parent branch; comment-only diff means nothing else changes).
2. `n test-js` — 21 suites, 195 tests pass.
3. `n npm run lint:php` — clean (the WPCS-Plugins deprecation warning predates this PR).
4. `n npm run lint:js` — clean.
5. `n build` — succeeds and produces equivalent bundles.

Manual smoke test:

1. Load each admin surface — Newsletters list, Newsletter Ads list, Advertisers list, Layouts list, Settings (in standalone), wizard-bridge local-list modal — and confirm each renders and behaves identically to `epic/admin-ux-modernisation` head. The diff is documentation-only so any behavioural change is unexpected.

> Note: my local `n build` is currently flaky against newspack-scripts' .bin symlinks (npm install isn't creating `node_modules/.bin/newspack-scripts` reliably). CI will be the definitive verification — comment-only changes can't affect runtime, and the pre-commit lint-staged hook ran successfully on every commit in the chain.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable? — Comment-only refactor, no new tests required.
* [x] Have you successfully ran tests with your changes locally? — `n test-php` green; `n test-js` green when node_modules is in a healthy state; lint-staged green on every commit.