### PR TITLE
fix: pre-existing trunk bugs uncovered by NEWS-2298 final review

### DIFF
--- a/includes/admin/class-admin-shell-legacy-redirect.php
+++ b/includes/admin/class-admin-shell-legacy-redirect.php
@@ -98,7 +98,7 @@ class Admin_Shell_Legacy_Redirect {
 			}
 			// phpcs:ignore WordPress.Security.NonceVerification.Recommended,WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Sanitised below.
 			$value = wp_unslash( $_GET[ $key ] );
-			if ( '' === $value ) {
+			if ( '' === $value || ( is_array( $value ) && empty( $value ) ) ) {
 				continue;
 			}
 			$forwarded[ $key ] = is_array( $value ) ? array_map( 'sanitize_text_field', $value ) : sanitize_text_field( $value );

--- a/includes/class-newspack-newsletters-subscription.php
+++ b/includes/class-newspack-newsletters-subscription.php
@@ -251,7 +251,15 @@ class Newspack_Newsletters_Subscription {
 	 * @return WP_REST_Response|WP_Error WP_REST_Response on success, or WP_Error object on failure.
 	 */
 	public static function api_update_lists( $request ) {
-		$update = self::update_lists( $request['lists'] );
+		$lists = $request['lists'];
+		if ( ! is_array( $lists ) ) {
+			return new \WP_Error(
+				'rest_invalid_param',
+				__( 'The "lists" parameter must be an array.', 'newspack-newsletters' ),
+				[ 'status' => 400 ]
+			);
+		}
+		$update = self::update_lists( $lists );
 		if ( is_wp_error( $update ) ) {
 			return \rest_ensure_response( $update );
 		}

--- a/includes/class-newspack-newsletters.php
+++ b/includes/class-newspack-newsletters.php
@@ -977,7 +977,8 @@ final class Newspack_Newsletters {
 		if ( ! is_string( $service_provider ) || '' === $service_provider ) {
 			$wp_error->add(
 				'newspack_newsletters_no_service_provider',
-				__( 'Please select a newsletter service provider.', 'newspack-newsletters' )
+				__( 'Please select a newsletter service provider.', 'newspack-newsletters' ),
+				[ 'status' => 400 ]
 			);
 			return $wp_error;
 		}
@@ -990,7 +991,8 @@ final class Newspack_Newsletters {
 		if ( ! is_array( $credentials ) || empty( $credentials ) ) {
 			$wp_error->add(
 				'newspack_newsletters_invalid_keys',
-				__( 'Please input credentials.', 'newspack-newsletters' )
+				__( 'Please input credentials.', 'newspack-newsletters' ),
+				[ 'status' => 400 ]
 			);
 			return $wp_error;
 		}
@@ -1000,7 +1002,8 @@ final class Newspack_Newsletters {
 		if ( ! $provider || ! method_exists( $provider, 'set_api_credentials' ) ) {
 			$wp_error->add(
 				'newspack_newsletters_provider_unavailable',
-				__( 'The selected service provider is not available on this site.', 'newspack-newsletters' )
+				__( 'The selected service provider is not available on this site.', 'newspack-newsletters' ),
+				[ 'status' => 400 ]
 			);
 			return $wp_error;
 		}
@@ -1008,7 +1011,7 @@ final class Newspack_Newsletters {
 		$status = $provider->set_api_credentials( $credentials );
 		if ( is_wp_error( $status ) ) {
 			foreach ( $status->errors as $code => $message ) {
-				$wp_error->add( $code, implode( ' ', $message ) );
+				$wp_error->add( $code, implode( ' ', $message ), [ 'status' => 400 ] );
 			}
 			return $wp_error;
 		}

--- a/includes/class-newspack-newsletters.php
+++ b/includes/class-newspack-newsletters.php
@@ -974,8 +974,6 @@ final class Newspack_Newsletters {
 		$credentials      = $request['credentials'];
 		$wp_error         = new WP_Error();
 
-		// The /settings route doesn't declare arg types, so guard here —
-		// otherwise an array slug trips a TypeError in `isset( $providers[ … ] )`.
 		if ( ! is_string( $service_provider ) || '' === $service_provider ) {
 			$wp_error->add(
 				'newspack_newsletters_no_service_provider',
@@ -997,8 +995,7 @@ final class Newspack_Newsletters {
 			return $wp_error;
 		}
 
-		// Only flip the stored provider on credentials success — a
-		// rejection must not leave the site pointing at an unconfigured ESP.
+		// Only commit set_service_provider on credentials success — a rejection must not leave the site pointing at an unconfigured ESP.
 		$provider = self::get_service_provider_instance( $service_provider );
 		if ( ! $provider || ! method_exists( $provider, 'set_api_credentials' ) ) {
 			$wp_error->add(

--- a/includes/class-newspack-newsletters.php
+++ b/includes/class-newspack-newsletters.php
@@ -974,34 +974,48 @@ final class Newspack_Newsletters {
 		$credentials      = $request['credentials'];
 		$wp_error         = new WP_Error();
 
-		// Service Provider slug.
 		if ( empty( $service_provider ) ) {
 			$wp_error->add(
 				'newspack_newsletters_no_service_provider',
 				__( 'Please select a newsletter service provider.', 'newspack-newsletters' )
 			);
-		} else {
+			return $wp_error;
+		}
+
+		if ( 'manual' === $service_provider ) {
 			self::set_service_provider( $service_provider );
+			return self::api_get_settings();
 		}
 
-		// Service Provider credentials.
-		if ( 'manual' !== $service_provider ) {
-			if ( empty( $credentials ) ) {
-				$wp_error->add(
-					'newspack_newsletters_invalid_keys',
-					__( 'Please input credentials.', 'newspack-newsletters' )
-				);
-			} else {
-				$status = self::$provider->set_api_credentials( $credentials );
-				if ( is_wp_error( $status ) ) {
-					foreach ( $status->errors as $code => $message ) {
-						$wp_error->add( $code, implode( ' ', $message ) );
-					}
-				}
+		if ( empty( $credentials ) ) {
+			$wp_error->add(
+				'newspack_newsletters_invalid_keys',
+				__( 'Please input credentials.', 'newspack-newsletters' )
+			);
+			return $wp_error;
+		}
+
+		// Only flip the stored provider on credentials success — a
+		// rejection must not leave the site pointing at an unconfigured ESP.
+		$provider = self::get_service_provider_instance( $service_provider );
+		if ( ! $provider || ! method_exists( $provider, 'set_api_credentials' ) ) {
+			$wp_error->add(
+				'newspack_newsletters_provider_unavailable',
+				__( 'The selected service provider is not available on this site.', 'newspack-newsletters' )
+			);
+			return $wp_error;
+		}
+
+		$status = $provider->set_api_credentials( $credentials );
+		if ( is_wp_error( $status ) ) {
+			foreach ( $status->errors as $code => $message ) {
+				$wp_error->add( $code, implode( ' ', $message ) );
 			}
+			return $wp_error;
 		}
 
-		return $wp_error->has_errors() ? $wp_error : self::api_get_settings();
+		self::set_service_provider( $service_provider );
+		return self::api_get_settings();
 	}
 
 	/**

--- a/includes/class-newspack-newsletters.php
+++ b/includes/class-newspack-newsletters.php
@@ -974,7 +974,9 @@ final class Newspack_Newsletters {
 		$credentials      = $request['credentials'];
 		$wp_error         = new WP_Error();
 
-		if ( empty( $service_provider ) ) {
+		// The /settings route doesn't declare arg types, so guard here —
+		// otherwise an array slug trips a TypeError in `isset( $providers[ … ] )`.
+		if ( ! is_string( $service_provider ) || '' === $service_provider ) {
 			$wp_error->add(
 				'newspack_newsletters_no_service_provider',
 				__( 'Please select a newsletter service provider.', 'newspack-newsletters' )
@@ -987,7 +989,7 @@ final class Newspack_Newsletters {
 			return self::api_get_settings();
 		}
 
-		if ( empty( $credentials ) ) {
+		if ( ! is_array( $credentials ) || empty( $credentials ) ) {
 			$wp_error->add(
 				'newspack_newsletters_invalid_keys',
 				__( 'Please input credentials.', 'newspack-newsletters' )

--- a/tests/test-api-set-settings.php
+++ b/tests/test-api-set-settings.php
@@ -15,6 +15,10 @@ class Api_Set_Settings_Test extends WP_UnitTestCase {
 	public function tear_down() {
 		$keys = [
 			'newspack_newsletters_service_provider',
+			'newspack_mailchimp_api_key',
+			'newspack_newsletters_mailchimp_api_key',
+			'newspack_newsletters_constant_contact_api_key',
+			'newspack_newsletters_constant_contact_api_secret',
 			'newspack_newsletters_active_campaign_url',
 			'newspack_newsletters_active_campaign_key',
 		];
@@ -63,6 +67,7 @@ class Api_Set_Settings_Test extends WP_UnitTestCase {
 
 		$this->assertInstanceOf( WP_Error::class, $result );
 		$this->assertNotEmpty( $result->get_error_message( 'newspack_newsletters_invalid_keys' ) );
+		$this->assertSame( 400, $result->get_error_data( 'newspack_newsletters_invalid_keys' )['status'] ?? null );
 		$this->assertSame(
 			'manual',
 			get_option( 'newspack_newsletters_service_provider' ),
@@ -100,6 +105,7 @@ class Api_Set_Settings_Test extends WP_UnitTestCase {
 
 		$this->assertInstanceOf( WP_Error::class, $result );
 		$this->assertNotEmpty( $result->get_error_message( 'newspack_newsletters_no_service_provider' ) );
+		$this->assertSame( 400, $result->get_error_data( 'newspack_newsletters_no_service_provider' )['status'] ?? null );
 		$this->assertSame( 'manual', get_option( 'newspack_newsletters_service_provider' ) );
 	}
 
@@ -123,6 +129,7 @@ class Api_Set_Settings_Test extends WP_UnitTestCase {
 
 		$this->assertInstanceOf( WP_Error::class, $result );
 		$this->assertNotEmpty( $result->get_error_message( 'newspack_newsletters_invalid_keys' ) );
+		$this->assertSame( 400, $result->get_error_data( 'newspack_newsletters_invalid_keys' )['status'] ?? null );
 		$this->assertSame( 'manual', get_option( 'newspack_newsletters_service_provider' ) );
 	}
 

--- a/tests/test-api-set-settings.php
+++ b/tests/test-api-set-settings.php
@@ -1,0 +1,113 @@
+<?php
+/**
+ * Class Test Legacy api_set_settings.
+ *
+ * @package Newspack_Newsletters
+ */
+
+/**
+ * Tests the legacy `Newspack_Newsletters::api_set_settings` endpoint.
+ */
+class Api_Set_Settings_Test extends WP_UnitTestCase {
+	/**
+	 * Reset between tests so option mutations don't leak between cases.
+	 */
+	public function tear_down() {
+		$keys = [
+			'newspack_newsletters_service_provider',
+			'newspack_newsletters_active_campaign_url',
+			'newspack_newsletters_active_campaign_key',
+		];
+		foreach ( $keys as $key ) {
+			delete_option( $key );
+		}
+		Newspack_Newsletters::memoize_service_provider();
+		parent::tear_down();
+	}
+
+	/**
+	 * Build a request without dispatching through the REST server — the
+	 * test targets the controller method directly.
+	 *
+	 * @param array $params Body params.
+	 * @return WP_REST_Request
+	 */
+	private function rest_request( $params = [] ) {
+		$request = new WP_REST_Request( 'POST', '/newspack-newsletters/v1/settings' );
+		foreach ( $params as $key => $value ) {
+			$request->set_param( $key, $value );
+		}
+		return $request;
+	}
+
+	/**
+	 * A rejected credentials POST must not leave the site pointing at the
+	 * rejected provider — set_service_provider should only commit on
+	 * credentials success.
+	 */
+	public function test_rejected_credentials_do_not_switch_provider() {
+		update_option( 'newspack_newsletters_service_provider', 'manual' );
+		Newspack_Newsletters::memoize_service_provider();
+
+		$result = Newspack_Newsletters::api_set_settings(
+			$this->rest_request(
+				[
+					'service_provider' => 'active_campaign',
+					'credentials'      => [
+						'url' => '',
+						'key' => '',
+					],
+				]
+			)
+		);
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertNotEmpty( $result->get_error_message( 'newspack_newsletters_invalid_keys' ) );
+		$this->assertSame(
+			'manual',
+			get_option( 'newspack_newsletters_service_provider' ),
+			'Provider option must roll back to the previous value on credential rejection.'
+		);
+	}
+
+	/**
+	 * Switching to `manual` skips the credential block and persists.
+	 */
+	public function test_switch_to_manual_persists() {
+		update_option( 'newspack_newsletters_service_provider', 'active_campaign' );
+		Newspack_Newsletters::memoize_service_provider();
+
+		$result = Newspack_Newsletters::api_set_settings(
+			$this->rest_request( [ 'service_provider' => 'manual' ] )
+		);
+
+		$this->assertNotInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'manual', get_option( 'newspack_newsletters_service_provider' ) );
+	}
+
+	/**
+	 * Accepted credentials commit both the provider option and the
+	 * credential fields.
+	 */
+	public function test_accepted_credentials_commit_provider_switch() {
+		update_option( 'newspack_newsletters_service_provider', 'manual' );
+		Newspack_Newsletters::memoize_service_provider();
+
+		$result = Newspack_Newsletters::api_set_settings(
+			$this->rest_request(
+				[
+					'service_provider' => 'active_campaign',
+					'credentials'      => [
+						'url' => 'https://example.api-us1.com',
+						'key' => 'test-key',
+					],
+				]
+			)
+		);
+
+		$this->assertNotInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'active_campaign', get_option( 'newspack_newsletters_service_provider' ) );
+		$this->assertSame( 'https://example.api-us1.com', get_option( 'newspack_newsletters_active_campaign_url' ) );
+		$this->assertSame( 'test-key', get_option( 'newspack_newsletters_active_campaign_key' ) );
+	}
+}

--- a/tests/test-api-set-settings.php
+++ b/tests/test-api-set-settings.php
@@ -86,6 +86,47 @@ class Api_Set_Settings_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * A non-string `service_provider` (e.g. an array payload from
+	 * `service_provider[]=mailchimp`) is rejected before it can trip a
+	 * TypeError in `isset( $providers[ $slug ] )` on PHP 8.
+	 */
+	public function test_non_string_service_provider_rejected() {
+		update_option( 'newspack_newsletters_service_provider', 'manual' );
+		Newspack_Newsletters::memoize_service_provider();
+
+		$result = Newspack_Newsletters::api_set_settings(
+			$this->rest_request( [ 'service_provider' => [ 'mailchimp' ] ] )
+		);
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertNotEmpty( $result->get_error_message( 'newspack_newsletters_no_service_provider' ) );
+		$this->assertSame( 'manual', get_option( 'newspack_newsletters_service_provider' ) );
+	}
+
+	/**
+	 * A non-array `credentials` payload (e.g. `credentials=foo`) is
+	 * rejected before reaching the provider's set_api_credentials() —
+	 * which would otherwise do string-offset access on `$credentials['…']`.
+	 */
+	public function test_non_array_credentials_rejected() {
+		update_option( 'newspack_newsletters_service_provider', 'manual' );
+		Newspack_Newsletters::memoize_service_provider();
+
+		$result = Newspack_Newsletters::api_set_settings(
+			$this->rest_request(
+				[
+					'service_provider' => 'active_campaign',
+					'credentials'      => 'foo',
+				]
+			)
+		);
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertNotEmpty( $result->get_error_message( 'newspack_newsletters_invalid_keys' ) );
+		$this->assertSame( 'manual', get_option( 'newspack_newsletters_service_provider' ) );
+	}
+
+	/**
 	 * Accepted credentials commit both the provider option and the
 	 * credential fields.
 	 */

--- a/tests/test-api-update-lists.php
+++ b/tests/test-api-update-lists.php
@@ -1,0 +1,76 @@
+<?php
+/**
+ * Class Test api_update_lists.
+ *
+ * @package Newspack_Newsletters
+ */
+
+/**
+ * Tests the `/newspack-newsletters/v1/lists` POST route validation rails.
+ */
+class Api_Update_Lists_Test extends WP_UnitTestCase {
+	/**
+	 * Set up REST server and an authenticated admin user.
+	 */
+	public function set_up() {
+		parent::set_up();
+
+		$user_id = self::factory()->user->create( [ 'role' => 'administrator' ] );
+		wp_set_current_user( $user_id );
+
+		global $wp_rest_server;
+		$wp_rest_server = new \WP_REST_Server();
+		do_action( 'rest_api_init' );
+	}
+
+	/**
+	 * Reset REST server.
+	 */
+	public function tear_down() {
+		global $wp_rest_server;
+		$wp_rest_server = null;
+		parent::tear_down();
+	}
+
+	/**
+	 * A non-array `lists` payload that the route schema can't coerce
+	 * (e.g. an object) is rejected with 400 by the REST layer.
+	 */
+	public function test_non_array_lists_payload_rejected_via_rest_dispatch() {
+		$request = new WP_REST_Request( 'POST', '/newspack-newsletters/v1/lists' );
+		$request->set_param( 'lists', (object) [ 'id' => 'x' ] );
+
+		$response = rest_do_request( $request );
+
+		$this->assertSame( 400, $response->get_status() );
+		$this->assertSame( 'rest_invalid_param', $response->get_data()['code'] ?? null );
+	}
+
+	/**
+	 * Omitting the required `lists` arg is rejected with 400.
+	 */
+	public function test_missing_lists_payload_rejected_with_400() {
+		$request = new WP_REST_Request( 'POST', '/newspack-newsletters/v1/lists' );
+
+		$response = rest_do_request( $request );
+
+		$this->assertSame( 400, $response->get_status() );
+	}
+
+	/**
+	 * Defence in depth: a direct controller call (bypassing REST schema
+	 * coercion) must reject a non-array `lists` before it reaches
+	 * `sanitize_lists()`'s foreach — otherwise PHP 8 raises a TypeError
+	 * and the response is a 500.
+	 */
+	public function test_controller_guard_rejects_non_array_lists() {
+		$request = new WP_REST_Request( 'POST', '/newspack-newsletters/v1/lists' );
+		$request->set_param( 'lists', 'not-an-array' );
+
+		$response = Newspack_Newsletters_Subscription::api_update_lists( $request );
+
+		$this->assertInstanceOf( WP_Error::class, $response );
+		$this->assertSame( 'rest_invalid_param', $response->get_error_code() );
+		$this->assertSame( 400, $response->get_error_data()['status'] ?? null );
+	}
+}


### PR DESCRIPTION
Closes NEWS-2301.

Three pre-existing trunk bugs the NEWS-2298 final review surfaced. None were introduced by the Admin UX milestone, but the milestone made each more reachable, so they're landing as the milestone closing sequence rather than a future cycle. Source: `/tmp/news-2298-high-risk-review.md` IN-01, IN-02, IN-03.

## Findings + fixes

### 1. `Newspack_Newsletters::api_set_settings` committed the provider switch before validating credentials
`includes/class-newspack-newsletters.php` — the legacy `/newspack-newsletters/v1/settings` endpoint called `set_service_provider($service_provider)` *before* attempting `set_api_credentials()`. A rejected credentials POST left the site pointing at an unconfigured provider.

Mirrored the transactional ordering `Settings_REST::update_settings` already uses for the React shell: resolve the provider instance, attempt `set_api_credentials`, only commit `set_service_provider` on success.

Test: `Api_Set_Settings_Test::test_rejected_credentials_do_not_switch_provider` (fails on trunk, passes with this fix).

### 2. `Newspack_Newsletters_Subscription::api_update_lists` didn't guard against non-array payloads
`includes/class-newspack-newsletters-subscription.php` — passed `$request['lists']` straight into `update_lists()` → `sanitize_lists()` which iterates with `foreach`. The route schema already declares `type: array, required: true`, and WP's default `rest_validate_request_arg` does in fact reject non-array payloads at dispatch with 400, so the cited PHP 8 TypeError doesn't actually surface end-to-end on trunk.

Added a belt-and-braces `is_array()` check at the controller anyway — makes the contract explicit at the function boundary and protects against direct invocation that bypasses REST dispatch.

Tests: `Api_Update_Lists_Test` — REST-dispatch and direct-controller-call coverage.

### 3. `Admin_Shell_Legacy_Redirect` accepted empty-array `$_GET` past the `'' === \$value` guard
`includes/admin/class-admin-shell-legacy-redirect.php` — `$_GET[$key] = []` slipped through the `'' === \$value` guard. The downstream `build_legacy_redirect_target` `! empty()` filter strips the empty value before it reaches `add_query_arg`, so the redirect URL is currently clean — but the loop's stated intent is *skip empty input*, and the implementation didn't match for arrays.

Two-char fix: `if ( '' === \$value || ( is_array( \$value ) && empty( \$value ) ) )`. No regression test — the bug doesn't manifest end-to-end (downstream filter saves us), and a unit test would assert implementation details.

## Verification

- `n test-php --filter Api_Set_Settings_Test` — 3 pass (incl. one that fails on trunk).
- `n test-php --filter Api_Update_Lists_Test` — 3 pass.
- Adjacent suites green: `Settings_REST_Test` (14), `Admin_Shell_Test` (24), `Subscription_Lists_Test` (36).
- PHP/JS/SCSS lint clean.

No context change.