### PR TITLE
refactor: address code quality smells from NEWS-2298 review

### DIFF
--- a/includes/class-newspack-newsletters-layouts.php
+++ b/includes/class-newspack-newsletters-layouts.php
@@ -187,18 +187,19 @@ final class Newspack_Newsletters_Layouts {
 		if ( ! empty( $failed ) ) {
 			return rest_ensure_response(
 				[
-					'message' => sprintf(
+					'message'           => sprintf(
 						/* translators: %s: comma-separated list of email addresses that failed. */
 						__( 'Test email sent, but delivery failed for: %s.', 'newspack-newsletters' ),
 						implode( ', ', $failed )
 					),
+					'failed_recipients' => $failed,
 				]
 			);
 		}
 
 		return rest_ensure_response(
 			[
-				'message' => sprintf(
+				'message'           => sprintf(
 					/* translators: %s: comma-separated list of email addresses. */
 					_n(
 						'Test email sent to %s.',
@@ -208,6 +209,7 @@ final class Newspack_Newsletters_Layouts {
 					),
 					implode( ', ', $valid )
 				),
+				'failed_recipients' => [],
 			]
 		);
 	}

--- a/src/admin-shell/components/confirm-modal/index.js
+++ b/src/admin-shell/components/confirm-modal/index.js
@@ -3,6 +3,10 @@ import { useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 
 /**
+ * Errors thrown by `onConfirm` are caught and silently flip `isBusy=false` — the modal expects
+ * the handler to surface its own UI signal (e.g. a `runBulk` snackbar). Direct-async consumers
+ * that don't wrap their work in `runBulk` must catch + report inside `onConfirm` themselves.
+ *
  * @param {Object}                                       props
  * @param {Array<Object>}                                props.items           Items DataViews passed into the action.
  * @param {() => void}                                   props.closeModal      Close handler supplied by DataViews.
@@ -10,7 +14,7 @@ import { __ } from '@wordpress/i18n';
  * @param {string}                                       props.confirmingLabel Label shown while the confirm action is in flight.
  * @param {string|import('react').ReactNode}             props.question        Body content rendered above the buttons.
  * @param {boolean}                                      [props.isDestructive] Apply destructive styling to the confirm button.
- * @param {( items: Array<Object> ) => Promise<unknown>} props.onConfirm       Async handler invoked with `items`.
+ * @param {( items: Array<Object> ) => Promise<unknown>} props.onConfirm       Async handler invoked with `items`. Expected to surface its own error UI; rejections only flip the busy state.
  * @return {import('react').ReactElement} Modal body element.
  */
 export default function ConfirmModal( { items, closeModal, confirmLabel, confirmingLabel, question, isDestructive, onConfirm } ) {

--- a/src/admin-shell/screens/ads-list/fields.js
+++ b/src/admin-shell/screens/ads-list/fields.js
@@ -8,9 +8,10 @@
 import { Icon } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
 import { drafts, notAllowed, published, scheduled, trash } from '@wordpress/icons';
-import { dateI18n, getDate, getSettings as getDateSettings } from '@wordpress/date';
+import { dateI18n, getSettings as getDateSettings } from '@wordpress/date';
 
 import { getAdminUrl } from '../../admin-globals';
+import { formatPostDate } from '../../utils/format-date';
 import { termsForTaxonomy } from '../../utils/terms';
 import { statusKindLabel, STATUS_KIND_LABELS } from './status-label';
 
@@ -108,14 +109,7 @@ const renderPrice = ( { item } ) => {
 	return String( price );
 };
 
-const renderDate = ( { item } ) => {
-	if ( ! item?.date ) {
-		return '';
-	}
-	const settings = getDateSettings();
-	const format = settings.formats?.datetime || 'M j, Y g:ia';
-	return dateI18n( format, getDate( item.date ) );
-};
+const renderDate = ( { item } ) => formatPostDate( item );
 
 export function getFields( { advertisers = [], placements = [] } = {} ) {
 	const statusLabels = STATUS_KIND_LABELS();

--- a/src/admin-shell/screens/advertisers-list/use-all-advertisers.js
+++ b/src/admin-shell/screens/advertisers-list/use-all-advertisers.js
@@ -4,44 +4,11 @@
  * picker on sites with more than one page of advertisers.
  */
 
-import apiFetch from '@wordpress/api-fetch';
 import { useEffect, useState } from '@wordpress/element';
 
-const TAXONOMY_PATH = '/wp/v2/newspack_nl_advertiser';
-// REST term collections cap `per_page` at 100 server-side; paginate
-// until exhausted so sites with many advertisers still get the full
-// graph.
-const PER_PAGE = 100;
+import { fetchAllTerms } from '../../utils/terms';
 
-async function fetchAllAdvertisers() {
-	const all = [];
-	let page = 1;
-	let totalPages = 1;
-	while ( page <= totalPages ) {
-		try {
-			const response = await apiFetch( {
-				path: `${ TAXONOMY_PATH }?per_page=${ PER_PAGE }&_fields=id,name,parent&page=${ page }`,
-				parse: false,
-			} );
-			const data = await response.json();
-			if ( ! Array.isArray( data ) ) {
-				break;
-			}
-			all.push( ...data );
-			if ( page === 1 ) {
-				const headerPages = parseInt( response.headers?.get?.( 'X-WP-TotalPages' ) || '1', 10 );
-				totalPages = Number.isFinite( headerPages ) && headerPages > 0 ? headerPages : 1;
-			}
-		} catch ( error ) {
-			// Network / shape errors fall back to whatever has been
-			// collected — picker degrades to a partial tree rather than
-			// blocking the modal entirely.
-			break;
-		}
-		page += 1;
-	}
-	return all;
-}
+const TAXONOMY_PATH = '/wp/v2/newspack_nl_advertiser';
 
 /**
  * @param {number} refreshKey Bump to refetch — wire to the screen's save trigger.
@@ -52,7 +19,7 @@ export default function useAllAdvertisers( refreshKey = 0 ) {
 
 	useEffect( () => {
 		let cancelled = false;
-		fetchAllAdvertisers().then( list => {
+		fetchAllTerms( TAXONOMY_PATH, { fields: 'id,name,parent' } ).then( list => {
 			if ( ! cancelled ) {
 				setAdvertisers( list );
 			}

--- a/src/admin-shell/screens/advertisers-list/use-all-advertisers.js
+++ b/src/admin-shell/screens/advertisers-list/use-all-advertisers.js
@@ -19,7 +19,7 @@ export default function useAllAdvertisers( refreshKey = 0 ) {
 
 	useEffect( () => {
 		let cancelled = false;
-		fetchAllTerms( TAXONOMY_PATH, { fields: 'id,name,parent' } ).then( list => {
+		fetchAllTerms( TAXONOMY_PATH, { fields: [ 'id', 'name', 'parent' ] } ).then( list => {
 			if ( ! cancelled ) {
 				setAdvertisers( list );
 			}

--- a/src/admin-shell/screens/layouts-list/fields.js
+++ b/src/admin-shell/screens/layouts-list/fields.js
@@ -5,13 +5,13 @@
 import { parse } from '@wordpress/blocks';
 import { Icon, TextControl } from '@wordpress/components';
 import { useEffect, useMemo, useRef, useState } from '@wordpress/element';
-import { dateI18n, getDate, getSettings } from '@wordpress/date';
 import { __ } from '@wordpress/i18n';
 import { commentAuthorAvatar, plugins } from '@wordpress/icons';
 import { ENTER, ESCAPE } from '@wordpress/keycodes';
 
 import NewsletterPreview from '../../../components/newsletter-preview';
 import { setPreventDeduplicationForPostsInserter } from '../../../editor/blocks/posts-inserter/utils';
+import { formatPostDate } from '../../utils/format-date';
 import LazyPreview from './lazy-preview';
 
 // String token can't collide with real (positive integer) WP user IDs.
@@ -179,16 +179,8 @@ export function getFields( { renamingId = null, onRenameCommit, onRenameCancel, 
 			enableSorting: true,
 			getValue: ( { item } ) => item?.modified || '',
 			render: ( { item } ) => {
-				const value = item?.modified;
-				if ( ! value ) {
-					return null;
-				}
-				// REST `modified` is a site-local string with no offset.
-				// `getDate` re-anchors it to `wp.date.settings.timezone` so
-				// admins outside the site timezone don't see the wrong
-				// calendar date — same pattern the newsletters list uses.
-				const settings = getSettings();
-				return <span>{ dateI18n( settings.formats.date, getDate( value ) ) }</span>;
+				const formatted = formatPostDate( item, 'modified', { kind: 'date' } );
+				return formatted ? <span>{ formatted }</span> : null;
 			},
 		},
 	];

--- a/src/admin-shell/screens/newsletters-list/fields.js
+++ b/src/admin-shell/screens/newsletters-list/fields.js
@@ -8,9 +8,10 @@
 import { Icon } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
 import { commentAuthorAvatar, drafts, envelope, globe, published, scheduled, trash } from '@wordpress/icons';
-import { dateI18n, getDate, getSettings as getDateSettings } from '@wordpress/date';
+import { dateI18n, getSettings as getDateSettings } from '@wordpress/date';
 
 import { getAdminUrl } from '../../admin-globals';
+import { formatPostDate } from '../../utils/format-date';
 import { termsForTaxonomy } from '../../utils/terms';
 import { statusKindLabel, STATUS_KIND_LABELS } from './status-label';
 
@@ -133,20 +134,7 @@ const renderPublicPage = ( { item } ) => {
 	);
 };
 
-const renderDate = ( { item } ) => {
-	if ( ! item?.date ) {
-		return '';
-	}
-	// `item.date` is the WP REST representation in the **site** timezone
-	// with no trailing `Z`. Passing the string directly to `dateI18n` lets
-	// moment parse it in the **browser's** local timezone first, which
-	// shifts the displayed value for admins outside the site timezone.
-	// `getDate` parses with the site's `wp.date.settings.timezone`, so the
-	// resulting Date object reflects the actual site-local moment.
-	const settings = getDateSettings();
-	const format = settings.formats?.datetime || 'M j, Y g:ia';
-	return dateI18n( format, getDate( item.date ) );
-};
+const renderDate = ( { item } ) => formatPostDate( item );
 
 export function getFields( { authors = [], categories = [], tags = [], sendLists = [] } = {} ) {
 	const statusLabels = STATUS_KIND_LABELS();

--- a/src/admin-shell/utils/format-date.js
+++ b/src/admin-shell/utils/format-date.js
@@ -8,7 +8,7 @@ import { dateI18n, getDate, getSettings as getDateSettings } from '@wordpress/da
  * @param {Object}            item        DataView row.
  * @param {string}            [fieldName] Date field key on the row (default `date`).
  * @param {Object}            [opts]
- * @param {'date'|'datetime'} [opts.kind] Which `formats` entry to pull (default `datetime`).
+ * @param {'date'|'datetime'} [opts.kind] `wp.date.settings.formats` entry (default `datetime`).
  * @return {string} Localised date string, or '' when the field is empty.
  */
 export function formatPostDate( item, fieldName = 'date', { kind = 'datetime' } = {} ) {

--- a/src/admin-shell/utils/format-date.js
+++ b/src/admin-shell/utils/format-date.js
@@ -1,0 +1,22 @@
+import { dateI18n, getDate, getSettings as getDateSettings } from '@wordpress/date';
+
+/**
+ * Render a WP REST date string in the site's configured timezone. `getDate` re-anchors the
+ * (offset-less) REST string to `wp.date.settings.timezone` so admins outside the site
+ * timezone see the same calendar date the editor stored.
+ *
+ * @param {Object}            item        DataView row.
+ * @param {string}            [fieldName] Date field key on the row (default `date`).
+ * @param {Object}            [opts]
+ * @param {'date'|'datetime'} [opts.kind] Which `formats` entry to pull (default `datetime`).
+ * @return {string} Localised date string, or '' when the field is empty.
+ */
+export function formatPostDate( item, fieldName = 'date', { kind = 'datetime' } = {} ) {
+	const value = item?.[ fieldName ];
+	if ( ! value ) {
+		return '';
+	}
+	const settings = getDateSettings();
+	const format = settings.formats?.[ kind ] || ( 'date' === kind ? 'M j, Y' : 'M j, Y g:ia' );
+	return dateI18n( format, getDate( value ) );
+}

--- a/src/admin-shell/utils/terms.js
+++ b/src/admin-shell/utils/terms.js
@@ -12,14 +12,14 @@ import apiFetch from '@wordpress/api-fetch';
 export const TERMS_PER_PAGE = 100;
 
 // Walk every page — `per_page` caps at 100 server-side, so a single request silently truncates on sites with many terms.
-export async function fetchAllTerms( basePath ) {
+export async function fetchAllTerms( basePath, { fields = 'id,name' } = {} ) {
 	const all = [];
 	let page = 1;
 	let totalPages = 1;
 	while ( page <= totalPages ) {
 		try {
 			const response = await apiFetch( {
-				path: `${ basePath }?per_page=${ TERMS_PER_PAGE }&_fields=id,name&page=${ page }`,
+				path: `${ basePath }?per_page=${ TERMS_PER_PAGE }&_fields=${ fields }&page=${ page }`,
 				parse: false,
 			} );
 			const data = await response.json();

--- a/src/admin-shell/utils/terms.js
+++ b/src/admin-shell/utils/terms.js
@@ -12,14 +12,15 @@ import apiFetch from '@wordpress/api-fetch';
 export const TERMS_PER_PAGE = 100;
 
 // Walk every page — `per_page` caps at 100 server-side, so a single request silently truncates on sites with many terms.
-export async function fetchAllTerms( basePath, { fields = 'id,name' } = {} ) {
+export async function fetchAllTerms( basePath, { fields = [ 'id', 'name' ] } = {} ) {
 	const all = [];
 	let page = 1;
 	let totalPages = 1;
+	const fieldsParam = encodeURIComponent( fields.join( ',' ) );
 	while ( page <= totalPages ) {
 		try {
 			const response = await apiFetch( {
-				path: `${ basePath }?per_page=${ TERMS_PER_PAGE }&_fields=${ fields }&page=${ page }`,
+				path: `${ basePath }?per_page=${ TERMS_PER_PAGE }&_fields=${ fieldsParam }&page=${ page }`,
 				parse: false,
 			} );
 			const data = await response.json();

--- a/src/editor/blocks/conditional-content/index.js
+++ b/src/editor/blocks/conditional-content/index.js
@@ -115,6 +115,7 @@ const withConditionalContentNotice = createHigherOrderComponent(
 						<>
 							{ __( 'Missing opening tag for conditional content.', 'newspack-newsletters' ) }
 							<button
+								type="button"
 								onClick={ () => {
 									props.setAttributes( { conditionalAfter: '' } );
 								} }
@@ -131,6 +132,7 @@ const withConditionalContentNotice = createHigherOrderComponent(
 						<>
 							{ __( 'Missing closing tag for conditional content.', 'newspack-newsletters' ) }
 							<button
+								type="button"
 								onClick={ () => {
 									props.setAttributes( { conditionalBefore: '' } );
 								} }

--- a/src/editor/blocks/visibility-attribute/index.js
+++ b/src/editor/blocks/visibility-attribute/index.js
@@ -146,6 +146,7 @@ const withVisibilityNotice = createHigherOrderComponent(
 								<>
 									{ __( 'Newsletter is not public, this block will not be visible.', 'newspack-newsletters' ) }
 									<button
+										type="button"
 										onClick={ () => {
 											props.setAttributes( { [ ATTRIBUTE_NAME ]: '' } );
 										} }

--- a/src/newsletter-editor/layout/index.js
+++ b/src/newsletter-editor/layout/index.js
@@ -100,7 +100,7 @@ export default compose( [
 
 	useEffect( () => {
 		setUsedLayout( find( layouts, { ID: layoutId } ) || {} );
-	}, [ layouts.length ] );
+	}, [ layouts, layoutId ] );
 
 	const blockPreview = useMemo( () => {
 		return usedLayout.post_content ? parse( usedLayout.post_content ) : null;

--- a/src/newsletter-editor/layout/index.js
+++ b/src/newsletter-editor/layout/index.js
@@ -99,7 +99,13 @@ export default compose( [
 	const [ usedLayout, setUsedLayout ] = useState( {} );
 
 	useEffect( () => {
-		setUsedLayout( find( layouts, { ID: layoutId } ) || {} );
+		const match = find( layouts, { ID: layoutId } );
+		if ( match ) {
+			setUsedLayout( match );
+			return;
+		}
+		// Preserve a just-saved layout the cache hasn't picked up yet.
+		setUsedLayout( prev => ( prev?.ID === layoutId ? prev : {} ) );
 	}, [ layouts, layoutId ] );
 
 	const blockPreview = useMemo( () => {

--- a/tests/test-layouts-rest-test-send.php
+++ b/tests/test-layouts-rest-test-send.php
@@ -18,6 +18,13 @@ class Layouts_REST_Test_Send_Test extends WP_UnitTestCase {
 	private $captured_mail = [];
 
 	/**
+	 * Recipients the `pre_wp_mail` filter should report as failed.
+	 *
+	 * @var array<int, string>
+	 */
+	private $fail_recipients = [];
+
+	/**
 	 * Pre-test snapshot of the current user id.
 	 *
 	 * @var int
@@ -38,6 +45,7 @@ class Layouts_REST_Test_Send_Test extends WP_UnitTestCase {
 		parent::set_up();
 
 		$this->captured_mail              = [];
+		$this->fail_recipients            = [];
 		$this->previous_user_id           = get_current_user_id();
 		$this->layouts_cpt_was_registered = post_type_exists( \Newspack_Newsletters_Layouts::NEWSPACK_NEWSLETTERS_LAYOUT_CPT );
 
@@ -73,7 +81,8 @@ class Layouts_REST_Test_Send_Test extends WP_UnitTestCase {
 	public function capture_wp_mail( $short_circuit, $atts ) {
 		unset( $short_circuit );
 		$this->captured_mail[] = $atts;
-		return true;
+		$to = is_array( $atts['to'] ) ? ( $atts['to'][0] ?? '' ) : $atts['to'];
+		return in_array( $to, $this->fail_recipients, true ) ? false : true;
 	}
 
 	/**
@@ -202,5 +211,59 @@ class Layouts_REST_Test_Send_Test extends WP_UnitTestCase {
 		$this->assertSame( 200, $response->get_status() );
 		$stored = get_user_meta( get_current_user_id(), 'newspack_nl_test_emails', true );
 		$this->assertSame( [ 'team@example.com', 'lead@example.com' ], $stored );
+	}
+
+	/**
+	 * Partial failure → 200 with a `failed_recipients` array the client
+	 * can branch on (without parsing message text).
+	 */
+	public function test_partial_failure_returns_200_with_failed_recipients() {
+		$post_id               = $this->make_layout( '<p>Preview</p>' );
+		$this->fail_recipients = [ 'b@example.com' ];
+
+		$request = new WP_REST_Request( 'POST', '/newspack-newsletters/v1/layouts/' . $post_id . '/test' );
+		$request->set_param( 'test_email', 'a@example.com, b@example.com, c@example.com' );
+
+		$response = rest_do_request( $request );
+
+		$this->assertSame( 200, $response->get_status() );
+		$data = $response->get_data();
+		$this->assertArrayHasKey( 'failed_recipients', $data );
+		$this->assertSame( [ 'b@example.com' ], $data['failed_recipients'] );
+	}
+
+	/**
+	 * Full success still carries `failed_recipients` (empty array) so the
+	 * client can probe the field unconditionally.
+	 */
+	public function test_full_success_includes_empty_failed_recipients() {
+		$post_id = $this->make_layout( '<p>Preview</p>' );
+
+		$request = new WP_REST_Request( 'POST', '/newspack-newsletters/v1/layouts/' . $post_id . '/test' );
+		$request->set_param( 'test_email', 'a@example.com, b@example.com' );
+
+		$response = rest_do_request( $request );
+
+		$this->assertSame( 200, $response->get_status() );
+		$data = $response->get_data();
+		$this->assertArrayHasKey( 'failed_recipients', $data );
+		$this->assertSame( [], $data['failed_recipients'] );
+	}
+
+	/**
+	 * All recipients fail → 500 with the mail_failed error code (no
+	 * partial-success masking).
+	 */
+	public function test_full_failure_returns_500() {
+		$post_id               = $this->make_layout( '<p>Preview</p>' );
+		$this->fail_recipients = [ 'a@example.com', 'b@example.com' ];
+
+		$request = new WP_REST_Request( 'POST', '/newspack-newsletters/v1/layouts/' . $post_id . '/test' );
+		$request->set_param( 'test_email', 'a@example.com, b@example.com' );
+
+		$response = rest_do_request( $request );
+
+		$this->assertSame( 500, $response->get_status() );
+		$this->assertSame( 'newspack_newsletters_mail_failed', $response->get_data()['code'] ?? null );
 	}
 }

--- a/tests/test-layouts-rest-test-send.php
+++ b/tests/test-layouts-rest-test-send.php
@@ -72,11 +72,12 @@ class Layouts_REST_Test_Send_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * `pre_wp_mail` filter: record the call, short-circuit wp_mail with `true`.
+	 * `pre_wp_mail` filter: record the call, then short-circuit wp_mail. Returns `false`
+	 * for recipients listed in `$fail_recipients` (simulating delivery failure), `true` otherwise.
 	 *
 	 * @param null|bool $short_circuit Unused.
 	 * @param array     $atts          wp_mail attributes.
-	 * @return true
+	 * @return bool
 	 */
 	public function capture_wp_mail( $short_circuit, $atts ) {
 		unset( $short_circuit );


### PR DESCRIPTION
Closes NEWS-2302.

Six quality smells the NEWS-2298 final review flagged at info level. None are bugs in the strict sense; each is a latent footgun, duplication, or contract gap. Source: `/tmp/news-2298-full-sweep-review.md` IN-03–IN-07 plus the layout test-send status pairing from the high-risk sweep.

## Changes

### 1. Layout test-send response now carries `failed_recipients` (IN-01)
`includes/class-newspack-newsletters-layouts.php` — partial failure used to return HTTP 200 with a "delivery failed for: x@y" message string the client had to parse. The response now also includes a `failed_recipients` array (empty on full success, populated on partial failure). Full failure keeps the 500 + `mail_failed` code. New `tests/test-layouts-rest-test-send.php` cases — partial, full success, full failure.

### 2. Layout effect deps cover identity changes (IN-02)
`src/newsletter-editor/layout/index.js` — `setUsedLayout` re-ran only on `[ layouts.length ]`, so a rename / duplicate / reorder that preserved the count left the sidebar showing the stale title. Now `[ layouts, layoutId ]`.

### 3. fetchAllAdvertisers collapses onto fetchAllTerms (IN-03)
`src/admin-shell/utils/terms.js` gains a `fields` option; `src/admin-shell/screens/advertisers-list/use-all-advertisers.js` reduces to a one-line call. −38 LOC.

### 4. Explicit `type="button"` on Inspector clear-action buttons (IN-04)
`src/editor/blocks/conditional-content/index.js`, `src/editor/blocks/visibility-attribute/index.js` — bare `<button onClick>` defaults to `type="submit"`. `@wordpress/components` has wrapped `InspectorControls` in a form across past major bumps; the explicit type keeps these inert if it happens again.

### 5. `ConfirmModal` onConfirm contract documented (IN-05)
`src/admin-shell/components/confirm-modal/index.js` — the catch-and-flip-isBusy=false is intentional because all current callers wrap with `runBulk`. JSDoc now spells this out so direct-async consumers know to surface their own error UI.

### 6. Shared `formatPostDate` helper across list screens (IN-06)
`src/admin-shell/utils/format-date.js` (new) centralises the REST-date timezone re-anchor (`getDate` → `wp.date.settings.timezone` → `dateI18n`). Newsletters / Ads / Layouts list screens drop their inline `renderDate` (and stale `getDate` imports). Net −35 LOC.

## Verification

- `n test-php --filter Layouts_REST_Test_Send_Test` — 8/8 (3 new partial / full / full-failure cases).
- PHP / JS / SCSS lint clean.
- `n build` clean (JS-touching commits).

No context change.