### PR TITLE
fix: update text alignment based on changes in WP 7.0

### DIFF
--- a/includes/class-newspack-newsletters-renderer.php
+++ b/includes/class-newspack-newsletters-renderer.php
@@ -417,6 +417,12 @@ final class Newspack_Newsletters_Renderer {
 			$attrs['border'] = $attrs['style']['border']['width'] . ' ' . $border_style . ' ' . $border_color;
 		}
 
+		// WP 7.0+ stores text alignment under style.typography.textAlign via the
+		// new textAlign block support (paragraph, heading, etc.).
+		if ( isset( $attrs['style']['typography']['textAlign'] ) && ! isset( $attrs['align'] ) && ! isset( $attrs['textAlign'] ) ) {
+			$attrs['align'] = $attrs['style']['typography']['textAlign'];
+		}
+
 		if ( isset( $attrs['textAlign'] ) && ! isset( $attrs['align'] ) ) {
 			$attrs['align'] = $attrs['textAlign'];
 			unset( $attrs['textAlign'] );

--- a/tests/test-renderer.php
+++ b/tests/test-renderer.php
@@ -87,33 +87,35 @@ class Newsletters_Renderer_Test extends WP_UnitTestCase {
 			);
 		};
 
-		$this->assertStringContainsString(
-			'align="center"',
+		// Anchor assertions to <mj-text …> so the test doesn't accept alignment
+		// that only landed on <mj-section> or another wrapper tag.
+		$this->assertMatchesRegularExpression(
+			'/<mj-text\b[^>]*\balign="center"/',
 			$render( [ 'align' => 'center' ] ),
 			'Legacy align attribute reaches mj-text'
 		);
 
-		$this->assertStringContainsString(
-			'align="center"',
+		$this->assertMatchesRegularExpression(
+			'/<mj-text\b[^>]*\balign="center"/',
 			$render( [ 'textAlign' => 'center' ] ),
 			'Top-level textAlign attribute reaches mj-text'
 		);
 
-		$this->assertStringContainsString(
-			'align="center"',
+		$this->assertMatchesRegularExpression(
+			'/<mj-text\b[^>]*\balign="center"/',
 			$render( [ 'style' => [ 'typography' => [ 'textAlign' => 'center' ] ] ] ),
 			'WP 7.0 style.typography.textAlign reaches mj-text'
 		);
 
-		$this->assertStringContainsString(
-			'align="right"',
+		$this->assertMatchesRegularExpression(
+			'/<mj-text\b[^>]*\balign="right"/',
 			$render( [ 'style' => [ 'typography' => [ 'textAlign' => 'right' ] ] ] ),
 			'WP 7.0 style.typography.textAlign right reaches mj-text'
 		);
 
 		// Top-level attributes win over style.typography to preserve existing behavior.
-		$this->assertStringContainsString(
-			'align="left"',
+		$this->assertMatchesRegularExpression(
+			'/<mj-text\b[^>]*\balign="left"/',
 			$render(
 				[
 					'align' => 'left',

--- a/tests/test-renderer.php
+++ b/tests/test-renderer.php
@@ -66,6 +66,65 @@ class Newsletters_Renderer_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test text alignment is promoted to mj-text's align attribute regardless of
+	 * which Gutenberg attribute shape is used:
+	 *   - `align` (legacy)
+	 *   - top-level `textAlign` (intermediate)
+	 *   - `style.typography.textAlign` (WP 7.0+ textAlign block support)
+	 */
+	public function test_render_text_alignment_variants() {
+		$inner_html = '<p class="has-text-align-center">Hello</p>';
+
+		$render = function ( $attrs ) use ( $inner_html ) {
+			return Newspack_Newsletters_Renderer::render_mjml_component(
+				[
+					'blockName'    => 'core/paragraph',
+					'attrs'        => $attrs,
+					'innerBlocks'  => [],
+					'innerContent' => [],
+					'innerHTML'    => $inner_html,
+				]
+			);
+		};
+
+		$this->assertStringContainsString(
+			'align="center"',
+			$render( [ 'align' => 'center' ] ),
+			'Legacy align attribute reaches mj-text'
+		);
+
+		$this->assertStringContainsString(
+			'align="center"',
+			$render( [ 'textAlign' => 'center' ] ),
+			'Top-level textAlign attribute reaches mj-text'
+		);
+
+		$this->assertStringContainsString(
+			'align="center"',
+			$render( [ 'style' => [ 'typography' => [ 'textAlign' => 'center' ] ] ] ),
+			'WP 7.0 style.typography.textAlign reaches mj-text'
+		);
+
+		$this->assertStringContainsString(
+			'align="right"',
+			$render( [ 'style' => [ 'typography' => [ 'textAlign' => 'right' ] ] ] ),
+			'WP 7.0 style.typography.textAlign right reaches mj-text'
+		);
+
+		// Top-level attributes win over style.typography to preserve existing behavior.
+		$this->assertStringContainsString(
+			'align="left"',
+			$render(
+				[
+					'align' => 'left',
+					'style' => [ 'typography' => [ 'textAlign' => 'right' ] ],
+				]
+			),
+			'Top-level align takes precedence over style.typography.textAlign'
+		);
+	}
+
+	/**
 	 * Test font-size preset mapping in paragraph rendering.
 	 */
 	public function test_render_font_size_presets() {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guideline](https://github.com/Automattic/newspack-plugin/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

WordPress 7.0 changed how text alignments are stored for blocks (from `{"align":"center"}` to `{"style":{"typography":{"textAlign":"center"}}}`). This hotfix makes sure our newsletter renderer can still grab the text alignments and apply them to emails.

Closes NPPM-2864

### How to test the changes in this Pull Request:

1. Set up a newsletter draft with three paragraph blocks and three heading blocks; change the text alignment so one of each is aligned left, centre, right.
2. Send yourself a test email; note that the alignments don't come through.
3. Apply this PR.
4. Repeat step 2 and confirm the alignments work again!

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
